### PR TITLE
Add results count to dkan admin views

### DIFF
--- a/modules/dkan/dkan_sitewide/dkan_sitewide.views_default.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.views_default.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * dkan_sitewide.views_default.inc

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.views_default.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.views_default.inc
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * dkan_sitewide.views_default.inc
@@ -114,6 +113,10 @@ function dkan_sitewide_views_default_views() {
   );
   $handler->display->display_options['style_options']['sticky'] = TRUE;
   $handler->display->display_options['style_options']['empty_table'] = TRUE;
+  /* Header: Global: Result summary */
+  $handler->display->display_options['header']['result']['id'] = 'result';
+  $handler->display->display_options['header']['result']['table'] = 'views';
+  $handler->display->display_options['header']['result']['field'] = 'result';
   /* No results behavior: Global: Unfiltered text */
   $handler->display->display_options['empty']['area_text_custom']['id'] = 'area_text_custom';
   $handler->display->display_options['empty']['area_text_custom']['table'] = 'views';
@@ -434,6 +437,10 @@ function dkan_sitewide_views_default_views() {
   );
   $handler->display->display_options['style_options']['sticky'] = TRUE;
   $handler->display->display_options['style_options']['empty_table'] = TRUE;
+  /* Header: Global: Result summary */
+  $handler->display->display_options['header']['result']['id'] = 'result';
+  $handler->display->display_options['header']['result']['table'] = 'views';
+  $handler->display->display_options['header']['result']['field'] = 'result';
   /* No results behavior: Global: Unfiltered text */
   $handler->display->display_options['empty']['area_text_custom']['id'] = 'area_text_custom';
   $handler->display->display_options['empty']['area_text_custom']['table'] = 'views';


### PR DESCRIPTION
Nice to know how many results you have when comparing content in various environments

## QA
- [x] Review `admin/content`, confirm you see `Displaying 1 - @ of @`
- [x] Review `admin/content/file`, confirm you see `Displaying 1 - @ of @`

Saving changelog update until next patch release.

## Reminders

- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
