### PR TITLE
Pause Import

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -5,7 +5,7 @@ includes:
 - https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-2.0/visualization_entity.make
 - https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-2.1/open_data_schema_map.make
 - https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/5a5f8faf664aeca02371f6692307580d9fab9116/leaflet_widget.make
-- https://raw.githubusercontent.com/NuCivic/recline/7.x-2.0/recline.make
+- https://raw.githubusercontent.com/NuCivic/recline/working-with-new-datastore/recline.make
 projects:
   admin_menu:
     version: 3.0-rc5
@@ -293,7 +293,7 @@ projects:
     download:
       type: git
       url: https://github.com/GetDKAN/recline.git
-      tag: 7.x-2.0
+      revision: 6b0b8fedf90f629a4a801cb0ffed4505cc801f27
   ref_field:
     download:
       type: git

--- a/modules/dkan/dkan_datastore/dkan_datastore.module
+++ b/modules/dkan/dkan_datastore/dkan_datastore.module
@@ -249,6 +249,17 @@ function dkan_datastore_node_update($node) {
 }
 
 /**
+ * Implements hook_node_delete().
+ */
+function dkan_datastore_node_delete($node) {
+  if ($node->type == "resource") {
+    /* @var  $manager ManagerInterface */
+    $manager = (new Factory(Resource::createFromDrupalNode($node)))->get();
+    $manager->drop();
+  }
+}
+
+/**
  * Implements hook_permission().
  */
 function dkan_datastore_permission() {
@@ -425,7 +436,8 @@ function dkan_datastore_cron() {
       if ($state['data_import'] == ManagerInterface::DATA_IMPORT_IN_PROGRESS) {
         $already_importing = TRUE;
         break;
-      } elseif ($state['data_import'] == ManagerInterface::DATA_IMPORT_READY || $state['data_import'] == ManagerInterface::DATA_IMPORT_PAUSED) {
+      }
+      elseif ($state['data_import'] == ManagerInterface::DATA_IMPORT_READY || $state['data_import'] == ManagerInterface::DATA_IMPORT_PAUSED) {
         $current_nid = $nid;
         break;
       }
@@ -445,7 +457,8 @@ function dkan_datastore_cron() {
 
       if ($finished) {
         print_r(PHP_EOL . "DKAN DATASTORE: Done Importing Resource {$current_nid}" . PHP_EOL);
-      } else {
+      }
+      else {
         $general = "DKAN DATASTORE: There was a problem while importing Resource {$current_nid}";
         $errors = $manager->getErrors();
         $error_string = implode(" | ", $errors);
@@ -453,10 +466,12 @@ function dkan_datastore_cron() {
         print_r(PHP_EOL . $final_error_string . PHP_EOL);
         watchdog("error", $final_error_string);
       }
-    } else {
+    }
+    else {
       if ($already_importing) {
         print_r(PHP_EOL . "DKAN DATASTORE: Already Importing {$nid}" . PHP_EOL);
-      } else {
+      }
+      else {
         print_r(PHP_EOL . "DKAN DATASTORE: No Resources to Import" . PHP_EOL);
       }
     }

--- a/modules/dkan/dkan_datastore/dkan_datastore.module
+++ b/modules/dkan/dkan_datastore/dkan_datastore.module
@@ -413,55 +413,52 @@ function dkan_datastore_node_presave($node) {
  * Implements hook_cron().
  */
 function dkan_datastore_cron() {
-  $storage = new LockableDrupalVariables("dkan_datastore");
+  if (drupal_is_cli()) {
+    $storage = new LockableDrupalVariables("dkan_datastore");
 
-  $bin = $storage->borrowBin();
+    $bin = $storage->borrowBin();
 
-  $already_importing = FALSE;
+    $already_importing = FALSE;
 
-  $current_nid = NULL;
-  foreach ($bin as $nid => $state) {
-    if ($state['data_import'] == ManagerInterface::DATA_IMPORT_IN_PROGRESS) {
-      $already_importing = TRUE;
-      break;
+    $current_nid = NULL;
+    foreach ($bin as $nid => $state) {
+      if ($state['data_import'] == ManagerInterface::DATA_IMPORT_IN_PROGRESS) {
+        $already_importing = TRUE;
+        break;
+      } elseif ($state['data_import'] == ManagerInterface::DATA_IMPORT_READY || $state['data_import'] == ManagerInterface::DATA_IMPORT_PAUSED) {
+        $current_nid = $nid;
+        break;
+      }
     }
-    elseif ($state['data_import'] == ManagerInterface::DATA_IMPORT_READY || $state['data_import'] == ManagerInterface::DATA_IMPORT_PAUSED) {
-      $current_nid = $nid;
-      break;
-    }
-  }
 
-  $storage->returnBin($bin);
+    $storage->returnBin($bin);
 
-  if ($current_nid) {
-    print_r(PHP_EOL . "DKAN DATASTORE: Starting Import of Resource {$nid}" . PHP_EOL);
+    if ($current_nid) {
+      print_r(PHP_EOL . "DKAN DATASTORE: Starting Import of Resource {$nid}" . PHP_EOL);
 
-    $resource = Resource::createFromDrupalNodeNid($current_nid);
+      $resource = Resource::createFromDrupalNodeNid($current_nid);
 
-    /* @var $manager ManagerInterface */
-    $manager = (new Factory($resource))->get();
+      /* @var $manager ManagerInterface */
+      $manager = (new Factory($resource))->get();
 
-    $finished = $manager->import();
+      $finished = $manager->import();
 
-    if ($finished) {
-      print_r(PHP_EOL . "DKAN DATASTORE: Done Importing Resource {$current_nid}" . PHP_EOL);
-    }
-    else {
-      $general = "DKAN DATASTORE: There was a problem while importing Resource {$current_nid}";
-      $errors = $manager->getErrors();
-      $error_string = implode(" | ", $errors);
-      $final_error_string = "{$general} - {$error_string}";
-      print_r(PHP_EOL . $final_error_string . PHP_EOL);
-      watchdog("error", $final_error_string);
-    }
-  }
-  else {
-    if ($already_importing) {
-      print_r(PHP_EOL . "DKAN DATASTORE: Already Importing {$nid}" . PHP_EOL);
-    }
-    else {
-      print_r(PHP_EOL . "DKAN DATASTORE: No Resources to Import" . PHP_EOL);
+      if ($finished) {
+        print_r(PHP_EOL . "DKAN DATASTORE: Done Importing Resource {$current_nid}" . PHP_EOL);
+      } else {
+        $general = "DKAN DATASTORE: There was a problem while importing Resource {$current_nid}";
+        $errors = $manager->getErrors();
+        $error_string = implode(" | ", $errors);
+        $final_error_string = "{$general} - {$error_string}";
+        print_r(PHP_EOL . $final_error_string . PHP_EOL);
+        watchdog("error", $final_error_string);
+      }
+    } else {
+      if ($already_importing) {
+        print_r(PHP_EOL . "DKAN DATASTORE: Already Importing {$nid}" . PHP_EOL);
+      } else {
+        print_r(PHP_EOL . "DKAN DATASTORE: No Resources to Import" . PHP_EOL);
+      }
     }
   }
-
 }

--- a/modules/dkan/dkan_datastore/dkan_datastore.module
+++ b/modules/dkan/dkan_datastore/dkan_datastore.module
@@ -253,9 +253,14 @@ function dkan_datastore_node_update($node) {
  */
 function dkan_datastore_node_delete($node) {
   if ($node->type == "resource") {
-    /* @var  $manager ManagerInterface */
-    $manager = (new Factory(Resource::createFromDrupalNode($node)))->get();
-    $manager->drop();
+    try {
+      /* @var  $manager ManagerInterface */
+      $manager = (new Factory(Resource::createFromDrupalNode($node)))->get();
+      $manager->drop();
+    }
+    catch(\Exception $e) {
+      
+    }
   }
 }
 

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -56,7 +56,7 @@ function normalize_fields($fields, $resources) {
       if (is_assoc($fields) && is_string($fields[$alias]) && $fields[$alias] == '*') {
 
         $table = dkan_datastore_api_tablename($id);
-        $schema = drupal_get_schema($table);
+        $schema = dkan_datastore_api_get_schema($id);
         $new_fields = build_qualified_fields(array_keys($schema['fields']), $alias);
 
         // Fields comes with table prefix either using an
@@ -79,7 +79,7 @@ function normalize_fields($fields, $resources) {
       }
       elseif (is_string($fields) && $fields == '*') {
         $table = dkan_datastore_api_tablename($id);
-        $schema = drupal_get_schema($table);
+        $schema = dkan_datastore_api_get_schema($id);
         $new_fields = build_qualified_fields(array_keys($schema['fields']), $alias);
 
         // Fields comes without table prefix and split by commas.
@@ -163,7 +163,7 @@ function schema_fields($resource_ids) {
   foreach ((array) $resource_ids as $id) {
     $table = dkan_datastore_api_tablename($id);
 
-    $schema = drupal_get_schema($table);
+    $schema = dkan_datastore_api_get_schema($id);
     $meta = array('fields' => array());
 
     $meta_fields = array_merge_recursive($meta['fields'], $schema['fields']);
@@ -669,8 +669,18 @@ function dkan_datastore_api_sort_clean($sort) {
  */
 function dkan_datastore_api_tablename($resource_id) {
   $resource = Resource::createFromDrupalNodeUuid($resource_id);
+  /* @var $manager \Dkan\Datastore\Manager\ManagerInterface */
   $manager = (new Factory($resource))->get();
-  return $manager->getTableName();
+  $table = $manager->getTableName();
+  return $table;
+}
+
+function dkan_datastore_api_get_schema($resource_id) {
+  $resource = Resource::createFromDrupalNodeUuid($resource_id);
+  /* @var $manager \Dkan\Datastore\Manager\ManagerInterface */
+  $manager = (new Factory($resource))->get();
+  $schema = $manager->getTableSchema();
+  return $schema;
 }
 
 /**

--- a/modules/dkan/dkan_datastore/src/LockableDrupalVariables.php
+++ b/modules/dkan/dkan_datastore/src/LockableDrupalVariables.php
@@ -33,6 +33,11 @@ class LockableDrupalVariables {
     return $bin;
   }
 
+  public function getBin() {
+    $bin = variable_get($this->binName, []);
+    return $bin;
+  }
+
   /**
    * Return bin.
    *

--- a/modules/dkan/dkan_datastore/src/Manager/Manager.php
+++ b/modules/dkan/dkan_datastore/src/Manager/Manager.php
@@ -32,7 +32,7 @@ abstract class Manager implements ManagerInterface {
 
     $this->resource = $resource;
 
-    $this->stateDataImport = self::DATA_IMPORT_UNINITIALIZED;
+    $this->stateDataImport = self::DATA_IMPORT_READY;
     $this->stateStorage = self::STORAGE_UNINITIALIZED;
 
     $this->configurableProperties = [];

--- a/modules/dkan/dkan_datastore/src/Manager/Manager.php
+++ b/modules/dkan/dkan_datastore/src/Manager/Manager.php
@@ -32,7 +32,7 @@ abstract class Manager implements ManagerInterface {
 
     $this->resource = $resource;
 
-    $this->stateDataImport = self::DATA_IMPORT_READY;
+    $this->stateDataImport = self::DATA_IMPORT_UNINITIALIZED;
     $this->stateStorage = self::STORAGE_UNINITIALIZED;
 
     $this->configurableProperties = [];

--- a/modules/dkan/dkan_datastore/src/Manager/Manager.php
+++ b/modules/dkan/dkan_datastore/src/Manager/Manager.php
@@ -114,6 +114,7 @@ abstract class Manager implements ManagerInterface {
 
     if (!db_table_exists($table_name)) {
       $schema = $this->getTableSchema();
+
       db_create_table($table_name, $schema);
 
       $this->stateStorage = self::STORAGE_INITIALIZED;
@@ -126,13 +127,14 @@ abstract class Manager implements ManagerInterface {
   }
 
   /**
-   * Private method.
+   * Get table schema.
    */
-  private function getTableSchema() {
+  public function getTableSchema() {
     $schema = [];
     $header = $this->getTableHeaders();
     foreach ($header as $field) {
       $schema['fields'][$field] = [
+        'label' => $field,
         'type' => "varchar",
         'length' => 255,
       ];

--- a/modules/dkan/dkan_datastore/src/Manager/ManagerInterface.php
+++ b/modules/dkan/dkan_datastore/src/Manager/ManagerInterface.php
@@ -107,4 +107,6 @@ interface ManagerInterface {
    */
   public function dropState();
 
+  public function getTableSchema();
+
 }

--- a/modules/dkan/dkan_datastore/src/Page/Component/Status.php
+++ b/modules/dkan/dkan_datastore/src/Page/Component/Status.php
@@ -26,14 +26,14 @@ class Status {
   public function getHtml() {
     $state = $this->datastoreManager->getStatus();
     $stringSubs = [
-      '%class' => $this->formatClassName(get_class($this->datastoreManager)),
-      '%records' => $this->datastoreManager->numberOfRecordsImported(),
-      '%import' => $this->datastoreStateToString($state['data_import']),
+      'class' => $this->formatClassName(get_class($this->datastoreManager)),
+      'records' => $this->datastoreManager->numberOfRecordsImported(),
+      'import' => $this->datastoreStateToString($state['data_import']),
     ];
 
-    $statusInfo = t("<dt>Importer</dt><dd>%class</dd>", $stringSubs);
-    $statusInfo .= t("<dt>Records Imported</dt><dd>%records</dd>", $stringSubs);
-    $statusInfo .= t("<dt>Data Importing</dt><dd>%import</dd>", $stringSubs);
+    $statusInfo ="<dt>" . t("Importer") . "</dt><dd>{$stringSubs['class']}</dd>";
+    $statusInfo .= "<dt>" . t("Records Imported") . "</dt><dd>{$stringSubs['records']}</dd>";
+    $statusInfo .= "<dt>" . t("Data Importing") . "</dt><dd>{$stringSubs['import']}</dd>";
 
     return "<dl>{$statusInfo}</dl>";
   }
@@ -59,28 +59,28 @@ class Status {
   private function datastoreStateToString($state) {
     switch ($state) {
       case ManagerInterface::STORAGE_UNINITIALIZED:
-        return t("Uninitialized");
+        return "<b>" . t("Uninitialized") . "</b>";
 
       case ManagerInterface::STORAGE_INITIALIZED:
-        return t("Initialized");
+        return "<b>" . t("Initialized") . "</b>";
 
       case ManagerInterface::DATA_IMPORT_UNINITIALIZED:
-        return t("Ready");
+        return "<b>" . t("Ready") . "</b>";
 
       case ManagerInterface::DATA_IMPORT_READY:
-        return t("Ready");
+        return "<b>" . t("Ready") . "</b>";
 
       case ManagerInterface::DATA_IMPORT_IN_PROGRESS:
-        return t("In Progress");
+        return "<b>" . t("In Progress") . "</b>";
 
       case ManagerInterface::DATA_IMPORT_PAUSED:
-        return t("Paused");
+        return "<b>" . t("Paused") . ":" . "</b> " . t("The datastore importer is currently paused. It will resume in the background the next time cron runs from drush. See the documentation for more more information.");
 
       case ManagerInterface::DATA_IMPORT_DONE:
-        return t("Done");
+        return "<b>" . t("Done") . "</b>";
 
       case ManagerInterface::DATA_IMPORT_ERROR:
-        return t("Error");
+        return "<b>" . t("Error") . "</b>";
     }
   }
 

--- a/modules/dkan/dkan_datastore/src/Page/Component/Status.php
+++ b/modules/dkan/dkan_datastore/src/Page/Component/Status.php
@@ -31,7 +31,7 @@ class Status {
       'import' => $this->datastoreStateToString($state['data_import']),
     ];
 
-    $statusInfo ="<dt>" . t("Importer") . "</dt><dd>{$stringSubs['class']}</dd>";
+    $statusInfo = "<dt>" . t("Importer") . "</dt><dd>{$stringSubs['class']}</dd>";
     $statusInfo .= "<dt>" . t("Records Imported") . "</dt><dd>{$stringSubs['records']}</dd>";
     $statusInfo .= "<dt>" . t("Data Importing") . "</dt><dd>{$stringSubs['import']}</dd>";
 
@@ -59,28 +59,29 @@ class Status {
   private function datastoreStateToString($state) {
     switch ($state) {
       case ManagerInterface::STORAGE_UNINITIALIZED:
-        return "<b>" . t("Uninitialized") . "</b>";
+        return t("Uninitialized");
 
       case ManagerInterface::STORAGE_INITIALIZED:
-        return "<b>" . t("Initialized") . "</b>";
+        return t("Initialized");
 
       case ManagerInterface::DATA_IMPORT_UNINITIALIZED:
-        return "<b>" . t("Ready") . "</b>";
+        return t("Ready");
 
       case ManagerInterface::DATA_IMPORT_READY:
-        return "<b>" . t("Ready") . "</b>";
+        return t("Ready");
 
       case ManagerInterface::DATA_IMPORT_IN_PROGRESS:
-        return "<b>" . t("In Progress") . "</b>";
+        return t("In Progress");
 
       case ManagerInterface::DATA_IMPORT_PAUSED:
-        return "<b>" . t("Paused") . ":" . "</b> " . t("The datastore importer is currently paused. It will resume in the background the next time cron runs from drush. See the documentation for more more information.");
+        drupal_set_message(t("The datastore importer is currently paused. It will resume in the background the next time cron runs from drush. See the documentation for more more information."));
+        return t("Paused");
 
       case ManagerInterface::DATA_IMPORT_DONE:
-        return "<b>" . t("Done") . "</b>";
+        return t("Done");
 
       case ManagerInterface::DATA_IMPORT_ERROR:
-        return "<b>" . t("Error") . "</b>";
+        return t("Error");
     }
   }
 

--- a/modules/dkan/dkan_datastore/src/Page/Page.php
+++ b/modules/dkan/dkan_datastore/src/Page/Page.php
@@ -63,7 +63,7 @@ class Page {
       ];
 
       $status = $manager->getStatus();
-      if (in_array($status['data_import'], [ManagerInterface::DATA_IMPORT_READY, ManagerInterface::DATA_IMPORT_UNINITIALIZED])) {
+      if (in_array($status['data_import'], [ManagerInterface::DATA_IMPORT_READY])) {
 
         $this->form += (new ManagerSelection($resource, $manager))->getForm();
 

--- a/modules/dkan/dkan_datastore/src/Page/Page.php
+++ b/modules/dkan/dkan_datastore/src/Page/Page.php
@@ -63,7 +63,7 @@ class Page {
       ];
 
       $status = $manager->getStatus();
-      if (in_array($status['data_import'], [ManagerInterface::DATA_IMPORT_READY])) {
+      if (in_array($status['data_import'], [ManagerInterface::DATA_IMPORT_READY, ManagerInterface::DATA_IMPORT_UNINITIALIZED])) {
 
         $this->form += (new ManagerSelection($resource, $manager))->getForm();
 

--- a/modules/dkan/dkan_datastore/src/Page/Page.php
+++ b/modules/dkan/dkan_datastore/src/Page/Page.php
@@ -152,7 +152,12 @@ class Page {
       $context['sandbox']['max'] = 1;
     }
     /* @var $manager ManagerInterface */
-    $manager->import();
+    $finished = $manager->import();
+
+    if ($finished == ManagerInterface::DATA_IMPORT_PAUSED) {
+      return FALSE;
+    }
+
     $context['sandbox']['progress']++;
 
     if ($context['sandbox']['progress'] != $context['sandbox']['max']) {
@@ -164,7 +169,7 @@ class Page {
    * Batch event handler.
    */
   public function batchFinished($success, $results, $operations) {
-    drupal_set_message(t("Import finished"));
+    drupal_set_message(t("The batch process completed successfully."));
   }
 
   /**

--- a/modules/dkan/dkan_datastore/src/Resource.php
+++ b/modules/dkan/dkan_datastore/src/Resource.php
@@ -99,14 +99,14 @@ class Resource {
    * Regardless of whether it was uploaded or a remote file.
    */
   private static function filePath($node) {
-    if (!empty($node->field_upload)) {
+    if (isset($node->field_upload[LANGUAGE_NONE][0]['fid'])) {
       // We can't trust that the field_upload array will contain a real uri, so
       // we need to load the full file object.
       $file = file_load($node->field_upload[LANGUAGE_NONE][0]['fid']);
       $drupal_uri = $file->uri;
       return drupal_realpath($drupal_uri);
     }
-    if (!empty($node->field_link_remote_file)) {
+    if (isset($node->field_link_remote_file[LANGUAGE_NONE][0]['fid'])) {
       $file = file_load($node->field_link_remote_file[LANGUAGE_NONE][0]['fid']);
       stream_wrapper_restore("https");
       stream_wrapper_restore("http");

--- a/test/features/resource.admin.feature
+++ b/test/features/resource.admin.feature
@@ -97,7 +97,7 @@ Feature: Resource
     When I click "Manage Datastore"
     Then I should see "Status"
     When I press "Import"
-    And I wait for "Import Finished"
+    And I wait for "The batch process completed successfully."
     And I press "Drop"
     And I press "Drop"
     Then I should see "Records Imported"

--- a/test/features/resource.author.feature
+++ b/test/features/resource.author.feature
@@ -297,7 +297,7 @@ Feature: Resource
     When I click "Manage Datastore"
     Then I should see "Status"
     When I press "Import"
-    And I wait for "Import Finished"
+    And I wait for "The batch process completed successfully."
     And I press "Drop"
     And I press "Drop"
     Then I should see "Records Imported"

--- a/test/features/resource.editor.feature
+++ b/test/features/resource.editor.feature
@@ -105,7 +105,7 @@ Feature: Resource
     When I click "Manage Datastore"
     Then I should see "Status"
     When I press "Import"
-    And I wait for "Import Finished"
+    And I wait for "The batch process completed successfully."
     And I press "Drop"
     And I press "Drop"
     Then I should see "Records Imported"


### PR DESCRIPTION
Connects #2684
**QA**
- Create a resource with a large file, like https://data.ca.gov/sites/default/files/SafeToSwim_2018-09-04.csv
- Start a datastore import from the UI
- Run cron from drush
- Go back to the UI, you should see that the datastore is in progress and a stop button should be available
- Press the stop button
- A message will let you know that the import will be stopped soon
- Refres the page
- The status should now be paused