### PR TITLE
Allow state select leaftlet

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -10,7 +10,7 @@ defaults[projects][subdir] = contrib
 projects[dkan_dataset][subdir] = dkan
 projects[dkan_dataset][download][type] = git
 projects[dkan_dataset][download][url] = https://github.com/NuCivic/dkan_dataset.git
-projects[dkan_dataset][download][branch] = validate_json_input_leaflet_draw_widget
+projects[dkan_dataset][download][branch] = allow_state_select_leaftlet
 
 projects[dkan_datastore][subdir] = dkan
 projects[dkan_datastore][download][type] = git
@@ -30,7 +30,7 @@ projects[visualization_entity_charts][download][branch] = master
 projects[visualization_entity_charts][type] = module
 
 ; Includes, since we're doing non-recusive
-includes[dkan_dataset_make] = https://raw.githubusercontent.com/NuCivic/dkan_dataset/validate_json_input_leaflet_draw_widget/dkan_dataset.make
+includes[dkan_dataset_make] = https://raw.githubusercontent.com/NuCivic/dkan_dataset/allow_state_select_leaftlet/dkan_dataset.make
 includes[dkan_datastore_make] = https://raw.githubusercontent.com/NuCivic/dkan_datastore/7.x-1.x/dkan_datastore.make
 
 includes[visualization_entity] = https://raw.githubusercontent.com/NuCivic/visualization_entity/master/visualization_entity.make

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -10,7 +10,7 @@ defaults[projects][subdir] = contrib
 projects[dkan_dataset][subdir] = dkan
 projects[dkan_dataset][download][type] = git
 projects[dkan_dataset][download][url] = https://github.com/NuCivic/dkan_dataset.git
-projects[dkan_dataset][download][branch] = 7.x-1.x
+projects[dkan_dataset][download][branch] = validate_json_input_leaflet_draw_widget
 
 projects[dkan_datastore][subdir] = dkan
 projects[dkan_datastore][download][type] = git

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -30,7 +30,6 @@ projects[visualization_entity_charts][download][branch] = master
 projects[visualization_entity_charts][type] = module
 
 ; Includes, since we're doing non-recusive
-
 includes[dkan_dataset_make] = https://raw.githubusercontent.com/NuCivic/dkan_dataset/validate_json_input_leaflet_draw_widget/dkan_dataset.make
 includes[dkan_datastore_make] = https://raw.githubusercontent.com/NuCivic/dkan_datastore/7.x-1.x/dkan_datastore.make
 

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -31,7 +31,7 @@ projects[visualization_entity_charts][type] = module
 
 ; Includes, since we're doing non-recusive
 
-includes[dkan_dataset_make] = https://raw.githubusercontent.com/NuCivic/dkan_dataset/7.x-1.x/dkan_dataset.make
+includes[dkan_dataset_make] = https://raw.githubusercontent.com/NuCivic/dkan_dataset/validate_json_input_leaflet_draw_widget/dkan_dataset.make
 includes[dkan_datastore_make] = https://raw.githubusercontent.com/NuCivic/dkan_datastore/7.x-1.x/dkan_datastore.make
 
 includes[visualization_entity] = https://raw.githubusercontent.com/NuCivic/visualization_entity/master/visualization_entity.make

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -68,6 +68,7 @@ projects[fieldable_panels_panes][version] = 1.6
 projects[honeypot][version] = 1.17
 
 projects[fontyourface][version] = 2.8
+projects[fontyourface[patch][2550253] = https://www.drupal.org/files/issues/fontface_regenerate-css-after-add-rule.patch
 
 projects[imagecache_actions][download][type] = git
 projects[imagecache_actions][download][url] = "http://git.drupal.org/project/imagecache_actions.git"

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -68,7 +68,7 @@ projects[fieldable_panels_panes][version] = 1.6
 projects[honeypot][version] = 1.17
 
 projects[fontyourface][version] = 2.8
-projects[fontyourface[patch][2550253] = https://www.drupal.org/files/issues/fontface_regenerate-css-after-add-rule.patch
+projects[fontyourface][patch][2550253] = https://www.drupal.org/files/issues/fontface_regenerate-css-after-add-rule.patch
 
 projects[imagecache_actions][download][type] = git
 projects[imagecache_actions][download][url] = "http://git.drupal.org/project/imagecache_actions.git"

--- a/test/features/groups.feature
+++ b/test/features/groups.feature
@@ -64,7 +64,7 @@ Feature: Groups
       And I press "edit-submit--2"
     Then I should see "Are you sure you want to perform Remove from group on the selected items?"
     When I press "edit-submit"
-      And I wait for "1" seconds
+      And I wait for "3" seconds
     Then I should see "Performed Remove from group"
     Given I am logged in as a user with the "authenticated user" role
       And I am on "/node/add/group"


### PR DESCRIPTION
ref: NuCivic/internal#865

We added two new utilities to leaflet widget:
  1.- On the settings field you can select to show use a list select with predefined states or regions. This is implemented with hook that other modules can extend (You need to enable leaflet_widget_us to show USA states on the list. After enable the checkbox on the field you can see the list on the map.
2.- Added new option for points and you can add a lat, long.

You should see the similar to the attachment page.
![north dakota gis data](https://cloud.githubusercontent.com/assets/838381/9478301/34e943fe-4b77-11e5-91f4-7485cd067a2a.png)
