### PR TITLE
Add UI to change allowed extensions

### DIFF
--- a/docs/components/dataset/usage.rst
+++ b/docs/components/dataset/usage.rst
@@ -60,7 +60,7 @@ Let's take a closer look at some of the metadata fields available on this form:
 :Author: The Dataset's author, in plain text.
 :Spatial / Geographical Coverage Area: Lets us define what region the data applies to. In this case, the US State of Wisconsin. You can use the map widget to draw an outline around the state borders, or, click the "Add data manually" button if you already have a `GeoJSON <http://geojson.org/>`_ string you can paste in.
 :Spatial / Geographical Coverage Location: The region the data applies to, written in plain text. This can be used instead of or in addition to the **Coverage Area** field.
-:Frequency: How often is this dataset updated? We might expect our list of polling places to be updated every year, so we could select "annually." However, often we don't expect the data to be updated (even in this case, perhaps we plan to post the next version of the data as a _separate_ dataset), in which case we can leave this blank.
+:Frequency: How often is this dataset updated? We might expect our list of polling places to be updated every year, so we could select "annually." However, often we don't expect the data to be updated (even in this case, perhaps we plan to post the next version of the data as a *separate* dataset), in which case we can leave this blank.
 :Temporal Coverage: Like Geographic Coverage, this field lets us give some context to the data, but now for the relevant time period. Here we could enter the year or years for which our polling places data is accurate.
 :Granularity: This is a somewhat open-ended metadata field that lets you describe the granularity or accuracy of your data. For instance: "Year". Note, this field is depreciated in DCAT and Project Open Data, and may be removed from DKAN.
 :Data Dictionary: This should be a URL to a resource that provides some sort of description that helps understanding the data. See `Project Open Data data dictionary <https://project-open-data.github.io/schema/#common-core-required-if-applicable-fields>`_ for more info.
@@ -72,11 +72,5 @@ After you click "Save", the metadata we enter will appear on the page for this D
 Configuration
 --------------
 
-Adding or Removing Allowed Resource File Types
-**********************************************
+Learn how to :doc:`add additional file types to your resources here <../../development/custom_file_extensions>`.
 
-Any type of file can be uploaded to Resources (though only CSV files can be imported to the :doc:`Datastore <../datastore>`.
-
-File types are controlled at "/admin/structure/types/manage/resource/fields/field_upload"
-
-To add or remove file types navigate as an 'administrator' and enter extensions into the "Allowed file extensions" field.

--- a/docs/development/custom_file_extensions.rst
+++ b/docs/development/custom_file_extensions.rst
@@ -1,0 +1,18 @@
+Adding additional file types to the *resource* allowed extensions list
+======================================================================
+
+Many different file types can be uploaded on a *resource* (though **only** CSV files can be imported to the :doc:`Datastore <../components/datastore>`.
+
+To view the allowed file extensions that come with DKAN visit ``admin/dkan/dataset_forms``.
+
+**To add additional file types**
+
+1. Navigate to DKAN > DKAN Dataset Forms
+2. Enter the extensions into the "Additional allowed file extensions" field
+3. Click "Save configuration".
+
+You can also add additional extensions in a custom module or with drush by using variable_set().
+
+.. code-block:: php
+
+  variable_set('dkan_custom_extensions', 'ods dct');

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -39,3 +39,4 @@ custom extentions to DKAN. For now, read additional information about:
    license
    modules
    metadatasource
+   custom_file_extensions

--- a/modules/dkan/dkan_dataset/dkan_dataset.admin.inc
+++ b/modules/dkan/dkan_dataset/dkan_dataset.admin.inc
@@ -132,9 +132,32 @@ function dkan_dataset_form_settings() {
         to create new datasets if this is enabled.'),
     '#default_value' => variable_get('dkan_dataset_form_group_validation', 0),
   );
+  $form['dkan_custom_extensions'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Additional allowed file extensions'),
+    '#prefix' => '<div><hr />' . t('DKAN allows the following file formats when adding resources: !default. To allow additional file extension(s), type them below, separated by a space, and save.', array('!default' => dkan_default_extensions())) . '</div>',
+    '#default_value' => variable_get('dkan_custom_extensions'),
+    '#size' => 60,
+    '#maxlength' => 1024,
+  );
 
   return system_settings_form($form);
 }
+
+/**
+ * Validate dkan_custom_extensions in DKAN Dataset form settings.
+ */
+function dkan_dataset_form_settings_validate($form, &$form_state) {
+  $block = ('php exe js sh jar bat ws wsf cmd msi vb vbs scf scr pif');
+  $form_state['values']['dkan_custom_extensions'] = preg_replace("#[[:punct:]]#", "", $form_state['values']['dkan_custom_extensions']);
+  $custom = explode(' ', $form_state['values']['dkan_custom_extensions']);
+  foreach ($custom as $key => $value) {
+    if (stripos($block, $value) !== false) {
+      form_set_error('dkan_custom_extensions', t('!value can not be added.', array('!value' => $value)));
+    }
+  }
+}
+
 
 /**
  * Create table of available formats.

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.module
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.module
@@ -36,6 +36,41 @@ function dkan_dataset_content_types_form_alter(&$form, &$form_state, $form_id) {
       $form['options']['#access'] = TRUE;
     }
   }
+  if ($form_id == 'resource_node_form') {
+    $allowed = dkan_allowed_extensions();
+    $form['field_upload'][LANGUAGE_NONE][0]['#file_resup_upload_validators']['file_validate_extensions'][0] = $allowed;
+    $form['field_link_remote_file'][LANGUAGE_NONE][0]['#upload_validators']['file_validate_extensions'][0] = $allowed;
+  }
+}
+
+/**
+ * Create default extensions variable from the resource upload field config.
+ */
+function dkan_default_extensions() {
+  $field_config = db_select('field_config_instance', 'f')
+    ->fields('f', array('data'))
+    ->condition('field_name', 'field_upload')
+    ->execute()
+    ->fetchCol();
+
+  $data = unserialize($field_config[0]);
+  $default = $data['settings']['file_extensions'];
+  return $default;
+}
+
+/**
+ * Store allowed file extensions in a variable for UI customization.
+ */
+function dkan_allowed_extensions() {
+  $default = dkan_default_extensions();
+  $custom = variable_get('dkan_custom_extensions');
+  if (isset($custom) && !empty($custom)) {
+    $allowed = $default . ' ' . $custom;
+  }
+  else {
+    $allowed = $default;
+  }
+  return $allowed;
 }
 
 /**


### PR DESCRIPTION
Currently custom file extensions are added to custom_config with a hook_form_alter() and when updates are made to DKAN the downstream sites do not get those updates as the override holds true.

By adding a UI where site managers can make adjustments it is easy to get new updates and make changes without a code change.

![form](https://user-images.githubusercontent.com/314172/45516088-aa3a4b00-b76f-11e8-81aa-e68d6804f7bc.png)

### QA Steps
- [ ] Log in as sitemanager
- [ ] Navigate to DKAN > DKAN Dataset Forms
- [ ] Add an extension 
- [ ] Create a new resource
- [ ] Confirm you can upload a file with that extension
