### PR TITLE
Apply custom validation rules to REST API node creation

### DIFF
--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_rest_api/dkan_dataset_rest_api.api.php
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_rest_api/dkan_dataset_rest_api.api.php
@@ -16,7 +16,8 @@
  * @param  $handlers
  *   Array of validation handler functions to call. Handlers should be functions
  *   that accept arguments:
- *     * $node - the node object being validated, not yet saved.
+ *     * $node - the node object being validated, not yet saved. Passed as
+ *               reference.
  *     * $field_name - the field name being validated.
  *     * $info - the info array for the field.
  *

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_rest_api/dkan_dataset_rest_api.api.php
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_rest_api/dkan_dataset_rest_api.api.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the DKAN Dataset REST API module.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Alter the list of validation handlers applied to all fields submited via API.
+ *
+ * @param  $handlers
+ *   Array of validation handler functions to call. Handlers should be functions
+ *   that accept arguments:
+ *     * $node - the node object being validated, not yet saved.
+ *     * $field_name - the field name being validated.
+ *     * $info - the info array for the field.
+ *
+ */
+function hook_dkan_dataset_rest_api_field_validate_alter(&$handlers) {
+  $handlers[] = 'mymodule_dkan_dataset_rest_api_validation_handler';
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_rest_api/dkan_dataset_rest_api.module
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_rest_api/dkan_dataset_rest_api.module
@@ -71,7 +71,7 @@ function _dkan_dataset_rest_api_resource_create($request) {
 
       try {
         field_attach_validate('node', $node);
-        _dkan_dataset_rest_api_field_validation($node);
+        _dkan_dataset_rest_api_validate_fields($node);
       }
       catch (\Exception $e) {
         return services_error($e->getMessage());
@@ -152,21 +152,33 @@ function _dkan_dataset_rest_api_resource_update($nid, $request) {
  * Currently we are only checking for required fields, and that the
  * values in an options/select list field are valid.
  */
-function _dkan_dataset_rest_api_field_validation($node) {
+function _dkan_dataset_rest_api_validate_fields($node) {
   $instances = field_info_instances('node', $node->type);
 
   foreach ($instances as $field_name => $info) {
-    if ($info['required'] == 1 && empty($node->{$field_name})) {
-      throw new Exception("Field {$field_name} is required");
+    $handlers = array('dkan_dataset_rest_api_validate_field');
+    drupal_alter('dkan_dataset_rest_api_field_validate', $handlers);
+    foreach($handlers as $function) {
+      $function($node, $field_name, $info);
     }
 
-    if (!empty($node->{$field_name})) {
-      $options = _dkan_dataset_rest_api_field_validation_get_options($node, $field_name, $info);
+  }
+}
 
-      // Check that the values match the options.
-      if (!empty($options) && is_array($options)) {
-        _dkan_dataset_rest_api_field_validation_check_field_values_against_options($field_name, $node->{$field_name}, $options);
-      }
+/**
+ * Default validation handler for Dataset REST API
+ */
+
+function dkan_dataset_rest_api_validate_field($node, $field_name, $info) {
+  if ($info['required'] == 1 && empty($node->{$field_name})) {
+    throw new Exception("Field {$field_name} is required");
+  }
+  if (!empty($node->{$field_name})) {
+    $options = _dkan_dataset_rest_api_field_validation_get_options($node, $field_name, $info);
+
+    // Check that the values match the options.
+    if (!empty($options) && is_array($options)) {
+      _dkan_dataset_rest_api_field_validation_check_field_values_against_options($field_name, $node->{$field_name}, $options);
     }
   }
 }

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_rest_api/dkan_dataset_rest_api.module
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_rest_api/dkan_dataset_rest_api.module
@@ -118,7 +118,7 @@ function _dkan_dataset_rest_api_resource_update($nid, $request) {
 
       try {
         field_attach_validate('node', $node);
-        _dkan_dataset_rest_api_field_validation($node);
+        _dkan_dataset_rest_api_validate_fields($node);
       }
       catch (\Exception $e) {
         return services_error($e->getMessage());
@@ -169,7 +169,7 @@ function _dkan_dataset_rest_api_validate_fields($node) {
  * Default validation handler for Dataset REST API
  */
 
-function dkan_dataset_rest_api_validate_field($node, $field_name, $info) {
+function dkan_dataset_rest_api_validate_field(&$node, $field_name, $info) {
   if ($info['required'] == 1 && empty($node->{$field_name})) {
     throw new Exception("Field {$field_name} is required");
   }

--- a/modules/dkan/dkan_dataset/tests/dkan_dataset_test.info
+++ b/modules/dkan/dkan_dataset/tests/dkan_dataset_test.info
@@ -1,0 +1,6 @@
+name = DKAN Dataset test module
+description = Functionality to assist DKAN Dataset testing.
+core = 7.x
+dependencies[] = dkan_dataset
+dependencies[] = dkan_dataset_rest_api
+hidden = TRUE

--- a/modules/dkan/dkan_dataset/tests/dkan_dataset_test.module
+++ b/modules/dkan/dkan_dataset/tests/dkan_dataset_test.module
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * Test module for DKAN Dataset and child modules.
+ */
+
+ function dkan_dataset_test_dkan_dataset_rest_api_field_validate_alter(&$handlers) {
+   $handlers[] = 'dkan_dataset_test_validation_handler';
+ }
+
+ function dkan_dataset_test_validation_handler(&$node, $field_name, $info) {
+   if ($field_name == "body" && $node->body['und'][0]['value'] == "PHPUNIT Test Dataset Custom Validation") {
+     throw new Exception("Test validation rejection");
+   }
+ }

--- a/test/phpunit/dkan_dataset/ApiTest.php
+++ b/test/phpunit/dkan_dataset/ApiTest.php
@@ -25,6 +25,14 @@ class ApiTest extends \PHPUnit_Framework_TestCase {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public static function setUpBeforeClass() {
+    // We need this module for the testResourceRedirect test.
+    module_enable(array('dkan_dataset_test'));
+  }
+
+  /**
    * Test required fields.
    */
   public function testRequiredFields() {
@@ -55,4 +63,29 @@ class ApiTest extends \PHPUnit_Framework_TestCase {
     }
   }
 
+  /**
+   * Test options.
+   */
+  public function testCustomValidation() {
+    try {
+      module_enable
+      $this->client->nodeCreate((object) [
+        'title' => 'PHPUNIT Custom Validation',
+        'body' => ['und' => [0 => ['value => "PHPUNIT Test Dataset Custom Validation"']]]
+        'type' => 'dataset',
+      ]);
+    }
+    catch (\Exception $e) {
+      $message = $e->getMessage();
+      $this->assertContains("Test validation rejection", $message);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tearDownAfterClass() {
+    // Clean enabled modules.
+    module_disable(array('dkan_dataset_test'));
+  }
 }

--- a/test/phpunit/dkan_dataset/ApiTest.php
+++ b/test/phpunit/dkan_dataset/ApiTest.php
@@ -68,10 +68,9 @@ class ApiTest extends \PHPUnit_Framework_TestCase {
    */
   public function testCustomValidation() {
     try {
-      module_enable
       $this->client->nodeCreate((object) [
         'title' => 'PHPUNIT Custom Validation',
-        'body' => ['und' => [0 => ['value => "PHPUNIT Test Dataset Custom Validation"']]]
+        'body' => ['und' => [0 => ['value => "PHPUNIT Test Dataset Custom Validation"']]],
         'type' => 'dataset',
       ]);
     }


### PR DESCRIPTION
This adds a new hook to the DKAN Dataset REST API module that allows adding to or removing the default validation rules in the module.

The new hook is documented in dkan_dataset_rest_api.api.php.

## QA Steps

The fact that the API tests pass should demonstrate that it's working -- this is a developer-facing feature that you would need to write a custom module to test out manually.

## Merge notes

I've created this against 7.x-1.x because it is a minor enhancement to existing functionality, with no effect on the database.