### PR TITLE
Automate group role assignments

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -237,7 +237,7 @@ projects:
       url: https://git.drupal.org/project/multistep.git
       revision: 3b0d40a
   og:
-    version: '2.9'
+    version: '2.10'
     patch:
       1090438: https://drupal.org/files/issues/og-add_users_and_entities_with_drush-1090438-12.patch
       2549071: https://www.drupal.org/files/issues/og_actions-bug-vbo-delete.patch

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_groups/dkan_dataset_groups.module
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_groups/dkan_dataset_groups.module
@@ -379,7 +379,6 @@ function dkan_dataset_groups_user_update(&$edit, $account, $category) {
         ->condition('o.rid', $rid);
       $result = $query->execute();
 
-      // If any, display a message to the user letting them know about the role update.
       if ($result) {
         $groups = '';
         foreach ($result as $delta => $row) {
@@ -388,7 +387,7 @@ function dkan_dataset_groups_user_update(&$edit, $account, $category) {
             $groups .= ', ';
           }
         }
-
+        // If there are groups, display a message to the user letting them know about the role update.
         if ($groups != '') {
           drupal_set_message(t('%user no longer has the editor or site manager role so has also been removed as an administrator on the following groups: %groups.', array('%user' => $account->name, '%groups' => $groups)), 'status');
         }
@@ -403,6 +402,7 @@ function dkan_dataset_groups_user_update(&$edit, $account, $category) {
 
     // If the user IS an editor, and belongs to a group or groups,
     // add the og administrator role if not already set.
+    // Note: Site managers can already edit any content without the group administrator role.
     if (user_has_role($rid1->rid, $account)) {
       // Get the list of groups associated with the user.
       $query = db_select('og_membership', 'm');
@@ -446,5 +446,37 @@ function dkan_dataset_groups_user_update(&$edit, $account, $category) {
         }
       }
     }
+  }
+}
+
+/**
+ * Implements hook_og_role_grant().
+ */
+function dkan_dataset_og_role_grant($entity_type, $gid, $uid, $rid) {
+  // Check to see if a content creator is being granted the group administrator role.
+  // Content creators should not be editing other user's content.
+  // Instruct the user trying to grant the role to first assign
+  // the content creator the editor role.
+  $user = user_load($uid);
+  $admin = dkan_dataset_groups_get_og_rid_by_name('administrator member');
+  $ok = array('administrator', 'site manager', 'editor', 'Workflow Moderator', 'Workflow Supervisor');
+  if (in_array('content creator', $user->roles)
+    && empty(array_intersect($ok, $user->roles))
+    && $rid == $admin) {
+
+    // Prepare variables for message.
+    if (module_exists('dkan_workflow')) {
+      $role = 'Workflow Moderator';
+    }
+    else {
+      $role = 'Editor';
+    }
+    $link = l(t('update their role'), '/user/' . $uid . '/edit');
+
+    // Explain why content creators can not be group administrators.
+    $message = t("@name is a content creator and should not be able to edit other user's content. If you would like @name to be an administrator of this group, first !update to @role.", array('@name' => $user->name, '!update' => $link, '@role' => $role));
+    // Remove the group administrator role.
+    og_role_revoke('node', $gid, $uid, $rid);
+    drupal_set_message($message, 'warning');
   }
 }

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_groups/dkan_dataset_groups.module
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_groups/dkan_dataset_groups.module
@@ -364,10 +364,17 @@ function dkan_dataset_groups_user_update(&$edit, $account, $category) {
   // also not a 'site manager' then the 'administrator member' OG role is removed.
   // The roles are modified on all the groups the updated user belongs to.
   if (module_exists('og')) {
-
+    if (module_exists('dkan_workflow')) {
+      $r1 = 'Workflow Moderator';
+      $r2 = 'Workflow Supervisor';
+    }
+    else {
+      $r1 = 'editor';
+      $r2 = 'site manager';
+    }
     $rid = dkan_dataset_groups_get_og_rid_by_name('administrator member');
-    $rid1 = user_role_load_by_name('editor');
-    $rid2 = user_role_load_by_name('site manager');
+    $rid1 = user_role_load_by_name($r1);
+    $rid2 = user_role_load_by_name($r2);
     // If the user is not an 'editor' or 'site manager'.
     if (!user_has_role($rid1->rid, $account) && !user_has_role($rid2->rid, $account)) {
       // Get the list of groups where the user has the 'administrator member' role.
@@ -389,7 +396,7 @@ function dkan_dataset_groups_user_update(&$edit, $account, $category) {
         }
         // If there are groups, display a message to the user letting them know about the role update.
         if ($groups != '') {
-          drupal_set_message(t('%user no longer has the editor or site manager role so has also been removed as an administrator on the following groups: %groups.', array('%user' => $account->name, '%groups' => $groups)), 'status');
+          drupal_set_message(t('%user no longer has the %role1 or %role2 role so has also been removed as an administrator on the following groups: %groups.', array('%user' => $account->name, '%groups' => $groups, '%role1' => $r1, '%role2' => $r2)), 'status');
         }
       }
 
@@ -406,8 +413,7 @@ function dkan_dataset_groups_user_update(&$edit, $account, $category) {
     if (user_has_role($rid1->rid, $account)) {
       // Get the list of groups associated with the user.
       $query = db_select('og_membership', 'm');
-      $query->join('og_users_roles', 'o', 'm.gid = o.gid');
-      $query->join('node', 'n', 'o.gid = n.nid');
+      $query->join('node', 'n', 'm.gid = n.nid');
       $query
         ->fields('n', array('nid', 'title'))
         ->condition('m.entity_type', 'user')
@@ -440,7 +446,7 @@ function dkan_dataset_groups_user_update(&$edit, $account, $category) {
 
             // Display a message to the user.
             if (isset($row->title)) {
-              drupal_set_message(t('%user is an editor so has also been granted the group administrator role for the group: %group.', array('%user' => $account->name, '%group' => $row->title)), 'status');
+              drupal_set_message(t('%user has the %role1 role so has also been granted the group administrator role for the group: %group.', array('%user' => $account->name, '%group' => $row->title, '%role1' => $r1)), 'status');
             }
           }
         }
@@ -452,31 +458,40 @@ function dkan_dataset_groups_user_update(&$edit, $account, $category) {
 /**
  * Implements hook_og_role_grant().
  */
-function dkan_dataset_og_role_grant($entity_type, $gid, $uid, $rid) {
-  // Check to see if a content creator is being granted the group administrator role.
-  // Content creators should not be editing other user's content.
-  // Instruct the user trying to grant the role to first assign
-  // the content creator the editor role.
+function dkan_dataset_groups_og_role_grant($entity_type, $gid, $uid, $rid) {
   $user = user_load($uid);
   $admin = dkan_dataset_groups_get_og_rid_by_name('administrator member');
   $ok = array('administrator', 'site manager', 'editor', 'Workflow Moderator', 'Workflow Supervisor');
+  // Check to see if a content creator is being granted the group administrator role.
+  // Content creators should not be editing other user's content.
+  // Upgrade the user to an editor or workflow moderator role.
   if (in_array('content creator', $user->roles)
     && empty(array_intersect($ok, $user->roles))
     && $rid == $admin) {
 
-    // Prepare variables for message.
+    // Provide account edit link in case user wants to undo the change.
+    $link = l(t('edit the user account'), '/user/' . $uid . '/edit');
+
+    // Prepare message to user.
     if (module_exists('dkan_workflow')) {
-      $role = 'Workflow Moderator';
+      $old_role = 'workflow contributor';
+      $new_role = 'workflow moderator';
+      $paired_role = 'editor';
     }
     else {
-      $role = 'Editor';
+      $old_role = 'content creator';
+      $new_role = 'editor';
     }
-    $link = l(t('update their role'), '/user/' . $uid . '/edit');
+    $message = t("<strong>@name</strong> was a @old_role. In order to be an administrator of this group, and edit content created by other users, @name was also given the <strong>@new_role</strong> role. If you would like @name to remain a @old_role, and not administer group content, !edituser to remove the @new_role role.", array('@name' => $user->name, '!edituser' => $link, '@old_role' => $old_role, '@new_role' => $new_role));
 
-    // Explain why content creators can not be group administrators.
-    $message = t("@name is a content creator and should not be able to edit other user's content. If you would like @name to be an administrator of this group, first !update to @role.", array('@name' => $user->name, '!update' => $link, '@role' => $role));
-    // Remove the group administrator role.
-    og_role_revoke('node', $gid, $uid, $rid);
+    $roles = array($new_role);
+    if (isset($paired_role)) {
+      $roles[] = $paired_role;
+    }
+    foreach($roles as $role) {
+      $update_role = user_role_load_by_name($role);
+      user_multiple_role_edit(array($user->uid), 'add_role', $update_role->rid);
+    }
     drupal_set_message($message, 'warning');
   }
 }

--- a/test/features/dataset.editor.feature
+++ b/test/features/dataset.editor.feature
@@ -11,46 +11,29 @@ Feature: Dataset Features
 
 
 Background:
-  Given pages:
-    | name      | url       |
-    | Datasets  | /dataset  |
   Given users:
     | name    | mail                | roles                |
     | John    | john@example.com    | site manager         |
     | Badmin  | admin@example.com   | site manager         |
-    | Gabriel | gabriel@example.com | content creator      |
-    | Jaz     | jaz@example.com     | editor               |
+    | Gabriel | gabriel@example.com | editor               |
     | Katie   | katie@example.com   | content creator      |
-    | Martin  | martin@example.com  | editor               |
     | Celeste | celeste@example.com | editor               |
   Given groups:
     | title    | author  | published |
     | Group 01 | Badmin  | Yes       |
     | Group 02 | Badmin  | Yes       |
-    | Group 03 | Badmin  | No        |
   And group memberships:
     | user    | group    | role on group        | membership status |
     | Gabriel | Group 01 | administrator member | Active            |
     | Katie   | Group 01 | member               | Active            |
-    | Jaz     | Group 01 | member               | Pending           |
-    | Admin   | Group 02 | administrator member | Active            |
     | Celeste | Group 02 | member               | Active            |
-  And "Tags" terms:
-    | name    |
-    | Health  |
-    | Gov     |
   And datasets:
-    | title      | publisher | author  | published | tags   | description | harvest source modified | date changed |
-    | Dataset 01 | Group 01  | Gabriel | Yes       | Health | Test        | 2015-01-02              | -5 year      |
-    | Dataset 02 | Group 01  | Gabriel | Yes       | Gov    | Test        | 2015-01-02              | -5 year      |
-    | Dataset 03 | Group 01  | Katie   | Yes       | Health | Test        | 2015-01-02              | -5 year      |
-    | Dataset 04 | Group 02  | Celeste | No        | Gov    | Test        | 2015-01-02              | -5 year      |
-    | Dataset 05 | Group 01  | Katie   | No        | Gov    | Test        | 2015-01-02              | -5 year      |
-  And resources:
-    | title       | publisher | author | published | dataset    | description |
-    | Resource 01 | Group 01  | Katie  | Yes       | Dataset 01 |             |
-    | Resource 02 | Group 01  | Katie  | Yes       | Dataset 01 |             |
-    | Resource 03 | Group 01  | Katie  | Yes       | Dataset 02 |             |
+    | title      | publisher | author  | published | description | harvest source modified | date changed |
+    | Dataset 01 | Group 01  | Gabriel | Yes       | Test        | 2015-01-02              | -5 year      |
+    | Dataset 02 | Group 01  | Gabriel | Yes       | Test        | 2015-01-02              | -5 year      |
+    | Dataset 03 | Group 01  | Katie   | Yes       | Test        | 2015-01-02              | -5 year      |
+    | Dataset 04 | Group 02  | Celeste | Yes       | Test        | 2015-01-02              | -5 year      |
+    | Dataset 05 | Group 01  | Katie   | No        | Test        | 2015-01-02              | -5 year      |
 
   @noworkflow
   Scenario: Replace node changed date with harvest source modified for harvested datasets
@@ -84,11 +67,12 @@ Background:
     And I press "Finish"
     Then I should see "Dataset Dataset 05 has been updated"
 
-  @noworkflow
+  @noworkflow @javascript
   Scenario: I should not be able to edit datasets of groups that I am not a member of
     Given I am logged in as "Gabriel"
     When I am on "Dataset 04" page
-    Then I should not see the link "Edit"
+    And I hide the admin menu
+    Then I should not see "Edit"
 
   @noworkflow
   Scenario: Delete any dataset associated with the groups that I am a member of

--- a/test/features/group.author.feature
+++ b/test/features/group.author.feature
@@ -46,7 +46,7 @@ Feature: Site Manager administer groups
     And I press "Join"
     Then I should see "Remove pending membership request" in the "group block" region
     When I click "Remove pending membership request" in the "group block" region
-    And I press "Remove"
+    And I press "Unsubscribe"
     Then I should be on the "Group 02" page
     And I should see "Request group membership" in the "group block" region
 
@@ -55,7 +55,7 @@ Feature: Site Manager administer groups
     Given I am logged in as "Katie"
     And I am on "Group 01" page
     When I click "Unsubscribe from group"
-    And I press "Remove"
+    And I press "Unsubscribe"
     Then I should be on the "Group 01" page
     And I should see "Request group membership" in the "group block" region
 

--- a/test/features/group.content_creator.feature
+++ b/test/features/group.content_creator.feature
@@ -1,0 +1,33 @@
+@api @disablecaptcha
+Feature: Content creator and groups
+
+  Background:
+    Given users:
+      | name    | mail                | roles                   |
+      | Cara    | cara@example.com    | content creator         |
+      | Eddy    | eddy@example.com    | editor, content creator |
+      | Shay    | shay@example.com    | site manager            |
+    Given groups:
+      | title      | author  | published |
+      | Test Group | Shay    | Yes       |
+
+  @group_cc_01
+  Scenario: Assign a content creator the group administrator role
+    Given I am logged in as "Shay"
+    And I am on "Test Group" page
+    When I click "Group"
+    And I click "Add people"
+    And I fill in "edit-name" with "Cara"
+    And I check the box "administrator member"
+    And I press "Add users"
+    Then I should see "Cara is a content creator and should not be able to edit other user's content."
+
+  @group_cc_02
+    Scenario: Assign an editor the group administrator role
+    Given I am logged in as "Shay"
+    And I am on "Test Group" page
+    When I click "Group"
+    And I click "Add people"
+    And I fill in "edit-name" with "Eddy"
+    And I press "Add users"
+    Then I should see "Eddy has the editor role, so has also been granted the group administrator role in this group."

--- a/test/features/group.content_creator.feature
+++ b/test/features/group.content_creator.feature
@@ -20,7 +20,7 @@ Feature: Content creator and groups
     And I fill in "edit-name" with "Cara"
     And I check the box "administrator member"
     And I press "Add users"
-    Then I should see "Cara is a content creator and should not be able to edit other user's content."
+    Then I should see "Cara was a content creator. In order to be an administrator of this group, and edit content created by other users, Cara was also given the editor role."
 
   @group_cc_02
     Scenario: Assign an editor the group administrator role

--- a/test/features/group.editor.feature
+++ b/test/features/group.editor.feature
@@ -16,11 +16,11 @@ Feature: Site Manager administer groups
       | Groups    | /groups         |
       | Content   | /admin/content/ |
     Given users:
-      | name    | mail                | roles                |
-      | Gabriel | gabriel@example.com | content creator      |
-      | Jaz     | jaz@example.com     | editor               |
-      | Katie   | katie@example.com   | content creator      |
-      | Martin  | martin@example.com  | editor               |
+      | name    | mail                | roles            |
+      | Gabriel | gabriel@example.com | editor           |
+      | Jaz     | jaz@example.com     | editor           |
+      | Katie   | katie@example.com   | content creator  |
+      | Martin  | martin@example.com  | content creator  |
     Given groups:
       | title    | author  | published |
       | Group A  | Gabriel | Yes       |
@@ -66,10 +66,11 @@ Feature: Site Manager administer groups
     And I click "People"
     Then I should not see "Katie"
 
-  Scenario: I should not be able to edit a group that I am not a member of
+   @javascript
+   Scenario: I should not be able to edit a group that I am not a member of
     Given I am logged in as "Gabriel"
     When I am on "Group B" page
-    Then I should not see the link "Edit"
+    Then I should not see "Edit"
     And I should not see the link "fa-users"
 
   Scenario: Edit membership status of group member as group administrator
@@ -147,11 +148,12 @@ Feature: Site Manager administer groups
     When I click "People"
     Then I should see "Total content: 1"
 
+  @debug
   Scenario: Edit resource content created by others on group as editor
     Given resources:
       | title    | publisher | format | author | published | description |
       | content1 | Group A   | csv    | Katie  | Yes       |             |
-    And I am logged in as "Martin"
+    And I am logged in as "Gabriel"
     And I am on "content1" page
     Then I should see "Edit"
 

--- a/test/features/resource.editor.feature
+++ b/test/features/resource.editor.feature
@@ -10,7 +10,7 @@ Feature: Resource
       | name    | mail                | roles                |
       | John    | john@example.com    | site manager         |
       | Badmin  | admin@example.com   | site manager         |
-      | Gabriel | gabriel@example.com | content creator      |
+      | Gabriel | gabriel@example.com | editor               |
       | Jaz     | jaz@example.com     | editor               |
       | Katie   | katie@example.com   | content creator      |
       | Martin  | martin@example.com  | editor               |
@@ -57,10 +57,11 @@ Feature: Resource
     When I am on "Dataset 01" page
     Then I should see "Resource 01 edited"
 
-  @resource_editor_2 @noworkflow
+  @resource_editor_2 @noworkflow @javascript
   Scenario: I should not be able to edit resources of groups that I am not a member of
     Given I am logged in as "Gabriel"
     And I am on "Resource 05" page
+    And I hide the admin menu
     Then I should not see "Edit"
 
   @resource_editor_3 @fixme @dkanBug @noworkflow


### PR DESCRIPTION
connects #2630
connects #2574

Group roles (member, administrator member) are confusing site managers, these roles should be handled entirely behind the scenes so that site managers don't have to worry about them.

## Issues

- When a user is assigned to a group from the user profile page, they are only in a pending state. You need to go to the group UI to set the user to 'active'. This is resolved by upgrading OG to 2.10
- The group administrator role should only be assigned to editors or site managers since it involves the ability to edit other user's content. This issue is addressed by adding a check before assigning the group administrator role.

## How to reproduce

- [ ] Go to a user account and edit, assign the user to a group and save
- [ ] Visit the group's 'people' page `group/node/[nid]/admin/people` and confirm that the user just added is in a pending state
- [ ] Go to a group's add user page `group/node/[nid]/admin/people/add-user` and add a content creator user, and check the box to give them the group administrator role. Then go to the user's account page and edit any setting and save.
- [ ] Confirm that the group administrator role was revoked.

## QA Steps

- [x] Create a new user, give them the content creator role and add the user to a group and save.
- [x] Go to the group's people page and confirm that the newly added user is 'active' and not 'pending'

- [x] Now use the modify role operation to assign the group administrator role to the user
- [x] Confirm that you get a message that the user was also assigned the editor role. And the user is a  group administrator.
- [x] Click the link in the message to go to the user edit page, uncheck the editor role and save.
- [x] Confirm that the group administrator role was also removed from the user.
- [x] Enable dkan_workflow and repeat the above steps using workflow roles