### PR TITLE
Patch features to add new line after <?php

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -94,6 +94,8 @@ projects:
     version: '1.4'
   features:
     version: '2.10'
+    patch:
+      2765721: https://www.drupal.org/files/issues/features-blank-line-after-php-tag-2765721-0.patch
   features_roles_permissions:
     version: '1.2'
   feeds:


### PR DESCRIPTION
Coder now asks for a blank line between the initial `<?php` and any code. This patch to features fixes an issue where any generated feature files fail coder due to this new standard.

This patch was used to re-export the features in this commit: 5d8bd06887f7ddeb9c065684a3f2d53361a55d93 , see for example