### PR TITLE
Import manager improvements

### DIFF
--- a/docs/components/datastore.rst
+++ b/docs/components/datastore.rst
@@ -140,17 +140,20 @@ Troubleshoot
 
 you will need to grant FILE permissions to your MYSQL user. To do so use this command: ``GRANT FILE ON *.* TO 'user-name'``
 
-Important notes when upgrading DKAN from previous versions to 7.x-1.16
+
+Important notes when upgrading DKAN to 7.x-1.16 from previous versions
 ----------------------------------------------------------------------
+.. warning::
+  Be sure to read the following breaking changes if you have code that depends on the datastore API.
 
 Field names
 ***********
 
 Prior to the DKAN 7.x-1.16 release, the datastore field names matched the column headers exactly as they
 were in the CSV file used to create the datastore. This has changed in the 7.x-1.16 version of
-the Datastore, now the fields are transformed into lower case and spaces are replaced with underscores.
+the Datastore, now the field names are transformed into lower case and spaces are replaced with underscores.
 For example, if your CSV file has a column name titled ``School Year``, after importing the file
-to the datastore you will have to access it using ``school_year`` as the field name.
+to the datastore you will need to access it using ``school_year`` as the field name.
 
 Empty values
 ************
@@ -158,7 +161,7 @@ Empty values
 On previous versions of DKAN, when there was a cell with an empty value in a CSV
 file, that value would be imported as NULL into the datastore. After importing a file
 to the datastore with DKAN 7.x-1.16 or later, those empty values are kept as empty strings
-and not as NULL values anymore.
+and not as NULL values.
 
 Use of feeds
 ************
@@ -174,14 +177,17 @@ will not be enabled by default. If you were previously using that option you wil
 DKAN Datastore tables
 *********************
 
-On previous versions of DKAN, the import to datastore was done via feeds module, which produced
-tables with the field `feeds_flatstore_entry_id` as primary key. Starting on 1.16 feeds is not used
-anymore so the new primary key for the DKAN datastore tables is a serial field called `entry_id`. Anyways,
-all existing datastore tables are not changed by default, so you have two options:
+On previous versions of DKAN, the import process was done via the feeds module, which produced
+tables with the field `feeds_flatstore_entry_id` as the primary key. Starting in 7.x-1.16, 
+the feeds module has been replaced by **DKAN Datastore Simple Import**, and the new primary key for the DKAN datastore tables 
+is a serial field called `entry_id`. 
 
-1) you can just drop datastore for each resource and reimport them: this will drop the
-corresponding table and on the reimport the new table will be created using the new schema.
-2) create a hook update in some of your modules and add this code inside:
+NOTE: If you are upgrading, existing datastore tables will NOT be updated automatically. 
+
+You have two options:
+
+1. You can drop the datastore for each resource and re-import: this will delete the corresponding table and importing will create the table using the new schema.
+2. Create a hook update in a custom module and add the following code:
 
 .. code-block:: php
 
@@ -200,6 +206,6 @@ corresponding table and on the reimport the new table will be created using the 
     );
   }
 
-That code looks for all the dkan_datastore tables in your database, drops the primary key,
-drops the field `feeds_flatstore_entry_id` and adds the new field `entry_id` as primary key
+This code will look for all of the dkan_datastore tables in your database, drop the primary key,
+drop the field `feeds_flatstore_entry_id` and add the new field `entry_id` as the primary key
 for each table.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,12 +20,12 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'DKAN Docs'
-copyright = u'2017'
+copyright = u'2019'
 author = u'DKAN Team'
 
 
-version = '1.14'
-release = '1.14'
+version = '1.16'
+release = '1.16'
 
 language = 'en'
 

--- a/docs/releases/notes/1.16.4.md
+++ b/docs/releases/notes/1.16.4.md
@@ -1,0 +1,7 @@
+# DKAN 1.16.4 Release notes
+
+ - #2837 Security updates for the [services](https://www.drupal.org/sa-contrib-2019-026) and [path_breadcrumbs](https://www.drupal.org/sa-contrib-2019-027) contrib modules
+ - #2834 Add drush command drush ddpr to reduce duplicate dataset revisions from the same timestamp to a single revision.
+ - #2830 Add patch to workbench_moderation to avoid deadlock on update
+ - #2821 Declare file size of remote files as 'unknown' since the value given can be inaccurate
+ - #2823 Update dkan_dataset_validate_date() function to work on additional date formats

--- a/docs/releases/notes/1.16.5.md
+++ b/docs/releases/notes/1.16.5.md
@@ -1,0 +1,7 @@
+# DKAN 1.16.5 Release notes
+
+ - #2846 Update for [views](https://www.drupal.org/project/views) 7.x-3.21 and [ctools](https://www.drupal.org/project/ctools) 7.x-1.15 
+- #2824 Handle missing harvest source with a warning rather than mass un-publishing of content.
+- #2840 Skip the dataset_changelog step when harvesting, datasets always get a new revision with out it
+- #2839 Add drush command for deleting orphaned data tables ``drush dkan-datastore-drop-orphan-tables``
+- #2828 Implement the --feedback flag when harvesting to avoid SSH time outs during long harvests

--- a/docs/releases/notes/1.16.6.md
+++ b/docs/releases/notes/1.16.6.md
@@ -1,0 +1,4 @@
+# DKAN 1.16.6 Release notes
+
+- #2848 Upgrade [Drupal to 7.65](https://www.drupal.org/sa-core-2019-004)
+- #2812 Use ISO 8601 Date Format for Temporal Coverage

--- a/docs/releases/notes/1.16.7.md
+++ b/docs/releases/notes/1.16.7.md
@@ -1,0 +1,4 @@
+# DKAN 1.16.7 Release notes
+
+- #2780 Run tests with dktl.
+- #2853 Security Upgrade of [Module Filter to 2.2](https://www.drupal.org/sa-contrib-2019-042).

--- a/docs/releases/notes/1.16.8.md
+++ b/docs/releases/notes/1.16.8.md
@@ -1,0 +1,5 @@
+# DKAN 1.16.8 Release notes
+
+- #2854 Wrap words on harvest summary sidebar.
+- #2856 Switch to forked version of font_icon_select module.
+- #2858 Security Upgrade of [Services to 3.24](https://www.drupal.org/sa-contrib-2019-043).

--- a/docs/releases/notes/1.16.9.md
+++ b/docs/releases/notes/1.16.9.md
@@ -1,0 +1,10 @@
+# DKAN 1.16.9 Release notes
+
+- #2864 [Tablefield security update](https://www.drupal.org/sa-contrib-2019-045)
+- #2864 [Drupal core security update](https://www.drupal.org/sa-core-2019-005)
+- #2863 Use the data.json mediaType value to assign the resource extension during Harvest if the format is not given.
+- #2809 Remove 'Feedback' from the list of content types managed by DKAN Workflow
+- #2809 Apply [patch](https://www.drupal.org/node/2543562) to views to fix a bug on set_group_operator when using hook_views_query_alter
+- #2809 Remove user picture from comment.tpl.php
+- #2860 Document new datastore behavior
+- #2852 Add 'count' to the list of functions supported by the Datastore API

--- a/docs/releases/notes/index.rst
+++ b/docs/releases/notes/index.rst
@@ -6,7 +6,13 @@ Release notes here will be identical to the releases kept in the `Github reposit
 
 .. toctree::
    :maxdepth: 1
-
+   
+   1.16.9 <1.16.9>
+   1.16.8 <1.16.8>
+   1.16.7 <1.16.7>
+   1.16.6 <1.16.6>
+   1.16.5 <1.16.5>
+   1.16.4 <1.16.4>
    1.16.3 <1.16.3>
    1.16.2 <1.16.2>
    1.16.1 <1.16.1>

--- a/modules/dkan/dkan_datastore/dkan_datastore.api.php
+++ b/modules/dkan/dkan_datastore/dkan_datastore.api.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the DKAN Datastore module.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Execute actions right after importing a resource to the datastore.
+ *
+ * @param $resource
+ *   Resource object.
+ */
+function hook_datastore_post_import($resource) {
+  if ($resource->getId()) {
+    // Load resource node and execute needed actions.
+  }
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/modules/dkan/dkan_datastore/src/Manager/Manager.php
+++ b/modules/dkan/dkan_datastore/src/Manager/Manager.php
@@ -245,6 +245,7 @@ abstract class Manager implements ManagerInterface {
     if ($import_state === self::DATA_IMPORT_DONE) {
       $this->stateDataImport = self::DATA_IMPORT_DONE;
       $this->saveState();
+      module_invoke_all('datastore_post_import', $this->resource);
     }
     elseif ($import_state === self::DATA_IMPORT_PAUSED) {
       $this->stateDataImport = self::DATA_IMPORT_PAUSED;

--- a/modules/dkan/dkan_datastore/src/Manager/Manager.php
+++ b/modules/dkan/dkan_datastore/src/Manager/Manager.php
@@ -143,6 +143,16 @@ abstract class Manager implements ManagerInterface {
         'type' => "text",
       ];
     }
+
+    $schema['fields']['entry_id'] = [
+      'label' => 'entry_id',
+      'type' => 'serial',
+      'unsigned' => TRUE,
+      'not null' => TRUE,
+    ];
+    $schema['primary key'] = [
+      '0' => 'entry_id',
+    ];
     return $schema;
   }
 

--- a/test/phpunit/dkan_datastore/DkanDatastoreTest.php
+++ b/test/phpunit/dkan_datastore/DkanDatastoreTest.php
@@ -44,7 +44,7 @@ class DkanDatastoreTest extends \PHPUnit_Framework_TestCase {
     $results = $results->fetchAllAssoc("country");
     $json = json_encode($results);
     $this->assertEquals(
-      "{\"US\":{\"country\":\"US\",\"population\":\"315209000\",\"id\":\"1\",\"timestamp\":\"1359062329\"},\"CA\":{\"country\":\"CA\",\"population\":\"35002447\",\"id\":\"2\",\"timestamp\":\"1359062329\"},\"AR\":{\"country\":\"AR\",\"population\":\"40117096\",\"id\":\"3\",\"timestamp\":\"1359062329\"},\"JP\":{\"country\":\"JP\",\"population\":\"127520000\",\"id\":\"4\",\"timestamp\":\"1359062329\"}}",
+      "{\"US\":{\"country\":\"US\",\"population\":\"315209000\",\"id\":\"1\",\"timestamp\":\"1359062329\",\"entry_id\":\"1\"},\"CA\":{\"country\":\"CA\",\"population\":\"35002447\",\"id\":\"2\",\"timestamp\":\"1359062329\"},\"AR\":{\"country\":\"AR\",\"population\":\"40117096\",\"id\":\"3\",\"timestamp\":\"1359062329\"},\"JP\":{\"country\":\"JP\",\"population\":\"127520000\",\"id\":\"4\",\"timestamp\":\"1359062329\"}}",
       $json);
 
     $this->assertEquals(4, $datastore->numberOfRecordsImported());

--- a/test/phpunit/dkan_datastore/DkanDatastoreTest.php
+++ b/test/phpunit/dkan_datastore/DkanDatastoreTest.php
@@ -44,7 +44,7 @@ class DkanDatastoreTest extends \PHPUnit_Framework_TestCase {
     $results = $results->fetchAllAssoc("country");
     $json = json_encode($results);
     $this->assertEquals(
-      "{\"US\":{\"country\":\"US\",\"population\":\"315209000\",\"id\":\"1\",\"timestamp\":\"1359062329\",\"entry_id\":\"1\"},\"CA\":{\"country\":\"CA\",\"population\":\"35002447\",\"id\":\"2\",\"timestamp\":\"1359062329\"},\"AR\":{\"country\":\"AR\",\"population\":\"40117096\",\"id\":\"3\",\"timestamp\":\"1359062329\"},\"JP\":{\"country\":\"JP\",\"population\":\"127520000\",\"id\":\"4\",\"timestamp\":\"1359062329\"}}",
+      "{\"US\":{\"country\":\"US\",\"population\":\"315209000\",\"id\":\"1\",\"timestamp\":\"1359062329\",\"entry_id\":\"1\"},\"CA\":{\"country\":\"CA\",\"population\":\"35002447\",\"id\":\"2\",\"timestamp\":\"1359062329\",\"entry_id\":\"2\"},\"AR\":{\"country\":\"AR\",\"population\":\"40117096\",\"id\":\"3\",\"timestamp\":\"1359062329\",\"entry_id\":\"3\"},\"JP\":{\"country\":\"JP\",\"population\":\"127520000\",\"id\":\"4\",\"timestamp\":\"1359062329\",\"entry_id\":\"4\"}}",
       $json);
 
     $this->assertEquals(4, $datastore->numberOfRecordsImported());


### PR DESCRIPTION
If in a site we need to execute any steps right after the import to datastore process, right now we don't have an easy way to do it, so in this PR we are introducing a new hook. This hook is called hook_datastore_post_import and it is fired when an import process is completed.

Right now, the dkan datastore tables don't have a primary key field, which may lead to issues when someone needs to index the items from a datastore, so in this PR we're also altering the datastore table schema to include a serial `entry_id` field which will work as the primary key.

## QA Steps

- [ ] Import a resource to the datastore, the resulting table should contain a field `entry_id` as primary key.
- [ ] Implement a hook_datastore_post_import and make sure it fires after a resource is imported into the datastore.