### PR TITLE
Handle missing harvest source without mass un-publishing all content from the source.

### DIFF
--- a/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
+++ b/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
@@ -687,7 +687,7 @@ class HarvestMigration extends MigrateDKAN {
     // Check if sourceCount is 0.
     // Show and add an error to the message table.
     if ($this->sourceCount() == 0) {
-      $message = t('Items to import is 0. Looks like source is missing. All the content previously harvested will be unpublished.');
+      $message = t('Items to import is 0. Looks like source is missing. No updates can be made at this time.');
       self::displayMessage($message, 'error');
       $this->saveMessage($message);
     }

--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -305,15 +305,16 @@ function dkan_harvest_page_preview($node) {
  *   The context associated with the batch process.
  */
 function dkan_harvest_cache_source_batch_op($harvest_source, $harvest_updatetime = NULL, array &$context = array()) {
-  $source = urlExists($harvest_source->uri) ? urlExists($harvest_source->uri) : FALSE;
+  $source = dkan_harvest_url_exists($harvest_source->uri) ? dkan_harvest_url_exists($harvest_source->uri) : FALSE;
   if ($source) {
     $harvest_cache = $harvest_source->cache($harvest_updatetime);
   }
   
   if (!$harvest_cache) {
-    $message = t('Harvest cache for source "@source_name" failed! The harvest source uri is not accessible.',
+    $message = t('Harvest cache for source "@source_name" failed! @source_uri is not accessible.',
       array(
         '@source_name' => $harvest_source->label,
+        '@source_uri' => $harvest_source->uri,
       ));
     dkan_harvest_log($message, 'error');
   }
@@ -1464,11 +1465,11 @@ function dkan_harvest_delete_confirmation_submit($form, $form_state) {
   dkan_harvest_process_source_datasets($selected_sources, $datasets_op);
 }
 
-function urlExists($url=NULL) {  
+function dkan_harvest_url_exists($url=NULL) {  
     if($url == NULL) return false;  
     $ch = curl_init($url);  
-    curl_setopt($ch, CURLOPT_TIMEOUT, 5);  
-    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);  
+    curl_setopt($ch, CURLOPT_TIMEOUT, 60);  
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 60);  
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);  
     $data = curl_exec($ch);  
     $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);  

--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -305,21 +305,12 @@ function dkan_harvest_page_preview($node) {
  *   The context associated with the batch process.
  */
 function dkan_harvest_cache_source_batch_op($harvest_source, $harvest_updatetime = NULL, array &$context = array()) {
-  $source = dkan_harvest_url_exists($harvest_source->uri) ? dkan_harvest_url_exists($harvest_source->uri) : FALSE;
-  if ($source) {
+  // Check that the source uri is available.
+  $source = dkan_harvest_url_exists($harvest_source->uri);
+  if ($source) { 
     $harvest_cache = $harvest_source->cache($harvest_updatetime);
-  }
-  
-  if (!$harvest_cache) {
-    $message = t('Harvest cache for source "@source_name" failed! @source_uri is not accessible.',
-      array(
-        '@source_name' => $harvest_source->label,
-        '@source_uri' => $harvest_source->uri,
-      ));
-    dkan_harvest_log($message, 'error');
-  }
-  else {
-    $message = t('Harvest cache for source "@source_name" completed (processed @cache_processed, failed @cache_failed, saved @cache_saved : (filtered @cache_filtered, excluded @cache_excluded, defaulted @cache_defaulted, overridden @cache_overridden)).',
+    if ($harvest_cache) {
+      $message = t('Harvest cache for source "@source_name" completed (processed @cache_processed, failed @cache_failed, saved @cache_saved : (filtered @cache_filtered, excluded @cache_excluded, defaulted @cache_defaulted, overridden @cache_overridden)).',
       array(
         '@source_name' => $harvest_source->label,
         '@cache_processed' => $harvest_cache->getProcessedCount(),
@@ -332,6 +323,16 @@ function dkan_harvest_cache_source_batch_op($harvest_source, $harvest_updatetime
       )
     );
     dkan_harvest_log($message, 'success');
+    }
+  }
+  else {
+    // Avoid mass orphaning of the datasets. Log an error instead.
+    $message = t('Harvest cache for source "@source_name" failed! @source_uri is not accessible.',
+      array(
+        '@source_name' => $harvest_source->label,
+        '@source_uri' => $harvest_source->uri,
+      ));
+    dkan_harvest_log($message, 'error');
   }
 }
 
@@ -1473,7 +1474,7 @@ function dkan_harvest_url_exists($url=NULL) {
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);  
     $data = curl_exec($ch);  
     $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);  
-    curl_close($ch);  
+    curl_close($ch);
     if($httpcode>=200 && $httpcode<300){  
         return true;  
     } else {  

--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -311,18 +311,18 @@ function dkan_harvest_cache_source_batch_op($harvest_source, $harvest_updatetime
     $harvest_cache = $harvest_source->cache($harvest_updatetime);
     if ($harvest_cache) {
       $message = t('Harvest cache for source "@source_name" completed (processed @cache_processed, failed @cache_failed, saved @cache_saved : (filtered @cache_filtered, excluded @cache_excluded, defaulted @cache_defaulted, overridden @cache_overridden)).',
-      array(
-        '@source_name' => $harvest_source->label,
-        '@cache_processed' => $harvest_cache->getProcessedCount(),
-        '@cache_failed' => $harvest_cache->getFailedCount(),
-        '@cache_saved' => $harvest_cache->getSavedCount(),
-        '@cache_filtered' => $harvest_cache->getFilteredCount(),
-        '@cache_excluded' => $harvest_cache->getExcludedCount(),
-        '@cache_defaulted' => $harvest_cache->getDefaultedCount(),
-        '@cache_overridden' => $harvest_cache->getOverriddenCount(),
-      )
-    );
-    dkan_harvest_log($message, 'success');
+        array(
+          '@source_name' => $harvest_source->label,
+          '@cache_processed' => $harvest_cache->getProcessedCount(),
+          '@cache_failed' => $harvest_cache->getFailedCount(),
+          '@cache_saved' => $harvest_cache->getSavedCount(),
+          '@cache_filtered' => $harvest_cache->getFilteredCount(),
+          '@cache_excluded' => $harvest_cache->getExcludedCount(),
+          '@cache_defaulted' => $harvest_cache->getDefaultedCount(),
+          '@cache_overridden' => $harvest_cache->getOverriddenCount(),
+        )
+      );
+      dkan_harvest_log($message, 'success');
     }
   }
   else {

--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -307,7 +307,7 @@ function dkan_harvest_page_preview($node) {
 function dkan_harvest_cache_source_batch_op($harvest_source, $harvest_updatetime = NULL, array &$context = array()) {
   // Check that the source uri is available.
   $source = dkan_harvest_url_exists($harvest_source->uri);
-  if ($source) { 
+  if ($source) {
     $harvest_cache = $harvest_source->cache($harvest_updatetime);
     if ($harvest_cache) {
       $message = t('Harvest cache for source "@source_name" completed (processed @cache_processed, failed @cache_failed, saved @cache_saved : (filtered @cache_filtered, excluded @cache_excluded, defaulted @cache_defaulted, overridden @cache_overridden)).',
@@ -1466,18 +1466,21 @@ function dkan_harvest_delete_confirmation_submit($form, $form_state) {
   dkan_harvest_process_source_datasets($selected_sources, $datasets_op);
 }
 
-function dkan_harvest_url_exists($url=NULL) {  
-    if($url == NULL) return false;  
-    $ch = curl_init($url);  
-    curl_setopt($ch, CURLOPT_TIMEOUT, 60);  
-    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 60);  
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);  
-    $data = curl_exec($ch);  
-    $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);  
-    curl_close($ch);
-    if($httpcode>=200 && $httpcode<300){  
-        return true;  
-    } else {  
-        return false;  
-    }  
+/**
+ * Helper function to see if a URL exists.
+ */
+function dkan_harvest_url_exists($url = NULL) {
+  if ($url == NULL) return false;
+  $ch = curl_init($url);
+  curl_setopt($ch, CURLOPT_TIMEOUT, 60);
+  curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 60);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+  $data = curl_exec($ch);
+  $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+  curl_close($ch);
+  if ($httpcode >= 200 && $httpcode < 300) {
+    return true;
+  } else {
+    return false;
+  }
 }

--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -305,10 +305,13 @@ function dkan_harvest_page_preview($node) {
  *   The context associated with the batch process.
  */
 function dkan_harvest_cache_source_batch_op($harvest_source, $harvest_updatetime = NULL, array &$context = array()) {
-  $harvest_cache = $harvest_source->cache($harvest_updatetime);
-
+  $source = urlExists($harvest_source->uri) ? urlExists($harvest_source->uri) : FALSE;
+  if ($source) {
+    $harvest_cache = $harvest_source->cache($harvest_updatetime);
+  }
+  
   if (!$harvest_cache) {
-    $message = t('Harvest cache for source "@source_name" failed!',
+    $message = t('Harvest cache for source "@source_name" failed! The harvest source uri is not accessible.',
       array(
         '@source_name' => $harvest_source->label,
       ));
@@ -1459,4 +1462,20 @@ function dkan_harvest_delete_confirmation_submit($form, $form_state) {
   $datasets_op = $form_state['values']['dataset_op'];
 
   dkan_harvest_process_source_datasets($selected_sources, $datasets_op);
+}
+
+function urlExists($url=NULL) {  
+    if($url == NULL) return false;  
+    $ch = curl_init($url);  
+    curl_setopt($ch, CURLOPT_TIMEOUT, 5);  
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);  
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);  
+    $data = curl_exec($ch);  
+    $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);  
+    curl_close($ch);  
+    if($httpcode>=200 && $httpcode<300){  
+        return true;  
+    } else {  
+        return false;  
+    }  
 }

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
@@ -40,22 +40,20 @@ function dkan_harvest_datajson_harvest_source_types() {
  *   A harvest cache object.
  */
 function dkan_harvest_datajson_cache(HarvestSource $source, $harvest_updatetime) {
-  // This is needed for remote uri.
-  $context = stream_context_create(
-    array(
-      'http' => array(
-        'timeout' => 36000,
-      ),
-      'https' => array(
-        'timeout' => 36000,
-      ),
-    )
-  );
-
-  $remote = @file_get_contents($source->uri, 0, $context);
-
-  if ($remote) {
-    // Some file begins with 'efbbbf' to mark the beginning of the file (The
+  $ch = curl_init($source->uri);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+  $remote = curl_exec($ch);
+  if ($remote === false) {
+    $error = 'Curl error: ' . curl_error($ch);
+    $message = t('Harvest cache for "@source_uri" failed! "@error".',
+      array(
+        '@error' => $error,
+        '@source_uri' => $source->uri,
+      ));
+    dkan_harvest_log($message, 'error');
+  }
+  elseif ($remote) {
+    // Some files begin with 'efbbbf' to mark the beginning of the file (The
     // byte-order mark). (binary level) here we detect it and we remove it,
     // basically it's the first 3 characters.
     if (0 === strpos(bin2hex($remote), 'efbbbf')) {

--- a/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
+++ b/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
@@ -330,7 +330,7 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
     // source.
     $this->assertEquals(1, count($migrationEmptyMessage));
     $messageEntry = end($migrationEmptyMessage);
-    $this->assertEquals("Items to import is 0. Looks like source is missing. All the content previously harvested will be unpublished.", $messageEntry->message);
+    $this->assertEquals("Items to import is 0. Looks like source is missing. No updates can be made at this time.", $messageEntry->message);
   }
 
   /**

--- a/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
+++ b/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
@@ -721,7 +721,8 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
    * Test Harvest Source.
    */
   public static function getAlternativeTestSource() {
-    return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_alternative.json');
+    $uri = file_create_url('profiles/dkan/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_alternative.json');
+    return new HarvestSourceDataJsonStub($uri);
   }
 
   /**
@@ -752,7 +753,8 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
    * Test Harvest Source.
    */
   public static function getNoResourceTestSource() {
-    return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_no_resources.json');
+    $uri = file_create_url('profiles/dkan/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_no_resources.json');
+    return new HarvestSourceDataJsonStub($uri);
   }
 
   /**
@@ -767,14 +769,16 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
    * Test Harvest Source.
    */
   public static function getResourceSchemeless() {
-    return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_schemeless_resource.json');
+    $uri = file_create_url('profiles/dkan/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_schemeless_resource.json');
+    return new HarvestSourceDataJsonStub($uri);
   }
 
   /**
    * Test Harvest Source.
    */
   public static function getResourceTemporal() {
-    return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_temporal.json');
+    $uri = file_create_url('profiles/dkan/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_temporal.json');
+    return new HarvestSourceDataJsonStub($uri);
   }
 
   /**

--- a/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
+++ b/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
@@ -713,7 +713,8 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
    * Test Harvest Source.
    */
   public static function getOriginalTestSource() {
-    return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_original.json');
+    $uri = file_create_url('profiles/dkan/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_original.json');
+    return new HarvestSourceDataJsonStub($uri);
   }
 
   /**
@@ -727,21 +728,24 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
    * Test Harvest Source.
    */
   public static function getGroupUpdatedTestSource() {
-    return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_group_updated.json');
+    $uri = file_create_url('profiles/dkan/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_group_updated.json');
+    return new HarvestSourceDataJsonStub($uri);
   }
 
   /**
    * Test Harvest Source.
    */
   public static function getErrorTestSource() {
-    return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_error.json');
+    $uri = file_create_url('profiles/dkan/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_error.json');
+    return new HarvestSourceDataJsonStub($uri);
   }
 
   /**
    * Test Harvest Source.
    */
   public static function getEmptyTestSource() {
-    return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_empty.json');
+    $uri = file_create_url('profiles/dkan/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_empty.json');
+    return new HarvestSourceDataJsonStub($uri);
   }
 
   /**
@@ -755,7 +759,8 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
    * Test Harvest Source.
    */
   public static function getResourceWithRedirects() {
-    return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_redirects.json');
+    $uri = file_create_url('profiles/dkan/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_redirects.json');
+    return new HarvestSourceDataJsonStub($uri);
   }
 
   /**
@@ -776,21 +781,24 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
    * Test Harvest Source.
    */
   public static function getResourceNoIssued() {
-    return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_noissued.json');
+    $uri = file_create_url('profiles/dkan/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_noissued.json');
+    return new HarvestSourceDataJsonStub($uri);
   }
 
   /**
    * Test Harvest Source.
    */
   public static function getResourceAccessUrl() {
-    return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_resource_accessurl.json');
+    $uri = file_create_url('profiles/dkan/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_resource_accessurl.json');
+    return new HarvestSourceDataJsonStub($uri);
   }
 
   /**
    * Test Harvest Source.
    */
   public static function getResourceBom() {
-    return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_bom.json');
+    $uri = file_create_url('profiles/dkan/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_bom.json');
+    return new HarvestSourceDataJsonStub($uri);
   }
 
   /**

--- a/test/phpunit/dkan_harvest/DatajsonHarvestMigrationTest.php
+++ b/test/phpunit/dkan_harvest/DatajsonHarvestMigrationTest.php
@@ -302,7 +302,8 @@ class DatajsonHarvestMigrationTest extends PHPUnit_Framework_TestCase {
    * Test Harvest Source.
    */
   public static function getOriginalTestSource() {
-    return new HarvestSourceDataJsonStub(__DIR__ . '/data/dkan_harvest_datajson_test_original.json');
+    $uri = file_create_url('profiles/dkan/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_original.json');
+    return new HarvestSourceDataJsonStub($uri);
   }
 
   /**


### PR DESCRIPTION
connects #2824

When a harvest source is temporarily unavailable, all content from that harvest is unpublished and marked as 'orphaned'. On large harvests this can mean huge amounts of unnecessary processing that fails to finish before the next harvest and the source is available again.

Let's instead just leave the content as-is. If the source is truly gone, the catalog maintainer can delete the content via the Harvest UI.

## QA Steps
**missing source**
1.  Create a harvest source from https://s3.amazonaws.com/dkan-default-content-files/files/data_harvest_orphan_test.json, and run the harvest.
2. Log in to S3 and make the file private
3. Re-run the harvest, note that rather than unpublishing all of the datasets, you only get the error message:
> Items to import is 0. Looks like source is missing. No updates will be made at this time.


**Actual change in the source**
1. Create a harvest source on a flavor build (http://janette.dkandemo.nuamsdev.com/data.json) and run the harvest.
2. Go to the source site and delete a dataset.
3. Run the harvest again
4. Confirm that the upstream deleted dataset was unpublished and marked as an 'orphan'


## Reminders

- [ ] There is test for the issue.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
