### PR TITLE
Use right table to delete orphans.

### DIFF
--- a/modules/dkan/dkan_datastore/dkan_datastore.drush.inc
+++ b/modules/dkan/dkan_datastore/dkan_datastore.drush.inc
@@ -53,9 +53,9 @@ function dkan_datastore_drush_drop_orphan_tables() {
     $t = (array)$record;
     $db = key($t);
     $table = $record->{$db};
-    if (strpos($table, 'datastore_dkan') !== false) {
-      // Removes 'feeds_datastore_dkan_file_';
-      $nids[] = substr($table, 26);
+    if (strpos($table, 'dkan_datastore') !== false) {
+      // Removes 'dkan_datastore_';
+      $nids[] = substr($table, 15);
     }
   }
   if (!empty($nids)) {
@@ -65,7 +65,7 @@ function dkan_datastore_drush_drop_orphan_tables() {
       $query = db_query('SELECT nid FROM {node} WHERE nid = :nid', array(':nid' => $nid));
       $result = $query->fetchAll();
       if (count($result) < 1) {
-        $to_truncate[] = 'feeds_datastore_dkan_file_' . $nid;
+        $to_truncate[] = 'dkan_datastore_' . $nid;
         $orphans++;
       }
     }


### PR DESCRIPTION
## Description

On https://github.com/GetDKAN/dkan/pull/2839 we introduced a command for deleting orphan tables for legacy tables. During switch to new datastore all tables were converted from `feeds_datastore_dkan_file_*` to `dkan_datastore_*` but the command was still using all table pattern and right now when we run it on a client site with datastores it just throws an error saying there are no datastore tables which is not accurate.

## How to reproduce

1. Create a datastore table for a nid that doesn't exist, for example `dkan_datastore_000`.
2. Run the command `drush dkan-datastore-dot`.
3. It returns a message saying "There are currently no datastore tables on this site."

## QA Steps

- [ ] Create a datastore table for a nid that doesn't exist, for example `dkan_datastore_000`.
- [ ] Run the command `drush dkan-datastore-dot`.
- [ ] The table created should be deleted and the command should show a message saying it did it.