### PR TITLE
Fix harvest validation for accessLevel values

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.14.1
 ----------
+ - #2263 Fix harvest validation for accessLevel values
  - #2249 Change timezone handling to 'none' on temporal coverage field
  - #2103 Fixed field mapping defaults for open data schema APIs
  - #2237 Migration of CircleCI from V1 to V2

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -104,6 +104,13 @@ class DatajsonHarvestMigration extends HarvestMigration {
       }
     }
 
+    if ($row->accessLevel == 'restricted public') {
+      $row->accessLevel = 'restricted';
+    }
+    if ($row->accessLevel == 'non-public') {
+      $row->accessLevel = 'private';
+    }
+
     // Process Temporal Coverage. The mapping are defined in the base main
     // class, we just need to set the properties.
     if (isset($row->temporal)) {


### PR DESCRIPTION
When harvesting non-public or restricted public data the harvest error log will display validation errors for the accessLevel field.

![errors___data_va_gov](https://user-images.githubusercontent.com/314172/33438409-5d843e48-d5b0-11e7-836a-e68dd2fa5642.png)

## QA Steps

- [x] Create a harvest source with "accessLevel": "non-public", and "accessLevel": "restricted public" values. Confirm there are no errors listed for accessLevel.



## Reminders

- [ ] There is test for the issue.
- [x] CHANGELOG updated.
- [x] Coding standards checked.
- [x] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
