### PR TITLE
Updating Workflow.rst in order to get rid of duplicate workflow doc

### DIFF
--- a/docs/components/workflow.rst
+++ b/docs/components/workflow.rst
@@ -1,8 +1,10 @@
+=============
 DKAN Workflow
 =============
 
 Introduction
-------
+-------------
+
 For large organizations, it can be difficult to moderate vast amounts of content submitted by a wide range of publishers and agencies.
 
 DKAN Workflow is an optional module for `DKAN
@@ -23,8 +25,10 @@ Workflow creates a moderation queue so that content is published to the live sit
 
 The above image displays what you see on My Workbench after login. The Workbench navigation bar contains your content, drafts, and more. The "Create Content" menu features a list of content types you can create.
 
-Installation
-------------
+There are also three different Workflow roles, each with their own moderation permissions. These roles are Workflow Contributor, Workflow Moderator and Workflow Supervisor. For more on Workflow Roles and Permissions, please skip ahead to the "Workflow Roles and Permissions" section of this document.
+
+Installing Workflow
+===================
 
 DKAN Workflow is included on all out-of-the-box DKAN sites; however, it is not enabled by default. It can be enabled either from the Modules management page or by using drush.
 
@@ -41,6 +45,7 @@ You may also see a message instructing you to rebuild permissions. If so, click 
 
 Requirements for DKAN Workflow
 --------------------------------
+
 The DKAN Workflow component as a whole is comprised of three modules:
 
 * DKAN Workflow
@@ -64,6 +69,38 @@ Finally, the following Drupal contrib modules provide extra functionality (Menu 
 All of the aforementioned dependencies are declared in the `drupal-org.make
 <https://github.com/GetDKAN/dkan/blob/7.x-1.x/drupal-org.make>`_ file.
 
+.. _`workflow-roles`:
+
+Workflow Roles and Permissions
+=============================
+
+The three Workflow roles correspond with the three core DKAN `roles and permissions <http://dkan.readthedocs.io/en/latest/components/permissions.html>`_ If a user is given a Workflow role, they must also be granted the corresponding core DKAN role.
+
+* **Workflow Contributor = Content Creator**
+  
+Workflow Contributor is the most basic role; users with this role can add content, save as Draft or move it to Needs Review, but cannot publish content directly to the live site. They can only view content that they've created, and cannot modify the content of others.
+
+* **Workflow Moderator = Editor** 
+
+Workflow Moderator is the middle role, mostly pertaining to moderating specific groups. This role reviews and publishes (or unpublishes) content for their group(s), rather than for the entire site. Workflow Moderators can also view and approve of content that has not yet been assigned to a group.
+
+* **Workflow Supervisor = Site Manager** 
+  
+Workflow Supervisor is the most powerful role and should only be assigned to highly trusted users. Users with the role of Workbench Supervisor can add, edit, modify, publish, unpublish, moderate or delete _all_ site content. This role is the only role that have access to the "Stale Drafts" and "Stale Review" tabs (more information below).
+
+Here is how core roles in DKAN are automatically correlated to Workbench roles and permissions:
+
++-------------------------+-------------------------------------+---------------------------------------------+
+| What a user will see    | "My Drafts"                         | "Needs Review"                              |
++=========================+=====================================+=============================================+
+| Workflow Contributor    |   Only content that they submitted. |   Can see only content they have submitted. |
++-------------------------+-------------------------------------+---------------------------------------------+
+| Workflow Moderator      |   The content submitted to their    |   The content submitted to their organic    |
+|                         |   organic group.                    |   group.                                    |
+|                         |   Their own content.                |   Their own content.                        |
++-------------------------+-------------------------------------+---------------------------------------------+
+| Workflow Supervisor     |  Only content that they submitted.  |  All the "Needs review" content.            |
++-------------------------+-------------------------------------+---------------------------------------------+
 
 My Workbench
 ============
@@ -74,7 +111,7 @@ When logged in as a user that has been assigned a Workbench role, the "My Workbe
 
 .. image:: ../images/workflow/dkan_workflow_main_interface.png
 
-The My Workbench Moderation Toolbar
+The "My Workbench" Moderation Toolbar
 ------------------------------------
 
 :My content: This tab provides a list of all of the content you've created.
@@ -110,39 +147,6 @@ text area.
 
 .. image:: ../images/workflow/workflow_node_edit.png
 
-.. _`workflow-roles`:
-
-Workflow Roles
----------------------------
-
-The three Workflow roles correspond with the three core DKAN `roles and permissions <http://dkan.readthedocs.io/en/latest/components/permissions.html>`_ If a user is given a Workflow role, they must also be granted the corresponding core DKAN role.
-
-* **Workflow Contributor = Content Creator**
-  
-Workflow Contributor is the most basic role; users with this role can add content, save as Draft or move it to Needs Review, but cannot publish content directly to the live site. They can only view content that they've created, and cannot modify the content of others.
-
-* **Workflow Moderator = Editor** 
-
-Workflow Moderator is the middle role, mostly pertaining to moderating specific groups. This role reviews and publishes (or unpublishes) content for their group(s), rather than for the entire site. Workflow Moderators can also view and approve of content that has not yet been assigned to a group.
-
-* **Workflow Supervisor = Site Manager** 
-  
-Workflow Supervisor is the most powerful role and should only be assigned to highly trusted users. Users with the role of Workbench Supervisor can add, edit, modify, publish, unpublish, moderate or delete _all_ site content. This role is the only role that have access to the "Stale Drafts" and "Stale Review" tabs (more information below).
-
-Here is how core roles in DKAN are automatically correlated to Workbench roles and permissions:
-
-+-------------------------+-------------------------------------+---------------------------------------------+
-| What a user will see    | "My Drafts"                         | "Needs Review"                              |
-+=========================+=====================================+=============================================+
-| Workflow Contributor    |   Only content that they submitted. |   Can see only content they have submitted. |
-+-------------------------+-------------------------------------+---------------------------------------------+
-| Workflow Moderator      |   The content submitted to their    |   The content submitted to their organic    |
-|                         |   organic group.                    |   group.                                    |
-|                         |   Their own content.                |   Their own content.                        |
-+-------------------------+-------------------------------------+---------------------------------------------+
-| Workflow Supervisor     |  Only content that they submitted.  |  All the "Needs review" content.            |
-+-------------------------+-------------------------------------+---------------------------------------------+
-
 Changing Notification Email Settings
 -------------------------------------
 
@@ -159,7 +163,7 @@ Emails will display the context that had triggered the notification as well as l
 updated content.
 
 Advanced Options
-==============================================
+==================
 
 Tweaking the Email template
 ---------------------------


### PR DESCRIPTION
Here's the other Workflow doc, which we can get rid of: https://dkan.readthedocs.io/en/latest/admin/people/dkan_workflow.html

This one contains all pertinent information about Workflow (though I'm concerned about RST and the headers looking right on ReadTheDocs!)

Description. Please write any background information about this PR you think is useful for the product team. Use any of the items below that are relevant to this pull request, and delete any that are not.

## User story

If this PR introduces new functionality, include a user story or stories describing what this pull request is intended for.

## How to reproduce

1.  If the PR fixes a bug, include step-by-step instructions for reproducing the bug on a current DKAN release.

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform to confirm that the feature or fix is working. Include as much details as possible so that the reviewer doesn't lose time figuring out how to perform steps.

## Merge process

- [ ] Note if there is a special sequence for merging (such as PRs on other repos that need to be merged first) or other abnormalities to look out for.

## Reminders

- [ ] There is test for the issue.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
