### PR TITLE
Skip dataset changelog when harvesting

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -73,7 +73,7 @@ projects:
   defaultconfig:
     version: 1.0-alpha11
   devel:
-    version: '1.5'
+    version: '1.7'
   diff:
     version: '3.4'
   double_field:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -351,6 +351,8 @@ projects:
     version: '1.2'
   views:
     version: '3.20'
+    patch:
+      2885660: https://www.drupal.org/files/issues/2018-06-28/2885660-13.patch
   views_autocomplete_filters:
     version: '1.2'
     patch:

--- a/modules/dkan/dkan_dataset/dkan_dataset.module
+++ b/modules/dkan/dkan_dataset/dkan_dataset.module
@@ -542,22 +542,21 @@ function dkan_dataset_node_update($node) {
       $resource = entity_metadata_wrapper('node', $node);
       $datasets = $resource->field_dataset_ref->raw();
       if (count($datasets)) {
-        $queue = DrupalQueue::get('dataset_changelog');
         foreach ($datasets as $dataset) {
-          // Skip the queue if harvesting since every resource is updated.
+          // Determine if the resource is part of a harvest.
+          // Skip the dataset_changelog update if harvesting since every resource is updated.
           $harvest = db_select('field_data_field_harvest_source_ref', 'r')
             ->fields('r', array('entity_id'))
             ->condition('entity_id', $dataset)
             ->execute()
             ->fetchAll();
-
           if (!$harvest) {
             $item = array(
               'dataset' => $dataset,
               'message' => 'Update to resource \'' . $node->title . '\'',
               'user' => $user->uid,
             );
-            $queue->createItem($item);
+            dkan_dataset_dataset_changelog_run($item);
           }
         }
       }

--- a/modules/dkan/dkan_dataset/dkan_dataset.module
+++ b/modules/dkan/dkan_dataset/dkan_dataset.module
@@ -542,6 +542,7 @@ function dkan_dataset_node_update($node) {
       $resource = entity_metadata_wrapper('node', $node);
       $datasets = $resource->field_dataset_ref->raw();
       if (count($datasets)) {
+        $queue = DrupalQueue::get('dataset_changelog');
         foreach ($datasets as $dataset) {
           // Determine if the resource is part of a harvest.
           // Skip the dataset_changelog update if harvesting since every resource is updated.
@@ -562,7 +563,7 @@ function dkan_dataset_node_update($node) {
               'message' => 'Update to resource \'' . $resource->title . '\'',
               'user' => $user->uid,
             );
-            dkan_dataset_dataset_changelog_run($item);
+            $queue->createItem($item);
           }
         }
       }

--- a/modules/dkan/dkan_dataset/dkan_dataset.module
+++ b/modules/dkan/dkan_dataset/dkan_dataset.module
@@ -544,12 +544,21 @@ function dkan_dataset_node_update($node) {
       if (count($datasets)) {
         $queue = DrupalQueue::get('dataset_changelog');
         foreach ($datasets as $dataset) {
-          $item = array(
-            'dataset' => $dataset,
-            'message' => 'Update to resource \'' . $node->title . '\'',
-            'user' => $user->uid,
-          );
-          $queue->createItem($item);
+          // Skip the queue if harvesting since every resource is updated.
+          $harvest = db_select('field_data_field_harvest_source_ref', 'r')
+            ->fields('r', array('entity_id'))
+            ->condition('entity_id', $dataset)
+            ->execute()
+            ->fetchAll();
+
+          if (!$harvest) {
+            $item = array(
+              'dataset' => $dataset,
+              'message' => 'Update to resource \'' . $node->title . '\'',
+              'user' => $user->uid,
+            );
+            $queue->createItem($item);
+          }
         }
       }
       break;

--- a/modules/dkan/dkan_dataset/dkan_dataset.module
+++ b/modules/dkan/dkan_dataset/dkan_dataset.module
@@ -551,13 +551,7 @@ function dkan_dataset_node_update($node) {
             ->condition('entity_id', $dataset)
             ->execute()
             ->fetchAll();
-          // Skip the dataset_changelog on default content as datasets are created after resources.
-          $default = db_select('migrate_map_dkan_default_content_resources', 'd')
-            ->fields('d', array('destid1'))
-            ->condition('destid1', $resource->getIdentifier())
-            ->execute()
-            ->fetchAll();
-          if (!$harvest && !$default) {
+          if (!$harvest) {
             $item = array(
               'dataset' => $dataset,
               'message' => 'Update to resource \'' . $resource->title . '\'',

--- a/modules/dkan/dkan_dataset/dkan_dataset.module
+++ b/modules/dkan/dkan_dataset/dkan_dataset.module
@@ -550,15 +550,19 @@ function dkan_dataset_node_update($node) {
             ->condition('entity_id', $dataset)
             ->execute()
             ->fetchAll();
-          if (!$harvest) {
+          // Skip the dataset_changelog on default content as datasets are created after resources.
+          $default = db_select('migrate_map_dkan_default_content_resources', 'd')
+            ->fields('d', array('destid1'))
+            ->condition('destid1', $resource->getIdentifier())
+            ->execute()
+            ->fetchAll();
+          if (!$harvest && !$default) {
             $item = array(
               'dataset' => $dataset,
               'message' => 'Update to resource \'' . $resource->title . '\'',
               'user' => $user->uid,
             );
-            if ($item) {
-              dkan_dataset_dataset_changelog_run($item);
-            }
+            dkan_dataset_dataset_changelog_run($item);
           }
         }
       }

--- a/modules/dkan/dkan_dataset/dkan_dataset.module
+++ b/modules/dkan/dkan_dataset/dkan_dataset.module
@@ -553,10 +553,12 @@ function dkan_dataset_node_update($node) {
           if (!$harvest) {
             $item = array(
               'dataset' => $dataset,
-              'message' => 'Update to resource \'' . $node->title . '\'',
+              'message' => 'Update to resource \'' . $resource->title . '\'',
               'user' => $user->uid,
             );
-            dkan_dataset_dataset_changelog_run($item);
+            if ($item) {
+              dkan_dataset_dataset_changelog_run($item);
+            }
           }
         }
       }


### PR DESCRIPTION
connects #2826 

When harvesting, all resources that are connected to a dataset are removed and recreated. The reason is that there is no unique identifier that can link the distribution info to a specific resource, any of the known values could be changed upstream.

The _dkan_dataset_node_update_ function will add a new revision for the dataset in the node_revision table for each resource. When harvesting large sources (1,000 datasets) and each dataset has 3-18 resources, the node_revision table is hammered with more revisions than necessary.

By skipping the dataset_changelog step, we will limit the revision rows to one for each resource and a single revision for the dataset.

### Steps to reproduce
1. create a harvest source from http://janette.dkandemo.nuamsdev.com/data.json
    identifier: 532105f1-d8a1-4777-88b1-9e6c01100811
2. run the harvest, you should have one dataset with 3 resources
3. edit one of the resources on the source site
4. run `drush dkan-h {harvest_machinename}`
5. run `drush queue-run dataset_changelog`
6. view the node_revision table, confirm you have a new revision on the dataset for each resource

### QA Steps
1. Same as above, this time you should only have a single revision added for the dataset.