### PR TITLE
Update to PHP7 CLI Container

### DIFF
--- a/.ahoy/docker-compose.common.yml
+++ b/.ahoy/docker-compose.common.yml
@@ -51,7 +51,7 @@ services:
   # Used for all console commands and tools.
   cli:
     hostname: cli
-    image: getdkan/dkan-docker:php5-cli
+    image: getdkan/dkan-docker:php7-cli
     environment:
       - XDEBUG_CONFIG=idekey=PHPSTORM
     env_file:

--- a/.ahoy/docker-compose.common.yml
+++ b/.ahoy/docker-compose.common.yml
@@ -3,7 +3,7 @@ version: "2"
 services:
   web:
     hostname: web
-    image: nuams/drupal-apache-php:1.0-5.6
+    image: getdkan/dkan-docker:php7-web
     ports:
       - "80"
       - "443"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,6 @@ jobs:
             cd /usr/local/bin
             ln -s /root/.composer/vendor/bin/drush drush
             drush --version
-            cd dkan && ahoy cmd-proxy "php -v"
       - run:
           name: Setup DKAN
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
             cd /usr/local/bin
             ln -s /root/.composer/vendor/bin/drush drush
             drush --version
-            ahoy cmd-proxy "php -v"
+            cd dkan && ahoy cmd-proxy "php -v"
       - run:
           name: Setup DKAN
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
             cd /usr/local/bin
             ln -s /root/.composer/vendor/bin/drush drush
             drush --version
+            ahoy cmd-proxy "php -v"
       - run:
           name: Setup DKAN
           command: |

--- a/modules/dkan/dkan_datastore/includes/DkanDatastore.inc
+++ b/modules/dkan/dkan_datastore/includes/DkanDatastore.inc
@@ -427,8 +427,10 @@ class DkanDatastore extends Datastore implements DatastoreFormInterface {
   public function importByCli() {
     $source = $this->source();
 
-    // Prepare for background process.
-    $source_prepared = $this->setupSourceBackground($source);
+    if (is_object($source)) {
+      // Prepare for background process.
+      $source_prepared = $this->setupSourceBackground($source);
+    }
 
     // Check we got the source up and ready.
     if (!$source_prepared) {


### PR DESCRIPTION
This PR is a test to see the performance difference between php 5.6 and php 7 to help evaluate updating to PHP 7. The dockerfile for this is here: https://github.com/GetDKAN/dkan-docker/blob/master/.docker/php7-cli/Dockerfile

I screwed up the conifg of the PHP7 cli so will have to wait to try an actual test.