### PR TITLE
Datastore one-step form

### DIFF
--- a/modules/dkan/dkan_datastore/dkan_datastore.module
+++ b/modules/dkan/dkan_datastore/dkan_datastore.module
@@ -63,32 +63,11 @@ function dkan_datastore_menu() {
   $items['node/%node/datastore'] = array(
     'title' => 'Manage Datastore',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('dkan_datastore_pages', 1, "importForm"),
+    'page arguments' => array('dkan_datastore_form', 1),
     'access callback' => 'dkan_datastore_access',
     'access arguments' => array('manage', 1),
     'file' => 'dkan_datastore.pages.inc',
     'weight' => '15',
-    'type' => MENU_LOCAL_TASK,
-  );
-  $items['node/%node/datastore/import'] = array(
-    'title' => 'Import',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('dkan_datastore_pages', 1, "importForm"),
-    'access callback' => 'dkan_datastore_access',
-    'access arguments' => array('import', 1),
-    'file' => 'dkan_datastore.pages.inc',
-    'weight' => 10,
-    'type' => MENU_DEFAULT_LOCAL_TASK,
-  );
-
-  $items['node/%node/datastore/drop'] = array(
-    'title' => 'Drop Datastore',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('dkan_datastore_pages', 1, "dropForm"),
-    'access callback' => 'dkan_datastore_access',
-    'access arguments' => array('drop', 1),
-    'file' => 'dkan_datastore.pages.inc',
-    'weight' => 12,
     'type' => MENU_LOCAL_TASK,
   );
   return $items;
@@ -225,12 +204,9 @@ function dkan_add_resource($node) {
 function dkan_datastore_node_insert($node) {
   $type = dkan_datastore_node_type();
   if ($node->type == $type) {
-    if (!isset($node->feeds)) {
-      // Feeds only saves if there is a form present. We want this to work
-      // programmatically as well.
-      feeds_node_prepare($node);
-      feeds_node_update($node);
-    }
+    $resource = Resource::createFromDrupalNode($node);
+    $datastore_manager = Factory::create($resource, 'Dkan\Datastore\Manager\SimpleImport\SimpleImport');
+    $datastore_manager->saveState();
   }
 }
 

--- a/modules/dkan/dkan_datastore/dkan_datastore.module
+++ b/modules/dkan/dkan_datastore/dkan_datastore.module
@@ -63,7 +63,7 @@ function dkan_datastore_menu() {
   $items['node/%node/datastore'] = array(
     'title' => 'Manage Datastore',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('dkan_datastore_form', 1),
+    'page arguments' => array('dkan_datastore_pages', 1),
     'access callback' => 'dkan_datastore_access',
     'access arguments' => array('manage', 1),
     'file' => 'dkan_datastore.pages.inc',

--- a/modules/dkan/dkan_datastore/dkan_datastore.pages.inc
+++ b/modules/dkan/dkan_datastore/dkan_datastore.pages.inc
@@ -55,18 +55,25 @@ function dkan_datastore_add_resource($node) {
 /**
  * Datastore forms menu callback.
  */
-function dkan_datastore_form($form, &$form_state, $node) {
+function dkan_datastore_pages($form, &$form_state, $node, $method) {
   $form['#node'] = $node;
   $pages = new Pages($node);
   return $pages->importForm($form, $form_state);
 }
 
-function dkan_datastore_form_import_submit($form, &$form_state) {
+function dkan_datastore_pages_submit($form, &$form_state) {
   $pages = new Pages($form['#node']);
-  $pages->importFormSubmit($form, $form_state);
+  if (isset($form_state['storage']['drop']) && $form_state['storage']['drop']) {
+    $pages->dropFormSubmit($form, $form_state);
+  }
+  else {
+    $pages->importFormSubmit($form, $form_state);
+  }
 }
 
-function dkan_datastore_form_drop_submit($form, &$form_state) {
-  $pages = new Pages($form['#node']);
-  $pages->dropFormSubmit($form, $form_state);
+function dkan_datastore_drop_submit($form, &$form_state) {
+  dpm($form_state);
+  $form_state['storage']['drop'] = TRUE;
+  $form_state['storage']['original_form'] = $form_state['values'];
+  $form_state['rebuild'] = TRUE;
 }

--- a/modules/dkan/dkan_datastore/dkan_datastore.pages.inc
+++ b/modules/dkan/dkan_datastore/dkan_datastore.pages.inc
@@ -55,7 +55,7 @@ function dkan_datastore_add_resource($node) {
 /**
  * Datastore forms menu callback.
  */
-function dkan_datastore_pages($form, &$form_state, $node, $method) {
+function dkan_datastore_pages($form, &$form_state, $node) {
   $form['#node'] = $node;
   $pages = new Pages($node);
   return $pages->loadForm($form, $form_state);

--- a/modules/dkan/dkan_datastore/dkan_datastore.pages.inc
+++ b/modules/dkan/dkan_datastore/dkan_datastore.pages.inc
@@ -55,23 +55,18 @@ function dkan_datastore_add_resource($node) {
 /**
  * Datastore forms menu callback.
  */
-function dkan_datastore_pages($form, &$form_state, $node, $method) {
+function dkan_datastore_form($form, &$form_state, $node) {
   $form['#node'] = $node;
-  $form['#pages_method'] = $method;
-
   $pages = new Pages($node);
-  return $pages->{$method}($form, $form_state);
+  return $pages->importForm($form, $form_state);
 }
 
-/**
- * Form submit handler.
- */
-function dkan_datastore_pages_submit($form, &$form_state) {
-  $node = $form['#node'];
+function dkan_datastore_form_import_submit($form, &$form_state) {
+  $pages = new Pages($form['#node']);
+  $pages->importFormSubmit($form, $form_state);
+}
 
-  $method = $form['#pages_method'];
-  $submit_method = "{$method}Submit";
-
-  $pages = new Pages($node);
-  $pages->{$submit_method}($form, $form_state);
+function dkan_datastore_form_drop_submit($form, &$form_state) {
+  $pages = new Pages($form['#node']);
+  $pages->dropFormSubmit($form, $form_state);
 }

--- a/modules/dkan/dkan_datastore/dkan_datastore.pages.inc
+++ b/modules/dkan/dkan_datastore/dkan_datastore.pages.inc
@@ -58,7 +58,7 @@ function dkan_datastore_add_resource($node) {
 function dkan_datastore_pages($form, &$form_state, $node, $method) {
   $form['#node'] = $node;
   $pages = new Pages($node);
-  return $pages->importForm($form, $form_state);
+  return $pages->loadForm($form, $form_state);
 }
 
 function dkan_datastore_pages_submit($form, &$form_state) {
@@ -72,7 +72,6 @@ function dkan_datastore_pages_submit($form, &$form_state) {
 }
 
 function dkan_datastore_drop_submit($form, &$form_state) {
-  dpm($form_state);
   $form_state['storage']['drop'] = TRUE;
   $form_state['storage']['original_form'] = $form_state['values'];
   $form_state['rebuild'] = TRUE;

--- a/modules/dkan/dkan_datastore/src/Pages.php
+++ b/modules/dkan/dkan_datastore/src/Pages.php
@@ -55,11 +55,12 @@ class Pages {
   }
 
   /**
-   * Private method.
+   * Create form element for chosing datastore manager. This is currently
+   * included in the impoort form and not a separate form page.
    */
-  private function chooseManagerForm($form) {
+  private function chooseManagerForm($form, $datastore_manager = NULL) {
     $managers_info = dkan_datastore_managers_info();
-
+    $class = isset($datastore_manager) ? get_class($datastore_manager) : NULL;
     $options = [];
 
     /* @var $manager_info \Dkan\Datastore\Manager\Info */
@@ -70,6 +71,7 @@ class Pages {
       '#type' => 'select',
       '#title' => t('Change datastore importer:'),
       '#options' => $options,
+      '#default_value' => "\\$class",
     );
 
     return $form;
@@ -84,7 +86,7 @@ class Pages {
     $status = $datastore_manager->getStatus();
 
     $form += $this->setStatusInfo($form, $datastore_manager);
-    $form += $this->chooseManagerForm($form);
+    $form += $this->chooseManagerForm($form, $datastore_manager);
 
     $form['import_options'] = [
       '#type' => 'fieldset',

--- a/modules/dkan/dkan_datastore/src/Pages.php
+++ b/modules/dkan/dkan_datastore/src/Pages.php
@@ -58,21 +58,26 @@ class Pages {
    * Create form element for chosing datastore manager. This is currently
    * included in the impoort form and not a separate form page.
    */
-  private function chooseManagerForm($form, $datastore_manager = NULL) {
-    $managers_info = dkan_datastore_managers_info();
-    $class = isset($datastore_manager) ? get_class($datastore_manager) : NULL;
-    $options = [];
+  private function chooseManagerForm($datastore_manager = NULL) {
 
-    /* @var $manager_info \Dkan\Datastore\Manager\Info */
-    foreach ($managers_info as $manager_info) {
-      $options[$manager_info->getClass()] = $manager_info->getLabel();
+    $managers_info = dkan_datastore_managers_info();
+    $form = array();
+    // We only show this if there are multiple managers.
+    if (count($managers_info) > 1) {
+      $class = isset($datastore_manager) ? get_class($datastore_manager) : NULL;
+      $options = [];
+
+      /* @var $manager_info \Dkan\Datastore\Manager\Info */
+      foreach ($managers_info as $manager_info) {
+        $options[$manager_info->getClass()] = $manager_info->getLabel();
+      }
+      $form['datastore_managers_selection'] = array(
+        '#type' => 'select',
+        '#title' => t('Change datastore importer:'),
+        '#options' => $options,
+        '#default_value' => "\\$class",
+      );
     }
-    $form['datastore_managers_selection'] = array(
-      '#type' => 'select',
-      '#title' => t('Change datastore importer:'),
-      '#options' => $options,
-      '#default_value' => "\\$class",
-    );
 
     return $form;
   }
@@ -100,7 +105,7 @@ class Pages {
     $form += $this->setStatusInfo($form, $datastore_manager);
 
     if (in_array($status['data_import'], [Manager::DATA_IMPORT_READY, Manager::DATA_IMPORT_UNINITIALIZED])) {
-      $form += $this->chooseManagerForm($form, $datastore_manager);
+      $form += $this->chooseManagerForm($datastore_manager);
 
       $form['import_options'] = [
         '#type' => 'fieldset',

--- a/modules/dkan/dkan_datastore/src/Resource.php
+++ b/modules/dkan/dkan_datastore/src/Resource.php
@@ -94,10 +94,13 @@ class Resource {
   }
 
   /**
-   * Private method.
+   * Get the full path to a resource's file regardless of whether upload or
+   * remote file.
    */
   private static function filePath($node) {
     if (!empty($node->field_upload)) {
+      // We can't trust that the field_upload array will contain a real uri, so
+      // we need to load the full file object.
       $file = file_load($node->field_upload[LANGUAGE_NONE][0]['fid']);
       $drupal_uri = $file->uri;
       return drupal_realpath($drupal_uri);

--- a/modules/dkan/dkan_datastore/src/Resource.php
+++ b/modules/dkan/dkan_datastore/src/Resource.php
@@ -98,13 +98,15 @@ class Resource {
    */
   private static function filePath($node) {
     if (!empty($node->field_upload)) {
-      $drupal_uri = $node->field_upload[LANGUAGE_NONE][0]['uri'];
+      $file = file_load($node->field_upload[LANGUAGE_NONE][0]['fid']);
+      $drupal_uri = $file->uri;
       return drupal_realpath($drupal_uri);
     }
     if (!empty($node->field_link_remote_file)) {
+      $file = file_load($node->field_link_remote_file[LANGUAGE_NONE][0]['fid']);
       stream_wrapper_restore("https");
       stream_wrapper_restore("http");
-      return $node->field_link_remote_file[LANGUAGE_NONE][0]['uri'];
+      return $file->uri;
     }
     throw new \Exception(t("Node !nid doesn't have a proper file path.", array('!nid' => $node->nid)));
   }


### PR DESCRIPTION
Fixes #2619 

Improve the UX of datastore import form and related pages by making the interface a single-page form.

## QA Steps

### One importer available

(Normal state upon install)

- [ ] Create a CSV resource
- [ ] Click "manage datastore".
- [ ] Run the import. Confirm that UX is intuitive and no choices are presented about what importer to use
- [ ] Drop the datastore. Confirm that UX is intuitive and datastore returns to initial state and can be re-imported

### Two importers available

- [ ] Enable fast import module
- [ ] Create a CSV resource
- [ ] Click "manage datastore"
- [ ] Confirm that there is an importer selector
- [ ] Run the import
- [ ] Confirm that correct importer was used
- [ ] Drop the datastore
- [ ] Change to a different importer and run the import again
- [ ] Confirm that the selected importer is used.

## Known issues

* Currently no way to set default importer, which was part of original acceptance criteria
* Config object now made on node creation. It's made for _any_ resource, not just ones with CSV files
* Still lacking help text