### PR TITLE
2750: import TSVs via datastore simple import

### DIFF
--- a/modules/dkan/dkan_datastore/src/Resource.php
+++ b/modules/dkan/dkan_datastore/src/Resource.php
@@ -104,7 +104,7 @@ class Resource {
       // we need to load the full file object.
       $file = file_load($node->field_upload[LANGUAGE_NONE][0]['fid']);
       $filemime = $file->filemime;
-      if (!in_array($filemime, ["text/csv", "text/tsv"])) {
+      if (!in_array($filemime, ["text/csv", "text/tsv", "text/tab-separated-values"])) {
         throw new \Exception("This filemime type ({$filemime}) can be added as a resource, but cannot be imported to our datastore.");
       }
 
@@ -114,7 +114,7 @@ class Resource {
     if (isset($node->field_link_remote_file[LANGUAGE_NONE][0]['fid'])) {
       $file = file_load($node->field_link_remote_file[LANGUAGE_NONE][0]['fid']);
       if ($filemime = $file->filemime) {
-        if (!in_array($filemime, ["text/csv", "text/tsv", "text/psv"])) {
+        if (!in_array($filemime, ["text/csv", "text/tsv", "text/psv", "text/tab-separated-values"])) {
           throw new \Exception("This filemime type ({$filemime}) can be added as a resource, but cannot be imported to our datastore.");
         }
       }


### PR DESCRIPTION
Connects #2750 

## Description. 

When adding a TSV, there is no import button available, the button for "Manage Datastore" isn't present and the "cannot be imported into the datastore" message appeared.
The issue is present when the filemime of a TSV file is "text/tab-separated-values", so I added that to the list of allowed resource filemime types to be imported in the datastore.

## How to reproduce

1. Create a new resource with a TSV file.
2. You should get a message "This filemime type (text/tab-separated-values) can be added as a resource, but cannot be imported to our datastore.".
3. You can't see a button for "Manage Datastore", an import button, nor the "Download" button.

## QA Steps

- [ ] Create a new resource with a TSV file.
- [ ] You shouldn't get a message about the resource not being able to get imported into the datastore.
- [ ] You should see the buttons for "Manage Datastore" and "Download".
- [ ] If you click on "Manage Datastore" you should be able to import the resource into the datastore without errors.