### PR TITLE
Moving the "Adding New Content" page to main admin doc tree

### DIFF
--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -35,8 +35,10 @@ Appearance
    :maxdepth: 1
 
    account_access_and_setup
+   adding_new_content
+   admin_menu
    appearance
    data_and_content/index
    people/index
    structure
-   admin_menu
+


### PR DESCRIPTION
"Adding New Content" is vital but was previously buried two levels in; page deserves to be accessible in main admin doc tree
