### PR TITLE
Fix Only variables should be passed by reference in dkan_datastore_api

### DIFF
--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -357,9 +357,10 @@ function dkan_datastore_api_query($params) {
     if (empty($resource_ids)) {
       throw new \Exception("The resource_id is a required parameter.");
     }
-
-    $alias = array_shift(array_keys($resource_ids));
-    $resource_id = array_shift(array_values($resource_ids));
+    $keys = array_keys($resource_ids);
+    $values = array_values($resource_ids);
+    $alias = array_shift($keys);
+    $resource_id = array_shift($values);
 
     $alias = is_string($alias) ? $alias : DKAN_DATASTORE_API_DEFAULT_TABLE_ALIAS;
     $table = dkan_datastore_api_tablename($resource_id);
@@ -707,14 +708,17 @@ function dkan_datastore_api_sort(&$data_select, $sort, $alias) {
   else {
     $columns = $sort;
   }
-
-  $key = end(array_values($sort));
+  $vs = array_values($sort);
+  $ks = array_keys($sort);
+  $key = end($vs);
   if (!in_array($key, ['desc', 'asc'])) {
     $columns = $key;
-    $alias = end(array_keys($sort));
+    $alias = end($ks);
   }
-  foreach ($columns as $field => $order) {
-    $data_select->orderBy($alias . '.' . $field, $order);
+  if (!empty($columns)) {
+    foreach ($columns as $field => $order) {
+      $data_select->orderBy($alias . '.' . $field, $order);
+    }
   }
 }
 


### PR DESCRIPTION
```
Notice: Only variables should be passed by reference in dkan_datastore_api_query() (line 361 of /var/www/dkan/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module).
Notice: Only variables should be passed by reference in dkan_datastore_api_query() (line 362 of /var/www/dkan/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module).
Notice: Only variables should be passed by reference in dkan_datastore_api_sort() (line 711 of /var/www/dkan/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module).
Notice: Only variables should be passed by reference in dkan_datastore_api_sort() (line 714 of /var/www/dkan/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module).
Warning: Invalid argument supplied for foreach() in dkan_datastore_api_sort() (line 716 of /var/www/dkan/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module).
```

## How to reproduce

1.  Create a resource with http://janette.dkandemo.nuamsdev.com/sites/default/files/VHAStats_2014_0.csv
2. Import it to the datastore.
3. Click the Data API button
4. Click the link below Example Query
5. Click your browser back button

## QA Steps

- [ ] Follow the steps above, confirm the errors are gone


## Reminders

- [ ] There is test for the issue.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.