### PR TITLE
Object check in the datastore_api_debug function.

### DIFF
--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -833,18 +833,21 @@ function dkan_datastore_api_resource_help() {
  * Returns sql statement for debug purposes.
  */
 function dkan_datastore_api_debug($data_select) {
-  if (method_exists($data_select, 'preExecute')) {
-    $data_select->preExecute();
+  if (is_object($data_select) && $data_select instanceof SelectQueryInterface) {
+    if (method_exists($data_select, 'preExecute')) {
+      $data_select->preExecute();
+    }
+    $sql = (string)$data_select;
+    $quoted = array();
+    $connection = Database::getConnection();
+    foreach ((array)$data_select->arguments() as $key => $val) {
+      $quoted[$key] = $connection->quote($val);
+    }
+    $sql = strtr($sql, $quoted);
+    $sql = str_replace('\n', ' ', $sql);
+    return (string)$sql;
   }
-  $sql = (string) $data_select;
-  $quoted = array();
-  $connection = Database::getConnection();
-  foreach ((array) $data_select->arguments() as $key => $val) {
-    $quoted[$key] = $connection->quote($val);
-  }
-  $sql = strtr($sql, $quoted);
-  $sql = str_replace('\n', ' ', $sql);
-  return (string) $sql;
+  return "";
 }
 
 /**


### PR DESCRIPTION
The ``dkan_datastore_api_debug`` function expect a ``SelectQuery`` object. Yet there is no protection against anything else being passed and breaking things.

This PR fixes that.