### PR TITLE
Replace CircleCI scripting with custom docker image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       TZ: "/usr/share/zoneinfo/America/New_York"
     parallelism: 5
     docker:
-      - image: circleci/php:5.6.31-apache-node-browsers
+      - image: getdkan/dkan-docker:5-latest 
         environment:
           MYSQL_HOST: "127.0.0.1"
           DATABASE_URL: "mysql://drupal:123@127.0.0.1:3306/drupal"
@@ -26,50 +26,12 @@ jobs:
           keys:
             - v1-dkan-{{ .Branch }}
             - v1-dkan-test-vendor
-      - run:
-          name: Install Selenium
-          command: |
-            sudo npm install selenium-standalone@latest -g
-            #npm install geckodriver
-            sudo selenium-standalone install
-
+      # Selenium is already installed, run it
       - run:
           name: Run Selenium
           command: |
             sudo selenium-standalone start
           background: true
-      - run:
-          name: Update Packages
-          command: sudo apt-get update
-      - run:
-          name: Install Packages
-          command: sudo apt-get install -y ruby libpng-dev libmcrypt-dev mysql-client x11vnc
-
-#Available Extensions:
-#bcmath bz2 calendar ctype curl dba dom enchant exif fileinfo filter ftp gd gettext gmp hash iconv imap interbase intl json ldap mbstring mcrypt mssql mysql mysqli oci8 odbc opcache pcntl pdo pdo_dblib pdo_firebird pdo_mysql pdo_oci pdo_odbc pdo_pgsql pdo_sqlite pgsql phar posix pspell readline recode reflection session shmop simplexml snmp soap sockets spl standard sybase_ct sysvmsg sysvsem sysvshm tidy tokenizer wddx xml xmlreader xmlrpc xmlwriter xsl zip
-      - run:
-          name: Install PHP Extensions
-          command: sudo docker-php-ext-install gd json mcrypt mysql mysqli opcache pdo pdo_mysql zip
-      - run:
-          name: Install Composer
-          command: |
-            curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer
-            composer global require hirak/prestissimo
-            echo 'export PATH=~/.composer/vendor/bin:$PATH' >> $BASH_ENV
-      - run:
-          name: Edit MySQL Configuration
-          command: |
-            mysql -uroot -e "grant FILE on *.* to 'drupal'@'%'"
-            sudo chmod 777 /etc/mysql/my.cnf
-            sudo echo -e "[client]\nloose-local-infile" >> /etc/mysql/my.cnf
-            sudo chmod 644 /etc/mysql/my.cnf
-      - run:
-          name: Adjust PHP Settings
-          command: |
-            sudo chmod 777 /usr/local/etc/php/conf.d
-            echo "memory_limit = 512M" > /usr/local/etc/php/conf.d/memory.ini
-            echo "always_populate_raw_post_data = -1" > /usr/local/etc/php/conf.d/deprecated.ini
-
       - checkout
       - run: php -i
       - run:
@@ -114,6 +76,10 @@ jobs:
           paths:
             - ~/.drush
             - ~/.composer
+      - run:
+          name: Edit MySQL Configuration
+          command: |
+            mysql -uroot -e "grant FILE on *.* to 'drupal'@'%'"
       - save_cache:
           key: v1-dkan-test-vendor
           paths:
@@ -143,7 +109,7 @@ jobs:
       TZ: "/usr/share/zoneinfo/America/New_York"
     parallelism: 5
     docker:
-      - image: pythagory/dkan-web:7-latest
+      - image: getdkan/dkan-docker:7-latest
         environment:
           MYSQL_HOST: "127.0.0.1"
           DATABASE_URL: "mysql://drupal:123@127.0.0.1:3306/drupal"


### PR DESCRIPTION
Experimental feature enhancement - Builds on work done in #2237 by moving some of the customization of the CircleCI php image to a custom docker image. In theory, this should simplify the process of using this image with Ahoy for local development, while also speeding up the build/test process.

