### PR TITLE
Truncate datastore table on re-import.

### DIFF
--- a/.ahoy/docker-compose.yml
+++ b/.ahoy/docker-compose.yml
@@ -30,7 +30,7 @@ web:
 # DB node
 db:
   hostname: db
-  image: blinkreaction/mysql:5.5
+  image: blinkreaction/mysql:5.6
   ports:
     - "3306"
   environment:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.14
 --------
+ - #2161 Fix Datastore Fast Import does not truncate old data on multiple imports.
  - #2075 DKAN Harvest: Modified batch process to split harvest migrations in chunks.
  - #2145 Front page hero image no longer requests empty URL if variable empty.
  - #2082 Add UI for generating ODSM file caches.

--- a/modules/dkan/dkan_datastore/dkan_datastore.module
+++ b/modules/dkan/dkan_datastore/dkan_datastore.module
@@ -632,3 +632,12 @@ function dkan_datastore_form_alter(&$form, &$form_state, $form_id) {
 function _dkan_datastore_search_redirect() {
   drupal_goto('/search');
 }
+
+/**
+ * Utility function for safely dropping a table.
+ */
+function dkan_datastore_db_truncate($table_name) {
+  if (db_table_exists($table_name)) {
+    db_truncate($table_name)->execute();
+  }
+}

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.module
@@ -150,6 +150,7 @@ function dkan_datastore_fast_import_cron_queue_info() {
  * Import csv using the most performant way.
  */
 function dkan_datastore_fast_import_import($source, $node, $table, $config) {
+  dkan_datastore_db_truncate($table->name);
   $load_data_type = variable_get('dkan_datastore_load_data_type', 'load_data_local_infile');
   $file = $node->field_upload->value();
   $file_path = drupal_realpath($file->uri);

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.module
@@ -140,7 +140,7 @@ function dkan_datastore_fast_import_cron_queue_info() {
   return array(
     dkan_datastore_fast_import_queue_name() => array(
       'worker callback' => 'dkan_datastore_fast_import_import_queue_worker',
-      'skip on cron' => TRUE,
+      'skip on cron' => FALSE,
       'time' => 600,
     ),
   );

--- a/test/phpunit/dkan_datastore/DkanDatastoreQueueTest.php
+++ b/test/phpunit/dkan_datastore/DkanDatastoreQueueTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @file
+ * Test that quequed imports run as expected.
+ */
+
+/**
+ * DkanDatastoreQueueTest class.
+ */
+class DkanDatastoreQueueTest extends \PHPUnit_Framework_TestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function setUpBeforeClass() {
+    if (!module_exists('dkan_datastore')) {
+      module_enable(array('dkan_datastore'));
+    }
+  }
+
+  /**
+   * Test that new rows aren't just tacked to end of data store.
+   */
+  public function testMultipleQueueImportSingleDatastore() {
+    // This resource uuid is from dkan fixtures.
+    $uuid = '49daa44a-efa6-4145-92a9-baedc7202e1f';
+    // Queue and run import three times.
+    dkan_datastore_queue_import($uuid);
+    drupal_cron_run();
+
+    dkan_datastore_queue_import($uuid);
+    drupal_cron_run();
+
+    dkan_datastore_queue_import($uuid);
+    drupal_cron_run();
+
+    $datastore = dkan_datastore_go($uuid);
+
+    $result = db_select($datastore->tableName, 'ds')->fields('ds')->execute();
+
+    $expected = 10;
+    $actual = $result->rowCount();
+    $this->assertEquals($actual, $expected);
+  }
+
+}

--- a/test/phpunit/dkan_datastore_fast_import/DkanDatastoreFastImportQueueTest.php
+++ b/test/phpunit/dkan_datastore_fast_import/DkanDatastoreFastImportQueueTest.php
@@ -60,14 +60,11 @@ class DkanDatastoreFastImportQueueTest extends \PHPUnit_Framework_TestCase {
     DrupalQueue::get(dkan_datastore_fast_import_queue_name())->createItem($item);
     drupal_cron_run();
 
-    $datastore = Datastore::instance("DkanDatastoreFastImport", $uuid);
-    $result = db_select($datastore->tableName, 'ds')->fields('ds')->execute();
+    $result = db_select($table->name, 'ds')->fields('ds')->execute();
 
     $expected = 2969;
     $actual = $result->rowCount();
     $this->assertEquals($actual, $expected);
-
-    $datastore->dropDataStore();
   }
 
   /**

--- a/test/phpunit/dkan_datastore_fast_import/DkanDatastoreFastImportQueueTest.php
+++ b/test/phpunit/dkan_datastore_fast_import/DkanDatastoreFastImportQueueTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @file
+ * Test that quequed imports run as expected.
+ */
+
+/**
+ * DkanDatastoreFastImport class.
+ */
+class DkanDatastoreFastImportQueueTest extends \PHPUnit_Framework_TestCase {
+
+  /**
+   * Test that new rows aren't just tacked to end of data store.
+   */
+  public function testMultipleQueueImportSingleDatastore() {
+    // This resource uuid is from dkan fixtures.
+    $uuid = '960687d8-582c-4f29-b1e4-113781e58e3b';
+    $nid = self::getNodeFromUuid($uuid);
+    $importerId = 'dkan_file';
+    $node = node_load($nid);
+    $node = entity_metadata_wrapper('node', $node);
+    $source = feeds_source($importerId, $nid);
+    $table = feeds_flatstore_processor_table($source, array());
+    $config = array(
+      'delimiter' => ',',
+      'no_headers' => 0,
+      'encoding' => 'UTF-8',
+    );
+
+    variable_set('dkan_datastore_load_data_type', 'load_data_infile');
+    variable_set('quote_delimiters', '"');
+    variable_set('lines_terminated_by', '\n');
+    variable_set('fields_escaped_by', '');
+    variable_set('dkan_datastore_fast_import_load_empty_cells_as_null', 0);
+
+    $item = array(
+      'source' => $source,
+      'node' => $node,
+      'table' => $table,
+      'config' => $config,
+    );
+
+    // Queue and run import three times.
+    DrupalQueue::get(dkan_datastore_fast_import_queue_name())->createItem($item);
+    drupal_cron_run();
+
+    DrupalQueue::get(dkan_datastore_fast_import_queue_name())->createItem($item);
+    drupal_cron_run();
+
+    DrupalQueue::get(dkan_datastore_fast_import_queue_name())->createItem($item);
+    drupal_cron_run();
+
+    $datastore = Datastore::instance("DkanDatastoreFastImport", $uuid);
+    $result = db_select($datastore->tableName, 'ds')->fields('ds')->execute();
+
+    $expected = 2969;
+    $actual = $result->rowCount();
+    $this->assertEquals($actual, $expected);
+
+    $datastore->dropDataStore();
+  }
+
+  /**
+   * Get the node id from a known uuid.
+   */
+  public static function getNodeFromUuid($uuid) {
+    $ids = entity_get_id_by_uuid('node', array($uuid));
+    foreach ($ids as $uid => $id) {
+      return $id;
+    }
+  }
+
+}

--- a/test/phpunit/dkan_datastore_fast_import/DkanDatastoreFastImportQueueTest.php
+++ b/test/phpunit/dkan_datastore_fast_import/DkanDatastoreFastImportQueueTest.php
@@ -11,6 +11,15 @@
 class DkanDatastoreFastImportQueueTest extends \PHPUnit_Framework_TestCase {
 
   /**
+   * {@inheritdoc}
+   */
+  public static function setUpBeforeClass() {
+    if (!module_exists('dkan_datastore_fast_import')) {
+      module_enable(array('dkan_datastore_fast_import'));
+    }
+  }
+
+  /**
    * Test that new rows aren't just tacked to end of data store.
    */
   public function testMultipleQueueImportSingleDatastore() {

--- a/test/phpunit/phpunit.xml
+++ b/test/phpunit/phpunit.xml
@@ -34,6 +34,7 @@
         </testsuite>
         <testsuite name="DKAN Datastore Fast Import Test Suite">
             <file>dkan_datastore_fast_import/DkanDatastoreFastImportTest.php</file>
+            <file>dkan_datastore_fast_import/DkanDatastoreFastImportQueueTest.php</file>
         </testsuite>
         <testsuite name="DKAN Migrate Base Test Suite">
             <!--<file>dkan_migrate_base/DeleteDuplicateDatasetsTest.php</file>

--- a/test/phpunit/phpunit.xml
+++ b/test/phpunit/phpunit.xml
@@ -25,6 +25,7 @@
             <file>dkan_dataset/DataJsonTest.php</file>
             <file>dkan_dataset/getRemoteFileInfoTest.php</file>
             <file>dkan_dataset/reclineEmbedCacheTest.php</file>
+            <file>dkan_datastore/DkanDatastoreQueueTest.php</file>
         </testsuite>
         <testsuite name="DKAN Datastore Test Suite">
           <file>dkan_datastore/DkanDatastoreTest.php</file>


### PR DESCRIPTION
Description
===
The fast dkan_datastore_fast_import module does not truncate data when doing multiple
imports of the same data.  This has the effect of gradually ballooning the size
of datastore DB tables under certain circumstances.

One particular scenario where this happens is with queued datastore_fast_import
imports. These imports are allowed 600 seconds and in cases where they do not
they will simply stop and then set to restart. 

Of course anything that prevents the queue from resolving can cause it to
reimport until it does resolve.

The regular dkan_datastore module does not exhibit this problem because feeds
automatically handles this problem correctly.

This PR makes the following changes to help with this issue:

* It adds unit tests that specifically test queuing multiple imports of the same data.
* It changes the dkan_datastore_fast_import queues so that they can be triggered
  by a regular cron_job call (this was previously disabled)
* It adds a truncate pre step to imports to resolve the issue.

This PR does not attempt to refactor the code as in #2122 as this refactoring is now
being worked on more comprehensively in another PR (#2146).

QA Steps
==
- [ ] Verify that the new phpunit tests meet the criteria of testing a regression of this issue.