### PR TITLE
Use dkan_allowed_extensions() during harvest

### DIFF
--- a/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
+++ b/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
@@ -1144,12 +1144,11 @@ class HarvestMigration extends MigrateDKAN {
       // page.
       if (!is_null($remoteFileInfo->getType())
         && !in_array($remoteFileInfo->getExtension(), $html_extensions)) {
-
         // Check if this file extension is allowed for field_link_remote_file.
-        $link_field = field_info_instance('node', 'field_link_remote_file', 'resource');
         // Reduce everything to lowercase to support files with uppercase
         // extensions.
-        $file_extensions = array_map('strtolower', explode(' ', $link_field['settings']['file_extensions']));
+        $file_extensions = array_map('strtolower', explode(' ', dkan_allowed_extensions()));
+
         // Reject if the extension is not allowed.
         if (!in_array($remoteFileInfo->getExtension(), $file_extensions)) {
           $message = t('Resource remote url (@url) extension (@extension) not allowed',


### PR DESCRIPTION
connects #2577
## Description.

The `dkan_allowed_extensions()` function (added in #2664 is the way to go when overriding resources allowed extensions. During a harvest a check on the allowed extensions is done to honor the user setting. This PR will update this check (done in HarvestMigration::prepareResourceHelper) to use `dkan_allowed_extensions()` instead of querying the field settings. 

## How to reproduce

Step-by-step instructions for reproducing the bug:
1. Add harvest source that have resources with extensions that are not part of the default field setting but allowed via the `dkan_allowed_extensions()`.
2. Run Harvest on the source.

**Expected**:
All the resources are harvested and imported correctly.

**Currently**:
Resources with non default extensions introduced via `dkan_allowed_extensions()` fail to be harvested.

## QA Steps

1. Add harvest source that have resources with extensions that are not part of the default field setting.
2. Make sure to allowed the non default extension via the `dkan_allowed_extensions()` mechanism.
2. Run Harvest on the source.
 
The Harvest should proceed without issues.

## Merge process

- N/A

## Reminders

- [ ] There is test for the issue.
- [x] Coding standards checked.
- [x] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.