### PR TITLE
Example showing the advantages of using a "locked" make file.

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -80,8 +80,7 @@ projects[feeds_flatstore_processor][download][url] = "https://github.com/NuCivic
 projects[feeds_flatstore_processor][download][branch] = "master"
 
 projects[schema][subdir] = "contrib"
-projects[schema][download][revision] = "08b02458694d186f8ab3bd0b24fbc738f9271108"
-projects[schema][download][type] = "git"
+projects[schema][version] = "1.2"
 
 projects[services][subdir] = "contrib"
 projects[services][version] = "3.12"
@@ -225,7 +224,7 @@ projects[open_data_schema_map_dkan][download][url] = "https://github.com/NuCivic
 projects[open_data_schema_map_dkan][download][branch] = "master"
 
 projects[pathauto][subdir] = "contrib"
-projects[pathauto][version] = "1.2"
+projects[pathauto][version] = "1.3"
 
 projects[rdfx][subdir] = "contrib"
 projects[rdfx][download][type] = "git"
@@ -296,17 +295,58 @@ projects[visualization_entity_charts][download][type] = "git"
 projects[visualization_entity_charts][download][url] = "https://github.com/NuCivic/visualization_entity_charts.git"
 projects[visualization_entity_charts][download][branch] = "master"
 
-projects[admin_menu][subdir] = "contrib"
-projects[admin_menu][version] = "3.0-rc5"
-
 projects[bueditor][subdir] = "contrib"
-projects[bueditor][version] = "1.7"
 projects[bueditor][patch][1931862] = "http://drupal.org/files/dont-render-bueditor-for-plain-text-textareas.patch"
+projects[bueditor][version] = "1.8"
 
 projects[colorizer][subdir] = "contrib"
-projects[colorizer][version] = "1.7"
 projects[colorizer][patch][2227651] = "https://www.drupal.org/files/issues/colorizer-add-rgb-vars-2227651-4b.patch"
 projects[colorizer][patch][2599298] = "https://www.drupal.org/files/issues/colorizer-bug_system_cron_delete_current_css-2599298-2.patch"
+projects[colorizer][version] = "1.7"
+
+projects[markdowneditor][subdir] = "contrib"
+projects[markdowneditor][patch][2045225] = "http://drupal.org/files/remove-dsm-from-hook-install-2045225-1.patch"
+projects[markdowneditor][version] = "1.4"
+
+projects[og_moderation][subdir] = "contrib"
+projects[og_moderation][version] = "2.3"
+
+projects[views_autocomplete_filters][subdir] = "contrib"
+projects[views_autocomplete_filters][patch][2277453] = "http://drupal.org/files/issues/ViewsAutocompleteFilters-no_results_on_some_environments-2277453-1.patch"
+projects[views_autocomplete_filters][patch][2374709] = "http://www.drupal.org/files/issues/views_autocomplete_filters-cache-2374709-2.patch"
+projects[views_autocomplete_filters][patch][2317351] = "http://www.drupal.org/files/issues/views_autocomplete_filters-content-pane-2317351-4.patch"
+projects[views_autocomplete_filters][version] = "1.2"
+
+projects[panopoly_widgets][subdir] = "contrib"
+projects[panopoly_widgets][patch][1] = "patches/panopoly_widgets_overrides.patch"
+projects[panopoly_widgets][patch][2] = "patches/panopoly_widgets_add_jquery_ui_tabs.patch"
+projects[panopoly_widgets][version] = "1.28"
+
+projects[panopoly_images][subdir] = "contrib"
+projects[panopoly_images][version] = "1.28"
+
+projects[restws][subdir] = "contrib"
+projects[restws][patch][2484829] = "https://www.drupal.org/files/issues/restws-fix-format-extension-2484829-53.patch"
+projects[restws][version] = "2.4"
+
+projects[omega][subdir] = "contrib"
+projects[omega][patch][1828552] = "http://drupal.org/files/1828552-omega-hook_views_mini_pager.patch"
+projects[omega][version] = "4.4"
+
+; Themes
+projects[nuboot_radix][subdir] = "contrib"
+projects[nuboot_radix][download][type] = "git"
+projects[nuboot_radix][download][url] = "https://github.com/NuCivic/nuboot_radix.git"
+projects[nuboot_radix][download][branch] = "7.x-1.x"
+projects[nuboot_radix][type] = "theme"
+
+projects[radix][subdir] = "contrib"
+projects[radix][type] = "theme"
+projects[radix][version] = "3.0-rc4"
+
+; Modules
+projects[admin_menu][subdir] = "contrib"
+projects[admin_menu][version] = "3.0-rc5"
 
 projects[conditional_styles][subdir] = "contrib"
 projects[conditional_styles][version] = "2.2"
@@ -324,7 +364,7 @@ projects[fieldable_panels_panes][subdir] = "contrib"
 projects[fieldable_panels_panes][version] = "1.7"
 
 projects[honeypot][subdir] = "contrib"
-projects[honeypot][version] = "1.17"
+projects[honeypot][version] = "1.21"
 
 projects[fontyourface][subdir] = "contrib"
 projects[fontyourface][version] = "2.8"
@@ -332,33 +372,11 @@ projects[fontyourface][version] = "2.8"
 projects[markdown][subdir] = "contrib"
 projects[markdown][version] = "1.2"
 
-projects[markdowneditor][subdir] = "contrib"
-projects[markdowneditor][version] = "1.2"
-projects[markdowneditor][patch][2045225] = "http://drupal.org/files/remove-dsm-from-hook-install-2045225-1.patch"
-
 projects[module_filter][subdir] = "contrib"
 projects[module_filter][version] = "2.0"
 
-projects[og_moderation][subdir] = "contrib"
-projects[og_moderation][version] = "2.2"
-projects[og_moderation][patch][2231737] = "https://drupal.org/files/issues/any-user-with-view-revision-can-revert-delete-2231737-1.patch"
-
 projects[defaultconfig][subdir] = "contrib"
-projects[defaultconfig][version] = "1.0-alpha9"
-
-projects[views_autocomplete_filters][subdir] = "contrib"
-projects[views_autocomplete_filters][version] = "1.1"
-projects[views_autocomplete_filters][patch][2277453] = "http://drupal.org/files/issues/ViewsAutocompleteFilters-no_results_on_some_environments-2277453-1.patch"
-projects[views_autocomplete_filters][patch][2374709] = "http://www.drupal.org/files/issues/views_autocomplete_filters-cache-2374709-2.patch"
-projects[views_autocomplete_filters][patch][2317351] = "http://www.drupal.org/files/issues/views_autocomplete_filters-content-pane-2317351-4.patch"
-
-projects[panopoly_widgets][subdir] = "contrib"
-projects[panopoly_widgets][version] = "1.25"
-projects[panopoly_widgets][patch][1] = "patches/panopoly_widgets_overrides.patch"
-projects[panopoly_widgets][patch][2] = "patches/panopoly_widgets_add_jquery_ui_tabs.patch"
-
-projects[panopoly_images][subdir] = "contrib"
-projects[panopoly_images][version] = "1.27"
+projects[defaultconfig][version] = "1.0-alpha11"
 
 projects[panels][subdir] = "contrib"
 projects[panels][version] = "3.5"
@@ -367,17 +385,13 @@ projects[path_breadcrumbs][subdir] = "contrib"
 projects[path_breadcrumbs][version] = "3.3"
 
 projects[radix_layouts][subdir] = "contrib"
-projects[radix_layouts][version] = "3.3"
+projects[radix_layouts][version] = "3.4"
 
 projects[r4032login][subdir] = "contrib"
-projects[r4032login][version] = "1.7"
+projects[r4032login][version] = "1.8"
 
 projects[rules][subdir] = "contrib"
-projects[rules][version] = "2.3"
-
-projects[restws][subdir] = "contrib"
-projects[restws][version] = "2.3"
-projects[restws][patch][2484829] = "https://www.drupal.org/files/issues/restws-fix-format-extension-2484829-53.patch"
+projects[rules][version] = "2.9"
 
 projects[adminrole][subdir] = "contrib"
 projects[adminrole][version] = "1.0"
@@ -390,21 +404,6 @@ projects[menu_token][version] = "1.0-beta5"
 
 projects[delta][subdir] = "contrib"
 projects[delta][version] = "3.0-beta11"
-
-projects[omega][subdir] = "contrib"
-projects[omega][version] = "3.1"
-projects[omega][patch][1828552] = "http://drupal.org/files/1828552-omega-hook_views_mini_pager.patch"
-
-; Themes
-projects[nuboot_radix][subdir] = "contrib"
-projects[nuboot_radix][download][type] = "git"
-projects[nuboot_radix][download][url] = "https://github.com/NuCivic/nuboot_radix.git"
-projects[nuboot_radix][download][branch] = "7.x-1.x"
-projects[nuboot_radix][type] = "theme"
-
-projects[radix][subdir] = "contrib"
-projects[radix][type] = "theme"
-projects[radix][version] = "3.0-rc4"
 
 ; Libraries
 libraries[jquery.imagesloaded][download][type] = "file"

--- a/drupal-org.make.unlocked
+++ b/drupal-org.make.unlocked
@@ -44,30 +44,28 @@ includes[dkan_data_story_make] = modules/dkan/dkan_data_story/dkan_data_story.ma
 projects[file_entity][patch][2308737] = https://www.drupal.org/files/issues/file_entity-remove-field-status-check-2308737-9509141.patch
 
 ; Contrib Modules
-projects[admin_menu][version] = 3.0-rc5
+projects[] = admin_menu
 
-projects[bueditor][version] = 1.7
+projects[bueditor][type] = module
 projects[bueditor][patch][1931862] = http://drupal.org/files/dont-render-bueditor-for-plain-text-textareas.patch
 
-projects[colorizer][version] = 1.7
+projects[colorizer][type] = module
 projects[colorizer][patch][2227651] = https://www.drupal.org/files/issues/colorizer-add-rgb-vars-2227651-4b.patch
 projects[colorizer][patch][2599298] = https://www.drupal.org/files/issues/colorizer-bug_system_cron_delete_current_css-2599298-2.patch
 
-projects[conditional_styles][version] = 2.2
+projects[] = conditional_styles
 
-projects[conditional_styles][version] = 2.2
+projects[] = diff
 
-projects[diff][version] = 3.2
+projects[] = draggableviews
 
-projects[draggableviews][version] = 2.1
+projects[] = entityreference_filter
 
-projects[entityreference_filter][version] = 1.5
+projects[] = fieldable_panels_panes
 
-projects[fieldable_panels_panes][version] = 1.7
+projects[] = honeypot
 
-projects[honeypot][version] = 1.17
-
-projects[fontyourface][version] = 2.8
+projects[] = fontyourface
 
 projects[imagecache_actions][download][type] = git
 projects[imagecache_actions][download][url] = "http://git.drupal.org/project/imagecache_actions.git"
@@ -75,65 +73,63 @@ projects[imagecache_actions][download][branch] = 7.x-1.x
 projects[imagecache_actions][download][revision] = cd19d2a
 projects[imagecache_actions][type] = module
 
-projects[markdown][version] = 1.2
+projects[] = markdown
 
-projects[markdowneditor][version] = 1.2
+projects[markdowneditor][type] = module
 projects[markdowneditor][patch][2045225] = http://drupal.org/files/remove-dsm-from-hook-install-2045225-1.patch
 
-projects[module_filter][version] = 2.0
+projects[] = module_filter
 
-projects[og_moderation][version] = 2.2
+projects[] = og_moderation
 projects[og_moderation][patch][2231737] = https://drupal.org/files/issues/any-user-with-view-revision-can-revert-delete-2231737-1.patch
 
-projects[defaultconfig][version] = 1.0-alpha9
+projects[] = defaultconfig
 
-projects[panelizer][version] = 3.1
+projects[] = panelizer
 
-projects[views_autocomplete_filters][version] = 1.1
+projects[views_autocomplete_filters][type] = module
 projects[views_autocomplete_filters][patch][2277453] = http://drupal.org/files/issues/ViewsAutocompleteFilters-no_results_on_some_environments-2277453-1.patch
 projects[views_autocomplete_filters][patch][2374709] = http://www.drupal.org/files/issues/views_autocomplete_filters-cache-2374709-2.patch
 projects[views_autocomplete_filters][patch][2317351] = http://www.drupal.org/files/issues/views_autocomplete_filters-content-pane-2317351-4.patch
 
 
-projects[panopoly_widgets][version] = 1.25
+projects[panopoly_widgets][type] = module
 includes[panopoly_widgets_make] = http://cgit.drupalcode.org/panopoly_widgets/plain/panopoly_widgets.make
 projects[panopoly_widgets][patch][1] = patches/panopoly_widgets_overrides.patch
 projects[panopoly_widgets][patch][2] = patches/panopoly_widgets_add_jquery_ui_tabs.patch
 
 
-projects[panopoly_images][version] = 1.27
+projects[panopoly_images][type] = module
 includes[panopoly_images_make] = http://cgit.drupalcode.org/panopoly_images/plain/panopoly_images.make
 
-projects[panels][version] = 3.5
+projects[] = panels
 
-projects[path_breadcrumbs][version] = 3.3
+projects[] = path_breadcrumbs
 
-projects[pathauto][version] = 1.2
+projects[] = pathauto
 
-projects[radix_layouts][version] = 3.3
+projects[] = radix_layouts
 
-projects[r4032login][version] = 1.7
+projects[] = r4032login
 
-projects[rules][version] = 2.3
+projects[] = rules
 
-projects[restws][version] = 2.3
+projects[restws][type] = module
 projects[restws][patch][2484829] = https://www.drupal.org/files/issues/restws-fix-format-extension-2484829-53.patch
 
-projects[schema][version] = 1.2
+projects[] = schema
 
-projects[adminrole][version] = 1.0
+projects[] = adminrole
 
-projects[admin_menu_source][version] = 1.0
-projects[admin_menu_source][subdir] = contrib
+projects[] = admin_menu_source
 
-projects[menu_token][version] = 1.0-beta5
-projects[menu_token][subdir] = contrib
+projects[] = menu_token
 
 ; Deprecated
-projects[delta][version] = 3.0-beta11
+projects[] = delta
 
 ; Themes
-projects[omega][version] = 3.1
+projects[omega][type] = module
 projects[omega][patch][1828552] = http://drupal.org/files/1828552-omega-hook_views_mini_pager.patch
 
 ;projects[bootstrap][download][version] = 3.x
@@ -151,7 +147,6 @@ projects[nuboot_radix][download][branch] = 7.x-1.x
 projects[nuboot_radix][type] = theme
 
 projects[radix][type] = theme
-projects[radix][version] = 3.0-rc4
 
 ; Libraries
 libraries[font_awesome][type] = libraries


### PR DESCRIPTION
Running this command in the `/dkan` directory will read from `drupal-org.make.base` (and any included make files) and then generate a `drupal.org.make` file with all the dependencies resolved and everything included (no more includes)

Benefits:
- All versions of projects are pegged to specific versions (exceptions are -dev or git versions)
- You can quickly upgrade all projects to their latest versions for any module you don't peg to a version in `drupal-org.make.base`
- You see the FULL list of dependencies in a single make file. You don't have to go looking in sub-make files for where a module came from.
- Resolving the dependencies and the includes ahead of time speeds up subsequent makes like when testing.
- you can rebuild the locked make file all at once, but selectively add only certain lines if it in git if for some reason you don't actually want to upgrade.
- The base make file can still be pegged to specific versions if you like for a few modules that need it, but they should be documented with comments as to WHY they're being held back.
