### PR TITLE
Remove changelog checkbox from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,5 @@ If this PR introduces new functionality, include a user story or stories describ
 ## Reminders
 
 - [ ] There is test for the issue.
-- [ ] CHANGELOG updated.
 - [ ] Coding standards checked.
 - [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.


### PR DESCRIPTION
We're not asking for changelog lines w/PRs anymore, generating those ourselves for releases.