### PR TITLE
point dkan datastore to release-1-12-update-services

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -3,7 +3,7 @@ api: '2'
 core: 7.x
 includes:
 - https://raw.githubusercontent.com/NuCivic/dkan_dataset/release-1-12/dkan_dataset.make
-- https://raw.githubusercontent.com/NuCivic/dkan_datastore/release-1-12/dkan_datastore.make
+- https://raw.githubusercontent.com/NuCivic/dkan_datastore/release-1-12-update-services/dkan_datastore.make
 - https://raw.githubusercontent.com/NuCivic/dkan_workflow/release-1-12/dkan_workflow.make
 - https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.0-beta1/visualization_entity.make
 - modules/dkan/dkan_data_story/dkan_data_story.make
@@ -45,7 +45,7 @@ projects:
     download:
       type: git
       url: https://github.com/NuCivic/dkan_datastore.git
-      branch: release-1-12
+      branch: release-1-12-update-services
   dkan_workflow:
     subdir: dkan
     download:

--- a/modules/dkan/dkan_topics/dkan_topics.make
+++ b/modules/dkan/dkan_topics/dkan_topics.make
@@ -17,9 +17,6 @@ projects[entity_path][version] = 1.x-dev
 projects[entity_path][patch][2809655] = https://www.drupal.org/files/issues/entity-path-mysql-5-7_3.diff
 projects[globalredirect][version] = 1.5
 
-; Patches
-projects[views][patch][1388684] = https://www.drupal.org/files/views_taxonomy_entity_uri-1388684-15.patch
-
 ; Libraries
 libraries[spectrum][type] = libraries
 libraries[spectrum][download][type] = git


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-5965

## Description

We need to update service to 3.19. The last version fix some problems with security. 

## QA Steps

- [ ] Check service module version is 3.19

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
