### PR TITLE
Drush command for deleting orphaned legacy datastore tables

### DIFF
--- a/modules/dkan/dkan_datastore/dkan_datastore.drush.inc
+++ b/modules/dkan/dkan_datastore/dkan_datastore.drush.inc
@@ -20,6 +20,13 @@ function dkan_datastore_drush_command() {
     ),
   );
 
+  // Delete ghost datastore tables.
+  $items['dkan-datastore-delete-ghost-tables'] = array(
+    'aliases' => array('dkan-datastore-dgt'),
+    'description' => 'Delete ghost datastore tables if they exist.',
+    'callback' => 'dkan_datastore_drush_delete_ghost_tables',
+  );
+
   return $items;
 }
 
@@ -31,5 +38,43 @@ function dkan_datastore_drush_delete_config($resource_id) {
   }
   else {
     print_r("Can not delete the configuration for an existing node.");
+  }
+}
+
+/**
+ * Delete ghost datastore tables.
+ */
+function dkan_datastore_drush_delete_ghost_tables() {
+  $query = db_query('SHOW TABLES');
+  $result = $query->fetchAll();
+  $nids = [];
+  $ghosts = 0;
+  foreach ($result as $record) {
+    $t = (array)$record;
+    $db = key($t);
+    $table = $record->{$db};
+    if (strpos($table, 'datastore_dkan') !== false) {
+      // Removes 'feeds_datastore_dkan_file_';
+      $nids[] = substr($table, 26);
+    }
+  }
+  if (!empty($nids)) {
+    drush_print("Looking through " . implode(', ', $nids));
+    $to_truncate = [];
+    foreach ($nids as $nid) {
+      $query = db_query('SELECT nid FROM {node} WHERE nid = :nid', array(':nid' => $nid));
+      $result = $query->fetchAll();
+      if (count($result) < 1) {
+        $to_truncate[] = 'feeds_datastore_dkan_file_' . $nid;
+        $ghosts++;
+      }
+    }
+    drush_print("Ghost tables found: $ghosts");
+    foreach ($to_truncate as $table) {
+      $query = db_drop_table($table);
+      drush_print("Deleted ghost table $table");
+    }
+  } else {
+    drush_print("There is currently no datastore tables.");
   }
 }

--- a/modules/dkan/dkan_datastore/dkan_datastore.drush.inc
+++ b/modules/dkan/dkan_datastore/dkan_datastore.drush.inc
@@ -20,11 +20,11 @@ function dkan_datastore_drush_command() {
     ),
   );
 
-  // Delete ghost datastore tables.
-  $items['dkan-datastore-delete-ghost-tables'] = array(
-    'aliases' => array('dkan-datastore-dgt'),
-    'description' => 'Delete ghost datastore tables if they exist.',
-    'callback' => 'dkan_datastore_drush_delete_ghost_tables',
+  // Drop orphan datastore tables.
+  $items['dkan-datastore-drop-orphan-tables'] = array(
+    'aliases' => array('dkan-datastore-dot'),
+    'description' => 'Drop orphan datastore tables if they exist.',
+    'callback' => 'dkan_datastore_drush_drop_orphan_tables',
   );
 
   return $items;
@@ -42,13 +42,13 @@ function dkan_datastore_drush_delete_config($resource_id) {
 }
 
 /**
- * Delete ghost datastore tables.
+ * Drop orphan datastore tables.
  */
-function dkan_datastore_drush_delete_ghost_tables() {
+function dkan_datastore_drush_drop_orphan_tables() {
   $query = db_query('SHOW TABLES');
   $result = $query->fetchAll();
   $nids = [];
-  $ghosts = 0;
+  $orphans = 0;
   foreach ($result as $record) {
     $t = (array)$record;
     $db = key($t);
@@ -59,22 +59,22 @@ function dkan_datastore_drush_delete_ghost_tables() {
     }
   }
   if (!empty($nids)) {
-    drush_print("Looking through " . implode(', ', $nids));
+    drush_print("Checking for the following nodes " . implode(', ', $nids));
     $to_truncate = [];
     foreach ($nids as $nid) {
       $query = db_query('SELECT nid FROM {node} WHERE nid = :nid', array(':nid' => $nid));
       $result = $query->fetchAll();
       if (count($result) < 1) {
         $to_truncate[] = 'feeds_datastore_dkan_file_' . $nid;
-        $ghosts++;
+        $orphans++;
       }
     }
-    drush_print("Ghost tables found: $ghosts");
+    drush_print("Orphan tables found: $orphans");
     foreach ($to_truncate as $table) {
       $query = db_drop_table($table);
-      drush_print("Deleted ghost table $table");
+      drush_print("Deleted orphan table $table");
     }
   } else {
-    drush_print("There is currently no datastore tables.");
+    drush_print("There are currently no datastore tables on this site.");
   }
 }


### PR DESCRIPTION
## User story

The ghost datastore tables are those for which there doesn't exist a related node, for example there exist a table `feeds_datastore_dkan_file_10000` but there isn't a node with id `10000`. Here we're adding a new drush command `drush dkan-datastore-delete-ghost-tables` with alias `drush dkan-datastore-dgt` to find ghost datastore tables and delete them.

## QA Steps

- When you run `drush dkan-datastore-drop-orphan-tables` or `drush dkan-datastore-dot` you'll get the following behaviour:
  - [ ] If there are no datastore tables, you'll get a message saying "There are currently no datastore tables on this site." (this will happen on a fresh install when you haven't imported anything to datastore).
  - [ ] If there are datastore tables, you'll get a message displaying the node IDs it is looking for (node IDs for which there is a datastore table).
  - [ ] Number of ghost tables found.
  - [ ] If there are ghost tables, it deletes them and shows the respective table names.

Connects NuCivic/dkan_management#171