### PR TITLE
Datastore upgrade path

### DIFF
--- a/dkan.install
+++ b/dkan.install
@@ -467,3 +467,50 @@ function dkan_update_7027() {
   }
   drupal_set_message(t('Removed harvest date values from @var non-harvested datasets.', array('@var' => $count)), 'status');
 }
+
+/**
+ * Enable the simple import module.
+ */
+function dkan_update_7028() {
+  module_enable(array('dkan_datastore_simple_import'));
+}
+
+/**
+ * Rename feeds_datastore tables.
+ */
+function dkan_update_7029() {
+  foreach(db_find_tables("feeds_datastore_dkan%") as $table_name) {
+    $new_table_name = str_replace("feeds_datastore_dkan_file", "dkan_datastore", $table_name);
+    $new_table_name = str_replace("feeds_datastore_dkan_link", "dkan_datastore", $new_table_name);
+    db_rename_table($table_name, $new_table_name);
+  }
+}
+
+/**
+ * Generate basic datastore configuration.
+ */
+function dkan_update_7030() {
+  foreach(db_find_tables("dkan_datastore%") as $table_name) {
+    $nid = str_replace("dkan_datastore_", "", $table_name);
+    $resource =  \Dkan\Datastore\Resource::createFromDrupalNodeNid($nid);
+
+    /* @var $datastore \Dkan\Datastore\Manager\SimpleImport\SimpleImport */
+    $datastore = \Dkan\Datastore\Manager\Factory::create($resource, \Dkan\Datastore\Manager\SimpleImport\SimpleImport::class);
+    $datastore->saveState();
+  }
+}
+
+/**
+ * Update the datastore configuration.
+ */
+function dkan_update_7031() {
+  $storage = new \Dkan\Datastore\LockableDrupalVariables("dkan_datastore");
+  $bin = $storage->borrowBin();
+
+  foreach ($bin as $nid => $state) {
+    $bin[$nid]['data_import'] = \Dkan\Datastore\Manager\ManagerInterface::DATA_IMPORT_DONE;
+    $bin[$nid]['storage'] = \Dkan\Datastore\Manager\ManagerInterface::STORAGE_INITIALIZED;
+  }
+
+  $storage->returnBin($bin);
+}

--- a/modules/dkan/dkan_datastore/src/LockableDrupalVariables.php
+++ b/modules/dkan/dkan_datastore/src/LockableDrupalVariables.php
@@ -39,8 +39,8 @@ class LockableDrupalVariables {
    * Sets the whole bin and all of its variables.
    * Releases the lock set if borrowBin() was called.
    *
-   * @param string $bin
-   *   A bin's id.
+   * @param array $bin
+   *   the full bin.
    */
   public function returnBin($bin) {
     variable_set($this->binName, $bin);


### PR DESCRIPTION
Fixes #2482 
**QA:**
1) In a DKAN built with 7.x-1.x move a resource to the datastore.
2) Save a copy of the db
3) Get the code from this branch
4) Rebuild the site with the new code (I used "ahoy dkan reinstall")
5) Load the previously saved database
6) Run "drush updb"
7) The datastore for the resource in the old site should work with the new codebase

