### PR TITLE
Fixes field mapping defaults for open data schema APIs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+7.x-1.14.1
+----------
+ - #2103 Fixed field mapping defaults for open data schema APIs
+
 7.x-1.14
 --------
  - #2208 Fix access to groups field when adding a resource inside the dataset form.

--- a/modules/dkan/open_data_schema_map_dkan/open_data_schema_map_dkan.features.inc
+++ b/modules/dkan/open_data_schema_map_dkan/open_data_schema_map_dkan.features.inc
@@ -1338,7 +1338,7 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
         'type' => 'string',
       ),
       'issued' => array(
-        'value' => '[node:field_harvest_source_issued:custom:Y-m-d] || [node:created:custom:Y-m-d]',
+        'value' => '[node:field-harvest-source-issued:custom:Y-m-d] || [node:created:custom:Y-m-d]',
         'type' => 'string',
       ),
       'keyword' => array(
@@ -1362,7 +1362,7 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
         'type' => 'string',
       ),
       'modified' => array(
-        'value' => '[node:field_harvest_source_modified:custom:Y-m-d] || [node:changed:custom:Y-m-d]',
+        'value' => '[node:field-harvest-source-modified:custom:Y-m-d] || [node:changed:custom:Y-m-d]',
         'type' => 'string',
       ),
       'PrimaryITInvestmentUII' => array(
@@ -1515,7 +1515,7 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
         'type' => 'string',
       ),
       'issued' => array(
-        'value' => '[node:field_harvest_source_issued:custom:Y-m-d] || [node:created:custom:Y-m-d]',
+        'value' => '[node:field-harvest-source-issued:custom:Y-m-d] || [node:created:custom:Y-m-d]',
         'type' => 'string',
       ),
       'keyword' => array(
@@ -1523,7 +1523,7 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
         'type' => 'array',
       ),
       'landingPage' => array(
-        'value' => '[node:field_landing_page:url] || [node:url]',
+        'value' => '[node:field-landing-page:url] || [node:url]',
         'type' => 'string',
       ),
       'language' => array(
@@ -1535,7 +1535,7 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
         'type' => 'string',
       ),
       'modified' => array(
-        'value' => '[node:field_harvest_source_modified:custom:Y-m-d] || [node:changed:custom:Y-m-d]',
+        'value' => '[node:field-harvest-source-modified:custom:Y-m-d] || [node:changed:custom:Y-m-d]',
         'type' => 'string',
       ),
       'primaryITInvestmentUII' => array(
@@ -1635,11 +1635,11 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
         'type' => 'string',
       ),
       'dct:issued' => array(
-        'value' => '[node:field_harvest_source_issued:custom:c] || [node:created:custom:c]',
+        'value' => '[node:field-harvest-source-issued:custom:c] || [node:created:custom:c]',
         'type' => 'string',
       ),
       'dct:modified' => array(
-        'value' => '[node:field_harvest_source_modified:custom:c] || [node:changed:custom:c]',
+        'value' => '[node:field-harvest-source-modified:custom:c] || [node:changed:custom:c]',
         'type' => 'string',
       ),
       'owl:versionInfo' => array(
@@ -1655,7 +1655,7 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
         'type' => 'array',
       ),
       'dcat:landingPage' => array(
-        'value' => '[node:field_landing_page:url]',
+        'value' => '[node:field-landing-page:url]',
         'type' => 'string',
       ),
       'dct:accrualPeriodicity' => array(
@@ -1839,11 +1839,11 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
         'type' => 'string',
       ),
       'dct:issued' => array(
-        'value' => '[node:field_harvest_source_issued:custom:c] || [node:created:custom:c]',
+        'value' => '[node:field-harvest-source-issued:custom:c] || [node:created:custom:c]',
         'type' => 'string',
       ),
       'dct:modified' => array(
-        'value' => '[node:field_harvest_source_modified:custom:c] || [node:changed:custom:c]',
+        'value' => '[node:field-harvest-source-modified:custom:c] || [node:changed:custom:c]',
         'type' => 'string',
       ),
       'owl:versionInfo' => array(
@@ -1859,7 +1859,7 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
         'type' => 'array',
       ),
       'dcat:landingPage' => array(
-        'value' => '[node:field_landing_page:url]',
+        'value' => '[node:field-landing-page:url]',
         'type' => 'string',
       ),
       'dct:accrualPeriodicity' => array(
@@ -2034,11 +2034,11 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
         'type' => 'string',
       ),
       'dct:issued' => array(
-        'value' => '[node:field_harvest_source_issued:custom:c] || [node:created:custom:c]',
+        'value' => '[node:field-harvest-source-issued:custom:c] || [node:created:custom:c]',
         'type' => 'string',
       ),
       'dct:modified' => array(
-        'value' => '[node:field_harvest_source_modified:custom:c] || [node:changed:custom:c]',
+        'value' => '[node:field-harvest-source-modified:custom:c] || [node:changed:custom:c]',
         'type' => 'string',
       ),
       'owl:versionInfo' => array(
@@ -2054,7 +2054,7 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
         'type' => 'array',
       ),
       'dcat:landingPage' => array(
-        'value' => '[node:field_landing_page:url]',
+        'value' => '[node:field-landing-page:url]',
         'type' => 'string',
       ),
       'dct:accrualPeriodicity' => array(

--- a/test/features/dataset.admin.feature
+++ b/test/features/dataset.admin.feature
@@ -93,5 +93,5 @@ Feature: Dataset Features
   Scenario: ODSM data.json 1.1 mapping
     Given I am logged in as a user with the "administrator" role
     And I go to "admin/config/services/odsm/edit/data_json_1_1"
-    Then the "Homepage URL (landingPage)" field should contain "[node:field_landing_page:url] || [node:url]"
+    Then the "Homepage URL (landingPage)" field should contain "[node:field-landing-page:url] || [node:url]"
 


### PR DESCRIPTION
Connects #2213 

## QA Steps
- [x] Edit a dataset and set a homepage URL. Load /catalog.json and verify dcat:landingPage" is set.
- [x] If possible, edit or create a harvested datasource and set a specific "Modified Source Date". That date source show in /catalog.json as the modified date instead of the resource node's modified date
- [ ] Add manual QA steps in checklist format for a reviewer to perform to confirm that the feature or fix is working. Include as much details as possible so that the reviewer doesn't lose time figuring out how to perform steps.

## Reminders

- [ ] There is test for the issue.
- [x] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
