### PR TITLE
Skip encoding '&' on search facets

### DIFF
--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.security.inc
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_search_db/dkan_sitewide_search_db.security.inc
@@ -10,6 +10,8 @@
  */
 function _filter_xss(&$facet) {
   $facet['#markup'] = filter_xss($facet['#markup']);
+  // Reverse encoding of the '&' character.
+  $facet['#markup'] = str_replace('&amp;', '&', $facet['#markup']);
 }
 
 /**


### PR DESCRIPTION
connects #2709

## QA Steps

- [ ] Create or edit a group and use an '&' in the title
- [ ] Go to `/datasets` and view the publishers facet, confirm the '&' is not encoded

## Reminders

- [ ] There is test for the issue.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
