### PR TITLE
Add option to adjust height of the hero region

### DIFF
--- a/themes/nuboot_radix/includes/panel.inc
+++ b/themes/nuboot_radix/includes/panel.inc
@@ -65,6 +65,8 @@ function nuboot_radix_preprocess(&$variables, $hook) {
         $variables['path'] = 'none';
       endif;
     endif;
+    $padding = theme_get_setting('hero_padding');
+    $variables['padding'] = isset($padding) ? $padding : '0';
   }
 }
 

--- a/themes/nuboot_radix/panels/layouts/dkan_front/panels-dkan-front.tpl.php
+++ b/themes/nuboot_radix/panels/layouts/dkan_front/panels-dkan-front.tpl.php
@@ -14,11 +14,13 @@
     <div class="panel-hero panel-row" <?php print 'style="background-image:' . $path . ';background-color:' . $bg_color . '"'; ?>>
       <div class="<?php print $tint; ?>"></div>
       <div class="container">
-        <div class="panel-col-first">
-          <div class="inside"><?php print $content['hero-first']; ?></div>
-        </div>
-        <div class="panel-col-second">
-          <div class="inside"><?php print $content['hero-second']; ?></div>
+        <div class="hero-wrapper" <?php print 'style="display:table;padding:' . $padding . 'px 0;"'; ?>>
+          <div class="panel-col-first">
+            <div class="inside"><?php print $content['hero-first']; ?></div>
+          </div>
+          <div class="panel-col-second">
+            <div class="inside"><?php print $content['hero-second']; ?></div>
+          </div>
         </div>
       </div>
     </div>

--- a/themes/nuboot_radix/theme-settings.php
+++ b/themes/nuboot_radix/theme-settings.php
@@ -38,7 +38,7 @@ function nuboot_radix_form_system_theme_settings_alter(&$form, &$form_state) {
   // Hero fieldset.
   $form['hero'] = array(
     '#type' => 'fieldset',
-    '#title' => t('Hero Unit'),
+    '#title' => t('Hero Region'),
     '#group' => 'general',
   );
   // Upload field.
@@ -66,6 +66,16 @@ function nuboot_radix_form_system_theme_settings_alter(&$form, &$form_state) {
     '#required' => FALSE,
     '#default_value' => theme_get_setting('background_option', 'nuboot_radix'),
     '#element_validate' => array('_background_option_setting'),
+  );
+
+// Hero container padding.
+  $form['hero']['hero_padding'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Extra Padding'),
+    '#description' => t('<p>Enter a number to add padding to the top and bottom of the hero container.'),
+    '#required' => FALSE,
+    '#default_value' => theme_get_setting('hero_padding', 'nuboot_radix'),
+    '#element_validate' => array('element_validate_number'),
   );
 
   // Add svg logo option.


### PR DESCRIPTION
## User story

As a site manager I want to control the height of the hero region.

## QA Steps

- [x] Log in as a site manager, enter a value into the hero padding field on `admin/appearance/settings/nuboot_radix` and save
- [x] Confirm the hero region is using the padding value set in the form.

## Reminders

- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.