### PR TITLE
Use JSON icon for GeoJSON format

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.14.1
 ----------
+ - #2288 Use JSON icon for GeoJSON files in listings
  - #2283 Share MySQL Credentials With Docker Containers
  - #2273 Remove dkan_workflow_permissions dependency
  - #2275 Docker Proxy Config Updates

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 7.x-1.14.1
 ----------
- - #2288 Use JSON icon for GeoJSON files in listings
+ - #2288 Use geojson icon for GeoJSON files in listings
  - #2283 Share MySQL Credentials With Docker Containers
  - #2273 Remove dkan_workflow_permissions dependency
  - #2275 Docker Proxy Config Updates

--- a/modules/dkan/dkan_dataset/css/dkan_dataset.css
+++ b/modules/dkan/dkan_dataset/css/dkan_dataset.css
@@ -462,7 +462,8 @@ li .heading:hover {
   background-color: blue;
 }
 .label[data-format=json],
-.label[data-format*=json] {
+.label[data-format*=json],
+.label[data-format=geojson] {
   background-color: #ef7100;
 }
 .label[data-format=xml],

--- a/modules/dkan/dkan_dataset/css/dkan_dataset.css
+++ b/modules/dkan/dkan_dataset/css/dkan_dataset.css
@@ -568,7 +568,8 @@ li .heading:hover {
   content: "\e64f";
   color: blue;
 }
-.format-label[data-format=json]:before {
+.format-label[data-format=json]:before,
+.format-label[data-format=geojson]:before {
   content: "\e651";
   color: #ef7100;
 }

--- a/modules/dkan/dkan_dataset/css/dkan_dataset.css
+++ b/modules/dkan/dkan_dataset/css/dkan_dataset.css
@@ -569,9 +569,12 @@ li .heading:hover {
   content: "\e64f";
   color: blue;
 }
-.format-label[data-format=json]:before,
-.format-label[data-format=geojson]:before {
+.format-label[data-format=json]:before {
   content: "\e651";
+  color: #ef7100;
+}
+.format-label[data-format=geojson]:before {
+  content: "\e923";
   color: #ef7100;
 }
 .format-label[data-format=pdf]:before {


### PR DESCRIPTION
Change the icon used for GeoJSON resources in the dataset resource list. We should add a special GeoJSON icon but for now, let's at least use the JSON icon rather than defaulting to "Data".

## QA Steps

- [ ] Create a resource with "geojson" format https://github.com/GetDKAN/visualization_entity/blob/7.x-1.x/docs/examples/africa.geojson
- [ ] Confirm that it uses the "geojson" icon

![dkan](https://user-images.githubusercontent.com/314172/34171731-11e15c78-e4b5-11e7-8fda-c42bda2f5f28.png)

## Reminders

- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
