### PR TITLE
Add patch to workbench_moderation

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -375,6 +375,7 @@ projects:
     patch:
       2360973: https://www.drupal.org/files/issues/workbench_moderation-install-warnings-2360973-3.patch
       1512442: https://www.drupal.org/files/issues/1512442-20-workbench_moderation-fix_access_check.patch
+      2252871: https://www.drupal.org/files/issues/2252871-workbench_moderation-db_update-6.patch
   xautoload:
     version: '5.7'
 libraries:


### PR DESCRIPTION
connects #2827

Easy to cause a deadlock if a non-INSERT write operation is more likely to not match any row because the INSERT part is yet to come on the transaction. Don’t do it or use REPLACE INTO or use READ-COMMITTED transaction isolation.

## How to reproduce

1. Create a draft
2. note the db_update is issued before any records for that nid are inserted

## QA Steps

- [ ] create a draft
- [ ] note that db_update is issued only on updates.

SEE: https://www.drupal.org/project/workbench_moderation/issues/2252871
and : https://www.percona.com/blog/2013/12/12/one-more-innodb-gap-lock-to-avoid/