### PR TITLE
Fix hard-coded revisions access for anonymous

### DIFF
--- a/modules/dkan/dkan_workflow/dkan_workflow.module
+++ b/modules/dkan/dkan_workflow/dkan_workflow.module
@@ -100,17 +100,6 @@ function dkan_workflow_menu() {
 function dkan_workflow_node_grants($user, $op) {
   $grants['dkan_workflow'] = array($user->uid);
   return $grants;
-}
-
-/**
- * Implements hook_workbench_moderation_acces_alter().
- */
-function dkan_workflow_workbench_moderation_access_alter(&$access, $op, $node) {
-  global $user;
-  // Allow anon users to see revision history.
-  if ($op == 'view history' && $user->uid == 0) {
-    $access = 1;
-  }
 } 
 
 /**
@@ -159,19 +148,11 @@ function dkan_workflow_menu_local_tasks_alter(&$data, $router_item, $root_path) 
   }
   // Restore 'Revisions' tab for anonymous users when dkan_workflow is enabled.
   global $user;
-  if ($user->uid == 0 && isset($data['tabs'][0]['output'][1]) &&
-    $data['tabs'][0]['output'][1]['#link']['page_callback'] == 'workbench_moderation_node_history_view') {
-    // Check if revisions exist.
-    $node = node_load(arg(1));
-    $r = count(node_revision_list($node));
-    if ($r > 1) {
-      // Change moderate button text to 'Revisions' if user is anonymous.
-      $data['tabs'][0]['output'][1]['#link']['title'] = 'Revisions';
-    }
-    else {
-      // Remove local tabs if there are no revisions.
-      unset($data['tabs']);
-    }
+  if (user_access('view moderation history') 
+    && isset($data['tabs'][0]['output'][1]) 
+    && $data['tabs'][0]['output'][1]['#link']['page_callback'] == 'workbench_moderation_node_history_view') {
+    // Change moderate button text to 'Revisions' if user is anonymous.
+    $data['tabs'][0]['output'][1]['#link']['title'] = 'Revisions';
   }
 }
 


### PR DESCRIPTION
Add @acouch 's fix for revision permissions.

## User story

As a site manager I would like the option to not allow anonymous access to revisions.

## How to reproduce

1.  Uncheck the permissions 'view revision history' and 'view node revisions' from the anonymous role
2. View a dataset that has revisions as Anonymous, confirm that you can still view the 'Revisions' tab

## QA Steps

- [x] Uncheck the permissions 'view revision history' and 'view node revisions' from the anonymous role
- [x] View a dataset that has revisions as Anonymous, confirm you do not see a 'Revisions' tab

