### PR TITLE
disable feeds modules

### DIFF
--- a/dkan.install
+++ b/dkan.install
@@ -812,3 +812,24 @@ function dkan_update_7034() {
 
   $storage->returnBin($bin);
 }
+
+/**
+ * Disable feeds modules.
+ */
+function dkan_update_7035() {
+  $records = array(
+    'feeds',
+    'feeds_import',
+    'feeds_news',
+    'feeds_ui',
+    'feeds_tests',
+    'feeds_field_fetcher',
+    'feeds_flatstore_processor'
+  );
+  foreach ($records as $record) {
+    db_update('system')
+      ->fields(array('status' => '0',))
+      ->condition ('name', 'feeds%', 'LIKE')
+      ->execute();
+  }
+}

--- a/dkan.install
+++ b/dkan.install
@@ -817,19 +817,9 @@ function dkan_update_7034() {
  * Disable feeds modules.
  */
 function dkan_update_7035() {
-  $records = array(
-    'feeds',
-    'feeds_import',
-    'feeds_news',
-    'feeds_ui',
-    'feeds_tests',
-    'feeds_field_fetcher',
-    'feeds_flatstore_processor'
-  );
-  foreach ($records as $record) {
-    db_update('system')
-      ->fields(array('status' => '0',))
-      ->condition ('name', 'feeds%', 'LIKE')
-      ->execute();
+  # Deprecating feeds modules as they are no longer used in dkan_datastore.
+  if( module_exists('feeds')) {
+    module_disable(array('feeds', 'feeds_field_fetcher', 'feeds_flatstore_processor'));
+    drupal_uninstall_modules(array('feeds', 'feeds_field_fetcher', 'feeds_flatstore_processor'));
   }
 }


### PR DESCRIPTION
Connects https://github.com/GetDKAN/dkan/issues/2802

We need to disable the Feeds module now that it's not used by DKAN Datastore.  This update hook does this.

## QA Steps

- [ ] Create a site using DKAN 1.15.x and load some data into the datastore
- [ ] Upgrade to this version of DKAN
- [ ] Confirm that data is still available in the new datastore, Feeds is correctly disabled and everything "looks right"