### PR TITLE
Fix 'non-numeric value encountered' error

### DIFF
--- a/modules/dkan/dkan_migrate_base/dkan_migrate_base.migrate.inc
+++ b/modules/dkan/dkan_migrate_base/dkan_migrate_base.migrate.inc
@@ -54,8 +54,8 @@ class CKANListJSON extends MigrateListJSON {
   public function __construct($list_url, $http_options = array()) {
     parent::__construct($list_url);
     $this->httpOptions = $http_options;
-    $this->page = isset($http_options['page']) ? $http_options['page'] : '';
-    $this->offset = isset($http_options['offset']) ? $http_options['offset'] : '';
+    $this->page = isset($http_options['page']) ? intval($http_options['page']) : 0;
+    $this->offset = isset($http_options['offset']) ? intval($http_options['offset']) : 0;
     $this->ids = isset($http_options['ids']) ? $http_options['ids'] : '';
   }
 


### PR DESCRIPTION
```
Migration failed with source plugin exception: <em
class="placeholder">A non-numeric value encountered
```
default content fails to build on php 7.1

## Reminders

- [ ] There is test for the issue.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
