### PR TITLE
Adding local_infile capabilities to the containers acting as mysql cl…

### DIFF
--- a/.ahoy/.docker/etc/mysql/my.cnf
+++ b/.ahoy/.docker/etc/mysql/my.cnf
@@ -18,4 +18,7 @@ long_query_time=1
 slow_query_log=1
 slow_query_log_file=slow.log
 local_infile=1
+
+[client]
+local_infile=1
 ###############################

--- a/.ahoy/.docker/etc/mysql/my.cnf
+++ b/.ahoy/.docker/etc/mysql/my.cnf
@@ -19,6 +19,5 @@ slow_query_log=1
 slow_query_log_file=slow.log
 local_infile=1
 
-[client]
-local_infile=1
-###############################
+[mysql]
+local-infile=1

--- a/.ahoy/.scripts/drupal-rebuild.sh
+++ b/.ahoy/.scripts/drupal-rebuild.sh
@@ -19,6 +19,6 @@ chmod +w docroot/sites/default/settings.php
 if [ "$AHOY_CMD_PROXY" = "DOCKER" ]; then
   printf "// Docker Database Settings\n\$databases['default']['default'] = array(\n  'database' => 'drupal',\n  'username' => 'drupal',\n  'password' => '123',\n  'host' => 'db',\n  'port' => '',\n  'driver' => 'mysql',\n  'prefix' => '',\n);\n" >> docroot/sites/default/settings.php
 fi
-printf "// DKAN Datastore Fast Import options.\n\$databases['default']['default']['pdo'] = array(\n  PDO::MYSQL_ATTR_LOCAL_INFILE => 1,\n  PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => 1,\n);\n" >> docroot/sites/default/settings.php
+printf "// DKAN Datastore Fast Import options.\n\$databases['default']['default']['pdo'] = array(\n  PDO::MYSQL_ATTR_LOCAL_INFILE => 1,\n  PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => 1,\n  PDO::MYSQL_ATTR_READ_DEFAULT_GROUP => 'mysql',);\n" >> docroot/sites/default/settings.php
 
 chmod -w docroot/sites/default/settings.php

--- a/.ahoy/docker-compose.yml
+++ b/.ahoy/docker-compose.yml
@@ -21,6 +21,8 @@ web:
     - "./.docker/etc/php5/php.ini:/etc/php5/fpm/conf.d/z_php.ini"
     # Project root folder mapping
     - &project_root "../../:/var/www/"
+    # MySQL configuration overrides
+    - "./.docker/etc/mysql/my.cnf:/etc/mysql/conf.d/z_my.cnf"
   links:
     - db
     # Uncomment this and the memcached service definition below to start using memcached.
@@ -63,6 +65,8 @@ cli:
     # Host SSH keys mapping. Uncomment one of the lines below based on your setup.
     # - /.ssh:/.ssh   # boot2docker-vagrant
     - ~/.ssh:/.ssh  # Linux
+    # MySQL configuration overrides
+    - "./.docker/etc/mysql/my.cnf:/etc/mysql/conf.d/z_my.cnf"
   links:
     - db
     - web

--- a/.docker/etc/mysql/my.cnf
+++ b/.docker/etc/mysql/my.cnf
@@ -18,5 +18,11 @@ max_allowed_packet = 128M
 long_query_time=1
 slow_query_log=1
 slow_query_log_file=slow.log
-
 ###############################
+
+[mysql]
+###############################
+local_infile=1
+###############################
+
+


### PR DESCRIPTION
Connects #2176 

This is necessary for the fast import functionality to work in our local docker based sandboxes.

This does not solve the issue 100% as LOAD DATA LOCAL INFILE based tests still have issues, but it is an improvement from previous states.