### PR TITLE
Remove dkan_workflow_permissions dependency

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@
  - #2249 Change timezone handling to 'none' on temporal coverage field
  - #2103 Fixed field mapping defaults for open data schema APIs
  - #2237 Migration of CircleCI from V1 to V2
+ - #2273 Remove dkan_workflow_permissions dependency
 
 7.x-1.14
 --------

--- a/modules/dkan/dkan_workflow/dkan_workflow.info
+++ b/modules/dkan/dkan_workflow/dkan_workflow.info
@@ -2,7 +2,6 @@ name = DKAN Workflow
 description = NuCivic Data publication workflow and related modules
 core = 7.x
 package = DKAN Workflow
-dependencies[] = dkan_workflow_permissions
 dependencies[] = dkan_sitewide_menu
 dependencies[] = entity
 dependencies[] = features

--- a/modules/dkan/dkan_workflow/dkan_workflow.install
+++ b/modules/dkan/dkan_workflow/dkan_workflow.install
@@ -16,6 +16,26 @@ function dkan_workflow_install() {
  * Implements hook_enable().
  */
 function dkan_workflow_enable() {
+  // Create new roles for workflow if don't exist.
+  $roles = array(
+    'Workflow Contributor',
+    'Workflow Moderator',
+    'Workflow Supervisor',
+  );
+
+  foreach ($roles as $role_name) {
+    $existing_role = user_role_load_by_name($role_name);
+    if (empty($existing_role)) {
+      $role = new stdClass();
+      $role->name = $role_name;
+      user_role_save($role);
+    }
+  }
+
+  // Enable dkan_workflow_permissions if not already.
+  if (!module_exists('dkan_workflow_permissions')) {
+    module_enable(array('dkan_workflow_permissions'));
+  }
 
   // Enable moderation for dkan_workflow enabled content types upon install.
   // This config is kept persistant using the hook_strongarm_alter().
@@ -43,18 +63,6 @@ function dkan_workflow_enable() {
   // Revert dkan sitewide menu to add links to command center.
   features_revert(array('dkan_sitewide_menu' => array('menu_links')));
 
-  // Assign role supervisor to editor users.
-  $uids = array();
-  $supervisor = user_role_load_by_name("Workflow Supervisor");
-  $site_manager = user_role_load_by_name("site manager");
-  $result = db_query("SELECT uid FROM {users_roles} WHERE rid=:site_manager AND uid NOT IN (SELECT uid FROM {users_roles} WHERE rid=:supervisor)", array(':site_manager' => $site_manager->rid, ':supervisor' => $supervisor->rid));
-
-  if (!empty($result)) {
-    foreach ($result as $user) {
-      $uids[] = $user->uid;
-    }
-    user_multiple_role_edit($uids, 'add_role', $supervisor->rid);
-  }
   dkan_workflow_admin_menu_source();
 
   // Add dkan workflow roles to roleassign config.

--- a/modules/dkan/dkan_workflow/modules/dkan_workflow_permissions/dkan_workflow_permissions.install
+++ b/modules/dkan/dkan_workflow/modules/dkan_workflow_permissions/dkan_workflow_permissions.install
@@ -21,6 +21,20 @@ function dkan_workflow_permissions_enable() {
   if (!module_exists('workbench_moderation')) {
     module_enable(array('workbench_moderation'));
   }
+
+  // Assign role supervisor to editor users.
+  $uids = array();
+  $supervisor = user_role_load_by_name("Workflow Supervisor");
+  $site_manager = user_role_load_by_name("site manager");
+  $result = db_query("SELECT uid FROM {users_roles} WHERE rid=:site_manager AND uid NOT IN (SELECT uid FROM {users_roles} WHERE rid=:supervisor)", array(':site_manager' => $site_manager->rid, ':supervisor' => $supervisor->rid));
+
+  if (!empty($result)) {
+    foreach ($result as $user) {
+      $uids[] = $user->uid;
+    }
+    user_multiple_role_edit($uids, 'add_role', $supervisor->rid);
+  }
+
   $anon = user_role_load_by_name('anonymous user');
   user_role_grant_permissions($anon->rid, array('view moderation history'));
 

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/WorkflowContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/WorkflowContext.php
@@ -25,14 +25,15 @@ class WorkflowContext extends RawDKANContext {
     define('MAINTENANCE_MODE', 'update');
     @module_enable(array(
       'dkan_workflow',
+      'dkan_workflow_permissions',
       'drafty',
       'workbench_moderation',
       'workbench_email', 'workbench',
       'views_dkan_workflow_tree',
       'menu_badges',
       'link_badges',
-      'dkan_workflow_permissions'
     ));
+
     if (module_exists('dkan_feeedback')) {
       features_revert(array('dkan_feedback'));
     }


### PR DESCRIPTION
Decouples dependency on dkan_workflow_permissions to allow custom workflow permission module overrides

## QA Steps
- [x] Verify you can run `drush dis dkan_workflow_permissions` without disabling `dkan_workflow` module
- [x] On a test installation, all site manager accounts should still continue to have the "workflow supervisor" role.

## Reminders

- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
