### PR TITLE
Update Drupal Core to 7.62

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -3,7 +3,7 @@ core: 7.x
 projects:
   drupal:
     type: core
-    version: '7.61'
+    version: '7.62'
     # Use vocabulary machine name for permissions, see http://drupal.org/node/995156
     patch:
       995156: 'https://drupal.org/files/issues/995156-5_portable_taxonomy_permissions.patch'


### PR DESCRIPTION
[SA-CORE-2019-002](https://www.drupal.org/sa-core-2019-002) is a critical security vulnerability (although it is doubtful it presents a real risk to DKAN sites).