### PR TITLE
Show filesize as unknown for remote files.

### DIFF
--- a/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
@@ -141,8 +141,9 @@ function dkan_sitewide_resource_additional_block($nid = '') {
     $upload = !$upload && isset($node->field_upload['und'][0]) ? $node->field_upload['und'][0] : $upload;
 
     if (($file = $link) || ($file = $upload)) {
+      $filesize = isset($node->field_link_remote_file[$lang][0]) ? 'unknown' : format_size($file['filesize']);
       $file_info[] = array(t('mimetype'), $file['filemime']);
-      $file_info[] = array(t('filesize'), format_size($file['filesize']));
+      $file_info[] = array(t('filesize'), $filesize);
       $file_info[] = array(t('resource type'), 'file upload');
       $file_info[] = array(t('timestamp'), date('M d, Y', $file['timestamp']));
       return theme('table',


### PR DESCRIPTION
When adding resources with remote files, the filesize is not always determined correctly, sometimes we get a reported filesize really small and the actual size is completely different.

For example adding a resource with this remote file https://data.chhs.ca.gov/dataset/e0216fbb-3739-4d92-9630-88d9f5686ac6/resource/cdb50347-6fe1-456e-a336-d7daf0aba595/download/road-traffic-injuries-2002-2010.csv We get the resource listed as 15.62MB (and when you download the file it is actually 132.9MB)

### Acceptance Criteria
- If the file is remote then in the resource page, in the `Additional Information` block shows the filesize as `unknown`.

## How to reproduce

1. Create a resource with a remote file, for example https://data.chhs.ca.gov/dataset/e0216fbb-3739-4d92-9630-88d9f5686ac6/resource/cdb50347-6fe1-456e-a336-d7daf0aba595/download/road-traffic-injuries-2002-2010.csv 
2. In the resource page, you'll get it listed with a size smaller than the actual size (you can see the actual size when downloaded).

## QA Steps

- [ ] Create a resource with a remote file, for example https://data.chhs.ca.gov/dataset/e0216fbb-3739-4d92-9630-88d9f5686ac6/resource/cdb50347-6fe1-456e-a336-d7daf0aba595/download/road-traffic-injuries-2002-2010.csv 
- [ ] In the resource page, under `Additional Information` block, you'll see the filesize as `unknown` for every remote file, for other files the respective size should be shown.

connects NuCivic/cadepttech#93