### PR TITLE
Fix access to groups field

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.14
 --------
+ - #2208 Fix access to groups field when adding a resource inside the dataset form.
  - #2189 #2190 Documentation updates (Add help, license, dkan sites pages. Update site manager guide. Update dkan README.)
  - #2186 Move the 'back to dataset' local task position so that the 'revisions' link position matches the standard location.
  - #1979 Allow users to set Groups on standalone resources.

--- a/modules/dkan/dkan_dataset/dkan_dataset.forms.inc
+++ b/modules/dkan/dkan_dataset/dkan_dataset.forms.inc
@@ -342,9 +342,11 @@ function dkan_dataset_form_alter(&$form, &$form_state, $form_id) {
     $form['field_link_api'][$field_link_api_langcode][0]['#title'] = '';
     $form['field_link_remote_file'][$field_link_remote_file_langcode][0]['#title'] = '';
 
-    // If the resource is not assigned to a dataset,
+    // If the resource is not assigned to a dataset, and not step two of a multi-part dataset form,
     // allow the user to edit the groups field.
-    if (empty($form['field_dataset_ref'][$field_dataset_ref_langcode][0]['target_id']['#default_value'])) {
+    $params = drupal_get_query_parameters();
+    if (empty($form['field_dataset_ref'][$field_dataset_ref_langcode][0]['target_id']['#default_value']) &&
+      empty($params['dataset'])) {
       $form['og_group_ref']['#access'] = TRUE;
       // Get a list of groups the user is a member of.
       $groups = dkan_dataset_get_group_options();

--- a/test/features/dataset.author.feature
+++ b/test/features/dataset.author.feature
@@ -85,6 +85,7 @@ Feature: Dataset Features
       | description     | Test description  |
       | publisher       | Group 01          |
     And I press "Next: Add data"
+    Then I should not see "Groups" in the "content" region
     And I fill in "title" with "Test Resource Link File"
     And I press "Next: Additional Info"
     And I press "Save"

--- a/test/features/resource.all.feature
+++ b/test/features/resource.all.feature
@@ -158,7 +158,9 @@ Feature: Resource
     Given resources:
       | title                    | publisher | format | dataset | author | published | description |
       | Resource Without Dataset | Group 01  | csv    |         | Katie  | Yes       | Old Body    |
+    And I am logged in as a user with the "site manager" role
     And I am on "Resource Without Dataset" page
     Then I should not see the link "Back to dataset"
-    And I should see "Groups" in the "content" region
+    When I click "Edit"
+    Then I should see "Groups" in the "content" region
 

--- a/test/features/resource.all.feature
+++ b/test/features/resource.all.feature
@@ -160,5 +160,5 @@ Feature: Resource
       | Resource Without Dataset | Group 01  | csv    |         | Katie  | Yes       | Old Body    |
     And I am on "Resource Without Dataset" page
     Then I should not see the link "Back to dataset"
-    And I should see "Groups"
+    And I should see "Groups" in the "content" region
 


### PR DESCRIPTION
Follow up fix for #2184 

When creating a dataset the user will see the groups field on 'step 2', this should be hidden.

## QA Steps

- [x] Create a standalone resource.
- [x] Confirm that you are able to assign the resource to a Group.
- [x] Edit a resource that is part of a dataset. Confirm that you do not see the groups field.
- [ ] Create a dataset, on step 2 _Add a Resource_, confirm you do not see the groups field

## Reminders

- [ ] There is test for the issue.
- [x] CHANGELOG updated.
- [x] Coding standards checked.
- [x] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
