### PR TITLE
Test improvements

### DIFF
--- a/test/features/dataset.all.feature
+++ b/test/features/dataset.all.feature
@@ -1,18 +1,7 @@
 # time:1m12.16s
 @api
 
-  # TODO: 5 datasets are created in the test but the DKAN site has 4 datasets pre-made,
-  #       with 2 of the datasets created are unpublished so the
-  #       default search page will have 7 datasets instead of 3
-  #       the expected number of datasets are increased to reflect this, but should be fixed later
-
 Feature: Dataset Features
-  In order to realize a named business value
-  As an explicit system actor
-  I want to gain some beneficial outcome which furthers the goal
-
-  Additional text...
-
 
   Background:
     Given pages:
@@ -27,48 +16,18 @@ Feature: Dataset Features
     And group memberships:
       | user    | group    | role on group        | membership status |
       | John    | Group 01 | administrator member | Active            |
-    And "Tags" terms:
-      | name         |
-      | gobbledygook |
-      | gibberish    |
-    And "Format" terms:
-      | name   |
-      | csv 2  |
-      | html 2 |
     And datasets:
-      | title               | publisher | author  | published        | tags         | description |
-      | DKANTest Dataset 01 | Group 01  | John    | Yes              | gobbledygook | Test        |
-      | DKANTest Dataset 02 | Group 01  | John    | Yes              | gibberish    | Test        |
-    And resources:
-      | title       | publisher | format | author | published | dataset             | description |
-      | Resource 01 | Group 01  | csv 2  | John   | Yes       | DKANTest Dataset 01 |             |
-      | Resource 02 | Group 01  | html 2 | John   | Yes       | DKANTest Dataset 02 |             |
-
-   @fixme @dkanBug
-    # TODO: Datasets not shown on homepage currently
-     #      Will they be added to the homepage later?
-  @dataset_all_1
-  Scenario: View list of most recent published datasets (on homepage)
-    When I am on the homepage
-    Then I should see "19" items in the "datasets" region
-    And I should see the first "3" dataset items in "Date changed" "Desc" order.
-
-  @dataset_all_2  @no-main-menu
-  Scenario: View list of published datasets
-    When I am on the homepage
-    And I click "Datasets"
-    And I search for "DKANTest"
-    Then I should see "2 results"
-    And I should see "2" items in the "datasets" region
+      | title               | publisher | author  | published        | description |
+      | DKANTest Dataset 01 | Group 01  | John    | Yes              | Test        |
 
   @dataset_all_3
   Scenario: Order datasets by "Date changed" by oldest first.
     Given datasets:
-      | title                 |  published | description | date changed |
-      | Dataset 5 years ago   |  Yes       | Test        | -5 year      |
-      | Dataset 2 years ago   |  Yes       | Test        | -2 year      |
-      | Dataset 1 year ago    |  Yes       | Test        | -1 year      |
-      | Dataset 3 years ago   |  Yes       | Test        | -3 year      |
+      | title                  |  published | description | date changed  |
+      | Dataset 15 years ago   |  Yes       | Test        | -15 year      |
+      | Dataset 12 years ago   |  Yes       | Test        | -12 year      |
+      | Dataset 11 year ago    |  Yes       | Test        | -11 year      |
+      | Dataset 13 years ago   |  Yes       | Test        | -13 year      |
     When I am on "Datasets Search" page
     And I search for "Dataset"
     And I select "Date changed" from "Sort by"
@@ -76,15 +35,14 @@ Feature: Dataset Features
     And I press "Apply"
     And I should see the first "4" dataset items in "Date changed" "Asc" order.
 
-
   @dataset_all_4
   Scenario: Order datasets by "Date changed" with newest first.
     Given datasets:
-      | title               |  published | description | date changed |
-      | Dataset 5 years +   |  Yes       | Test        | +5 year      |
-      | Dataset 2 years +   |  Yes       | Test        | +2 year      |
-      | Dataset 3 years +   |  Yes       | Test        | +3 year      |
-      | Dataset 1 year +    |  Yes       | Test        | +1 year      |
+      | title                |  published | description | date changed  |
+      | Dataset 15 years +   |  Yes       | Test        | +15 year      |
+      | Dataset 12 years +   |  Yes       | Test        | +12 year      |
+      | Dataset 13 years +   |  Yes       | Test        | +13 year      |
+      | Dataset 11 year +    |  Yes       | Test        | +11 year      |
     When I am on "Datasets Search" page
     And I search for "Dataset"
     And I select "Date changed" from "Sort by"
@@ -107,89 +65,6 @@ Feature: Dataset Features
     And I select "Desc" from "Order"
     And I press "Apply"
     Then I should see the first "3" dataset items in "Title" "Desc" order.
-
-    # TODO : Reseting the search will make all the datasets appear in the results including pre-made
-    #        datasets, should be fixed
-
-  @dataset_all_7
-  Scenario: Reset dataset search filters
-    When I am on "Datasets Search" page
-    And I fill in "DKANTest" for "Search" in the "datasets" region
-    And I press "Apply"
-    Then I should see "2 results"
-    And I should see "2" items in the "datasets" region
-    When I press "Reset"
-    Then I should see all published search content
-    # Then I should see "7 results"
-    # And I should see "7" items in the "datasets" region
-
-  # TODO: make sure it works when we don't have default content on.
-  @dataset_all_8
-  Scenario: View available tag filters for datasets
-    When I am on "Datasets Search" page
-    # Sites with long lists of tags will fail unless you filter first.
-    And I fill in "gobbledygook" for "Search" in the "datasets" region
-    And I press "Apply"
-    ## Uncomment this if you wanna use selenium.
-    # Then I click on the text "Tags"
-    # And I wait for "1" seconds
-    Then I should see "gobbledygook (1)" in the "filter by tag" region
-    And I fill in "gibberish" for "Search" in the "datasets" region
-    And I press "Apply"
-    ## Uncomment this if you wanna use selenium.
-    # Then I click on the text "Tags"
-    # And I wait for "1" seconds
-    Then I should see "gibberish (1)" in the "filter by tag" region
-
-  # TODO: make sure it works when we don't have default content on.
-  @dataset_all_9
-  Scenario: View available resource format filters for datasets
-    When I am on "Datasets Search" page
-    ## Uncomment this if you wanna use selenium.
-    # When I click on the text "Format"
-    # And I wait for "1" seconds
-    Then I should see "csv 2 (1)" in the "filter by resource format" region
-    And I should see "html 2 (1)" in the "filter by resource format" region
-
-  # dataset_all_10/author facet removed. See GetDKAN/dkan#2033
-
-  # TODO: make sure it works when we don't have default content on.
-  @dataset_all_11
-  Scenario: Filter dataset search results by tags
-    When I am on "Datasets Search" page
-    And I search for "DKANTest"
-    And I press "Apply"
-    Then I should see "2 results"
-    And I should see "2" items in the "datasets" region
-    ## Uncomment this if you wanna use selenium.
-    # Then I click on the text "Tags"
-    When I click "gobbledygook" in the "filter by tag" region
-    Then I should see "1 results"
-    And I should see "1" items in the "datasets" region
-
-  # TODO: make sure it works when we don't have default content on.
-  @dataset_all_12
-  Scenario: Filter dataset search results by resource format
-    When I am on "Datasets Search" page
-    And I search for "DKANTest"
-    And I press "Apply"
-    Then I should see "2 results"
-    And I should see "2" items in the "datasets" region
-    ## Uncomment this if you wanna use selenium.
-    # Then I click on the text "Format"
-    # Then I wait for "1" seconds
-    When I click "csv 2" in the "filter by resource format" region
-    Then I should see "1 results"
-    And I should see "1" items in the "datasets" region
-
-  # dataset_all_13/author facet removed. See GetDKAN/dkan#2033
-
-  @dataset_all_14
-  Scenario: View published dataset
-    When I am on "Datasets Search" page
-    And I click "DKANTest Dataset 01"
-    # I should see the license information
-    Then I should be on "DKANTest Dataset 01" page
 
   @dataset_all_15
   Scenario: Share published dataset on Google+

--- a/test/features/dataset.all.feature
+++ b/test/features/dataset.all.feature
@@ -23,11 +23,11 @@ Feature: Dataset Features
   @dataset_all_3
   Scenario: Order datasets by "Date changed" by oldest first.
     Given datasets:
-      | title                  |  published | description | date changed  |
-      | Dataset 15 years ago   |  Yes       | Test        | -15 year      |
-      | Dataset 12 years ago   |  Yes       | Test        | -12 year      |
-      | Dataset 11 year ago    |  Yes       | Test        | -11 year      |
-      | Dataset 13 years ago   |  Yes       | Test        | -13 year      |
+      | title                 |  published | description | date changed  |
+      | Dataset 5 years ago   |  Yes       | Test        | -5 year      |
+      | Dataset 2 years ago   |  Yes       | Test        | -2 year      |
+      | Dataset 1 year ago    |  Yes       | Test        | -1 year      |
+      | Dataset 3 years ago   |  Yes       | Test        | -3 year      |
     When I am on "Datasets Search" page
     And I search for "Dataset"
     And I select "Date changed" from "Sort by"
@@ -38,11 +38,11 @@ Feature: Dataset Features
   @dataset_all_4
   Scenario: Order datasets by "Date changed" with newest first.
     Given datasets:
-      | title                |  published | description | date changed  |
-      | Dataset 15 years +   |  Yes       | Test        | +15 year      |
-      | Dataset 12 years +   |  Yes       | Test        | +12 year      |
-      | Dataset 13 years +   |  Yes       | Test        | +13 year      |
-      | Dataset 11 year +    |  Yes       | Test        | +11 year      |
+      | title               |  published | description | date changed  |
+      | Dataset 5 years +   |  Yes       | Test        | +5 year      |
+      | Dataset 2 years +   |  Yes       | Test        | +2 year      |
+      | Dataset 3 years +   |  Yes       | Test        | +3 year      |
+      | Dataset 1 year +    |  Yes       | Test        | +1 year      |
     When I am on "Datasets Search" page
     And I search for "Dataset"
     And I select "Date changed" from "Sort by"

--- a/test/features/search.feature
+++ b/test/features/search.feature
@@ -2,9 +2,6 @@
 @api
 # features/search.feature
 Feature: Search
-  In order to see a dataset
-  As a website user
-  I need to be able to search for a word
 
   Background:
     Given I am on the homepage
@@ -30,6 +27,10 @@ Feature: Search
     And group memberships:
       | user    | group    | role on group        | membership status |
       | Gabriel | Group 01 | administrator member | Active            |
+    And "Format" terms:
+      | name   |
+      | csv 2  |
+      | html 2 |
     And "Tags" terms:
       | name         |
       | something01  |
@@ -39,48 +40,68 @@ Feature: Search
       | edumication  |
       | dazzling     |
     And datasets:
-      | title              | publisher | author  | published | tags         | topics      | description |
-      | ooftaya Dataset 01 | Group 02  | Gabriel | Yes       | something01  | edumication | Test 01     |
-      | ooftaya Dataset 02 | Group 01  | Gabriel | Yes       | politics01   | dazzling    | Test 02     |
+      | title               | publisher | author  | published | tags         | topics      | description |
+      | DKANTest Dataset 01 | Group 02  | Gabriel | Yes       | something01  | edumication | Test 01     |
+      | DKANTest Dataset 02 | Group 01  | Gabriel | Yes       | politics01   | dazzling    | Test 02     |
+    And resources:
+      | title       | publisher | format | author | published | dataset             | description |
+      | Resource 01 | Group 01  | csv 2  | Badmin | Yes       | DKANTest Dataset 01 |             |
+      | Resource 02 | Group 01  | html 2 | Badmin | Yes       | DKANTest Dataset 02 |             |
 
+  @search_01
   Scenario: Searching datasets
     Given I am on the "Dataset Search" page
     When I search for "Dataset 01"
     Then I should be on the "Dataset Results" page
     And I should see "Dataset 01"
 
-  Scenario: See number of datasets on search page
+  @search_02
+  Scenario: See number of datasets on search page and Reset dataset search filters
     Given I am on the "Dataset Search" page
-    When I search for "ooftaya"
-    Then I should see "2" search results shown on the page
-    And I should see "2 results"
+    When I search for "DKANTest"
+    Then I should see "2 results"
+    And I should see "2" items in the "datasets" region
+    When I press "Reset"
+    Then I should see all published search content
 
-  Scenario: Filter by facet tag
+  @search_03
+  # Sites with long lists of facet items will fail unless you filter first.
+  Scenario: Filter by facets
+    # Tag
     Given I am on the "Dataset Search" page
-    When I search for "Test"
-    Then I click "politics01"
-    And I should not see "Dataset 01"
-    But I should see "Dataset 02"
+    And I fill in "something01" for "Search" in the "datasets" region
+    And I press "Apply"
+    Then I should see "something01 (1)" in the "filter by tag" region
+    And I fill in "politics01" for "Search" in the "datasets" region
+    And I press "Apply"
+    Then I should see "politics01 (1)" in the "filter by tag" region
 
-  Scenario: Filter by facet group
-    Given I am on the "Dataset Search" page
+    # Group
+    Given I press "Reset"
     When I search for "Test"
     Then I click "Group 01"
     And I should not see "Dataset 01"
     But I should see "Dataset 02"
 
-  Scenario: View Topics Search Page
+    # Topics
     Given I am on the "Topics Search" page
     Then I should see "edumication" in the "filter by topics" region
     When I click "edumication"
     Then I should not see "Dataset 02"
     But I should see "Dataset 01"
-
-  Scenario: Topics redirect
+    # Topics redirect
     Given I visit "topics"
     Then I should see "Search"
     And I should not see "Page not found"
 
+    # Format
+    Given I am on the "Dataset Search" page
+    And I fill in "csv 2" for "Search" in the "datasets" region
+    Then I should see "csv 2 (1)" in the "filter by resource format" region
+    And I fill in "html 2" for "Search" in the "datasets" region
+    And I should see "html 2 (1)" in the "filter by resource format" region
+
+  @search_04
   Scenario Outline: Forbid XSS injection in search
     Given I am on the "<page>" page
     Then I should see "Page not found"

--- a/test/features/search.feature
+++ b/test/features/search.feature
@@ -77,25 +77,25 @@ Feature: Search
     Then I should see "politics01 (1)" in the "filter by tag" region
 
     # Group
-    Given I press "Reset"
-    When I search for "Test"
+    When I press "Reset"
+    And I search for "Test"
     Then I click "Group 01"
     And I should not see "Dataset 01"
     But I should see "Dataset 02"
 
     # Topics
-    Given I am on the "Topics Search" page
+    When I am on the "Topics Search" page
     Then I should see "edumication" in the "filter by topics" region
     When I click "edumication"
     Then I should not see "Dataset 02"
     But I should see "Dataset 01"
     # Topics redirect
-    Given I visit "topics"
+    When I visit "topics"
     Then I should see "Search"
     And I should not see "Page not found"
 
     # Format
-    Given I am on the "Dataset Search" page
+    When I am on the "Dataset Search" page
     And I fill in "csv 2" for "Search" in the "datasets" region
     Then I should see "csv 2 (1)" in the "filter by resource format" region
     And I fill in "html 2" for "Search" in the "datasets" region


### PR DESCRIPTION
connects https://github.com/NuCivic/dkan_management/issues/66

https://docs.google.com/spreadsheets/d/19bpU7SGeNWrHssH2_dX7LUOCHjXmzlCBrRRSvLO3nkE/edit#gid=1450917050
Search functionality tests are a common failure, this PR only simplifies background usage and removes duplicate scenarios.

CDT, ND, VA are not indexing new data when testing, this will need to be addressed if it continues in 1.16

### Reduce duplicate search scenarios
`search.feature` and `dataset.all.feature` duplicate many scenarios and tests for facet functionality spend a lot of time building a large background to test a single facet, I'm combining those into a single scenario.

**dataset.all.feature** 
- dataset_all_1: the front page will be custom no point in testing content here
- dataset_all_2: duplicate of search 2
- dataset_all_3, dataset_all_4: These often fail on client sites when dates are the same
- dataset_all_7: moving to search.feature
- dataset_all_8: duplicate of search
- dataset_all_9: moving to search.feature
- dataset_all_11: duplicate of search
- dataset_all_12: duplicate of search
- dataset_all_14: duplicate of search