### PR TITLE
On dev branch, test static beforecreate function

### DIFF
--- a/test/composer.json
+++ b/test/composer.json
@@ -2,7 +2,7 @@
     "require": {
         "behat/behat": "3.1.*@dev",
         "devinci/devinci-behat-extension": "dev-master",
-        "nucivic/dkanextension": "master-dev"
+        "nucivic/dkanextension": "dev-static-beforecreate"
     },
     "config": {
         "bin-dir": "bin/"

--- a/test/composer.lock
+++ b/test/composer.lock
@@ -5,6 +5,7 @@
         "This file is @generated automatically"
     ],
     "hash": "def1eb64cf11ae68a35dd277ea5c7a10",
+    "content-hash": "5b0b01e369aa2b7b64649e620b03615a",
     "packages": [
         {
             "name": "behat/behat",
@@ -12,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Behat/Behat.git",
-                "reference": "3da167e77f4d4d6a7b24845146b24f81b20cb580"
+                "reference": "9ea38bc0fdeb996bd4df1de4ed26f5d01839be82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Behat/zipball/ebcc5b4185b340d7908cb487b8beb3fed069d756",
-                "reference": "3da167e77f4d4d6a7b24845146b24f81b20cb580",
+                "url": "https://api.github.com/repos/Behat/Behat/zipball/9ea38bc0fdeb996bd4df1de4ed26f5d01839be82",
+                "reference": "9ea38bc0fdeb996bd4df1de4ed26f5d01839be82",
                 "shasum": ""
             },
             "require": {
@@ -34,6 +35,7 @@
                 "symfony/yaml": "~2.1||~3.0"
             },
             "require-dev": {
+                "herrera-io/box": "~1.6.1",
                 "phpunit/phpunit": "~4.5",
                 "symfony/process": "~2.1|~3.0"
             },
@@ -84,7 +86,7 @@
                 "symfony",
                 "testing"
             ],
-            "time": "2016-06-21 17:48:18"
+            "time": "2016-08-21 14:46:05"
         },
         {
             "name": "behat/gherkin",
@@ -479,12 +481,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/devinci-code/devinci-behat-extension.git",
-                "reference": "d08228e8236341761e7975a53b96ec5c24b79efd"
+                "reference": "0b0f0f75b1723827e3db52ed88f5e7e716fe9792"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/devinci-code/devinci-behat-extension/zipball/0b0f0f75b1723827e3db52ed88f5e7e716fe9792",
-                "reference": "d08228e8236341761e7975a53b96ec5c24b79efd",
+                "reference": "0b0f0f75b1723827e3db52ed88f5e7e716fe9792",
                 "shasum": ""
             },
             "require": {
@@ -515,7 +517,7 @@
                 "Behat",
                 "test"
             ],
-            "time": "2016-06-13 23:05:10"
+            "time": "2016-06-21 17:28:28"
         },
         {
             "name": "drupal/drupal-driver",
@@ -912,12 +914,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/NuCivic/dkanextension.git",
-                "reference": "ade0dc61347b75b7bff7507739553b15b8ad0390"
+                "reference": "f24ab2898879412db17f4b196ed2fae2f054c9e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/NuCivic/dkanextension/zipball/ade0dc61347b75b7bff7507739553b15b8ad0390",
-                "reference": "ade0dc61347b75b7bff7507739553b15b8ad0390",
+                "url": "https://api.github.com/repos/NuCivic/dkanextension/zipball/f24ab2898879412db17f4b196ed2fae2f054c9e1",
+                "reference": "f24ab2898879412db17f4b196ed2fae2f054c9e1",
                 "shasum": ""
             },
             "require": {
@@ -945,7 +947,7 @@
                 "test",
                 "web"
             ],
-            "time": "2016-07-14 21:22:51"
+            "time": "2016-08-25 05:25:51"
         },
         {
             "name": "psr/http-message",

--- a/test/composer.lock
+++ b/test/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "def1eb64cf11ae68a35dd277ea5c7a10",
-    "content-hash": "5b0b01e369aa2b7b64649e620b03615a",
+    "hash": "05873d37b03c11916732ba61ebb7bf5b",
+    "content-hash": "7069f17f7bb637f6fa1e43681f73b83f",
     "packages": [
         {
             "name": "behat/behat",
@@ -910,16 +910,16 @@
         },
         {
             "name": "nucivic/dkanextension",
-            "version": "dev-master",
+            "version": "dev-static-beforecreate",
             "source": {
                 "type": "git",
                 "url": "https://github.com/NuCivic/dkanextension.git",
-                "reference": "f24ab2898879412db17f4b196ed2fae2f054c9e1"
+                "reference": "1780331c4baffab79eae65c576547ee589000940"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/NuCivic/dkanextension/zipball/f24ab2898879412db17f4b196ed2fae2f054c9e1",
-                "reference": "f24ab2898879412db17f4b196ed2fae2f054c9e1",
+                "url": "https://api.github.com/repos/NuCivic/dkanextension/zipball/1780331c4baffab79eae65c576547ee589000940",
+                "reference": "1780331c4baffab79eae65c576547ee589000940",
                 "shasum": ""
             },
             "require": {
@@ -947,7 +947,7 @@
                 "test",
                 "web"
             ],
-            "time": "2016-08-25 05:25:51"
+            "time": "2016-08-25 22:59:44"
         },
         {
             "name": "psr/http-message",

--- a/test/features/bootstrap/FeatureContext.php
+++ b/test/features/bootstrap/FeatureContext.php
@@ -16,7 +16,7 @@ class FeatureContext extends RawDKANContext
   /**
    * @beforeDKANEntityCreate
    */
-  public function setGlobalUserBeforeEntity(\Drupal\DKANExtension\Hook\Scope\BeforeDKANEntityCreateScope $scope) {
+  public static function setGlobalUserBeforeEntity(\Drupal\DKANExtension\Hook\Scope\BeforeDKANEntityCreateScope $scope) {
     // Don't do anything if workbench isn't enabled or this isn't a node.
     $wrapper = $scope->getEntity();
     if (!function_exists('workbench_moderation_moderate_node_types') || $wrapper->type() !== 'node'){
@@ -36,7 +36,7 @@ class FeatureContext extends RawDKANContext
       // Then set the global user so that stupid workbench is happy.
       global $user;
       // Save a backup of the user (should be anonymous)
-      $this->old_global_user = $user;
+      self::$old_global_user = $user;
       $user = $wrapper->author->value();
     }
   }
@@ -44,11 +44,11 @@ class FeatureContext extends RawDKANContext
   /**
    * @afterDKANEntityCreate
    */
-  public function removeGlobalUserAfterEntity(\Drupal\DKANExtension\Hook\Scope\AfterDKANEntityCreateScope $scope) {
+  public static function removeGlobalUserAfterEntity(\Drupal\DKANExtension\Hook\Scope\AfterDKANEntityCreateScope $scope) {
     // After we've created the entity, set it back the the old global user (anon) so it doesn't pollute other things.
-    if (isset($this->old_global_user)) {
+    if (isset(self::$old_global_user)) {
       global $user;
-      $user = $this->old_global_user;
+      $user = self::$old_global_user;
     }
   }
 


### PR DESCRIPTION
Test new branch of dkanextention and making beforecreate and aftercreate functions static. 

This branches off of the behat-update branch, which branches off of 7.x-1.x.

It cherry-picks a commit from the static-beforecreate branch, which is a branch off of the _dcat_ branch, not 7.x-1.x.

If we merge this from 7.x-1.x, should simply rebase 7.x-1.x into dcat rather than merging the static-beforecreate branch into dcat.
