### PR TITLE
Use direct license url

### DIFF
--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.license_field.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.license_field.inc
@@ -65,19 +65,19 @@ function dkan_dataset_content_types_license_subscribe() {
   return array(
     "cc-by" => array(
       "label" => t("Creative Commons Attribution"),
-      "uri" => "http://opendefinition.org/licenses/cc-by/",
+      "uri" => "https://creativecommons.org/licenses/by/4.0/",
     ),
     "cc-by-sa" => array(
       "label" => t("Creative Commons Attribution Share-Alike"),
-      "uri" => "http://opendefinition.org/licenses/cc-by-sa/",
+      "uri" => "https://creativecommons.org/licenses/by-sa/4.0/",
     ),
     "cc-zero" => array(
       "label" => t("Creative Commons CCZero"),
-      "uri" => "http://opendefinition.org/licenses/cc-zero/",
+      "uri" => "https://creativecommons.org/publicdomain/zero/1.0/",
     ),
     "cc-nc"  => array(
-      "label" => t("Creative Commons Non-Commercial (Any)"),
-      "uri" => "http://opendefinition.org/licenses/cc-nc/",
+      "label" => t("Creative Commons Non-Commercial (2.5)"),
+      "uri" => "https://creativecommons.org/licenses/by-nc/2.5/",
     ),
     "cc-by-nc-nd" => array(
       "label" => t("Attribution NonCommercial NoDerivatives 4.0 International"),
@@ -85,15 +85,15 @@ function dkan_dataset_content_types_license_subscribe() {
     ),
     "gfdl" => array(
       "label" => t("GNU Free Documentation License"),
-      "uri" => "http://opendefinition.org/licenses/gfdl/",
+      "uri" => "https://www.gnu.org/licenses/fdl.html",
     ),
     "odc-by" => array(
       "label" => t("Open Data Commons Attribution License"),
-      "uri" => "http://opendefinition.org/licenses/odc-by/",
+      "uri" => "https://opendatacommons.org/licenses/by/1.0/",
     ),
     "odc-odbl" => array(
       "label" => t("Open Data Commons Open Database License (ODbL)"),
-      "uri" => "http://opendefinition.org/licenses/odc-odbl/",
+      "uri" => "https://opendatacommons.org/licenses/odbl/1.0/",
     ),
     "odc-pddl" => array(
       "label" => t("Open Data Commons Public Domain Dedication and Licence (PDDL)"),

--- a/test/features/dataset.author.feature
+++ b/test/features/dataset.author.feature
@@ -87,7 +87,7 @@ Feature: Dataset Features
     And I click "Log out"
     When I am on "Dataset 01" page
     And I click "Creative Commons Attribution"
-    Then I should see "The Creative Commons Attribution license allows re-distribution and re-use of a licensed work"
+    Then I should see "Attribution — You must give appropriate credit, provide a link to the license"
 
   @dataset_author_5 @fixme @noworkflow
   # TODO: Needs definition. How can a data contributor unpublish content?


### PR DESCRIPTION
Re-run of #2052 

DKAN is not using the direct URLs for license types. This change updates these
URLs to the more direct URL.

QA Steps:
==
- [ ] Look at code change and verify that new URLs are correct.