### PR TITLE
Remove group member count and link from group page

### DIFF
--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_groups/dkan_dataset_groups.module
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_groups/dkan_dataset_groups.module
@@ -69,12 +69,7 @@ function dkan_dataset_groups_block_view_alter(&$data, $block) {
 
       // If the user is logged in then display the 'Request membership' link.
       if (user_is_logged_in()) {
-        $data['content']['#markup'] .= '<div class="group-owner-message"><strong>' . $subscribe_link . '</strong></div>';
-      }
-
-      // Hide member count if group is empty.
-      if (count($members)) {
-        $data['content']['#markup'] .= '<div class="group-subscribe-message"><a href="/node/' . $group['gid'] . '/members">Members (' . count($members) . ')</a></div>';
+        $data['content']['#markup'] .= '<div class="group-subscribe-message"><strong>' . $subscribe_link . '</strong></div>';
       }
 
     }

--- a/test/features/group.admin.feature
+++ b/test/features/group.admin.feature
@@ -72,8 +72,9 @@ Feature: Site managers administer groups
     And I press "Add users"
     Then I should see "Katie has been added to the group Group 02"
     When I am on "Group 02" page
-    And I click "Members"
-    Then I should see "Katie" in the "group members" region
+    And I click "Group"
+    And I click "People"
+    Then I should see "Katie"
 
   @group_admin_04
   Scenario: Remove a group member from any group
@@ -85,8 +86,9 @@ Feature: Site managers administer groups
     And I press "Remove"
     Then I should see "The membership was removed"
     And I am on "Group 01" page
-    And I click "Members"
-    And I should not see "Katie" in the "group members" region
+    And I click "Group"
+    And I click "People"
+    And I should not see "Katie"
 
   @group_admin_05
   Scenario: Delete any group

--- a/test/features/group.all.feature
+++ b/test/features/group.all.feature
@@ -100,11 +100,12 @@ Feature: Site Manager administer groups
   Scenario: View the list of group members
     Given I am logged in as "Gabriel"
     And I am on "Group 01" page
-    When I click "Members" in the "group block" region
-    Then I should see "Gabriel" in the "group members" region
-    And I should see "Katie" in the "group members" region
-    And I should not see "Jaz" in the "group members" region
-    And I should not see "John" in the "group members" region
+    When I click "Group"
+    And I click "People"
+    Then I should see "Gabriel"
+    And I should see "Katie"
+    And I should see "Jaz" in the "Pending" row
+    And I should not see "John"
 
   @group_all_06
   Scenario: Search datasets on group

--- a/test/features/group.editor.feature
+++ b/test/features/group.editor.feature
@@ -50,8 +50,9 @@ Feature: Site Manager administer groups
     And I press "Add users"
     Then I should see "Martin has been added to the group Group A"
     When I am on "Group A" page
-    And I click "Members"
-    Then I should see "Martin" in the "group members" region
+    And I click "Group"
+    And I click "People"
+    Then I should see "Martin"
 
   Scenario: Remove group member from a group as group administrator
     Given I am logged in as "Gabriel"
@@ -61,9 +62,9 @@ Feature: Site Manager administer groups
     And I click "remove" in the "Katie" row
     And I press "Remove"
     Then I should see "The membership was removed"
-    When I am on "Group A" page
-    And I click "Members"
-    Then I should not see "Katie" in the "group members" region
+    And I click "Group"
+    And I click "People"
+    Then I should not see "Katie"
 
   Scenario: I should not be able to edit a group that I am not a member of
     Given I am logged in as "Gabriel"


### PR DESCRIPTION
connects #2558

### QA Steps
- Add users to a group
- View the group page
- Confirm you do not see the member info at the bottom of the Group block