### PR TITLE
Fix cartodb preview error

### DIFF
--- a/modules/dkan/dkan_dataset/dkan_dataset.module
+++ b/modules/dkan/dkan_dataset/dkan_dataset.module
@@ -1063,7 +1063,7 @@ function dkan_dataset_preview_url_cartodb($node) {
     $resource_file_url = file_create_url($resource_wrapper->field_upload->value()->uri);
   }
   elseif ($resource_wrapper->field_link_remote_file->value()) {
-    $resource_file_url = $resource_wrapper->field_link_remote_file->value()->uri;
+    $resource_file_url = $resource_wrapper->field_link_remote_file->value()['uri'];
   }
   if ($resource_file_url) {
     return sprintf($pattern, $resource_file_url);


### PR DESCRIPTION
```
Trying to get property of non-object in dkan_dataset_preview_url_cartodb() (line 1066 of /var/www/dkan/modules/dkan/dkan_dataset/dkan_dataset.module).
```
Missing CartoDB Preview buttons

## How to reproduce

1. Go to `/admin/dkan/dataset_preview` and enable CartoDB preview option for geojson files.
2. Create a resource with this file: http://data-cdfw.opendata.arcgis.com/datasets/3920d5a1ff0f4af3b5540b0cf084c1af_0.geojson
3. Fill in the 'Format' field with `geojson` and save.
4. View the resource, confirm you see the error above and do NOT see the CartoDB Preview button next to the Download button.

![geojson_preview](https://user-images.githubusercontent.com/314172/49831144-c80c5180-fd58-11e8-86c2-97a2aaad268f.png)


## QA Steps

- [ ] Follow the steps above.
- [ ] Confirm that you do not get an error and that you DO see the CartoDB Preview button.


## Reminders

- [ ] There is test for the issue.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
