### PR TITLE
2336 schema display

### DIFF
--- a/modules/dkan/dkan_data_dictionary/dkan_data_dictionary.features.field_instance.inc
+++ b/modules/dkan/dkan_data_dictionary/dkan_data_dictionary.features.field_instance.inc
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * dkan_data_dictionary.features.field_instance.inc
@@ -94,9 +93,9 @@ function dkan_data_dictionary_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'above',
-        'module' => 'text',
+        'module' => 'dkan_data_dictionary',
         'settings' => array(),
-        'type' => 'text_default',
+        'type' => 'text_schema_table',
         'weight' => 24,
       ),
       'search_result' => array(

--- a/modules/dkan/dkan_data_dictionary/dkan_data_dictionary.module
+++ b/modules/dkan/dkan_data_dictionary/dkan_data_dictionary.module
@@ -74,38 +74,65 @@ function dkan_data_dictionary_field_formatter_view($entity_type, $entity, $field
 
       if (json_last_error() === JSON_ERROR_NONE && property_exists($schema, 'fields')) {
         // Parse the schema array and build the table.
+        $headers = array();
         $rows = array();
 
+        // Build our collection of unique table headers.
         foreach ($schema->fields as $field) {
-          $name = (property_exists($field, 'name')) ? $field->name : '';
-          $type = (property_exists($field, 'type')) ? $field->type : '';
-          $format = (property_exists($field, 'format')) ? $field->format : 'default';
-          $description = (property_exists($field, 'description')) ? $field->description : '';
-          $constraints = '';
+          $item = (array) $field;
+          $new_keys = array_keys($item);
+          $headers = array_merge($headers, array_diff($new_keys, $headers));
+        }
 
-          if (property_exists($field, 'constraints')) {
-            $array = (array) $field->constraints;
+        // Check the set of values for each field description against all table headers.
+        foreach ($schema->fields as $field) {
+          $row = array();
+          $item = (array) $field;
 
-            $constraints = implode(', ', array_map(
-              function ($v, $k) { return sprintf("%s = %s", $k, $v); },
-              $array,
-              array_keys($array)
-            ));
+          foreach ($headers as $header) {
+            $column = '';
 
+            // Compare all properties for the current field definition ($item)
+            // against each table header ($headers).
+            // Default behavior:
+            // If the $item contains a value for the $header return it.
+            // If the $item does not contain a value for the $header return ''.
+            // Special cases can be defined using the switch statement below.
+            switch ($header) {
+              case 'format':
+                $column = (array_key_exists($header, $item)) ? $item[$header] : 'default';
+                break;
+
+              case 'constraints':
+                if (array_key_exists($header, $item)) {
+                  $constraints = (array) $item[$header];
+
+                  $column = implode(', ', array_map(
+                    function ($v, $k) { return sprintf("%s = %s", $k, $v); },
+                    $constraints,
+                    array_keys($constraints)
+                  ));
+                }
+                else {
+                  $column = '';
+                }
+                break;
+
+              default:
+                $column = (array_key_exists($header, $item)) ? $item[$header] : '';
+                break;
+            }
+
+            $row[] = $column;
           }
 
-          $rows[] = array($name, $type, $format, $description, $constraints);
+          $rows[] = $row;
+
         }
 
         $elements[$delta] = array(
           '#theme' => 'table',
-          '#header' => array(
-            t('Name'),
-            t('Type'),
-            t('Format'),
-            t('Description'),
-            t('Constraints'),
-          ),
+          '#header' => array_map('t', array_map('ucfirst', $headers)),
           '#rows' => $rows,
         );
 

--- a/modules/dkan/dkan_data_dictionary/dkan_data_dictionary.module
+++ b/modules/dkan/dkan_data_dictionary/dkan_data_dictionary.module
@@ -15,6 +15,32 @@ function dkan_data_dictionary_form_resource_node_form_alter(&$form, &$form_state
   $form['#attached']['libraries_load'][] = array('jsoneditor');
   $form['#attached']['js'][] = drupal_get_path('module', 'dkan_data_dictionary') . '/js/editor.js';
   drupal_add_css(drupal_get_path('module', 'dkan_data_dictionary') . '/css/dkan_data_dictionary.css');
+  $form['#validate'][] = 'dkan_data_dictionary_validate_resource';
+}
+
+/**
+ * Custom validation function for resource node
+ */
+function dkan_data_dictionary_validate_resource($form, &$form_state) {
+  $language = $form_state['values']['language'];
+  foreach ($form_state['values']['field_describedby_schema'][$language] as $item) {
+    if ($item['value'] == "{}") {
+      // Default "empty" value for the JSON editor.
+      return;
+    }
+    else {
+      $schema = json_decode($item['value']);
+
+      if (json_last_error() !== JSON_ERROR_NONE) {
+        form_set_error('field_describedby_schema', t('Schema provided is not valid JSON.'));
+        return;
+      }
+      elseif (!property_exists($schema, 'fields')) {
+        form_set_error('field_describedby_schema', t('Schema provided does not match expected format - unable to locate fields object.'));
+        return;
+      }
+    }
+  }
 }
 
 /**

--- a/modules/dkan/dkan_data_dictionary/dkan_data_dictionary.module
+++ b/modules/dkan/dkan_data_dictionary/dkan_data_dictionary.module
@@ -64,6 +64,12 @@ function dkan_data_dictionary_field_formatter_view($entity_type, $entity, $field
 
   if ($display['type'] == 'text_schema_table') {
     foreach ($items as $delta => $item) {
+      if ($item['value'] === '{}' || $item['value'] === '') {
+        // If this field value is empty unset it and skip display processing.
+        unset($items[$delta]);
+        continue;
+      }
+
       $schema = json_decode($item['value']);
 
       if (json_last_error() === JSON_ERROR_NONE && property_exists($schema, 'fields')) {

--- a/modules/dkan/dkan_data_dictionary/dkan_data_dictionary.module
+++ b/modules/dkan/dkan_data_dictionary/dkan_data_dictionary.module
@@ -42,3 +42,75 @@ function dkan_data_dictionary_libraries_info() {
   );
   return $libraries;
 }
+
+/**
+* Implements hook_field_formatter_info().
+*/
+function dkan_data_dictionary_field_formatter_info() {
+  return array(
+    'text_schema_table' => array(
+      'label' => t('Schema Table'),
+      'field types' => array('text_long'),
+    ),
+  );
+}
+
+/**
+ * Implements hook_field_formatter_view().
+ */
+function dkan_data_dictionary_field_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display) {
+  $settings = $display['settings'];
+  $elements = array();
+
+  if ($display['type'] == 'text_schema_table') {
+    foreach ($items as $delta => $item) {
+      $schema = json_decode($item['value']);
+
+      if (json_last_error() === JSON_ERROR_NONE && property_exists($schema, 'fields')) {
+        // Parse the schema array and build the table.
+        $rows = array();
+
+        foreach ($schema->fields as $field) {
+          $name = (property_exists($field, 'name')) ? $field->name : '';
+          $type = (property_exists($field, 'type')) ? $field->type : '';
+          $format = (property_exists($field, 'format')) ? $field->format : 'default';
+          $description = (property_exists($field, 'description')) ? $field->description : '';
+          $constraints = '';
+
+          if (property_exists($field, 'constraints')) {
+            $array = (array) $field->constraints;
+
+            $constraints = implode(', ', array_map(
+              function ($v, $k) { return sprintf("%s = %s", $k, $v); },
+              $array,
+              array_keys($array)
+            ));
+
+          }
+
+          $rows[] = array($name, $type, $format, $description, $constraints);
+        }
+
+        $elements[$delta] = array(
+          '#theme' => 'table',
+          '#header' => array(
+            t('Name'),
+            t('Type'),
+            t('Format'),
+            t('Description'),
+            t('Constraints'),
+          ),
+          '#rows' => $rows,
+        );
+
+      }
+      else {
+        // If the supplied value isn't valid JSON or it is valid JSON but
+        // isn't a schema containing fields - simply output the raw text.
+        $elements[$delta] = array('#markup' => $item['value']);
+      }
+    }
+  }
+
+  return $elements;
+}

--- a/modules/dkan/dkan_data_dictionary/dkan_data_dictionary.module
+++ b/modules/dkan/dkan_data_dictionary/dkan_data_dictionary.module
@@ -123,17 +123,24 @@ function dkan_data_dictionary_field_formatter_view($entity_type, $entity, $field
                 break;
             }
 
-            $row[] = $column;
+            $row[] = array('data' => $column, 'class' => array('json-schema-item', 'json-schema-' . $header));
+
           }
 
           $rows[] = $row;
 
         }
 
+        // Format headers.
+        foreach ($headers as $key => $header) {
+          $headers[$key] = array('data' => t(ucfirst($header)), 'class' => array('json-schema-item', 'json-schema-' . $header));
+        }
+
         $elements[$delta] = array(
           '#theme' => 'table',
-          '#header' => array_map('t', array_map('ucfirst', $headers)),
+          '#header' => $headers,
           '#rows' => $rows,
+          '#attributes' => array('class' => array('json-schema')),
         );
 
       }

--- a/themes/nuboot_radix/assets/css/nuboot_radix.style.css
+++ b/themes/nuboot_radix/assets/css/nuboot_radix.style.css
@@ -9339,6 +9339,12 @@ body.maintenance-page .form-actions .media-widget > a:active:first-child,
 p.dkan-profile-page-user-name {
   display: inline-block; }
 
+.node-resource .field-name-field-describedby-spec {
+  margin-bottom: 20px; }
+
+.node-resource .field-name-field-describedby-schema table.json-schema {
+  margin-top: 0; }
+
 .table-select-processed .checkbox input[type="checkbox"],
 .permissions-processed .checkbox input[type="checkbox"] {
   margin-left: 0px; }

--- a/themes/nuboot_radix/scss/components/_dkan.scss
+++ b/themes/nuboot_radix/scss/components/_dkan.scss
@@ -63,4 +63,16 @@
 // Move this to dkan_sitewide_profile_page.css.
 p.dkan-profile-page-user-name {
   display: inline-block;
-}   
+}
+
+.node-resource {
+  .field-name-field-describedby-spec {
+    margin-bottom: 20px;
+  }
+
+  .field-name-field-describedby-schema {
+    table.json-schema {
+      margin-top: 0;
+    }
+  }
+}


### PR DESCRIPTION
This adds a table display for the field_describedby_schema JSON field. If the value supplied for this field is an empty JSON object or an empty string altogether, the field will not be displayed. If the value supplied is valid JSON and matches the sample format below, it will be converted to a table:

```
{
  "fields": [
    {
      "name": "Name",
      "type": "string",
      "description": "User’s name"
    },
    {
      "name": "Email",
      "type": "string",
      "format": "email",
      "description": "User’s email"
    },
    {
      "name": "Age",
      "type": "integer",
      "description": "User’s age",
      "constraints": {
        "minimum": 18
      }
    }
  ]
}
```

The first item in the supplied JSON object must be a fields collection. If the supplied JSON object doesn't contain a fields collection as the first item a validation check will notify users with an error message.

## QA Steps

- [ ] Create a new Resource
- [ ] Scroll down to the Data Dictionary fieldset
- [ ] Click on JSON Schema
- [ ] Paste in the JSON code above
- [ ] View the resource, you should see a table display formatted like the example image below

![screenshot of dkan 1](https://user-images.githubusercontent.com/21045418/36346126-c3fec0ac-13f5-11e8-8587-5b1aa7467b61.jpg)