### PR TITLE
Refactor dataset.author.feature and resource.author.feature

### DIFF
--- a/test/features/dataset.author.feature
+++ b/test/features/dataset.author.feature
@@ -1,4 +1,4 @@
-# time:2m45.53s
+# time:2m56.53s
 @api @disablecaptcha
 Feature: Dataset Features
   In order to realize a named business value
@@ -18,51 +18,19 @@ Feature: Dataset Features
     Given users:
       | name    | mail                | roles                |
       | John    | john@example.com    | site manager         |
-      | Badmin  | admin@example.com   | site manager         |
-      | Gabriel | gabriel@example.com | editor               |
       | Jaz     | jaz@example.com     | editor               |
-      | Daniel  | daniel@example.com  | editor               |
       | Katie   | katie@example.com   | content creator      |
-      | Keith   | keith@example.com   | content creator      |
-      | Martin  | martin@example.com  | authenticated user   |
-      | Celeste | celeste@example.com | authenticated user   |
     Given groups:
       | title    | author | published |
-      | Group 01 | Admin  | Yes       |
-      | Group 02 | Admin  | Yes       |
-      | Group 03 | Admin  | No        |
-      | Group 04 | Admin  | Yes       |
+      | Group 01 | Jaz    | Yes       |
+      | Group 02 | Jaz    | Yes       |
+      | Group 03 | John   | Yes       |
     And group memberships:
       | user    | group    | role on group        | membership status |
-      | Gabriel | Group 01 | administrator member | Active            |
       | Katie   | Group 01 | member               | Active            |
-      | Jaz     | Group 01 | member               | Pending           |
-      | Celeste | Group 02 | member               | Active            |
       | Katie   | Group 02 | member               | Active            |
-      | Daniel  | Group 02 | member               | Active            |
-    And "Tags" terms:
-      | name   |
-      | price1 |
-      | election1 |
-    And datasets:
-      | title      | publisher | author  | published        | tags      | description |
-      | Dataset 01 | Group 01  | Gabriel | Yes              | price1    |             |
-      | Dataset 02 | Group 01  | Gabriel | Yes              | election1 |             |
-      | Dataset 03 | Group 02  | Katie   | Yes              | price1    |             |
-      | Dataset 04 | Group 02  | Celeste | No               | election1 |             |
-      | Dataset 05 | Group 01  | Katie   | No               | election1 |             |
-      | Dataset 06 | Group 01  | Katie   | Yes              | election1 |             |
-      | Dataset 07 | Group 01  | Katie   | Yes              | election1 |             |
-      | Dataset 08 | Group 01  | Katie   | Yes              | election1 |             |
-      | Dataset 09 | Group 02  | Katie   | Yes              | election1 |             |
-    And resources:
-      | title       | publisher | author | published | dataset    | description |
-      | Resource 01 | Group 01  | Katie  | Yes       | Dataset 01 |             |
-      | Resource 02 | Group 01  | Katie  | Yes       | Dataset 01 |             |
-      | Resource 03 | Group 01  | Katie  | Yes       | Dataset 02 |             |
-      | Resource 04 |           | Katie  | Yes       |            |             |
-      | Resource 05 |           | Katie  | Yes       | Dataset 08 |             |
-      | Resource 06 | Group 02  | Katie  | Yes       | Dataset 09 |             |
+      | Jaz     | Group 01 | member               | Active            |
+      | Jaz     | Group 02 | member               | Active            |
 
   @dataset_author_1 @noworkflow
   Scenario: Create dataset as content creator
@@ -94,24 +62,30 @@ Feature: Dataset Features
 
   @dataset_author_3 @noworkflow
   Scenario: Edit own dataset as a content creator
+    Given datasets:
+      | title      | author  | published | description | publisher |
+      | Dataset 01 | Katie   | Yes       |             | Group 01  |
     Given I am logged in as "Katie"
-    And I am on "Dataset 03" page
+    And I am on "Dataset 01" page
     When I click "Edit"
-    And I fill in "edit-title" with "Dataset 03 edited"
+    And I fill in "edit-title" with "Dataset 01 edited"
     And I press "Finish"
-    Then I should see "Dataset Dataset 03 edited has been updated"
+    Then I should see "Dataset Dataset 01 edited has been updated"
     When I am on "My Content" page
-    Then I should see "Dataset 03 edited"
+    Then I should see "Dataset 01 edited"
 
   @dataset_author_4 @noworkflow
   Scenario: Seeing the License
+    Given datasets:
+      | title      | author  | published | description | publisher |
+      | Dataset 01 | Katie   | Yes       |             | Group 01  |
     Given I am logged in as "Katie"
-    And I am on "Dataset 03" page
+    And I am on "Dataset 01" page
     When I click "Edit"
     Given I select "Creative Commons Attribution" from "edit-field-license-und-select"
     And I press "edit-submit"
     And I click "Log out"
-    When I am on "Dataset 03" page
+    When I am on "Dataset 01" page
     And I click "Creative Commons Attribution"
     Then I should see "The Creative Commons Attribution license allows re-distribution and re-use of a licensed work"
 
@@ -122,66 +96,90 @@ Feature: Dataset Features
 
   @dataset_author_6 @noworkflow
   Scenario: Delete own dataset as content creator
+    Given datasets:
+      | title      | author  | published | description | publisher |
+      | Dataset 01 | Katie   | Yes       |             | Group 01  |
     Given I am logged in as "Katie"
-    And I am on "Dataset 03" page
+    And I am on "Dataset 01" page
     When I click "Edit"
     And I press "Delete"
     And I press "Delete"
-    Then I should see "Dataset 03 has been deleted"
+    Then I should see "Dataset 01 has been deleted"
 
   @dataset_author_7 @noworkflow
   Scenario: Add a dataset to group that I am a member of
+    Given datasets:
+      | title      | author  | published | description |
+      | Dataset 01 | Katie   | Yes       |             |
     Given I am logged in as "Katie"
-    And I am on "Dataset 03" page
+    And I am on "Dataset 01" page
     When I click "Edit"
     And I select "Group 01" from "og_group_ref[und][]"
     And I press "Finish"
-    Then I should see "Dataset Dataset 03 has been updated"
+    Then I should see "Dataset Dataset 01 has been updated"
     When I am on "Group 01" page
-    Then I should see "Dataset 03" in the "content" region
+    Then I should see "Dataset 01" in the "content" region
 
   @dataset_author_8 @noworkflow
   Scenario: Add a resource with no dataset to a dataset with no resource
+    Given datasets:
+      | title      | author  | published | description | publisher |
+      | Dataset 01 | Katie   | Yes       |             | Group 01  |
+    Given resources:
+      | title       | author   | published | description |
+      | Resource 01 | Jaz      | Yes       | No          |
     Given I am logged in as "Katie"
-    And I am on "Dataset 06" page
+    And I am on "Dataset 01" page
     When I click "Edit"
-    And I fill in "field_resources[und][0][target_id]" with "Resource 04"
+    And I fill in "field_resources[und][0][target_id]" with "Resource 01"
     And I press "Finish"
-    Then I should see "Dataset 06 has been updated"
+    Then I should see "Dataset 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
-    And I should see "Resource 04" in the "dataset resource list" region
-    When I click "Resource 04"
-    Then I should see "Resource 04" in the "resource title" region
+    And I should see "Resource 01" in the "dataset resource list" region
+    When I click "Resource 01"
+    Then I should see "Resource 01" in the "resource title" region
 
   # NOTE: Datasets and resources associated through the 'Background' steps cannot be used here
   #       because the URL of the resources change based on the datasets where they are added
   #       so going back to a resource page after the dataset association is modified throws an error.
   @dataset_author_9 @noworkflow
   Scenario: Remove a resource with only one dataset from the dataset
+    Given datasets:
+      | title      | author  | published | description | publisher |
+      | Dataset 01 | Katie   | Yes       |             | Group 01  |
+    Given resources:
+      | title       | author   | published | description |
+      | Resource 01 | Jaz      | Yes       | No          |
     Given I am logged in as "Katie"
-    And I am on "Dataset 06" page
+    And I am on "Dataset 01" page
     When I click "Edit"
-    And I fill in "field_resources[und][0][target_id]" with "Resource 04"
+    And I fill in "field_resources[und][0][target_id]" with "Resource 01"
     And I press "Finish"
-    Then I should see "Dataset 06 has been updated"
-    And I should see "Resource 04" in the "dataset resource list" region
+    Then I should see "Dataset 01 has been updated"
+    And I should see "Resource 01" in the "dataset resource list" region
     When I click "Edit"
     And I empty the field "edit-field-resources-und-0-target-id"
     And I press "Finish"
-    Then I should see "Dataset 06 has been updated"
+    Then I should see "Dataset 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
-    And I should not see "Resource 04" in the "resource title" region
-    When I am on "Resource 04" page
+    And I should not see "Resource 01" in the "resource title" region
+    When I am on "Resource 01" page
     Then I should not see the link "Back to dataset"
 
   @dataset_author_10 @noworkflow
   Scenario: Add a resource with no group to a dataset with group
+    Given datasets:
+      | title      | author  | published | description | publisher |
+      | Dataset 01 | Katie   | Yes       |             | Group 01  |
+    Given resources:
+      | title       | author   | published | description |
+      | Resource 01 | Jaz      | Yes       | No          |
     Given I am logged in as "Katie"
-    And I am on "Dataset 07" page
+    And I am on "Dataset 01" page
     When I click "Edit"
-    And I fill in "field_resources[und][0][target_id]" with "Resource 04"
+    And I fill in "field_resources[und][0][target_id]" with "Resource 01"
     And I press "Finish"
-    Then I should see "Dataset 07 has been updated"
+    Then I should see "Dataset 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
   # NOTE: Datasets and resources associated through the 'Background' steps cannot be used here
@@ -189,51 +187,75 @@ Feature: Dataset Features
   #       so going back to a resource page after the dataset association is modified throws an error.
   @dataset_author_11 @noworkflow
   Scenario: Remove a resource from a dataset with group
+    Given datasets:
+      | title      | author  | published | description | publisher |
+      | Dataset 01 | Katie   | Yes       |             | Group 01  |
+    Given resources:
+      | title       | author   | published | description |
+      | Resource 01 | Jaz      | Yes       | No          |
     Given I am logged in as "Katie"
-    And I am on "Dataset 07" page
+    And I am on "Dataset 01" page
     When I click "Edit"
-    And I fill in "field_resources[und][0][target_id]" with "Resource 04"
+    And I fill in "field_resources[und][0][target_id]" with "Resource 01"
     And I press "Finish"
-    Then I should see "Dataset 07 has been updated"
+    Then I should see "Dataset 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
-    When I am on "Dataset 07" page
+    When I am on "Dataset 01" page
     And I click "Edit"
     And I empty the field "edit-field-resources-und-0-target-id"
     And I press "Finish"
-    Then I should see "Dataset 07 has been updated"
+    Then I should see "Dataset 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
   @dataset_author_12 @noworkflow
   Scenario: Add group to a dataset with resources
+    Given datasets:
+      | title      | author  | published | description | publisher |
+      | Dataset 01 | Katie   | Yes       |             | Group 01  |
+    Given resources:
+      | title       | author   | published | description | dataset    |
+      | Resource 01 | Jaz      | Yes       | No          | Dataset 01 |
     Given I am logged in as "Katie"
-    And I am on "Dataset 08" page
+    And I am on "Dataset 01" page
     When I click "Edit"
     And I select "Group 02" from "og_group_ref[und][]"
     And I press "Finish"
-    Then I should see "Dataset 08 has been updated"
+    Then I should see "Dataset 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
   @dataset_author_13 @noworkflow
   Scenario: Remove group from dataset with resources
+    Given datasets:
+      | title      | author  | published | description | publisher           |
+      | Dataset 01 | Katie   | Yes       |             | Group 01, Group 02  |
+    Given resources:
+      | title       | author   | published | description | dataset    |
+      | Resource 01 | Jaz      | Yes       | No          | Dataset 01 |
     Given I am logged in as "Katie"
-    And I am on "Dataset 09" page
+    And I am on "Dataset 01" page
     When I click "Edit"
     And I select "" from "og_group_ref[und][]"
     And I press "Finish"
-    Then I should see "Dataset 09 has been updated"
+    Then I should see "Dataset 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
   @dataset_author_14 @noworkflow @javascript
   Scenario: Add group and resource to a dataset on the same edition
+    Given datasets:
+      | title      | author  | published | description | publisher |
+      | Dataset 01 | Katie   | Yes       |             | Group 01  |
+    Given resources:
+      | title       | author   | published | description |
+      | Resource 01 | Jaz      | Yes       | No          |
     Given I am logged in as "Katie"
-    And I am on "Dataset 08" page
+    And I am on "Dataset 01" page
     When I click "Edit"
     And I fill in the chosen field "edit_og_group_ref_und_chosen" with "Group 02"
-    And I fill in "field_resources[und][0][target_id]" with "Resource 04"
+    And I fill in "field_resources[und][0][target_id]" with "Resource 01"
     And I press "Finish"
-    Then I should see "Dataset 08 has been updated"
+    Then I should see "Dataset 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
-    And I should see "Resource 04" in the "dataset resource list" region
+    And I should see "Resource 01" in the "dataset resource list" region
 
   @dataset_author_15 @noworkflow
   Scenario: Site Managers should see groups they are not member of
@@ -247,14 +269,14 @@ Feature: Dataset Features
     Given I am logged in as "Katie"
     When I visit "node/add/dataset"
     Then I should see the "Group 02" groups option
-    And I should not see the "Group 04" groups option
+    And I should not see the "Group 03" groups option
 
   @dataset_author_17 @noworkflow
   Scenario: Editors should only see the groups they are member of
-    Given I am logged in as "Daniel"
+    Given I am logged in as "Jaz"
     When I visit "node/add/dataset"
     Then I should see the "Group 02" groups option
-    And I should not see the "Group 04" groups option
+    And I should not see the "Group 03" groups option
 
   @dataset_author_18 @noworkflow
   Scenario: Site Managers should see authoring information and publishing options
@@ -265,6 +287,9 @@ Feature: Dataset Features
 
   @dataset_author_19 @noworkflow
   Scenario: Content Creators not part of a group should see publishing options
+    Given users:
+      | name    | mail                | roles                |
+      | Keith   | keith@example.com   | content creator      |
     Given I am logged in as "Keith"
     When I visit "node/add/dataset"
     Then I should not see "Authoring information"

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -1,65 +1,17 @@
-# time:5m47.66s
+# time:4m30.30s
 @api @disablecaptcha
 Feature: Resource
 
   Background:
     Given pages:
-      | name          | url                |
-      | Content       | /node/add          |
-      | User          | /user              |
+      | name          | url           |
+      | Content       | /node/add     |
+      | User          | /user         |
     Given users:
-      | name    | mail                | roles                |
-      | John    | john@example.com    | site manager         |
-      | Badmin  | admin@example.com   | site manager         |
-      | Gabriel | gabriel@example.com | content creator   |
-      | Jaz     | jaz@example.com     | editor               |
+      | name    | mail                | roles             |
+      | John    | john@example.com    | site manager      |
       | Katie   | katie@example.com   | content creator   |
-      | Martin  | martin@example.com  | editor               |
-      | Celeste | celeste@example.com | editor               |
-    Given groups:
-      | title    | author  | published |
-      | Group 01 | Badmin  | Yes       |
-      | Group 02 | Badmin  | Yes       |
-      | Group 03 | Badmin  | No        |
-    And group memberships:
-      | user    | group    | role on group        | membership status |
-      | Gabriel | Group 01 | administrator member | Active            |
-      | Katie   | Group 01 | member               | Active            |
-      | Jaz     | Group 01 | member               | Pending           |
-      | Admin   | Group 02 | administrator member | Active            |
-      | Celeste | Group 01 | member               | Active            |
-      | Katie   | Group 02 | member               | Active            |
-    And "Tags" terms:
-      | name    |
-      | world   |
-      | results |
-    And datasets:
-      | title      | publisher | author  | published        | tags     | description |
-      | Dataset 01 | Group 01  | Gabriel | Yes              | world    | Test        |
-      | Dataset 02 | Group 01  | Gabriel | Yes              | results  | Test        |
-      | Dataset 03 |           | Katie   | Yes              | world    | Test        |
-      | Dataset 04 |           | Katie   | Yes              | results  | Test        |
-      | Dataset 05 | Group 01  | Katie   | Yes              | results  | Test        |
-      | Dataset 06 | Group 02  | Katie   | Yes              | results  | Test        |
-    And resources:
-      | title       | publisher | format | dataset    | author   | published | description |
-      | Resource 01 | Group 01  | csv    | Dataset 01 | Katie    | Yes       | No          |
-      | Resource 02 | Group 01  | csv    | Dataset 01 | Katie    | Yes       | No          |
-      | Resource 03 | Group 01  | csv    | Dataset 02 | Celeste  | No        | Yes         |
-      | Resource 04 | Group 01  | csv    | Dataset 01 | Katie    | No        | Yes         |
-      | Resource 05 | Group 01  | csv    | Dataset 02 | Celeste  | Yes       | Yes         |
-      | Resource 06 |           | csv    |            | Katie    | Yes       | Test        |
-      | Resource 07 |           | csv    | Dataset 04 | Katie    | Yes       | Test        |
-      | Resource 08 | Group 01  | csv    | Dataset 05 | Katie    | Yes       | Test        |
-    And resources:
-      | title       | author   | published | description | link file |
-      | Resource 11 | Katie    | Yes       | Test        | https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv |
-      | Resource 12 | Katie    | Yes       | Test        | https://s3.amazonaws.com/dkan-default-content-files/files/geography.png |
-      | Resource 13 | Katie    | Yes       | Test        | https://s3.amazonaws.com/dkan-default-content-files/files/metadata.zip |
-      | Resource 14 | Katie    | Yes       | Test        | https://s3.amazonaws.com/dkan-default-content-files/files/catalog.xml |
-      | Resource 15 | Katie    | Yes       | Test        | https://s3.amazonaws.com/dkan-default-content-files/files/data.json |
-      | Resource 16 | Katie    | Yes       | Test        | https://s3.amazonaws.com/dkan-default-content-files/files/USA.geo.json |
-      | Resource 17 | Katie    | Yes       | Test        | https://data.wa.gov/api/views/mu24-67ke/rows.csv?accessType=DOWNLOAD |
+      | Celeste | celeste@example.com | editor            |
 
   @resource_author_01 @noworkflow
   Scenario: Create resource
@@ -97,30 +49,48 @@ Feature: Resource
     Then I should see "Remote file is populated - only one resource type can be used at a time"
     And I should see "API or Website URL is populated - only one resource type can be used at a time"
 
-  @resource_author_04 @noworkflow
-  #TODO: Content creator will be a role added later, but for now we stick with authenticated user
+  @resource_author_04 @noworkflow @javascript
   Scenario: Edit own resource as content creator
+    Given resources:
+      | title       | author   | published | description |
+      | Resource 01 | Katie    | Yes       | No content  |
     Given I am logged in as "Katie"
-    And I am on "Resource 02" page
+    And I am on "Resource 01" page
     When I click "Edit"
-    And I fill in "Title" with "Resource 02 edited"
+    And I fill in "Title" with "Resource 01 edited"
     And I press "Save"
-    Then I should see "Resource Resource 02 edited has been updated"
+    Then I should see "Resource Resource 01 edited has been updated"
     When I am on "User" page
-    Then I should see "Resource 02 edited"
+    Then I should see "Resource 01 edited"
 
   @resource_author_05 @noworkflow
-  #TODO: Content creator will be a role added later, but for now we stick with authenticated user
   Scenario: Delete own resource
+    Given resources:
+      | title       | format | author   | published | description |
+      | Resource 01 | csv    | Katie    | Yes       | No content  |
     Given I am logged in as "Katie"
-    And I am on "Resource 02" page
+    And I am on "Resource 01" page
     When I click "Edit"
     And I press "Delete"
     And I press "Delete"
-    Then I should see "Resource 02 has been deleted"
+    Then I should see "Resource 01 has been deleted"
 
   @resource_author_06 @dkanBug @noworkflow
   Scenario: Change dataset on resource
+    Given groups:
+      | title    | author  | published |
+      | Group 01 | John    | Yes       |
+    And group memberships:
+      | user    | group    | role on group        | membership status |
+      | John    | Group 01 | administrator member | Active            |
+      | Katie   | Group 01 | member               | Active            |
+    And datasets:
+      | title      | publisher | author  | published    | description |
+      | Dataset 01 | Group 01  | John    | Yes          | Test        |
+      | Dataset 02 | Group 01  | John    | Yes          | Test        |
+    And resources:
+      | title       | publisher | format | dataset    | author   | published | description |
+      | Resource 01 | Group 01  | csv    | Dataset 01 | Katie    | Yes       | No          |
     Given I am logged in as "Katie"
     And I am on "Resource 01" page
     When I click "Edit"
@@ -133,166 +103,276 @@ Feature: Resource
 
   @resource_author_07 @noworkflow
   Scenario: Add a resource with no datasets to a dataset with no resource
+    Given groups:
+      | title    | author  | published |
+      | Group 01 | John    | Yes       |
+    And group memberships:
+      | user    | group    | role on group        | membership status |
+      | John    | Group 01 | administrator member | Active            |
+      | Katie   | Group 01 | member               | Active            |
+    And datasets:
+      | title      | publisher | author  | published  | description |
+      | Dataset 01 | Group 01  | John    | Yes        | Test        |
+    And resources:
+      | title       | author   | published | description |
+      | Resource 01 | Katie    | Yes       | No content  |
     Given I am logged in as "Katie"
-    And I am on "Resource 06" page
+    And I am on "Resource 01" page
     When I click "Edit"
-    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 03"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 01"
     And I press "Save"
-    Then I should see "Resource 06 has been updated"
+    Then I should see "Resource 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
     When I click "Back to dataset"
-    Then I should see "Dataset 03" in the "dataset title" region
-    And I should see "Resource 06" in the "dataset resource list" region
+    Then I should see "Dataset 01" in the "dataset title" region
+    And I should see "Resource 01" in the "dataset resource list" region
 
   @resource_author_08 @noworkflow
   Scenario: Remove a resource with only one dataset from the dataset
+    Given groups:
+      | title    | author  | published |
+      | Group 01 | John    | Yes       |
+    And group memberships:
+      | user    | group    | role on group        | membership status |
+      | John    | Group 01 | administrator member | Active            |
+      | Katie   | Group 01 | member               | Active            |
+    And datasets:
+      | title      | publisher | author  | published    | description |
+      | Dataset 01 | Group 01  | John    | Yes          | Test        |
+    And resources:
+      | title       | publisher | format | dataset    | author   | published | description |
+      | Resource 01 | Group 01  | csv    | Dataset 01 | Katie    | Yes       | No          |
     Given I am logged in as "Katie"
-    And I am on "Resource 07" page
+    And I am on "Resource 01" page
     When I click "Edit"
     And I fill in "edit-field-dataset-ref-und-0-target-id" with ""
     And I press "Save"
-    Then I should see "Resource 07 has been updated"
+    Then I should see "Resource 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
     And I should not see the link "Back to dataset"
 
   @resource_author_09 @noworkflow
   Scenario: Add a resource with no group to a dataset with group
+    Given groups:
+      | title    | author  | published |
+      | Group 01 | John    | Yes       |
+    And group memberships:
+      | user    | group    | role on group        | membership status |
+      | John    | Group 01 | administrator member | Active            |
+      | Katie   | Group 01 | member               | Active            |
+    And datasets:
+      | title      | publisher | author  | published    | description |
+      | Dataset 01 | Group 01  | John    | Yes          | Test        |
+    And resources:
+      | title       | format | author   | published | description |
+      | Resource 01 | csv    | Katie    | Yes       | No          |
     Given I am logged in as "Katie"
-    And I am on "Resource 06" page
+    And I am on "Resource 01" page
     When I click "Edit"
-    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 05"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 01"
     And I press "Save"
-    Then I should see "Resource 06 has been updated"
+    Then I should see "Resource 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
   @resource_author_10 @noworkflow
   Scenario: Remove a resource from a dataset with group
+    Given groups:
+      | title    | author  | published |
+      | Group 01 | John    | Yes       |
+    And group memberships:
+      | user    | group    | role on group        | membership status |
+      | John    | Group 01 | administrator member | Active            |
+      | Katie   | Group 01 | member               | Active            |
+    And datasets:
+      | title      | publisher | author  | published    | description |
+      | Dataset 01 | Group 01  | John    | Yes          | Test        |
+    And resources:
+      | title       | publisher | format | dataset    | author   | published | description |
+      | Resource 01 | Group 01  | csv    | Dataset 01 | Katie    | Yes       | No          |
     Given I am logged in as "Katie"
-    And I am on "Resource 08" page
+    And I am on "Resource 01" page
     When I click "Edit"
     And I fill in "edit-field-dataset-ref-und-0-target-id" with ""
     And I press "Save"
-    Then I should see "Resource 08 has been updated"
+    Then I should see "Resource 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
-    When I am on "Dataset 05" page
-    Then I should not see "Resource 08" in the "dataset resource list" region
+    When I am on "Dataset 01" page
+    Then I should not see "Resource 01" in the "dataset resource list" region
 
   @resource_author_11 @noworkflow
   Scenario: Add a resource to multiple datasets with groups
+    Given groups:
+      | title    | author  | published |
+      | Group 01 | John    | Yes       |
+    And group memberships:
+      | user    | group    | role on group        | membership status |
+      | John    | Group 01 | administrator member | Active            |
+      | Katie   | Group 01 | member               | Active            |
+    And datasets:
+      | title      | publisher | author  | published    | description |
+      | Dataset 01 | Group 01  | John    | Yes          | Test        |
+      | Dataset 02 | Group 01  | John    | Yes          | Test        |
+    And resources:
+      | title       | format | author   | published | description |
+      | Resource 01 | csv    | Katie    | Yes       | No          |
     Given I am logged in as "Katie"
-    And I am on "Resource 06" page
+    And I am on "Resource 01" page
     When I click "Edit"
-    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 05"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 01"
     And I press "Add another item"
-    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 06"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 02"
     And I press "Save"
-    Then I should see "Resource 06 has been updated"
+    Then I should see "Resource 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
   @resource_author_12 @noworkflow
   Scenario: Remove one dataset with group from resource with multiple datasets
+    Given groups:
+      | title    | author  | published |
+      | Group 01 | John    | Yes       |
+    And group memberships:
+      | user    | group    | role on group        | membership status |
+      | John    | Group 01 | administrator member | Active            |
+      | Katie   | Group 01 | member               | Active            |
+    And datasets:
+      | title      | publisher | author  | published    | description |
+      | Dataset 01 | Group 01  | John    | Yes          | Test        |
+      | Dataset 02 | Group 01  | John    | Yes          | Test        |
+    And resources:
+      | title       | format | author   | published | description |
+      | Resource 01 | csv    | Katie    | Yes       | No          |
     Given I am logged in as "Katie"
-    And I am on "Resource 06" page
+    And I am on "Resource 01" page
     When I click "Edit"
-    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 05"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 01"
     And I press "Add another item"
-    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 06"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 02"
     And I press "Save"
-    Then I should see "Resource 06 has been updated"
+    Then I should see "Resource 01 has been updated"
     When I click "Edit"
     And I fill in "edit-field-dataset-ref-und-0-target-id" with ""
     And I press "Save"
-    Then I should see "Resource 06 has been updated"
+    Then I should see "Resource 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
   @resource_author_13 @noworkflow
   Scenario: Remove all datasets with groups from resource
+    Given groups:
+      | title    | author  | published |
+      | Group 01 | John    | Yes       |
+    And group memberships:
+      | user    | group    | role on group        | membership status |
+      | John    | Group 01 | administrator member | Active            |
+      | Katie   | Group 01 | member               | Active            |
+    And datasets:
+      | title      | publisher | author  | published    | description |
+      | Dataset 01 | Group 01  | John    | Yes          | Test        |
+      | Dataset 02 | Group 01  | John    | Yes          | Test        |
+    And resources:
+      | title       | format | author   | published | description |
+      | Resource 01 | csv    | Katie    | Yes       | No          |
     Given I am logged in as "Katie"
-    And I am on "Resource 06" page
+    And I am on "Resource 01" page
     When I click "Edit"
-    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 05"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 01"
     And I press "Add another item"
-    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 06"
+    And I fill in "field_dataset_ref[und][0][target_id]" with "Dataset 02"
     And I press "Save"
-    Then I should see "Resource 06 has been updated"
+    Then I should see "Resource 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
     When I click "Edit"
     And I fill in "edit-field-dataset-ref-und-0-target-id" with ""
     And I fill in "edit-field-dataset-ref-und-1-target-id" with ""
     And I press "Save"
-    Then I should see "Resource 06 has been updated"
+    Then I should see "Resource 01 has been updated"
     And I should see "Groups were updated on 1 resource(s)"
 
   @resource_author_14 @dkanBug @noworkflow
-    # TODO: Managing own datastore not currently supported for authenticated users
-    # TODO: Permissions for a user to manage the datastore of their own resource are not set (they can't access)
   Scenario: Manage datastore of own resource
+    Given resources:
+      | title       | author   | published | description |
+      | Resource 01 | Celeste  | Yes       | No          |
     Given I am logged in as "Celeste"
-    And I am on "Resource 05" page
+    And I am on "Resource 01" page
     When I click "Edit"
     And I click "Manage Datastore"
     Then I should see "There is nothing to manage! You need to upload or link to a file in order to use the datastore."
 
   @resource_author_15 @datastore @noworkflow @javascript
   Scenario: Import items on datastore of own resource
+    Given resources:
+      | title       | author   | published | description |
+      | Resource 01 | Celeste  | Yes       | No          |
     Given I am logged in as "Celeste"
-    And I am on "Resource 05" page
+    And I am on "Resource 01" page
     And I click "Edit"
     And I click "Remote file"
     And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/datastore-simple4.csv"
     And I press "Save"
-    And I am on "Resource 05" page
+    And I am on "Resource 01" page
     When I click "Manage Datastore"
     And I press "Import"
     And I wait for "Delete items"
-    Then "Resource 05" should have datastore records
+    Then I should see "Last import"
+    And I wait for "imported items total"
 
   @resource_author_16 @datastore @noworkflow @javascript
   Scenario: Delete items on datastore of own resource
+    Given resources:
+      | title       | author   | published | description |
+      | Resource 01 | Celeste  | Yes       | No          |
     Given I am logged in as "John"
-    And I am on "Resource 03" page
+    And I am on "Resource 01" page
     And I click "Edit"
     And I click "Remote file"
     And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/datastore-simple5.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
-    And I am on "Resource 03" page
+    And I am on "Resource 01" page
     When I click "Manage Datastore"
     And I press "Import"
     And I wait for "Delete Items"
-    Then "Resource 03" should have datastore records
     And I click "Delete items"
     And I press "Delete"
     Then I wait for "items have been deleted"
-    And "Resource 03" should have no datastore records
+    # This test is not really sufficient, but we are going to consolidate the
+    # "drop" and "delete" datastore functions and do other refactoring, so will
+    # revisit then.
 
   @resource_author_17 @datastore @noworkflow @javascript
   Scenario: Drop datastore of own resource
+    Given resources:
+      | title       | author   | published | description |
+      | Resource 01 | Celeste  | Yes       | No          |
     Given I am logged in as "John"
-    And I am on "Resource 03" page
+    And I am on "Resource 01" page
     And I click "Edit"
     And I click "Remote file"
     And I fill in "edit-field-link-remote-file-und-0-filefield-dkan-remotefile-url" with "https://s3.amazonaws.com/dkan-default-content-files/files/datastore-simple6.csv"
     And I press "Save"
     Given I am logged in as "Celeste"
-    And I am on "Resource 03" page
+    And I am on "Resource 01" page
     When I click "Manage Datastore"
     And I press "Import"
     And I wait for "Delete Items"
-    Then "Resource 03" should have datastore records
     When I click "Drop Datastore"
     And I press "Drop"
     Then I should see "Datastore dropped!"
-    And "Resource 03" should have no datastore records
+    And I should see "Your file for this resource is not added to the datastore"
+    When I click "Manage Datastore"
+    Then I wait for "No imported items."
 
   @resource_author_18 @noworkflow
   Scenario: Add revision to own resource
+    Given resources:
+      | title       | author   | published | description |
+      | Resource 01 | Katie    | Yes       | No          |
     Given I am logged in as "Katie"
-    And I am on "Resource 02" page
+    And I am on "Resource 01" page
     When I click "Edit"
-    And I fill in "title" with "Resource 02 edited"
+    And I fill in "title" with "Resource 01 edited"
     And I press "Save"
-    Then I should see "Resource Resource 02 edited has been updated"
+    Then I should see "Resource Resource 01 edited has been updated"
     When I click "Revisions"
     Then I should see "by Katie"
 
@@ -300,61 +380,82 @@ Feature: Resource
   # We need to edit and save to trigger auto type discover
   @resource_author_19 @javascript
   Scenario: Remote CSV preview
+    Given resources:
+      | title       | author   | published | description | link file |
+      | Resource 01 | Katie    | Yes       | Test        | https://s3.amazonaws.com/dkan-default-content-files/files/district_centerpoints_0.csv |
     Given I am logged in as "Katie"
-    And I am on "Resource 11" page
+    And I am on "Resource 01" page
     When I click "Edit"
     And I press "Save"
     Then I should see a recline preview
 
   @resource_author_20 @javascript
   Scenario: Image preview
+    Given resources:
+      | title       | author   | published | description | link file |
+      | Resource 01 | Katie    | Yes       | Test        | https://s3.amazonaws.com/dkan-default-content-files/files/geography.png |
     Given I am logged in as "Katie"
-    And I am on "Resource 12" page
+    And I am on "Resource 01" page
     When I click "Edit"
     And I press "Save"
     Then I should see a image preview
 
   @resource_author_21
   Scenario: ZIP preview
+    Given resources:
+      | title       | author   | published | description | link file |
+      | Resource 01 | Katie    | Yes       | Test        | https://s3.amazonaws.com/dkan-default-content-files/files/metadata.zip |
     Given I am logged in as "Katie"
-    And I am on "Resource 13" page
+    And I am on "Resource 01" page
     When I click "Edit"
     And I press "Save"
     Then I should see a zip preview
 
   @resource_author_22 @javascript
   Scenario: XML preview
+    Given resources:
+      | title       | author   | published | description | link file |
+      | Resource 01 | Katie    | Yes       | Test        | https://s3.amazonaws.com/dkan-default-content-files/files/catalog.xml |
     Given I am logged in as "Katie"
-    And I am on "Resource 14" page
+    And I am on "Resource 01" page
     When I click "Edit"
     And I press "Save"
     Then I should see a xml preview
 
   @resource_author_23
   Scenario: JSON preview
+    Given resources:
+      | title       | author   | published | description | link file |
+      | Resource 01 | Katie    | Yes       | Test        | https://s3.amazonaws.com/dkan-default-content-files/files/data.json |
     Given I am logged in as "Katie"
-    And I am on "Resource 15" page
+    And I am on "Resource 01" page
     When I click "Edit"
     And I press "Save"
     Then I should see a json preview
 
   @resource_author_24
   Scenario: GEOJSON preview
+    Given resources:
+      | title       | author   | published | description | link file |
+      | Resource 01 | Katie    | Yes       | Test        | https://s3.amazonaws.com/dkan-default-content-files/files/USA.geo.json |
     Given I am logged in as "Katie"
-    And I am on "Resource 16" page
+    And I am on "Resource 01" page
     When I click "Edit"
     And I press "Save"
     Then I should see a geojson preview
 
   @resource_author_25 @javascript
   Scenario: Generated CSV preview
+    Given resources:
+      | title       | author   | published | description | link file |
+      | Resource 01 | Katie    | Yes       | Test        | https://data.wa.gov/api/views/mu24-67ke/rows.csv?accessType=DOWNLOAD |
     Given I am logged in as "Katie"
-    And I am on "Resource 17" page
+    And I am on "Resource 01" page
     When I click "Edit"
     And I press "Save"
     Then I should see a recline preview
 
-  @noworkflow
+  @resource_author_26 @noworkflow
   Scenario: Create resource with a tsv file
     Given I am logged in as "John"
     And I am on the "Content" page
@@ -369,7 +470,7 @@ Feature: Resource
     When I click "Edit"
     Then the "field_format[und][textfield]" field should contain "tsv"
 
-  @noworkflow
+  @resource_author_27 @noworkflow
   Scenario: Create resource with a tab file
     Given I am logged in as "John"
     And I am on the "Content" page


### PR DESCRIPTION
The backgrounds used on these two files are unnecessarily large, many scenarios do not need any of the set up content and the time it takes to create and tear down all of this test content takes longer than it takes to run the test. This causes SQLSTATE[23000]: Integrity constraint violation: duplicate entry errors on CircleCi

**dataset.author.feature background**
- 9 users
- 4 groups
- 2 tags
- 9 datasets
- 6 resources

**resource.author.feature background**
- 7 users
- 3 groups
- 2 tags
- 6 datasets
- 15 resources!!

Rather than creating all of this content, lets just create the minimum amount per scenario rather than putting everything in the background.