### PR TITLE
Change 'stage' to 'test' in dkan_environment

### DIFF
--- a/modules/dkan/dkan_environment/dkan_environment.module
+++ b/modules/dkan/dkan_environment/dkan_environment.module
@@ -11,9 +11,9 @@ function dkan_environment_environment() {
     'description' => t('Local Development Environment.'),
   );
 
-  $environments['stage'] = array(
-    'label' => t('Stage'),
-    'description' => t('Staging Environment.'),
+  $environments['test'] = array(
+    'label' => t('Test'),
+    'description' => t('Test/Staging Environment.'),
   );
 
   return $environments;


### PR DESCRIPTION
Acquia uses 'test' to refer to its staging environment so updating the lingo here to match
