### PR TITLE
Simplify background content on tests

### DIFF
--- a/test/behat.yml
+++ b/test/behat.yml
@@ -130,7 +130,9 @@ default:
       tags: ~@fixme
   extensions:
     Behat\MinkExtension:
-      goutte: []
+      goutte:
+        guzzle_parameters:
+          verify: false
 
       selenium2: []
 

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/DKANContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/DKANContext.php
@@ -1038,7 +1038,7 @@ public function iWaitForTextToDisappear($text)
     );
     $title->click();
   }
-    
+
   /**
    * Assert selector count in given region.
    *
@@ -1082,6 +1082,21 @@ public function iWaitForTextToDisappear($text)
 
     if (!$optionField->isSelected()) {
       throw new \Exception('Select option field with value|text "' . $option . '" is not selected in the select "' . $select . '"', $this->getSession());
+    }
+  }
+
+  /**
+   * @Given I hide the admin menu
+   */
+  public function iHideTheAdminMenu()
+  {
+    $selector = '#admin-menu';
+    // Does the admin-menu exist in the dom?
+    if (is_array($this->getSession()->evaluateScript("document.querySelector('$selector');"))) {
+      // Hide it so it does not overlap the item we are testing.
+      $this->getSession()->executeScript("document.querySelector('$selector').style.display = 'none';");
+    } else {
+      throw new \Exception("admin-menu not exist");
     }
   }
 

--- a/test/features/dataset.all.feature
+++ b/test/features/dataset.all.feature
@@ -16,29 +16,17 @@ Feature: Dataset Features
 
   Background:
     Given pages:
-      | name             | url                        |
-      | Datasets Search  | /search/type/dataset       |
+      | name             | url                    |
+      | Datasets Search  | /search/type/dataset   |
     Given users:
-      | name    | mail             | roles                |
-      | John    | john@example.com    | site manager         |
-      | Badmin  | admin@example.com   | site manager         |
-      | Gabriel | gabriel@example.com | editor               |
-      | Jaz     | jaz@example.com     | editor               |
-      | Katie   | katie@example.com   | content creator      |
-      | Martin  | martin@example.com  | editor               |
-      | Celeste | celeste@example.com | editor               |
+      | name    | mail             | roles        |
+      | John    | john@example.com | site manager |
     Given groups:
       | title    | author  | published |
-      | Group 01 | Badmin  | Yes       |
-      | Group 02 | Badmin  | Yes       |
-      | Group 03 | Badmin  | No        |
+      | Group 01 | John    | Yes       |
     And group memberships:
       | user    | group    | role on group        | membership status |
-      | Gabriel | Group 01 | administrator member | Active            |
-      | Katie   | Group 01 | member               | Active            |
-      | Jaz     | Group 01 | member               | Pending           |
-      | Admin   | Group 02 | administrator member | Active            |
-      | Celeste | Group 02 | member               | Active            |
+      | John    | Group 01 | administrator member | Active            |
     And "Tags" terms:
       | name     |
       | Health 2 |
@@ -48,17 +36,13 @@ Feature: Dataset Features
       | csv 2  |
       | html 2 |
     And datasets:
-      | title                | publisher | author  | published        | tags     | description |
-      | DKANTest Dataset 01 | Group 01  | Gabriel | Yes              | Health 2 | Test        |
-      | DKANTest Dataset 02 | Group 01  | Gabriel | Yes              | Gov 2    | Test        |
-      | DKANTest Dataset 03 | Group 01  | Katie   | Yes              | Health 2 | Test        |
-      | DKANTest Dataset 04 | Group 02  | Celeste | No               | Gov 2    | Test        |
-      | DKANTest Dataset 05 | Group 01  | Katie   | No               | Gov 2    | Test        |
+      | title               | publisher | author  | published        | tags     | description |
+      | DKANTest Dataset 01 | Group 01  | John    | Yes              | Health 2 | Test        |
+      | DKANTest Dataset 02 | Group 01  | John    | Yes              | Gov 2    | Test        |
     And resources:
       | title       | publisher | format | author | published | dataset             | description |
-      | Resource 01 | Group 01  | csv 2  | Katie  | Yes       | DKANTest Dataset 01 |             |
-      | Resource 02 | Group 01  | html 2 | Katie  | Yes       | DKANTest Dataset 01 |             |
-      | Resource 03 | Group 01  | html 2 | Katie  | Yes       | DKANTest Dataset 02 |             |
+      | Resource 01 | Group 01  | csv 2  | John   | Yes       | DKANTest Dataset 01 |             |
+      | Resource 02 | Group 01  | html 2 | John   | Yes       | DKANTest Dataset 02 |             |
 
    @fixme @dkanBug
     # TODO: Datasets not shown on homepage currently
@@ -74,8 +58,8 @@ Feature: Dataset Features
     When I am on the homepage
     And I click "Datasets"
     And I search for "DKANTest"
-    Then I should see "3 results"
-    And I should see "3" items in the "datasets" region
+    Then I should see "2 results"
+    And I should see "2" items in the "datasets" region
 
   @dataset_all_3
   Scenario: Order datasets by "Date changed" by oldest first.
@@ -132,8 +116,8 @@ Feature: Dataset Features
     When I am on "Datasets Search" page
     And I fill in "DKANTest" for "Search" in the "datasets" region
     And I press "Apply"
-    Then I should see "3 results"
-    And I should see "3" items in the "datasets" region
+    Then I should see "2 results"
+    And I should see "2" items in the "datasets" region
     When I press "Reset"
     Then I should see all published search content
     # Then I should see "7 results"
@@ -146,7 +130,7 @@ Feature: Dataset Features
     ## Uncomment this if you wanna use selenium.
     # Then I click on the text "Tags"
     # And I wait for "1" seconds
-    Then I should see "Health 2 (2)" in the "filter by tag" region
+    Then I should see "Health 2 (1)" in the "filter by tag" region
     Then I should see "Gov 2 (1)" in the "filter by tag" region
 
   # TODO: make sure it works when we don't have default content on.
@@ -157,7 +141,7 @@ Feature: Dataset Features
     # When I click on the text "Format"
     # And I wait for "1" seconds
     Then I should see "csv 2 (1)" in the "filter by resource format" region
-    And I should see "html 2 (2)" in the "filter by resource format" region
+    And I should see "html 2 (1)" in the "filter by resource format" region
 
   # dataset_all_10/author facet removed. See GetDKAN/dkan#2033
 
@@ -167,13 +151,13 @@ Feature: Dataset Features
     When I am on "Datasets Search" page
     And I search for "DKANTest"
     And I press "Apply"
-    Then I should see "3 results"
-    And I should see "3" items in the "datasets" region
+    Then I should see "2 results"
+    And I should see "2" items in the "datasets" region
     ## Uncomment this if you wanna use selenium.
     # Then I click on the text "Tags"
     When I click "Health 2" in the "filter by tag" region
-    Then I should see "2 results"
-    And I should see "2" items in the "datasets" region
+    Then I should see "1 results"
+    And I should see "1" items in the "datasets" region
 
   # TODO: make sure it works when we don't have default content on.
   @dataset_all_12
@@ -181,8 +165,8 @@ Feature: Dataset Features
     When I am on "Datasets Search" page
     And I search for "DKANTest"
     And I press "Apply"
-    Then I should see "3 results"
-    And I should see "3" items in the "datasets" region
+    Then I should see "2 results"
+    And I should see "2" items in the "datasets" region
     ## Uncomment this if you wanna use selenium.
     # Then I click on the text "Format"
     # Then I wait for "1" seconds

--- a/test/features/datastore.feature
+++ b/test/features/datastore.feature
@@ -99,9 +99,11 @@ Feature: Datastore
   @api @noworkflow @javascript @datastore
   Scenario: Import a csv tab delimited file.
     Given I am logged in as a user with the "site manager" role
+    And I hide the admin menu
     And I am on "dataset/dataset-02"
     When I click "Resource 03"
     And I click "Edit"
+    And I wait for "Remote file"
     And I attach the drupal file "dkan/TAB_delimiter_large_raw_number.csv" to "files[field_upload_und_0]"
     #And I select "tab" from "Delimiter"
     And I press "Save"

--- a/test/features/group.admin.feature
+++ b/test/features/group.admin.feature
@@ -18,44 +18,24 @@ Feature: Site managers administer groups
     Given users:
       | name    | mail                | roles        |
       | John    | john@example.com    | site manager |
-      | Badmin  | admin@example.com   | site manager |
       | Gabriel | gabriel@example.com | editor       |
       | Jaz     | jaz@example.com     | editor       |
       | Katie   | katie@example.com   | editor       |
-      | Martin  | martin@example.com  | editor       |
-      | Celeste | celeste@example.com | editor       |
     Given groups:
       | title    | author | published |
       | Group 01 | John   | Yes       |
       | Group 02 | John   | Yes       |
       | Group 03 | John   | No        |
-    And "Tags" terms:
-      | name    |
-      | world   |
-      | results |
     And group memberships:
       | user    | group    | role on group        | membership status |
       | Gabriel | Group 01 | administrator member | Active            |
       | Katie   | Group 01 | member               | Active            |
       | Jaz     | Group 01 | member               | Pending           |
-      | Celeste | Group 02 | member               | Active            |
-    And "Tags" terms:
-      | name     |
-      | price    |
-      | election |
     And datasets:
-      | title      | publisher | tags       | author  | published | description                |
-      | Dataset 01 | Group 01  | world      | Katie   | Yes       | Increase of toy prices     |
-      | Dataset 02 | Group 01  | world      | Katie   | No        | Cost of oil in January     |
-      | Dataset 03 | Group 01  | results    | Gabriel | Yes       | Election results           |
-    And "format" terms:
-      | name |
-      | csv  |
-      | zip |
-    And resources:
-      | title       | publisher | format | author | published | dataset    | description |
-      | Resource 01 | Group 01  | csv    | Katie  | Yes       | Dataset 01 |             |
-      | Resource 02 | Group 01  | zip    | Katie  | Yes       | Dataset 01 |             |
+      | title      | publisher | author  | published | description                |
+      | Dataset 01 | Group 01  | Katie   | Yes       | Increase of toy prices     |
+      | Dataset 02 | Group 01  | Katie   | No        | Cost of oil in January     |
+      | Dataset 03 | Group 01  | Gabriel | Yes       | Election results           |
 
   @group_admin_01
   Scenario: Create group
@@ -195,7 +175,7 @@ Feature: Site managers administer groups
     And I am on "Group 01" page
     And I click "Group"
     When I click "People"
-    Then I should see "Total content: 5"
+    Then I should see "Total content: 3"
 
   @group_admin_14
   Scenario: View list of unpublished groups

--- a/test/features/group.author.feature
+++ b/test/features/group.author.feature
@@ -17,45 +17,15 @@ Feature: Site Manager administer groups
       | Content   | /admin/content/ |
     Given users:
       | name    | mail                | roles                |
-      | John    | john@example.com    | site manager         |
-      | Badmin  | admin@example.com   | site manager         |
-      | Gabriel | gabriel@example.com | editor               |
-      | Jaz     | jaz@example.com     | editor               |
+      | Juan    | juan@example.com    | site manager         |
       | Katie   | katie@example.com   | content creator      |
-      | Martin  | martin@example.com  | editor               |
-      | Celeste | celeste@example.com | editor               |
     Given groups:
       | title    | author | published |
-      | Group 01 | Badmin | Yes       |
-      | Group 02 | Badmin | Yes       |
-      | Group 03 | Badmin | No        |
-    And "Tags" terms:
-      | name    |
-      | world   |
-      | results |
+      | Group 01 | Juan   | Yes       |
+      | Group 02 | Juan   | Yes       |
     And group memberships:
       | user    | group    | role on group        | membership status |
-      | Gabriel | Group 01 | administrator member | Active            |
       | Katie   | Group 01 | member               | Active            |
-      | Jaz     | Group 01 | member               | Pending           |
-      | Celeste | Group 02 | member               | Active            |
-    And "Tags" terms:
-      | name     |
-      | price    |
-      | election |
-    And datasets:
-      | title      | publisher | tags       | author  | published | description                |
-      | Dataset 01 | Group 01  | world      | Katie   | Yes       | Increase of toy prices     |
-      | Dataset 02 | Group 01  | world      | Katie   | No        | Cost of oil in January     |
-      | Dataset 03 | Group 01  | results    | Gabriel | Yes       | Election results           |
-    And "format" terms:
-      | name |
-      | csv  |
-      | zip |
-    And resources:
-      | title       | publisher | format | author | published | dataset    | description |
-      | Resource 01 | Group 01  | csv    | Katie  | Yes       | Dataset 01 |             |
-      | Resource 02 | Group 01  | zip    | Katie  | Yes       | Dataset 01 |             |
 
   @api
   Scenario: Request group membership

--- a/test/features/group.editor.feature
+++ b/test/features/group.editor.feature
@@ -31,9 +31,9 @@ Feature: Site Manager administer groups
       | Gabriel | Group A | administrator member | Active            |
       | Katie   | Group A | member               | Active            |
       | Jaz     | Group A | member               | Pending           |
-    And datasets:
-      | title  | publisher | author  | published | description |
-      | GC1    | Group A   | Gabriel | Yes       | --test--    |
+    And resources:
+      | title    | publisher | format | author | published | description |
+      | GER1     | Group A   | csv    | Katie  | Yes       |             |
 
   Scenario: Edit group as group administrator
     Given I am logged in as "Gabriel"
@@ -147,9 +147,9 @@ Feature: Site Manager administer groups
     When I click "People"
     Then I should see "Total content: 1"
 
-  Scenario: Edit dataset content created by others on group as editor
+  Scenario: Edit resource content created by others on group as editor
     Given I am logged in as "Martin"
-    And I am on "GC1" page
+    And I am on "GER1" page
     Then I should see "Edit"
 
   Scenario: Show correct number of groups to which user belongs

--- a/test/features/group.editor.feature
+++ b/test/features/group.editor.feature
@@ -25,7 +25,6 @@ Feature: Site Manager administer groups
       | title    | author  | published |
       | Group A  | Gabriel | Yes       |
       | Group B  | Katie   | Yes       |
-      | Group C  | Gabriel | No        |
     And group memberships:
       | user    | group   | role on group        | membership status |
       | Gabriel | Group A | administrator member | Active            |

--- a/test/features/group.editor.feature
+++ b/test/features/group.editor.feature
@@ -17,89 +17,67 @@ Feature: Site Manager administer groups
       | Content   | /admin/content/ |
     Given users:
       | name    | mail                | roles                |
-      | John    | john@example.com    | site manager         |
-      | Badmin  | admin@example.com   | site manager         |
       | Gabriel | gabriel@example.com | content creator      |
       | Jaz     | jaz@example.com     | editor               |
       | Katie   | katie@example.com   | content creator      |
       | Martin  | martin@example.com  | editor               |
-      | Celeste | celeste@example.com | editor               |
     Given groups:
-      | title    | author | published |
-      | Group 01 | Badmin | Yes       |
-      | Group 02 | Badmin | Yes       |
-      | Group 03 | Badmin | No        |
-    And "Tags" terms:
-      | name    |
-      | world   |
-      | results |
+      | title    | author  | published |
+      | Group A  | Gabriel | Yes       |
+      | Group B  | Katie   | Yes       |
+      | Group C  | Gabriel | No        |
     And group memberships:
-      | user    | group    | role on group        | membership status |
-      | Gabriel | Group 01 | administrator member | Active            |
-      | Katie   | Group 01 | member               | Active            |
-      | Jaz     | Group 01 | member               | Pending           |
-      | Celeste | Group 02 | member               | Active            |
-    And "Tags" terms:
-      | name     |
-      | price    |
-      | election |
+      | user    | group   | role on group        | membership status |
+      | Gabriel | Group A | administrator member | Active            |
+      | Katie   | Group A | member               | Active            |
+      | Jaz     | Group A | member               | Pending           |
     And datasets:
-      | title      | publisher | tags       | author  | published | description                |
-      | Dataset 01 | Group 01  | world      | Katie   | Yes       | Increase of toy prices     |
-      | Dataset 02 | Group 01  | world      | Katie   | No        | Cost of oil in January     |
-      | Dataset 03 | Group 01  | results    | Gabriel | Yes       | Election results           |
-    And "format" terms:
-      | name |
-      | csv  |
-      | zip |
-    And resources:
-      | title       | publisher | format | author | published | dataset    | description |
-      | Resource 01 | Group 01  | csv    | Katie  | Yes       | Dataset 01 |             |
-      | Resource 02 | Group 01  | zip    | Katie  | Yes       | Dataset 01 |             |
+      | title  | publisher | author  | published | description |
+      | GC1    | Group A   | Gabriel | Yes       | --test--    |
 
   Scenario: Edit group as group administrator
     Given I am logged in as "Gabriel"
-    And I am on "Group 01" page
+    And I am on "Group A" page
     When I click "Edit"
     And I fill in "Description" with "Edited page"
     And I press "Save"
-    Then I should see "Group Group 01 has been updated"
-    And I should be on the "Group 01" page
+    Then I should see "Group Group A has been updated"
+    And I should be on the "Group A" page
 
   Scenario: Add group member on a group as group administrator
     Given I am logged in as "Gabriel"
-    And I am on "Group 01" page
+    And I am on "Group A" page
     And I click "Group"
     And I click "Add people"
     #When I fill in the "member" form for "Martin"
     When I fill in "Martin" for "User name"
     And I press "Add users"
-    Then I should see "Martin has been added to the group Group 01"
-    When I am on "Group 01" page
+    Then I should see "Martin has been added to the group Group A"
+    When I am on "Group A" page
     And I click "Members"
     Then I should see "Martin" in the "group members" region
 
   Scenario: Remove group member from a group as group administrator
     Given I am logged in as "Gabriel"
-    And I am on "Group 01" page
+    And I am on "Group A" page
     And I click "Group"
     And I click "People"
     And I click "remove" in the "Katie" row
     And I press "Remove"
     Then I should see "The membership was removed"
-    When I am on "Group 01" page
+    When I am on "Group A" page
     And I click "Members"
     Then I should not see "Katie" in the "group members" region
 
   Scenario: I should not be able to edit a group that I am not a member of
     Given I am logged in as "Gabriel"
-    When I am on "Group 02" page
+    When I am on "Group B" page
     Then I should not see the link "Edit"
     And I should not see the link "fa-users"
 
   Scenario: Edit membership status of group member as group administrator
     Given I am logged in as "Gabriel"
-    And I am on "Group 01" page
+    And I am on "Group A" page
     And I click "Group"
     And I click "People"
     And I click "edit" in the "Katie" row
@@ -109,7 +87,7 @@ Feature: Site Manager administer groups
 
   Scenario: Edit group roles of group member as group administrator
     Given I am logged in as "Gabriel"
-    And I am on "Group 01" page
+    And I am on "Group A" page
     And I click "Group"
     And I click "People"
     And I click "edit" in the "Katie" row
@@ -119,21 +97,21 @@ Feature: Site Manager administer groups
 
   Scenario: View permissions of group as group administrator
     Given I am logged in as "Gabriel"
-    And I am on "Group 01" page
+    And I am on "Group A" page
     And I click "Group"
     When I click "Permissions (read-only)"
     Then I should see the list of permissions for the group
 
   Scenario: View group roles of group as group administrator
     Given I am logged in as "Gabriel"
-    And I am on "Group 01" page
+    And I am on "Group A" page
     And I click "Group"
     When I click "Roles (read-only)"
-    Then I should see the list of roles for the group "Group 01"
+    Then I should see the list of roles for the group "Group A"
 
   Scenario Outline: View group role permissions of group as administrator
     Given I am logged in as "Gabriel"
-    And I am on "Group 01" page
+    And I am on "Group A" page
     And I click "Group"
     When I click "Permissions (read-only)"
     Then I should see the list of permissions for "<role name>" role
@@ -146,7 +124,7 @@ Feature: Site Manager administer groups
 
   Scenario: Approve new group members as group administrator
     Given I am logged in as "Gabriel"
-    And I am on "Group 01" page
+    And I am on "Group A" page
     And I click "Group"
     And I click "People"
     And I click "edit" in the "Jaz" row
@@ -157,25 +135,25 @@ Feature: Site Manager administer groups
 
   Scenario: View the number of members on group as group administrator
     Given I am logged in as "Gabriel"
-    And I am on "Group 01" page
+    And I am on "Group A" page
     And I click "Group"
     When I click "People"
-    Then I should see "Total members: 4"
+    Then I should see "Total members: 3"
 
   Scenario: View the number of content on group as group administrator
     Given I am logged in as "Gabriel"
-    And I am on "Group 01" page
+    And I am on "Group A" page
     And I click "Group"
     When I click "People"
-    Then I should see "Total content: 5"
+    Then I should see "Total content: 1"
 
   Scenario: Edit dataset content created by others on group as editor
     Given I am logged in as "Martin"
-    And I am on "Dataset 01" page
+    And I am on "GC1" page
     Then I should see "Edit"
 
   Scenario: Show correct number of groups to which user belongs
-    Given I am logged in as "Celeste"
+    Given I am logged in as "Katie"
     When I am on "user"
-    Then I should see "1 Groups" in the "content" region
+    Then I should see "2 Groups" in the "content" region
 

--- a/test/features/leaflet_draw_widget.feature
+++ b/test/features/leaflet_draw_widget.feature
@@ -22,6 +22,7 @@ Feature: Leaflet Map Widget
     And I am logged in as "Gabriel"
     And I visit the "This is a test dataset" page
     And I click "Edit"
+    And I hide the admin menu
     Then I should see "Spatial / Geographical Coverage Area"
     And I should see the link "Map" in the "dataset spatial" region
     And I should see the link "GeoJSON" in the "dataset spatial" region

--- a/test/features/theme.admin.feature
+++ b/test/features/theme.admin.feature
@@ -11,12 +11,13 @@ Feature: Theme
       | name    | mail                | roles                |
       | John    | john@example.com    | administrator         |
       | Site Manager | sitemanager@example.com | site manager |
-  
-  @noworkflow 
+
+  @noworkflow
   Scenario: Add custom logo
     Given I am logged in as "John"
     And I am on "Settings" page
     Then I should see "Logo image settings"
+    And I hide the admin menu
     And I uncheck "Use the default logo"
     And I attach the drupal file "dkan/dkan_logo.png" to "files[logo_upload]"
     And I wait for the file upload to finish
@@ -35,9 +36,10 @@ Feature: Theme
     Then I wait for "3" seconds
     Then I should see "The configuration options have been saved"
 
-  @noworkflow 
+  @noworkflow
   Scenario: Add custom site information
     Given I am logged in as "Site Manager"
+    And I hide the admin menu
     Then I am on "Settings" page
     And I should see "E-mail address"
     And I fill in "Site name" with "sitename test"

--- a/test/features/user.admin.feature
+++ b/test/features/user.admin.feature
@@ -12,36 +12,9 @@ Feature: User
     Given users:
       | name    | mail                | roles                |
       | John    | john@example.com    | site manager         |
-      | Badmin  | admin@example.com   | site manager         |
       | aadmin  | admin@example.com   | administrator        |
-      | Gabriel | gabriel@example.com | content creator      |
       | Jaz     | jaz@example.com     | editor               |
       | Katie   | katie@example.com   | content creator      |
-      | Martin  | martin@example.com  | editor               |
-      | Celeste | celeste@example.com | editor               |
-    Given groups:
-      | title    | author  | published |
-      | Group 01 | Badmin  | Yes       |
-      | Group 02 | Badmin  | Yes       |
-      | Group 03 | Badmin  | No        |
-    And group memberships:
-      | user    | group    | role on group        | membership status |
-      | Gabriel | Group 01 | administrator member | Active            |
-      | Katie   | Group 01 | member               | Active            |
-      | Jaz     | Group 01 | member               | Pending           |
-      | Admin   | Group 02 | administrator member | Active            |
-      | Celeste | Group 02 | member               | Active            |
-    And "Tags" terms:
-      | name    |
-      | world   |
-      | results |
-    And datasets:
-      | title      | publisher | author  | published        | tags     | description |
-      | Dataset 01 | Group 01  | Katie   | Yes              | world    | Test        |
-      | Dataset 02 | Group 01  | Katie   | No               | world    | Test        |
-      | Dataset 03 | Group 01  | Gabriel | Yes              | results  | Test        |
-      | Dataset 04 | Group 01  | Katie   | Yes              | world    | Test        |
-
 
   Scenario: Edit any user account
     Given I am logged in as "John"

--- a/test/features/user.all.feature
+++ b/test/features/user.all.feature
@@ -11,32 +11,18 @@ Feature: User
     Given users:
       | name    | mail                | roles                | pass     |
       | John    | john@example.com    | site manager         | johnpass |
-      | Badmin  | admin@example.com   | site manager         | pass     |
-      | Gabriel | gabriel@example.com | content creator      | pass     |
-      | Jaz     | jaz@example.com     | editor               | pass     |
       | Katie   | katie@example.com   | content creator      | pass     |
-      | Martin  | martin@example.com  | editor               | pass     |
-      | Celeste | celeste@example.com | editor               | pass     |
     Given groups:
       | title    | author  | published |
-      | Group 01 | Badmin  | Yes       |
-      | Group 02 | Badmin  | Yes       |
-      | Group 03 | Badmin  | No        |
+      | Group 01 | John    | Yes       |
     And group memberships:
       | user    | group    | role on group        | membership status |
-      | Gabriel | Group 01 | administrator member | Active            |
+      | John    | Group 01 | administrator member | Active            |
       | Katie   | Group 01 | member               | Active            |
-      | Jaz     | Group 01 | member               | Pending           |
-      | Admin   | Group 02 | administrator member | Active            |
-      | Celeste | Group 02 | member               | Active            |
-    And "Tags" terms:
-      | name    |
-      | world   |
-      | results |
     And datasets:
-      | title      | publisher | author  | published        | tags     | description |
-      | Dataset 01 | Group 01  | Katie   | Yes              | world    | Test        |
-      | Dataset 02 | Group 01  | Katie   | Yes              | world    | Test        |
+      | title      | publisher | author  | published        | description |
+      | Dataset 01 | Group 01  | Katie   | Yes              | Test        |
+      | Dataset 02 | Group 01  | Katie   | Yes              | Test        |
 
   @user_all_01 @login
   Scenario: Login

--- a/test/features/user.site_manager.feature
+++ b/test/features/user.site_manager.feature
@@ -44,6 +44,7 @@ Feature: User command center links for site manager role.
     And I click "Page"
     Then I should see "Create Page"
     When I fill in "title" with "My new page"
+    And I hide the admin menu
     And I select the radio button "Boxton" with the id "edit-layout-radix-boxton"
     And I press "Save"
     And I wait for "View"


### PR DESCRIPTION
### Background simplification
Often tests fail due to **integrity constraint violations** because we are creating more content than needed for many test scenarios and the create/teardown process is not keeping up with the speed of the tests. Lets only create what is needed for the tests and simplify the backgrounds. 

### Admin menu gets in the way
Recently tests are failing due to the admin menu overlaying the field/text that a test is trying to use/view. Adding wait steps to allow the menu to snap to the top do not work so adding a context to hide the menu when it is in the way.

### Ignore SSL verification
Updating behat.yml to not worry about self-signed SSL when running tests
