### PR TITLE
Security update services to 3.24.

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -329,7 +329,7 @@ projects:
   select_or_other:
     version: '2.24'
   services:
-    version: '3.22'
+    version: '3.24'
   simple_gmap:
     version: '1.4'
   strongarm:


### PR DESCRIPTION
Security update of services to 3.24 because of https://www.drupal.org/sa-contrib-2019-043