### PR TITLE
Stop xdebug in web and cli for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
             docker cp .ahoy.yml $(docker-compose ps -q cli):/var/www
             mkdir -p dkan/test/assets/junit
             docker cp dkan $(docker-compose ps -q cli):/var/www
+            ahoy docker xdebug stop
       - run:
           name: Install Drupal
           command: |
@@ -110,7 +111,6 @@ jobs:
       - run:
           name: Copy Assets to Base Image
           command: |
-            ahoy docker xdebug stop
             docker cp $(docker-compose ps -q cli):/var/www/dkan/test/assets assets
       - run:
           name: Run Lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ jobs:
       - run:
           name: Copy Assets to Base Image
           command: |
+            ahoy docker xdebug stop
             docker cp $(docker-compose ps -q cli):/var/www/dkan/test/assets assets
       - run:
           name: Run Lint


### PR DESCRIPTION
I discovered that xdebug is on by default in our web and cli containers. I am not sure why it is on by default in our CLI container.

Longer-term it would be good to have it off by default. However adding ``ahoy docker xdebug off`` to the tests shaves a couple of mins off the tests it looks like.

