### PR TITLE
Switch to mariadb and remove php conviguration

### DIFF
--- a/.ahoy/.docker/etc/mysql/my.cnf
+++ b/.ahoy/.docker/etc/mysql/my.cnf
@@ -1,21 +1,3 @@
 [mysqld]
-###############################
-# Acquia DD settings
-#set innodb as default
-default-storage-engine=InnoDB
-
-innodb_log_buffer_size=32M
-innodb_buffer_pool_size=256M
-innodb_log_file_size=32M
-
-innodb_file_per_table=1
-
-#Max packets
-max_allowed_packet = 128M
-
-#Enable slow query log
-long_query_time=1
-slow_query_log=1
-slow_query_log_file=slow.log
 local_infile=1
 ###############################

--- a/.ahoy/docker-compose.common.yml
+++ b/.ahoy/docker-compose.common.yml
@@ -32,7 +32,7 @@ services:
   # DB node
   db:
     hostname: db
-    image: blinkreaction/mysql:5.5
+    image: wodby/mariadb:latest
     ports:
       - "3306"
     # MYSQL Credentials in mysql.env


### PR DESCRIPTION
This switches to the mariadb container (rather than the blinkreaction mysql) and removes a bunch of mysql configuration that was killing performance in docker. With this improvement, site installs and other heavy db operations should run relatively quickly in docker without needing to run through docker-machine, especially in linux.