### PR TITLE
Point to vis entity branch with proper tag for spectrum colorpicker d…

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -73,7 +73,7 @@ projects:
     download:
       type: git
       url: 'https://github.com/NuCivic/visualization_entity_charts.git'
-      branch: master
+      branch: fix-spectrum-dep
     type: module
   admin_menu:
     version: 3.0-rc5


### PR DESCRIPTION
Issue:https://jira.govdelivery.com/browse/CIVIC-2275
## Description

There was a bad commit tag for the makefile in viz entity charts so the spectrum colorpicker library was not loading. This should be fixed.
## User story / stories
- [ ] Users should be able to use the colorpicker widget to select colors for their charts.
## Acceptance criteria
- [ ] Make a chart. Use colorpicker to choose colors.
## PR dependencies

https://github.com/NuCivic/visualization_entity_charts/pull/26
