### PR TITLE
Revision fix

### DIFF
--- a/modules/dkan/dkan_workflow/dkan_workflow.module
+++ b/modules/dkan/dkan_workflow/dkan_workflow.module
@@ -103,6 +103,16 @@ function dkan_workflow_node_grants($user, $op) {
 }
 
 /**
+ * Implements hook_workbench_moderation_acces_alter().
+ */
+function dkan_workflow_workbench_moderation_access_alter(&$access, $op, $node) {
+  global $user;
+  if ($op == 'view history' && $user->uid == 0) {
+    $access = 1;
+  }
+} 
+
+/**
  * Implements hook_node_access_records().
  */
 function dkan_workflow_node_access_records($node) {
@@ -110,14 +120,17 @@ function dkan_workflow_node_access_records($node) {
     // It's published, default handling is okay.
     return;
   }
-  $grants[] = array(
-    'realm' => 'dkan_workflow',
-    'gid' => $node->uid,
-    'grant_view' => 1,
-    'grant_update' => 0,
-    'grant_delete' => 0,
-    'priority' => 0,
-  );
+  // Ensure anon user doesn't have access.
+  if ($node->uid != 0) {
+    $grants[] = array(
+      'realm' => 'dkan_workflow',
+      'gid' => $node->uid,
+      'grant_view' => 1,
+      'grant_update' => 0,
+      'grant_delete' => 0,
+      'priority' => 0,
+    );  
+  }
   return !empty($grants) ? $grants : array();
 }
 

--- a/modules/dkan/dkan_workflow/dkan_workflow.module
+++ b/modules/dkan/dkan_workflow/dkan_workflow.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Code for the NuCivic workflow feature.
+ * Code for the DKAN workflow feature.
  */
 
 include_once 'dkan_workflow.features.inc';

--- a/modules/dkan/dkan_workflow/dkan_workflow.module
+++ b/modules/dkan/dkan_workflow/dkan_workflow.module
@@ -107,6 +107,7 @@ function dkan_workflow_node_grants($user, $op) {
  */
 function dkan_workflow_workbench_moderation_access_alter(&$access, $op, $node) {
   global $user;
+  // Allow anon users to see revision history.
   if ($op == 'view history' && $user->uid == 0) {
     $access = 1;
   }


### PR DESCRIPTION
This keeps anon content from being viewable when dkan_worfklow is turned on. It also brings back the "revision" tab.

## How to reproduce

1. Turn on dkan_worfklow
2. Create an unpublished node and remove the user. See that it is viewable by anon.

## QA Steps

- [ ] Turn on ``dkan_worfklow``
- [ ] Anon users should not be able to see a node without a user
- [ ] Anon users should be able to see "revivsions" tab for datasets

Fixes #2728