### PR TITLE
If there is no resource title, use format instead of remote file name.

### DIFF
--- a/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
+++ b/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
@@ -1180,8 +1180,7 @@ class HarvestMigration extends MigrateDKAN {
     $resource->format = isset($format) ? strtolower($format) : $format_detected;
 
     // Title.
-    $name = isset($title) ? $title : $remoteFileInfo->getName();
-    $resource->title = isset($name) ? $name : $resource->format;
+    $resource->title = isset($title) ? $title : $resource->format;
 
     // Created.
     $resource->created = isset($created) ? $created : time();


### PR DESCRIPTION
Connects #2797 

## Description

When harvesting from a Socrata source (e.g. https://data.medicare.gov/data.json or https://data.ftb.ca.gov/data.json), the resources are named based on the filename producing resources with titles like `rows.csv`, `rows.json` and similar.

## How to reproduce

1.  Create a new harvest source using https://data.medicare.gov/data.json and filter by `identifier` = `https://data.medicare.gov/api/views/twwm-t8ug` and harvest the datasets.
2. Go to the imported dataset and confirm the resources names are based on the filename:
![image](https://user-images.githubusercontent.com/2200763/52136275-4d9bd780-260d-11e9-8fa8-5f9878c0b772.png)

## QA Steps

- [ ] Create a new harvest source using https://data.medicare.gov/data.json and filter by `identifier` = `https://data.medicare.gov/api/views/twwm-t8ug` and harvest the datasets.
- [ ] Go to the imported dataset and confirm the resources names are using the file format.
