### PR TITLE
Add views title and move page_alter to dkan_dataset submodule

### DIFF
--- a/modules/dkan/dkan_sitewide/dkan_sitewide.module
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.module
@@ -34,10 +34,6 @@ function dkan_sitewide_page_alter(&$page) {
   // Context module does this in hook_page_alter() so we need to as well if
   // we want to add this.
   $breadcrumbs = drupal_get_breadcrumb();
-  if (arg(0) == 'dataset' && is_array($breadcrumbs)) {
-    $breadcrumbs[1] = t('Datasets');
-    $breadcrumbs[2] = t('Search');
-  }
   $node = menu_get_object();
   if ($node && $node->type == 'resource') {
     $node_wrapper = entity_metadata_wrapper('node', $node);

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.views_default.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.views_default.inc
@@ -22,6 +22,7 @@ function dkan_sitewide_search_db_views_default_views() {
 
   /* Display: Master */
   $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'Datasets';
   $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['access']['type'] = 'none';
   $handler->display->display_options['cache']['type'] = 'none';


### PR DESCRIPTION
As in the subject, having title here can be useful with modules like "metatag_views" which build metatags using views title and description.
Follows a pull request on dkan_dataset module.
