### PR TITLE
Wrap words on harvest summary sidebar.

### DIFF
--- a/themes/nuboot_radix/assets/css/nuboot_radix.style.css
+++ b/themes/nuboot_radix/assets/css/nuboot_radix.style.css
@@ -9600,7 +9600,8 @@ div.horizontal-tabs {
   border-style: solid;
   margin-top: 15px; }
   .pane-dkan-harvest-harvest-source-summary .summary-details div {
-    padding: 4px 5px; }
+    padding: 4px 5px;
+    word-wrap: break-word; }
 
 .pane-dkan-harvest-harvest-source-summary h6 {
   background: #eee;

--- a/themes/nuboot_radix/scss/components/_harvest.scss
+++ b/themes/nuboot_radix/scss/components/_harvest.scss
@@ -9,6 +9,7 @@
     margin-top: 15px;
     div {
       padding: 4px 5px;
+      word-wrap: break-word;
     }
   }
 


### PR DESCRIPTION
Connects #2847 
Long strings in sidebar should wrap more gracefully.

## User story

As a site manager, I'd like to specify harvests with long filters or excludes, without the resulting text overflowing the left sidebar into search results. For example look at http://andrew.dkandemo.nuamsdev.com/harvest_source/cotest


## How to reproduce

1.  Add a harvest source with long filter or excludes, for example `license` set to ` http://opendefinition.org/licenses/odc-odbl/`, or `accessURL` set to http://www.cha.com/CHA/_Resources/New%20DataBank.aspx`, in those cases the text overflows the left sidebar.

## QA Steps

- [ ] Go to a harvest source with long filter or excludes, that text should be wrapped in the same harvest summary column and not overflow into the search results section.