### PR TITLE
Wrap Dkan defined string to improve multilingual support

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,3 @@
-7.x-1.x
-----------
-- #2557 Wrap user facing strings with Drupal's t() function.
-
 7.x-1.15.1
 ----------
 - #2533 #2546 Updates docker-compose to use updated cli container

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+7.x-1.x
+----------
+- #2557 Wrap user facing strings with Drupal's t() function.
+
 7.x-1.15.1
 ----------
 - #2533 #2546 Updates docker-compose to use updated cli container

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.license_field.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.license_field.inc
@@ -64,62 +64,62 @@ function dkan_dataset_content_types_license_subscribed_values() {
 function dkan_dataset_content_types_license_subscribe() {
   return array(
     "cc-by" => array(
-      "label" => "Creative Commons Attribution",
+      "label" => t("Creative Commons Attribution"),
       "uri" => "http://opendefinition.org/licenses/cc-by/",
     ),
     "cc-by-sa" => array(
-      "label" => "Creative Commons Attribution Share-Alike",
+      "label" => t("Creative Commons Attribution Share-Alike"),
       "uri" => "http://opendefinition.org/licenses/cc-by-sa/",
     ),
     "cc-zero" => array(
-      "label" => "Creative Commons CCZero",
+      "label" => t("Creative Commons CCZero"),
       "uri" => "http://opendefinition.org/licenses/cc-zero/",
     ),
     "cc-nc"  => array(
-      "label" => "Creative Commons Non-Commercial (Any)",
+      "label" => t("Creative Commons Non-Commercial (Any)"),
       "uri" => "http://opendefinition.org/licenses/cc-nc/",
     ),
     "cc-by-nc-nd" => array(
-      "label" => "Attribution NonCommercial NoDerivatives 4.0 International",
+      "label" => t("Attribution NonCommercial NoDerivatives 4.0 International"),
       "uri" => "https://creativecommons.org/licenses/by-nc-nd/4.0/",
     ),
     "gfdl" => array(
-      "label" => "GNU Free Documentation License",
+      "label" => t("GNU Free Documentation License"),
       "uri" => "http://opendefinition.org/licenses/gfdl/",
     ),
     "odc-by" => array(
-      "label" => "Open Data Commons Attribution License",
+      "label" => t("Open Data Commons Attribution License"),
       "uri" => "http://opendefinition.org/licenses/odc-by/",
     ),
     "odc-odbl" => array(
-      "label" => "Open Data Commons Open Database License (ODbL)",
+      "label" => t("Open Data Commons Open Database License (ODbL)"),
       "uri" => "http://opendefinition.org/licenses/odc-odbl/",
     ),
     "odc-pddl" => array(
-      "label" => "Open Data Commons Public Domain Dedication and Licence (PDDL)",
+      "label" => t("Open Data Commons Public Domain Dedication and Licence (PDDL)"),
       "uri" => "http://opendefinition.org/licenses/odc-pddl/",
     ),
     "uk-ogl" => array(
-      "label" => "UK Open Government Licence (OGL)",
+      "label" => t("UK Open Government Licence (OGL)"),
       "url" => 'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/',
     ),
     "other-at" => array(
-      "label" => "Other (Attribution)",
+      "label" => t("Other (Attribution)"),
     ),
     "other-nc" => array(
-      "label" => "Other (Non-Commercial)",
+      "label" => t("Other (Non-Commercial)"),
     ),
     "other-closed" => array(
-      "label" => "Other (Not Open)",
+      "label" => t("Other (Not Open)"),
     ),
     "other-open" => array(
-      "label" => "Other (Open)",
+      "label" => t("Other (Open)"),
     ),
     "other-pd" => array(
-      "label" => "Other (Public Domain)",
+      "label" => t("Other (Public Domain)"),
     ),
     "notspecified" => array(
-      "label" => "License Not Specified",
+      "label" => t("License Not Specified"),
     ),
   );
 }

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.module
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.module
@@ -113,7 +113,7 @@ function dkan_sitewide_form_alter(&$form, &$form_state, $form_id) {
     $form['#id'] == 'views-exposed-form-dkan-datasets-panel-pane-1') {
     $form['#info']['filter-search_api_views_fulltext']['description'] = '';
     $form['submit']['#title'] = '';
-    $form['query']['#title'] = 'Search';
+    $form['query']['#title'] = t('Search');
     $form['query']['#attributes'] = array('placeholder' => t('Search'));
     $form['query']['#size'] = 60;
   }

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.module
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.module
@@ -269,8 +269,8 @@ function dkan_sitewide_preprocess_page(&$variables) {
 }
 
 /**
-* Implements hook_entity_info_alter().
-*/
+ * Implements hook_entity_info_alter().
+ */
 function dkan_sitewide_entity_info_alter(&$entity_info) {
   // Add print view mode.
   $entity_info['node']['view modes']['print'] = array(


### PR DESCRIPTION
We support a couple of Dkan installs in Spanish. This is a simple patch to wrap a number of user facing strings with the standard t() function. 

## QA Steps

The changes should be strait forward but this would be a bit tricky to test with the default Dkan setup since multilingual is not yet part of it. We worked on a [Dkan module (dkan_l10n_es_co)](https://github.com/angrycactus/dkan_l10n_es_co) that enables the spanish language but  requires a number of i18n Drupal modules.

- [ ] Add a language using the i18n interface.
- [ ] Make sure that the newly wrapped strings are translated in the i18n translation interface.
- [ ] Enable the new language for the current context (as default or for the logged in user).
- [ ] On the /search page. The text form should show a translated "search" string.
- [ ] On any dataset view page. The License displayed should be translated.
- [ ] On any dataset edit page. The Licenses displayed in the select list should be translated.

## Reminders

- [ ] ~There is test for the issue.~ Not sure translations are supported in default Dkan yet. 
- [x] CHANGELOG updated.
- [x] Coding standards checked.
- [x] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
