### PR TITLE
Include dkan.profile to prevent undefined function in update

### DIFF
--- a/dkan.install
+++ b/dkan.install
@@ -411,6 +411,7 @@ function dkan_update_7023() {
  * Update default variables.
  */
 function dkan_update_7024(&$context) {
+  require_once('dkan.profile');
   dkan_misc_variables_set($context);
 }
 


### PR DESCRIPTION
In some builds we get an undefined function error for dkan_misc_variables_set() on this update. Not sure why it never came up before but this fixes it.