### PR TITLE
Add redirect to search page on 404 status

### DIFF
--- a/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
@@ -491,7 +491,7 @@ function dkan_sitewide_dataset_search_form($form, $form_state) {
  */
 function dkan_sitewide_dataset_search_form_submit($form, &$form_state) {
   if ($query = $form_state['input']['search']) {
-    drupal_goto('dataset', array('query' => array('query' => $query)));
+    drupal_goto('search', array('query' => array('query' => $query)));
 
   }
 }

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.module
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.module
@@ -266,6 +266,15 @@ function dkan_sitewide_preprocess_page(&$variables) {
   if (isset($variables['is_front']) && $variables['is_front'] == TRUE) {
     drupal_set_title('');
   }
+  // Redirect 404 to search page.
+  $header = drupal_get_http_header("status");
+  if($header == "404 Not Found") {
+    $message = t('The page you requested does not exist or has moved. Try searching the site.');
+    drupal_set_message($message, 'status', FALSE);
+    $query = str_replace('/', ' ', $_SERVER['REQUEST_URI']);
+    unset($_GET['destination']);
+    drupal_goto('search', array('query' => array('query' => $query)));
+  }
 }
 
 /**

--- a/test/features/search.feature
+++ b/test/features/search.feature
@@ -8,14 +8,14 @@ Feature: Search
     And pages:
       | name                      | url                                                |
       | Dataset Search            | /search/type/dataset                               |
-      | Dataset Results           | /search/type/dataset?query=Dataset%2001            |
+      | Dataset Results           | /search?query=Dataset%2001                         |
       | Topics Search             | /search/field_topics                               |
       | Topics Redirect           | /topics                                            |
-      | Not valid type search     | /search/type/notvalid                              |
-      | Not valid tags search     | /search/field_tags/notvalid                        |
-      | Not valid topics search   | /search/field_topic/notvalid                       |
-      | Not valid resource search | /search/field_resources%253Afield_format/notvalid  |
-      | Not valid license search  | /search/field_license/notvalid                     |
+      | Not valid type search     | /search?query=%20search%20type%20notvalid          |
+      | Not valid tags search     | /search?query=%20search%20field_tags%20notvalid    |
+      | Not valid topics search   | /search?query=%20search%20field_topic%20notvalid   |
+      | Not valid resource search | /search?query=%20search%20field_resources%25253Afield_format%20notvalid |
+      | Not valid license search  | /search?query=%20search%20field_license%20notvalid |
     Given users:
       | name    | mail                | roles                |
       | Badmin  | admin@example.com   | site manager         |
@@ -59,8 +59,8 @@ Feature: Search
   Scenario: See number of datasets on search page and Reset dataset search filters
     Given I am on the "Dataset Search" page
     When I search for "DKANTest"
-    Then I should see "2 results"
-    And I should see "2" items in the "datasets" region
+    Then I should see "4 results"
+    And I should see "4" items in the "datasets" region
     When I press "Reset"
     Then I should see all published search content
 
@@ -104,7 +104,7 @@ Feature: Search
   @search_04
   Scenario Outline: Forbid XSS injection in search
     Given I am on the "<page>" page
-    Then I should see "Page not found"
+    Then I should see "No results were found. Please try another keyword."
     Examples:
     | page                      |
     | Not valid type search     |


### PR DESCRIPTION
Fixes https://github.com/GetDKAN/dkan/issues/2484

Changes 404 behavior to produce a working search initially set to the bad URL. Also changes the header search box behavior to search whole site, not just datasets.

### Steps to reproduce
- Type in a url that does not exist, when on the 404 page, try to use the search block in the header
- Confirm the search is not performed
- Now go to an existing page, use the search block in the header
- Confirm that the results are filtered to only include datasets 

### QA Steps
- [ ] Type in a url that does not exist
- [ ] Confirm that you are redirected to the search page 
- [ ] Confirm that the search block in the header works and does not limit results to datasets