### PR TITLE
Control datastore via REST API

### DIFF
--- a/modules/dkan/dkan_datastore/dkan_datastore.module
+++ b/modules/dkan/dkan_datastore/dkan_datastore.module
@@ -12,6 +12,120 @@ use \Dkan\Datastore\Manager\Factory;
 use \Dkan\Datastore\Resource;
 
 /**
+ * Implements hook_services_resources().
+ */
+function dkan_datastore_services_resources() {
+  return array(
+    'datastore' => array(
+      'operations' => array(
+        'retrieve' => array(
+          'help' => 'Retrieve information about a datastore',
+          'file' => array('type' => 'inc', 'module' => 'dkan_datastore', 'name' => 'resources/dkan_datastore_resource'),
+          'callback' => '_dkan_datastore_resource_retrieve',
+          'args' => array(
+            array(
+              'name' => 'resource_nid',
+              'optional' => FALSE,
+              'source' => array('path' => 0),
+              'type' => 'int',
+              'description' => 'The nid of the resource the datastore is connected to.',
+            ),
+          ),
+          'access callback' => '_dkan_datastore_resource_access',
+        ),
+        'create' => array(
+          'help' => 'Create a datastore for the given resource.',
+          'file' => array('type' => 'inc', 'module' => 'dkan_datastore', 'name' => 'resources/dkan_datastore_resource'),
+          'callback' => '_dkan_datastore_resource_create',
+          'args' => array(
+            array(
+              'name' => 'nid',
+              'optional' => FALSE,
+              'source' => array('path' => 0),
+              'type' => 'int',
+              'description' => 'The nid of the resource to configure a datastore for.',
+            ),
+            array(
+              'name' => 'manager',
+              'optional' => FALSE,
+              'type' => 'string',
+              'source' => 'data',
+              'description' => 'The machine name of the datastore manager that should be used.',
+            ),
+            array(
+              'name' => 'configuration',
+              'optional' => FALSE,
+              'type' => 'object',
+              'source' => 'data',
+              'description' => 'An array of keys and values with the specific configuration for the given manager.',
+            ),
+          ),
+          'access callback' => '_dkan_datastore_resource_access',
+        ),
+        /*'update' => array(
+          'help' => 'Update a node',
+          'file' => array('type' => 'inc', 'module' => 'services', 'name' => 'resources/node_resource'),
+          'callback' => '_node_resource_update',
+          'args' => array(
+            array(
+              'name' => 'nid',
+              'optional' => FALSE,
+              'source' => array('path' => 0),
+              'type' => 'int',
+              'description' => 'The nid of the node to update',
+            ),
+            array(
+              'name' => 'node',
+              'optional' => FALSE,
+              'source' => 'data',
+              'description' => 'The node data to update',
+              'type' => 'array',
+            ),
+          ),
+          'access callback' => '_node_resource_access',
+          'access arguments' => array('update'),
+          'access arguments append' => TRUE,
+        ),
+        'delete' => array(
+          'help' => t('Delete a node'),
+          'file' => array('type' => 'inc', 'module' => 'services', 'name' => 'resources/node_resource'),
+          'callback' => '_node_resource_delete',
+          'args' => array(
+            array(
+              'name' => 'nid',
+              'optional' => FALSE,
+              'source' => array('path' => 0),
+              'type' => 'int',
+              'description' => 'The nid of the node to delete',
+            ),
+          ),
+          'access callback' => '_node_resource_access',
+          'access arguments' => array('delete'),
+          'access arguments append' => TRUE,
+        ),*/
+      ),
+    ),
+  );
+
+  /*return array(
+    'dkan_datastore' => array(
+      'targeted_actions' => array(
+        'import' => array(
+
+        ),
+
+      'actions' => array(
+        'info' => array(
+          'file' => array('type' => 'inc', 'module' => 'dkan_datastore', 'name' => 'resources/dkan_datastore_resource'),
+          'callback' => '_dkan_datastore_resource_info',
+          'access callback' => '_dkan_datastore_resource_import_access',
+        ),
+      ),
+    ),
+  );*/
+}
+
+/**
  * Implements hook_menu().
  */
 function dkan_datastore_menu() {

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -247,8 +247,6 @@ function dkan_datastore_api_ctools_plugin_api($owner, $api) {
  */
 function dkan_datastore_api_services_resources() {
 
-  $datastore_node_type = dkan_datastore_node_type();
-
   return array(
     'dkan_datastore_search' => array(
       'index' => array(

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.module
@@ -3,6 +3,7 @@
 function dkan_datastore_fast_import_dkan_datastore_manager() {
   $info = new \Dkan\Datastore\Manager\Info(
     '\Dkan\Datastore\Manager\FastImport',
+    'fast',
     "Fast Import"
   );
 

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_simple_import/dkan_datastore_simple_import.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_simple_import/dkan_datastore_simple_import.module
@@ -3,6 +3,7 @@
 function dkan_datastore_simple_import_dkan_datastore_manager() {
   $info = new \Dkan\Datastore\Manager\Info(
     '\Dkan\Datastore\Manager\SimpleImport',
+    "simple",
     "Simple Import"
   );
 

--- a/modules/dkan/dkan_datastore/psr-4/Manager/Info.php
+++ b/modules/dkan/dkan_datastore/psr-4/Manager/Info.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Manager metadata.
+ */
 
 namespace Dkan\Datastore\Manager;
 

--- a/modules/dkan/dkan_datastore/psr-4/Manager/Manager.php
+++ b/modules/dkan/dkan_datastore/psr-4/Manager/Manager.php
@@ -54,7 +54,7 @@ abstract class Manager implements ManagerInterface {
   }
 
   /**
-   * Get pareser.
+   * Get parser.
    *
    * @return CsvParser
    *   Parser object.

--- a/modules/dkan/dkan_datastore/psr-4/Resource.php
+++ b/modules/dkan/dkan_datastore/psr-4/Resource.php
@@ -101,7 +101,6 @@ class Resource {
       return $node->field_link_remote_file[LANGUAGE_NONE][0]['uri'];
     }
     throw new \Exception(t("Node !nid doesn't have a proper file path.", array('!nid' => $node->nid)));
-
   }
 
 }

--- a/modules/dkan/dkan_datastore/resources/dkan_datastore_resource.inc
+++ b/modules/dkan/dkan_datastore/resources/dkan_datastore_resource.inc
@@ -1,0 +1,97 @@
+<?php
+
+function _dkan_datastore_resource_get_resource($resource_nid) {
+  try {
+    $resource = \Dkan\Datastore\Resource::createFromDrupalNodeNid($resource_nid);
+  }
+  catch (\Exception $e) {
+    services_error("Resource {$resource_nid} does not exist | {$e->getMessage()}");
+    die();
+  }
+  return $resource;
+}
+
+function _dkan_datastore_resource_get_datastore($resource_nid) {
+  /* @var $datastore \Dkan\Datastore\Manager\ManagerInterface */
+  $datastore = \Dkan\Datastore\Manager\Factory::create(_dkan_datastore_resource_get_resource($resource_nid));
+
+  if (!$datastore) {
+    services_error("The datastore for Resource {$resource_nid} has not been configured.");
+  }
+
+  return $datastore;
+}
+
+function _dkan_datastore_resource_retrieve($resource_nid) {
+  /* @var $datastore \Dkan\Datastore\Manager\ManagerInterface */
+  $datastore = _dkan_datastore_resource_get_datastore($resource_nid);
+  return $datastore->getStatus();
+}
+
+function _dkan_datastore_resource_import($nid) {
+  /* @var $datastore \Dkan\Datastore\Manager\ManagerInterface */
+  $datastore = _dkan_datastore_resource_get_datastore($nid);
+
+  $finished = $datastore->import();
+  if ($finished) {
+    return "Success";
+  }
+  else {
+    return $datastore->getErrors();
+  }
+}
+
+function _dkan_datastore_resource_create($resource_nid, $data) {
+
+  $manager = $data['manager'];
+  $configuration = $data['configuration'];
+
+  try {
+    _dkan_datastore_resource_get_datastore($resource_nid);
+    services_error("Configuration for this resource's datastore already exists.");
+    die();
+  }
+  catch (\Exception $e) {
+    return $e->getMessage();
+  }
+
+  $class = _dkan_datastore_resource_get_class($manager);
+  if (!$class) {
+    services_error("The manager {$manager} does not exist or is not active.");
+    die();
+  }
+  else {
+    $resource = \Dkan\Datastore\Resource::createFromDrupalNodeNid($resource_nid);
+
+    /* @var $datastore \Dkan\Datastore\Manager\ManagerInterface */
+    $datastore = \Dkan\Datastore\Manager\Factory::create($resource, $class);
+    $properties = $datastore->getConfigurableProperties();
+    foreach ($properties as $property_name => $default_value) {
+      if (!isset($configuration[$property_name])) {
+        services_error("The configuration property {$property_name} was not set.");
+      }
+      $datastore->setConfigurableProperties($configuration);
+      return "Success";
+    }
+  }
+}
+
+function _dkan_datastore_resource_get_class($manager_machine_name) {
+  $info = dkan_datastore_managers_info();
+  /* @var $i \Dkan\Datastore\Manager\Info */
+  foreach ($info as $i) {
+    if ($i->getMachineName() == $manager_machine_name) {
+      return $i->getClass();
+    }
+  }
+  return NULL;
+}
+
+function _dkan_datastore_resource_info() {
+  $info = dkan_datastore_managers_info();
+  return $info;
+}
+
+function _dkan_datastore_resource_access() {
+  return TRUE;
+}


### PR DESCRIPTION
This PR adds the ability to configure, import, and drop a datastore from the Dataset REST API

Our main services resource is "datastore". I takes the nid of a resource as an argument. The full API should look something like this:

/datastore/: GET - Gives configuration information about the datastore for that resource.
/datastore/: POST - Configures the datastore.
/datastore/: DELETE - Drops the datastore.
/datastore//import: ? - Action to do and import or just to schedule and import?.