### PR TITLE
Fixed description of aggregation functions min and max in docs.

### DIFF
--- a/docs/apis/datastore-api.rst
+++ b/docs/apis/datastore-api.rst
@@ -34,8 +34,8 @@ Aggregation functions
 
 -  **sum** (*string*) – field to compute the sum
 -  **avg** (*string*) – field to compute the average
--  **min** (*string*) – field to compute the maximum
--  **max** (*string*) – field to compute the minimum
+-  **min** (*string*) – field to compute the minimum
+-  **max** (*string*) – field to compute the maximum
 -  **std** (*string*) – field to compute the standard deviation
 -  **variance** (*string*) – field to compute the variance
 


### PR DESCRIPTION
## Description. 

In https://docs.getdkan.com/en/latest/apis/datastore-api.html the description of aggregation functions min and max is wrong, we have:

```
min (string) – field to compute the maximum
max (string) – field to compute the minimum
```