### PR TITLE
Update dkan_migrate_base.migrate.inc

### DIFF
--- a/modules/dkan/dkan_migrate_base/dkan_migrate_base.migrate.inc
+++ b/modules/dkan/dkan_migrate_base/dkan_migrate_base.migrate.inc
@@ -54,8 +54,8 @@ class CKANListJSON extends MigrateListJSON {
   public function __construct($list_url, $http_options = array()) {
     parent::__construct($list_url);
     $this->httpOptions = $http_options;
-    $this->page = isset($http_options['page']) ? $http_options['page'] : '';
-    $this->offset = isset($http_options['offset']) ? $http_options['offset'] : '';
+    $this->page = isset($http_options['page']) ? $http_options['page'] : 0;
+    $this->offset = isset($http_options['offset']) ? $http_options['offset'] : 0;
     $this->ids = isset($http_options['ids']) ? $http_options['ids'] : '';
   }
 


### PR DESCRIPTION
This fixes a type error that is raised by adding strings using PHP 7+.