### PR TITLE
Fixed problem not reset fields options on chart type into visualization entity form

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.x
 --------------------------
+ - Reset fields options when you select another chart on form creating entity visualization
  - Update leaflet library to v1.0.2 and leaflet markercluster to v1.0.0. Unift leaflet libraries (was using a separate version for recline module)
  - Upgraded to new 1.0 release of Visualization Entity module
  - Add install hook to DKAN Workflow to force a Features revert of dkan_sitewide_menu, to make sure Workflow links added correctly

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -1,7 +1,7 @@
 api: '2'
 core: 7.x
 includes:
-  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0/visualization_entity.make"
+  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/reset_field_options_graph_CIVIC_513/visualization_entity.make"
   - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
   - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"
@@ -346,7 +346,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/visualization_entity.git
-      tag: 7.x-1.0
+      tag: reset_field_options_graph_CIVIC_513
     type: module
   workbench:
     version: '1.2'

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -346,7 +346,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/visualization_entity.git
-      tag: reset_field_options_graph_CIVIC_5132
+      branch: reset_field_options_graph_CIVIC_5132
     type: module
   workbench:
     version: '1.2'

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -1,7 +1,7 @@
 api: '2'
 core: 7.x
 includes:
-  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/reset_field_options_graph_CIVIC_513/visualization_entity.make"
+  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/reset_field_options_graph_CIVIC_5132/visualization_entity.make"
   - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
   - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
   - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"
@@ -346,7 +346,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/visualization_entity.git
-      tag: reset_field_options_graph_CIVIC_513
+      tag: reset_field_options_graph_CIVIC_5132
     type: module
   workbench:
     version: '1.2'


### PR DESCRIPTION
Issue: CIVIC-5132

## Description
Some charts have configuration options that other charts do not. If you select one type of chart and then switch to another type of chart, the options will get messed up. We need a reset when returning to the chart selection screen.

For example, if you select a multiBarChart chart type and then select 'stacked' and then you go back to select another chart type, the stacked option continues to be active and effects the new graph. The available options need to be reset when switching charts.

The fix will be in the **recline.view.nvd3.js** repo, to test in dkan, you will need a PR on **visualization_entity** to use the fixed branch on recline.view.nvd3.js. Then you will need a PR on **DKAN** to pull the PR branch from visualization_entity.

## How to reproduce

1.  Go to create new chart and select multiBarChart with stacked option.
2. Back and select multiBarHorizontalChart 
3. Stacked is applied to multiBarHorizontalChart 

## QA Tests

- [ ] Create a chart and select multiBarChart with stacked option.
- [ ] Back and select multiBarHorizontalChart. Should be a Chart without stacked.

## PR dependencies

- [ ] https://github.com/NuCivic/recline.view.nvd3.js/pull/34
- [ ] https://github.com/NuCivic/visualization_entity/pull/58

Fixes #1572 