### PR TITLE
Patch globalredirect to fix network issue

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -172,6 +172,8 @@ projects:
       2816837: https://www.drupal.org/files/issues/font_your_face-remove_div_general_text_option-D7.patch
   globalredirect:
     version: '1.6'
+    patch:
+      3053515: https://www.drupal.org/files/issues/2019-05-08/globalredirect-3053515-is-dir-external-check.patch
   gravatar:
     download:
       type: git


### PR DESCRIPTION
Security scans detected network activity when passing a URL to the search_api page. This patch to globalredirect prevents `is_dir()` from running on an external url, which in conjunction with remote_stream_wrapper module will cause a network request to be sent and received from the webserver to a potentially malicious URL.