### PR TITLE
Allow mediaType to specify resource type during Harvest

### DIFF
--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -257,18 +257,22 @@ class DatajsonHarvestMigration extends HarvestMigration {
 
       $format = $resource_row_data->format;
 
-      // If mediayType is defined, then get the right format based on that mimetype.
-      if (isset($resource_row_data->mediaType)) {
-        include_once DRUPAL_ROOT . '/includes/file.mimetypes.inc';
-        $mimetype_mappings = file_mimetype_mapping();
-        $mimetype_keys = array_keys($mimetype_mappings['mimetypes'], $resource_row_data->mediaType);
-        // Get the candidate extensions from the mimetype_keys.
-        $extensions_lookup = array();
-        foreach ($mimetype_keys as $mimetype_key) {
-          $extensions_lookup = array_merge($extensions_lookup, array_keys($mimetype_mappings['extensions'], $mimetype_key));
-        }
-        if (!empty($extensions_lookup)) {
-          $format = array_pop($extensions_lookup);
+      if (empty($format)) {
+        // If mediayType is defined, then get the right format based on that mimetype.
+        if (!empty($resource_row_data->mediaType)) {
+          include_once DRUPAL_ROOT . '/includes/file.mimetypes.inc';
+          $mimetype_mappings = file_mimetype_mapping();
+          $mimetype_keys = array_keys($mimetype_mappings['mimetypes'], $resource_row_data->mediaType);
+          // Get the candidate extensions from the mimetype_keys.
+          $extensions_lookup = array();
+          foreach ($mimetype_keys as $mimetype_key) {
+            $extensions_lookup = array_merge($extensions_lookup, array_keys($mimetype_mappings['extensions'], $mimetype_key));
+          }
+          if (!empty($extensions_lookup)) {
+            $format = array_pop($extensions_lookup);
+          } else {
+            $format = '';
+          }
         }
       }
 

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -255,8 +255,25 @@ class DatajsonHarvestMigration extends HarvestMigration {
         $url = $resource_row_data->accessURL;
       }
 
+      $format = $resource_row_data->format;
+
+      // If mediayType is defined, then get the right format based on that mimetype.
+      if (isset($resource_row_data->mediaType)) {
+        include_once DRUPAL_ROOT . '/includes/file.mimetypes.inc';
+        $mimetype_mappings = file_mimetype_mapping();
+        $mimetype_keys = array_keys($mimetype_mappings['mimetypes'], $resource_row_data->mediaType);
+        // Get the candidate extensions from the mimetype_keys.
+        $extensions_lookup = array();
+        foreach ($mimetype_keys as $mimetype_key) {
+          $extensions_lookup = array_merge($extensions_lookup, array_keys($mimetype_mappings['extensions'], $mimetype_key));
+        }
+        if (!empty($extensions_lookup)) {
+          $format = array_pop($extensions_lookup);
+        }
+      }
+
       $resource = $this->prepareResourceHelper($url,
-        $resource_row_data->format,
+        $format,
         $resource_row_data->title,
         NULL,
         $resource_row_data->description);


### PR DESCRIPTION
Connects #2850 

Description. If mediaType is defined, use its respective extension as the format for resources harvested.

## User story

As a site manager harvesting from a remote JSON source, I want resources that are created to use a resource type that is specified by the mediaType in the JSON, when it is specified, so that in cases where the JSON and remote server mimetype conflict, the resulting resource is correctly typed according to what the JSON intends.

## How to reproduce

1. Create a harvest from https://bythenumbers.sco.ca.gov/data.json
2. Confirm that some resources in the JSON use "mediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
3. Confirm that these resources show up as type "html" or "Web page", though, if downloaded, they're XLSX files

## QA Steps

- [x] Create a harvest from https://bythenumbers.sco.ca.gov/data.json
- [x] Confirm that some resources in the JSON use "mediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
- [x] Run the harvest
- [x] Confirm that resources with mediaType are using that to get the resource format.
- [x] Confirm that resources with mediaType set to `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` are shown as resources with format `xlsx`.
