### PR TITLE
Strengthening Datastore Behat Tests (#2183)

### DIFF
--- a/modules/dkan/dkan_datastore/dkan_datastore.module
+++ b/modules/dkan/dkan_datastore/dkan_datastore.module
@@ -391,7 +391,8 @@ function dkan_datastore_records($nid) {
         $query = db_select($table, 't')
           ->fields('t', array('timestamp'))
           ->range(0, 1);
-        if ($result = $query->execute()) {
+        $result = $query->execute();
+        if (!empty($result->rowCount())) {
           return TRUE;
         }
       }

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/DatastoreContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/DatastoreContext.php
@@ -105,6 +105,28 @@ class DatastoreContext extends RawDKANContext {
   }
 
   /**
+   * @Then :title should have no datastore records
+   */
+  public function assertHasNoDatastoreRecords($title) {
+    $nid = $this->getNidByTitle($title);
+    $status = dkan_datastore_records($nid);
+    if (!empty($status)) {
+      throw new \Exception($title . ' has datastore records.'); 
+    }
+  }
+
+  /**
+   * @Then :title should have datastore records
+   */
+  public function assertHasDatastoreRecords($title) {
+    $nid = $this->getNidByTitle($title);
+    $status = dkan_datastore_records($nid);
+    if (empty($status)) {
+      throw new \Exception($title . ' has no datastore records.'); 
+    }
+  }
+
+  /**
    * @BeforeScenario @datastore
    *
    * @param BeforeScenarioScope $scope

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/PODContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/PODContext.php
@@ -34,12 +34,8 @@ class PODContext extends RawDKANContext {
    */
   public function iSeeAValidDataJson($should)
   {
-    $data_json = open_data_schema_map_api_load('data_json_1_1');
-    // Get base URL.
-    $url = $this->getMinkParameter('base_url') ? $this->getMinkParameter('base_url') : "http://127.0.0.1:8888";
-
     // Validate POD.
-    $results = open_data_schema_pod_process_validate($url . '/data.json', TRUE);
+    $results = _open_data_schema_map_process_validate('PodValidator', TRUE);
     if ($results['errors'] && $should === 'should') {
       throw new \Exception(sprintf('Data.json is not valid.'));
     }
@@ -53,33 +49,9 @@ class PODContext extends RawDKANContext {
    * @Then I should see a valid catalog xml
    */
   public function iShouldSeeAValidCatalogXml() {
-    // Change /catalog.xml path to /catalog during tests. The '.' on the filename breaks tests on CircleCI's server.
-    $dcat = open_data_schema_map_api_load('dcat_v1_1');
-    if ($dcat->endpoint !== 'catalog') {
-      $dcat->endpoint = 'catalog';
-      drupal_write_record('open_data_schema_map', $dcat, 'id');
-      drupal_static_reset('open_data_schema_map_api_load_all');
-      menu_rebuild();
-    }
-
-    // Change /catalog.json path to /catalogjson during tests. The '.' on the filename breaks tests on CircleCI's server.
-    $dcat_json = open_data_schema_map_api_load('dcat_v1_1_json');
-    if ($dcat_json->endpoint !== 'catalogjson') {
-      $dcat_json->endpoint = 'catalogjson';
-      drupal_write_record('open_data_schema_map', $dcat_json, 'id');
-      drupal_static_reset('open_data_schema_map_api_load_all');
-      menu_rebuild();
-    }
-
-    // Get base URL.
-    $url = $this->getMinkParameter('base_url') ? $this->getMinkParameter('base_url') : "http://127.0.0.1::8888";
-    $url_xml = $url . '/catalog';
-    $url_json = $url . '/catalogjson';
-    $this->visitPath($url_xml);
-    $this->assertSession()->statusCodeEquals('200');
-
     // Validate DCAT.
-    $results = open_data_schema_dcat_process_validate($url_json, TRUE);
+    $results = _open_data_schema_map_process_validate('DcatValidator', TRUE);
+
     if ($results['errors']) {
       throw new \Exception(sprintf('catalog.xml is not valid.'));
     }

--- a/test/features/resource.admin.feature
+++ b/test/features/resource.admin.feature
@@ -91,10 +91,10 @@ Feature: Resource
     And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/datastore-simple.csv"
     And I press "Save"
     When I click "Manage Datastore"
+    And I wait for "Import"
     And I press "Import"
     And I wait for "Delete Items"
-    Then I should see "Last import"
-    And I should see "imported items total"
+    Then "Resource 02" should have datastore records
 
   @noworkflow @datastore @javascript
   Scenario: Delete items on datastore of any resource
@@ -109,9 +109,11 @@ Feature: Resource
     When I click "Manage Datastore"
     And I press "Import"
     And I wait for "Delete Items"
+    Then "Resource 04" should have datastore records
     And I click "Delete items"
     And I press "Delete"
-    Then I wait for "items have been deleted"
+    And I wait for "items have been deleted"
+    Then "Resource 04" should have no datastore records
 
   @noworkflow @datastore @javascript
   Scenario: Drop datastore of any resource
@@ -126,12 +128,11 @@ Feature: Resource
     When I click "Manage Datastore"
     And I press "Import"
     And I wait for "Delete Items"
+    Then "Resource 04" should have datastore records
     When I click "Drop Datastore"
     And I press "Drop"
     Then I should see "Datastore dropped!"
-    And I should see "Your file for this resource is not added to the datastore"
-    When I click "Manage Datastore"
-    Then I wait for "No imported items."
+    And "Resource 04" should have no datastore records
 
   @noworkflow
   Scenario: Add revision to any resource

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -245,8 +245,7 @@ Feature: Resource
     When I click "Manage Datastore"
     And I press "Import"
     And I wait for "Delete items"
-    Then I should see "Last import"
-    And I wait for "imported items total"
+    Then "Resource 05" should have datastore records
 
   @resource_author_16 @datastore @noworkflow @javascript
   Scenario: Delete items on datastore of own resource
@@ -261,12 +260,11 @@ Feature: Resource
     When I click "Manage Datastore"
     And I press "Import"
     And I wait for "Delete Items"
+    Then "Resource 03" should have datastore records
     And I click "Delete items"
     And I press "Delete"
     Then I wait for "items have been deleted"
-    # This test is not really sufficient, but we are going to consolidate the
-    # "drop" and "delete" datastore functions and do other refactoring, so will
-    # revisit then.
+    And "Resource 03" should have no datastore records
 
   @resource_author_17 @datastore @noworkflow @javascript
   Scenario: Drop datastore of own resource
@@ -281,12 +279,11 @@ Feature: Resource
     When I click "Manage Datastore"
     And I press "Import"
     And I wait for "Delete Items"
+    Then "Resource 03" should have datastore records
     When I click "Drop Datastore"
     And I press "Drop"
     Then I should see "Datastore dropped!"
-    And I should see "Your file for this resource is not added to the datastore"
-    When I click "Manage Datastore"
-    Then I wait for "No imported items."
+    And "Resource 03" should have no datastore records
 
   @resource_author_18 @noworkflow
   Scenario: Add revision to own resource

--- a/test/features/resource.editor.feature
+++ b/test/features/resource.editor.feature
@@ -95,56 +95,57 @@ Feature: Resource
   @resource_editor_6 @datastore @noworkflow @javascript
   Scenario: Import items on datastore of resources associated with groups that I am a member of
     Given I am logged in as "John"
-    And I am on "Resource 01" page
+    And I am on "Resource 02" page
     And I click "Edit"
     And I click "Remote file"
     And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/datastore-simple7.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
-    And I am on "Resource 01" page
+    And I am on "Resource 02" page
     When I click "Manage Datastore"
     And I wait for "Import"
     And I press "Import"
     And I wait for "Delete Items"
-    Then I should see "Last import"
-    And I should see "imported items total"
+    Then "Resource 02" should have datastore records
 
   @resource_editor_7 @datastore @db @noworkflow @javascript
   Scenario: Delete items on datastore of resources associated with groups that I am a member of
       Given I am logged in as "John"
-      And I am on "Resource 01" page
+      And I am on "Resource 02" page
       And I click "Edit"
       And I click "Remote file"
       And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/datastore-simple8.csv"
       And I press "Save"
       Given I am logged in as "Celeste"
-      When I am on "Resource 01" page
+      When I am on "Resource 02" page
       When I click "Manage Datastore"
+      And I wait for "Import"
       And I press "Import"
       And I wait for "Delete Items"
+      Then "Resource 02" should have datastore records
       And I click "Delete items"
       And I press "Delete"
-      Then I wait for "items have been deleted"
+      And I wait for "items have been deleted"
+      Then "Resource 02" should have no datastore records
 
   @resource_editor_8 @datastore @noworkflow @javascript
   Scenario: Drop datastore of resources associated with groups that I am a member of
     Given I am logged in as "John"
-    And I am on "Resource 01" page
+    And I am on "Resource 02" page
     And I click "Edit"
     And I click "Remote file"
     And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/datastore-simple9.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
-    And I am on "Resource 01" page
+    And I am on "Resource 02" page
     When I click "Manage Datastore"
+    And I wait for "Import"
     And I press "Import"
     And I wait for "Delete Items"
+    Then "Resource 02" should have datastore records
     When I click "Drop Datastore"
     And I press "Drop"
-    Then I should see "Datastore dropped!"
-    And I should see "Your file for this resource is not added to the datastore"
-    When I click "Manage Datastore"
-    Then I should see "No imported items."
+    Then "Resource 02" should have no datastore records
 
   @resource_editor_9 @noworkflow
   Scenario: Add revision to resources associated with groups that I am a member of

--- a/test/features/user.site_manager.feature
+++ b/test/features/user.site_manager.feature
@@ -12,118 +12,31 @@ Feature: User command center links for site manager role.
       | name    | mail                | roles                |
       | John    | john@example.com    | site manager         |
 
-  Scenario: Site manager role can view admin menu links under Add Content
+  Scenario: Site manager role can view admin menu links under Add Content, DKAN, Visualizations, People and Site Configuration
     Given I am logged in as "John"
-    When I click "Add content" in the "admin menu" region
-    Then I should see "Add content"
+    #Add Content
     When I hover over the admin menu item "Add content"
-    And I click "Dataset"
-    Then I should see "Create dataset"
-    When I hover over the admin menu item "Add content"
-    And I click "Resource"
-    Then I should see "Add resource"
-    When I hover over the admin menu item "Add content"
-    And I click "Group"
-    Then I should see "Create Group"
-    When I hover over the admin menu item "Add content"
-    And I click "Page"
-    Then I should see "Create Page"
-    When I hover over the admin menu item "Add content"
-    And I click "Data Story"
-    Then I should see "Create Data Story"
-    When I hover over the admin menu item "Add content"
-    And I click "Data Dashboard"
-    Then I should see "Create Data Dashboard"
-    When I hover over the admin menu item "Add content"
-    Then I hover over the admin menu item "Visualization"
-    And I click "Chart"
-    Then I should see "Add Chart"
-    When I hover over the admin menu item "Add content"
-    And I click "Harvest Source"
-    Then I should see "Create Harvest Source"
-
-  Scenario: Site manager role can view admin menu links under DKAN
-    Given I am logged in as "John"
-    When I click "DKAN" in the "admin menu" region
-    Then I should see "DKAN"
+    Then I hover over the admin menu item "Page"
+    And I hover over the admin menu item "Data Story"
+    And I hover over the admin menu item "Data Dashboard"
+    #DKAN
     When I hover over the admin menu item "DKAN"
-    And I click "Data Dashboards" in the "admin menu" region
-    Then I should see "Data Dashboards"
-    When I hover over the admin menu item "DKAN"
-    And I click "DKAN Dataset Forms" in the "admin menu" region
-    Then I should see "DKAN Dataset Forms"
-    When I hover over the admin menu item "DKAN"
-    And I click "Data Previews" in the "admin menu" region
-    Then I should see "DKAN Dataset Previews"
-    When I hover over the admin menu item "DKAN"
-    And I click "DKAN Harvest Dashboard" in the "admin menu" region
-    Then I should see "DKAN Harvest Dashboard"
-    When I hover over the admin menu item "DKAN"
-    And I click "Featured Groups Sort Order" in the "admin menu" region
-    Then I should see "Featured Groups Sort Order"
-    When I hover over the admin menu item "DKAN"
-    And I click "Recline Configuration" in the "admin menu" region
-    Then I should see "Recline Configuration"
-
-  Scenario: Site manager role can view admin menu link Content
-    Given I am logged in as "John"
-    When I click "Content" in the "admin menu" region
-    Then I should see "Choose an operation"
-
-  Scenario: Site manager role can view admin menu links under Visualizations
-    Given I am logged in as "John"
-    When I click "Visualizations" in the "admin menu" region
-    Then I should see "Visualization"
+    Then I hover over the admin menu item "DKAN Dataset Forms"
+    And I hover over the admin menu item "Data Dashboards"
+    And I hover over the admin menu item "Recline Configuration"
+    #Visualization
     When I hover over the admin menu item "Visualizations"
-    And I click "Charts"
-    Then I should see "Chart"
-
-  Scenario: Site manager role can view admin menu links under People
-    Given I am logged in as "John"
-    When I click "People" in the "admin menu" region
-    Then I should see "Choose an operation"
+    Then I hover over the admin menu item "Charts"
+    #People
     When I hover over the admin menu item "People"
-    And I click "Create user"
-    Then I should see "This web page allows administrators to register new users."
-    When I hover over the admin menu item "People"
-    And I click "Manage Users"
-    Then I should see "Choose an operation"
+    Then I hover over the admin menu item "Manage Users"
+    #Site Configuration
+    When I hover over the admin menu item "Site Configuration"
+    Then I hover over the admin menu item "Open Data Schema Mapper"
+    And I hover over the admin menu item "Taxonomy"
+    And I hover over the admin menu item "Tags"
+    Then I hover over the admin menu item "Add term"
 
-  Scenario: Site manager role can view admin menu links under Site Configuration
-    Given I am logged in as "John"
-    When I hover over the admin menu item "Site Configuration"
-    And I click "Open Data Schema Mapper"
-    Then I should see "Open Data Schema Mapper"
-    When I hover over the admin menu item "Site Configuration"
-    And I hover over the admin menu item "Open Data Schema Mapper"
-    And I click "DCAT validation"
-    Then I should see "DCAT validation"
-    When I hover over the admin menu item "Site Configuration"
-    And I click "Colorizer"
-    Then I should see "Color Scheme Settings"
-    When I hover over the admin menu item "Site Configuration"
-    And I click "Theme Settings"
-    Then I should see "Appearance"
-    When I hover over the admin menu item "Site Configuration"
-    And I click "Menus"
-    Then I should see "Main menu"
-    When I hover over the admin menu item "Site Configuration"
-    And I click "Taxonomy"
-    Then I should see "Taxonomy"
-    When I hover over the admin menu item "Site Configuration"
-    Then I hover over the admin menu item "Taxonomy"
-    And I click "Format"
-    Then I should see "Format"
-    Then I wait for "Site Configuration"
-    When I hover over the admin menu item "Site Configuration"
-    Then I hover over the admin menu item "Taxonomy"
-    And I click "Tags"
-    Then I should see "Tags"
-    Then I wait for "Site Configuration"
-    When I hover over the admin menu item "Site Configuration"
-    Then I hover over the admin menu item "Taxonomy"
-    And I click "Topics" in the "admin menu" region
-    Then I should see "Topics"
 
   Scenario: Site manager role should not see Customize Display link
     Given I am logged in as "John"


### PR DESCRIPTION
* Fixed bug with dkan_datastore_records() not returning FALSE

    * Added new Behat step to DatastoreContext.php for calling dkan_datastore_records()

    * Modified Behat tests to use this new step in favor of searching for text strings to determine status of datastore

This PR addresses some issues raised in #2183. The modifications to resource behat features will hopefully address the recurring random failures with these tests.

No QA Steps other than to confirm that tests are passing in CI.

## User story

Fixes #2183