### PR TITLE
Work-around for version check until the version strategy is determined

### DIFF
--- a/modules/dkan/dkan_sitewide/dkan_sitewide.module
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.module
@@ -188,12 +188,11 @@ function dkan_sitewide_update_status_alter(&$projects) {
     }
   }
 
-  $project = 'dkan';
-  $tags = drupal_http_request('https://api.github.com/repos/GetDKAN/' . $project . '/tags');
+  $tags = drupal_http_request('https://api.github.com/repos/GetDKAN/dkan/tags');
   $tags = json_decode($tags->data);
   if (isset($tags->message)) {
     drupal_set_message("Could not get an update from Github on DKAN since github rate limit exceeded.");
-    unset($projects[$project]);
+    unset($projects['dkan']);
     return;
   }
   $dkan_tag = $tags[0]->name;
@@ -203,8 +202,8 @@ function dkan_sitewide_update_status_alter(&$projects) {
   $tag_commit = json_decode($tag_commit->data);
   $tag_date = date("U", strtotime($tag_commit->commit->author->date));
 
-  $current_version = $projects[$project]['existing_version'];
-  // To do: fix this when version info is implemented.
+  $current_version = isset($projects['dkan']) ? $projects['dkan']['existing_version'] : '';
+
   if (!empty($current_version)) {
     if ($current_version == $dkan_tag) {
       $projects[$project]['status'] = UPDATE_CURRENT;

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.module
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.module
@@ -189,9 +189,7 @@ function dkan_sitewide_update_status_alter(&$projects) {
   }
 
   $project = 'dkan';
-  $org = 'nucivic';
-
-  $tags = drupal_http_request('https://api.github.com/repos/NuCivic/' . $project . '/tags');
+  $tags = drupal_http_request('https://api.github.com/repos/GetDKAN/' . $project . '/tags');
   $tags = json_decode($tags->data);
   if (isset($tags->message)) {
     drupal_set_message("Could not get an update from Github on DKAN since github rate limit exceeded.");
@@ -206,47 +204,50 @@ function dkan_sitewide_update_status_alter(&$projects) {
   $tag_date = date("U", strtotime($tag_commit->commit->author->date));
 
   $current_version = $projects[$project]['existing_version'];
-  if ($current_version == $dkan_tag) {
-    $projects[$project]['status'] = UPDATE_CURRENT;
-  }
-  else {
-    $projects[$project]['status'] = UPDATE_NOT_CHECKED;
-  }
-  $minor = str_replace('7.x-1.', '', $dkan_tag);
-  foreach (array($current_version, $dkan_tag) as $version) {
-    $projects[$project]['releases'][$version]['name'] = $project . ' ' . $version;
-    $projects[$project]['releases'][$version]['version'] = $version;
-    $projects[$project]['releases'][$version]['tag'] = $version;
-    $projects[$project]['releases'][$version]['date'] = time();
-    $projects[$project]['releases'][$version]['tag'] = $version;
-    $projects[$project]['releases'][$version]['reason'] = $version . ' Release';
-    $projects[$project]['releases'][$version]['version_major'] = $projects[$project]['existing_major'];
-    $projects[$project]['releases'][$version]['version_extra'] = str_replace('7.x-', '', $version);
-    $projects[$project]['releases'][$version]['status'] = 'published';
-    if ($minor != 'x') {
-      $projects[$project]['releases'][$version]['download_link'] = str_replace('7.x-1.', '', $dkan_tag);
+  // To do: fix this when version info is implemented.
+  if (!empty($current_version)) {
+    if ($current_version == $dkan_tag) {
+      $projects[$project]['status'] = UPDATE_CURRENT;
     }
     else {
-      $projects[$project]['releases'][$version]['download_link'] = '';
+      $projects[$project]['status'] = UPDATE_NOT_CHECKED;
     }
-  }
-  $projects[$project]['releases'][$dkan_tag]['date'] = $tag_date;
+    $minor = str_replace('7.x-1.', '', $dkan_tag);
+    foreach (array($current_version, $dkan_tag) as $version) {
+      $projects[$project]['releases'][$version]['name'] = $project . ' ' . $version;
+      $projects[$project]['releases'][$version]['version'] = $version;
+      $projects[$project]['releases'][$version]['tag'] = $version;
+      $projects[$project]['releases'][$version]['date'] = time();
+      $projects[$project]['releases'][$version]['tag'] = $version;
+      $projects[$project]['releases'][$version]['reason'] = $version . ' Release';
+      $projects[$project]['releases'][$version]['version_major'] = $projects[$project]['existing_major'];
+      $projects[$project]['releases'][$version]['version_extra'] = str_replace('7.x-', '', $version);
+      $projects[$project]['releases'][$version]['status'] = 'published';
+      if ($minor != 'x') {
+        $projects[$project]['releases'][$version]['download_link'] = str_replace('7.x-1.', '', $dkan_tag);
+      }
+      else {
+        $projects[$project]['releases'][$version]['download_link'] = '';
+      }
+    }
+    $projects[$project]['releases'][$dkan_tag]['date'] = $tag_date;
 
-  $projects[$project]['datestamp'] = $tag_date;
-  $projects[$project]['link'] = 'https://github.com/GetDKAN/' . $project;
-  $projects[$project]['reason'] = 'Development Release';
-  $projects[$project]['releases']['latest_version'] = $dkan_tag;
-  $projects[$project]['releases']['7.x-1.x-dev']['release_link'] = 'https://github.com/GetDKAN/' . $project;
-  $projects[$project]['releases']['7.x-1.x-dev']['reason'] = 'Development Release';
-  $projects[$project]['releases']['7.x-1.x-dev']['download_link'] = 'https://api.github.com/repos/NuCivic/' . $project . '/zipball/7.x-1.x';
+    $projects[$project]['datestamp'] = $tag_date;
+    $projects[$project]['link'] = 'https://github.com/GetDKAN/' . $project;
+    $projects[$project]['reason'] = 'Development Release';
+    $projects[$project]['releases']['latest_version'] = $dkan_tag;
+    $projects[$project]['releases']['7.x-1.x']['release_link'] = 'https://github.com/GetDKAN/' . $project;
+    $projects[$project]['releases']['7.x-1.x']['reason'] = 'Development Release';
+    $projects[$project]['releases']['7.x-1.x']['download_link'] = 'https://api.github.com/repos/GetDKAN/' . $project . '/zipball/7.x-1.x';
 
-  $projects[$project]['releases']['7.x-1.x-dev']['date'] = time();
+    $projects[$project]['releases']['7.x-1.x']['date'] = time();
 
-  $projects[$project]['releases'][$dkan_tag]['release_link'] = 'https://api.github.com/repos/NuCivic/' . $project . '/zipball/' . $dkan_tag;
+    $projects[$project]['releases'][$dkan_tag]['release_link'] = 'https://api.github.com/repos/GetDKAN/' . $project . '/zipball/' . $dkan_tag;
 
-  // Checks to see if last digit is number which means it is on a tag.
-  if (preg_match("/.*?(\d+)$/", $projects[$project]['existing_version'])) {
-    $projects[$project]['recommended'] = $dkan_tag;
+    // Checks to see if last digit is number which means it is on a tag.
+    if (preg_match("/.*?(\d+)$/", $projects[$project]['existing_version'])) {
+      $projects[$project]['recommended'] = $dkan_tag;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #2537

### QA
When on the Available Updates page, you should not see
```
* Warning: Invalid argument supplied for foreach() in theme_update_report() (line 53 of /var/www/docroot/modules/update/update.report.inc).
* Warning: sort() expects parameter 1 to be array, null given in theme_update_report() (line 182 of /var/www/docroot/modules/update/update.report.inc).
* Warning: implode(): Invalid arguments passed in theme_update_report() (line 193 of /var/www/docroot/modules/update/update.report.inc).

```
