### PR TITLE
Remove redundant debug output.

### DIFF
--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -903,7 +903,6 @@ function dkan_datastore_api_output($data_select, $results, $table, $fields, $res
   $return->limit = (int) $limit;
   $return->total = (int) $count;
   $return->records = $items;
-  $return->sql = dkan_datastore_api_debug($data_select);
   return $help + $success + array('result' => $return);
 }
 


### PR DESCRIPTION
Checking different datastore outputs on our sites show a sql.debug output.

## How to reproduce

Import a resource into the datastore. Check the API Url and find the sql-property, eg:

`,"sql":"SELECT t.*\nFROM \n{feeds_datastore_dkan_file_40390} t\nORDER BY t.feeds_flatstore_entry_id ASC\nLIMIT 10 OFFSET 0"}}`