### PR TITLE
Upgrade drupal to 7.63

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -3,7 +3,7 @@ core: 7.x
 projects:
   drupal:
     type: core
-    version: '7.62'
+    version: '7.63'
     # Use vocabulary machine name for permissions, see http://drupal.org/node/995156
     patch:
       995156: 'https://drupal.org/files/issues/995156-5_portable_taxonomy_permissions.patch'


### PR DESCRIPTION
This is a hotfix release for a regression affecting some Drush installations that was introduced by the fix for SA-CORE-2019-002. No other fixes are included.