### PR TITLE
Fix Dataset and Resource(s) Orphan Field Update Harvest Post Import Operations

### DIFF
--- a/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
+++ b/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
@@ -783,9 +783,10 @@ class HarvestMigration extends MigrateDKAN {
           $dataset_emw = entity_metadata_wrapper('node', $dataset_nid);
           $related_count = 0;
 
-          // Unpublish attached resources.
+          // Publish attached resources.
           if (isset($dataset_emw->field_resources)) {
             foreach ($dataset_emw->field_resources->getIterator() as $delta => $resource_emw) {
+              $resource_emw->field_orphan->set(0);
               $resource_emw->status->set(1);
               $resource_emw->save();
               $related_count++;
@@ -800,6 +801,7 @@ class HarvestMigration extends MigrateDKAN {
           }
 
           // Publish the dataset.
+          $dataset_emw->field_orphan->set(0);
           $dataset_emw->status->set(1);
           $dataset_emw->save();
 


### PR DESCRIPTION
## Description
During post import operations, Harvest will check if the dataset is still provided by the source or not, and will update the publishing status and field_orphan property/field to reflect the dataset situation. Currently the logic will update the publish status of the dataset/resource(s) correctly but will miss the field_orphan field update. This will lead to conflicting results on the "Manage Datasets" tab.


## How to reproduce
1. Create a Harvest Source with a source that can be altered later.
2. Harvest the Source, this should result in all the datatsets and associated resources published status set to TRUE and the field_orphan status set to FALSE.
3. Alter the Source to delete a single test dataset.
4. Harvest the Source, this should result in the test datatset and associated resource(s) published status set to FALSE and the field_orphan status set to TRUE.
5. Alter the Source to restore the test dataset.
6. Harvest the Source.

**Expected**:
The final action should result in the test datatset and associated resource(s) published status set to TRUE and the field_orphan status set to FALSE

**Current**:
The final action results in the test datatset and associated resource(s) published status set to TRUE but the field_orphan status set to TRUE

## QA Steps

- Same as *How to reproduce*.

## Merge process

- N/A

## Reminders

- [ ] There is test for the issue.
- [x] Coding standards checked.
- [x] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
