### PR TITLE
Update css for ppt/pptx files

### DIFF
--- a/modules/dkan/dkan_dataset/css/dkan_dataset.css
+++ b/modules/dkan/dkan_dataset/css/dkan_dataset.css
@@ -519,6 +519,13 @@ li .heading:hover {
 .label[data-format*=kmz] {
   background-color: #3F6EA5;
 }
+.label[data-format=ppt],
+.label[data-format*=ppt],
+.label[data-format=pptx],
+.label[data-format*=pptx] {
+  background-color: #CF452C;
+}
+
 
 .format-label {
   color: transparent;
@@ -626,6 +633,11 @@ li .heading:hover {
 .format-label[data-format=kmz]:before {
   content: "\e655";
   color: #3F6EA5;
+}
+.format-label[data-format=ppt]:before,
+.format-label[data-format=pptx]:before {
+  content: "\e682";
+  color: #CF452C;
 }
 
 .node-resource .download .format-label {


### PR DESCRIPTION
small css update for clients allowing ppt/pptx files

### QA steps
- Create a resource with https://cnra-assets.s3.amazonaws.com/resources/27c66899-ed33-4b29-93f4-2f0fecaa59cb/dsm2usersgroupmtg06192018.pptx
- Confirm you see the pptx icon and not the generic 'data' icon

<img width="486" alt="pptx" src="https://user-images.githubusercontent.com/314172/42858479-72b4a758-8a14-11e8-8119-6e3a5b875a55.png">
