### PR TITLE
Support harvest dataset source identifiers that ends with a '/'

### DIFF
--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
@@ -377,9 +377,11 @@ function dkan_harvest_datajson_prepare_item_id($identifier) {
   if (filter_var($identifier, FILTER_VALIDATE_URL)) {
     $identifier = parse_url($identifier, PHP_URL_PATH);
     $frag = explode('/', $identifier);
-    // Does not produce "Strict warning: Only variables should be passed by
-    // reference" like end(explode('/', $identifier));.
-    $identifier = $frag[count($frag) - 1];
+
+    // Return the last non empty URL Path element.
+    $frag = array_filter($frag);
+    $identifier = end($frag);
   }
+
   return $identifier;
 }


### PR DESCRIPTION
Harvest sources with datasets `identifier` fields that ends with "/" (for example `http://dx.doi.org/10.7927/H4PZ56R2/`) will result in an empty generated identifier during the Harvest. 

This PR tweaks the `dkan_harvest_datajson_prepare_item_id` function to account for this case and return the last non empty segment of the `identifier`.

## How to reproduce

1. Harvest a source that have a dataset with an `identifier` that is a URL that ends with a "/" (in the following example the `identifier` is "http://demo.getdkan.com/90a2b708-7fea-4b92-8aee-43c4cfdd5f48/").

```json
        {
            "@type": "dcat:Dataset",
            "accessLevel": "public",
            "contactPoint": {
                "fn": "admin",
                "hasEmail": "mailto:admin@example.com"
            },
            "description": "<p>Polling places in the state of Wisconsin</p>",
            "distribution": [
                {
                    "@type": "dcat:Distribution",
                    "description": "No description provided",
                    "downloadURL": "https://s3.amazonaws.com/dkan-default-content-files/phpunit/Polling_Places_Madison_0.csv",
                    "format": "csv",
                    "mediaType": "text/csv"
                }
            ],
            "identifier": "http://demo.getdkan.com/90a2b708-7fea-4b92-8aee-43c4cfdd5f48/",
            "keyword": [
                "election"
            ],
            "language": [
                "en"
            ],
            "license": "http://opendefinition.org/licenses/cc-by/",
            "modified": "2015-07-11",
            "publisher": {
                "@type": "org:Organization",
                "name": "Geospatial Data Explorer Examples"
            },
            "title": "Wisconsin Polling Places TEST"
        },
```

**Expected Behavior**:
Harvest works.

**Current Behavior**:
Harvest fail and identifier recorded is empty.

## QA Steps

- Following the **How to reproduce** section steps should result in the source harvested with no errors.

## Merge process

- N/A.

## Reminders

- [ ] There is test for the issue.
- [x] Coding standards checked.
- [x] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
