### PR TITLE
Add dkan_sci_metadata module

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.15
 --------
+ - #2299 Added dkan_sci_metadata module
  - #2290 Add Extended Metadata Field for Datasets
 
 7.x-1.14.1

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -70,6 +70,11 @@ projects:
       type: git
       url: https://github.com/GetDKAN/dkan_dataset_paragraphs.git
       branch: 7.x-1.x
+  dkan_sci_metadata:
+    download:
+      type: git
+      url: https://github.com/GetDKAN/dkan_sci_metadata.git
+      branch: 7.x-1.x
   double_field:
     version: '2.5'
   draggableviews:


### PR DESCRIPTION
Adds https://github.com/GetDKAN/dkan_sci_metadata to DKAN to provide additional Sciene Metadata fields to DKAN dataset

## QA Steps
- [x] Run `ahoy dkan remake` / `ahoy dkan reinstall` and verify you can enable `ahoy drush en dkan_sci_metadata` module.

## Reminders

- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
