### PR TITLE
Added "count" to the list of functions supported on datastore api.

### DIFF
--- a/docs/apis/datastore-api.rst
+++ b/docs/apis/datastore-api.rst
@@ -38,6 +38,7 @@ Aggregation functions
 -  **max** (*string*) – field to compute the maximum
 -  **std** (*string*) – field to compute the standard deviation
 -  **variance** (*string*) – field to compute the variance
+-  **count** (*string*) – field to compute the count
 
 URL format
 ----------


### PR DESCRIPTION
The function "count" is a function already supported by the datastore API but we didn't have that in the docs, so I'm adding that here.