### PR TITLE
Switch to forked version of font_icon_select module

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -161,7 +161,7 @@ projects:
   font_icon_select:
     download:
       type: git
-      url: https://git.drupal.org/sandbox/wolffereast/2319993.git
+      url: https://github.com/GetDKAN/font_icon_select.git
       branch: 7.x-1.x
   fontyourface:
     version: '2.8'


### PR DESCRIPTION
sandbox module is not accessible: You won't be able to pull or push project code via HTTPS until you create a personal access token on your account