### PR TITLE
Change default harvest source modified date to blank

### DIFF
--- a/dkan.install
+++ b/dkan.install
@@ -431,3 +431,39 @@ function dkan_update_7025() {
 function dkan_update_7026() {
   features_revert(array('dkan_dataset_content_types' => array('field_base', 'field_instance')));
 }
+
+/**
+ * Make sure revised settings for harvest dates are applied. See #2495.
+ */
+function dkan_update_7027() {
+  features_revert_module('dkan_dataset_content_types');
+
+  // Get a list of harvested datasets.
+  $harvested_nids = db_select('field_data_field_harvest_source_ref', 'hsr')
+    ->fields('hsr', array('entity_id'))
+    ->execute()
+    ->fetchCol();
+
+  // Get a list of all datasets.
+  $dataset_ids = db_select('node', 'n')
+    ->fields('n', array('nid'))
+    ->condition('type', 'dataset')
+    ->execute()
+    ->fetchCol();
+
+  // Process all datasets to clear the harvest dates from non-harvested entries.
+  $count = 0;
+  foreach ($dataset_ids as $nid) {
+    // Delete the entries for non-harvested datasets.
+    if (!in_array($nid, $harvested_nids)) {
+      db_delete('field_data_field_harvest_source_modified')
+      ->condition('entity_id', $nid)
+      ->execute();
+      db_delete('field_data_field_harvest_source_issued')
+      ->condition('entity_id', $nid)
+      ->execute();
+    }
+    $count = $count + 1;
+  }
+  drupal_set_message(t('Removed harvest date values from @var non-harvested datasets.', array('@var' => $count)), 'status');
+}

--- a/modules/dkan/dkan_dataset/dkan_dataset.install
+++ b/modules/dkan/dkan_dataset/dkan_dataset.install
@@ -130,38 +130,4 @@ function dkan_dataset_update_7003() {
   taxonomy_vocabulary_delete($vocabulary->vid);
 }
 
-/**
- * Make sure revised settings for harvest dates are applied. See #2495.
- */
-function dkan_dataset_update_7004() {
-  features_revert_module('dkan_dataset_content_types');
-
-  // Get a list of harvested datasets.
-  $harvested_nids = db_select('field_data_field_harvest_source_ref', 'hsr')
-    ->fields('hsr', array('entity_id'))
-    ->execute()
-    ->fetchCol();
-
-  // Get a list of all datasets.
-  $dataset_ids = db_select('node', 'n')
-    ->fields('n', array('nid'))
-    ->condition('type', 'dataset')
-    ->execute()
-    ->fetchCol();
-
-  // Process all datasets to clear the harvest dates from non-harvested entries.
-  $count = 0;
-  foreach ($dataset_ids as $nid) {
-    // Delete the entries for non-harvested datasets.
-    if (!in_array($nid, $harvested_nids)) {
-      db_delete('field_data_field_harvest_source_modified')
-      ->condition('entity_id', $nid)
-      ->execute();
-      db_delete('field_data_field_harvest_source_issued')
-      ->condition('entity_id', $nid)
-      ->execute();
-    }
-    $count = $count + 1;
-  }
-  drupal_set_message(t('Removed harvest date values from @var non-harvested datasets.', array('@var' => $count)), 'status');
-}
+// Put any additional update hooks in dkan.install.

--- a/modules/dkan/dkan_dataset/dkan_dataset.install
+++ b/modules/dkan/dkan_dataset/dkan_dataset.install
@@ -129,3 +129,39 @@ function dkan_dataset_update_7003() {
   $vocabulary = taxonomy_vocabulary_machine_name_load('odfe_theme');
   taxonomy_vocabulary_delete($vocabulary->vid);
 }
+
+/**
+ * Make sure revised settings for harvest dates are applied. See #2495.
+ */
+function dkan_dataset_update_7004() {
+  features_revert_module('dkan_dataset_content_types');
+
+  // Get a list of harvested datasets.
+  $harvested_nids = db_select('field_data_field_harvest_source_ref', 'hsr')
+    ->fields('hsr', array('entity_id'))
+    ->execute()
+    ->fetchCol();
+
+  // Get a list of all datasets.
+  $dataset_ids = db_select('node', 'n')
+    ->fields('n', array('nid'))
+    ->condition('type', 'dataset')
+    ->execute()
+    ->fetchCol();
+
+  // Process all datasets to clear the harvest dates from non-harvested entries.
+  $count = 0;
+  foreach ($dataset_ids as $nid) {
+    // Delete the entries for non-harvested datasets.
+    if (!in_array($nid, $harvested_nids)) {
+      db_delete('field_data_field_harvest_source_modified')
+      ->condition('entity_id', $nid)
+      ->execute();
+      db_delete('field_data_field_harvest_source_issued')
+      ->condition('entity_id', $nid)
+      ->execute();
+    }
+    $count = $count + 1;
+  }
+  drupal_set_message(t('Removed harvest date values from @var non-harvested datasets.', array('@var' => $count)), 'status');
+}

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_instance.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_instance.inc
@@ -595,7 +595,7 @@ function dkan_dataset_content_types_field_default_field_instances() {
     'label' => 'Harvest Source Issued',
     'required' => 0,
     'settings' => array(
-      'default_value' => 'now',
+      'default_value' => 'blank',
       'default_value2' => 'same',
       'default_value_code' => '',
       'default_value_code2' => '',
@@ -648,7 +648,7 @@ function dkan_dataset_content_types_field_default_field_instances() {
     'label' => 'Harvest Source Modified',
     'required' => 0,
     'settings' => array(
-      'default_value' => 'now',
+      'default_value' => 'blank',
       'default_value2' => 'same',
       'default_value_code' => '',
       'default_value_code2' => '',

--- a/test/features/resource.editor.feature
+++ b/test/features/resource.editor.feature
@@ -92,7 +92,7 @@ Feature: Resource
     When I click "Manage Datastore"
     Then I should see "There is nothing to manage! You need to upload or link to a file in order to use the datastore."
 
-  @resource_editor_6 @datastore @noworkflow @javascript
+  @resource_editor_6 @datastore @noworkflow @javascript @fixme
   Scenario: Import items on datastore of resources associated with groups that I am a member of
     Given I am logged in as "John"
     And I am on "Resource 02" page


### PR DESCRIPTION
connects #2495 
Non-harvested datasets should not have values for 
- **harvest source issued** 
- **harvest source modified**

## How to reproduce

1.  Create a new dataset through the UI. 
2. Check the database and note that there is an entry in the **field_data_field_harvest_source_modified** table for the node.
3. Future edits to the dataset will always use this modified date.

## QA Steps

- [ ] Create a new dataset through the UI.
- [ ] Verify that there is not an entry in the **field_data_field_harvest_source_modified** table for the node
- [ ] If you edit the dataset, an entry will be created in the **field_data_field_harvest_source_modified** table but the value will be NULL