### PR TITLE
Harvest support range dates separated by dashes

### DIFF
--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -144,7 +144,7 @@ class DatajsonHarvestMigration extends HarvestMigration {
     // Process Temporal Coverage. The mapping are defined in the base main
     // class, we just need to set the properties.
     if (isset($row->temporal)) {
-      $date = [];
+      $date = $row->temporal;
       if (strpos($row->temporal, '/')) {
         $date = explode("/", $row->temporal);
       }
@@ -204,9 +204,7 @@ class DatajsonHarvestMigration extends HarvestMigration {
           }
         }
 
-        if ($value_date) {
-          $value = $value_date->getTimestamp();
-        }
+        $value = $value_date->getTimestamp();
       }
 
       if (isset($date[0])) {

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -144,7 +144,13 @@ class DatajsonHarvestMigration extends HarvestMigration {
     // Process Temporal Coverage. The mapping are defined in the base main
     // class, we just need to set the properties.
     if (isset($row->temporal)) {
-      $date = explode("/", $row->temporal);
+      $date = [];
+      if (strpos($row->temporal, '/')) {
+        $date = explode("/", $row->temporal);
+      }
+      elseif (strpos($row->temporal, '-')) {
+        $date = explode("-", $row->temporal);
+      }
       // The first key is the start date of the 'temporal coverage' and the second key is the
       // end date of the 'temporal coverage'.
       foreach ($date as $key => &$value) {

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -204,7 +204,9 @@ class DatajsonHarvestMigration extends HarvestMigration {
           }
         }
 
-        $value = $value_date->getTimestamp();
+        if ($value_date) {
+          $value = $value_date->getTimestamp();
+        }
       }
 
       if (isset($date[0])) {

--- a/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
+++ b/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
@@ -564,6 +564,10 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
         'value' => "2000-01-15T00:45:00Z",
         'value2' => "2010-01-15T00:06:00Z",
       ),
+      'Test' => array(
+        'value' => "2005-01-01 00:00:00",
+        'value2' => "2016-12-31 00:00:00",
+      ),
     );
 
     // Harvest the faulty source.

--- a/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_temporal.json
+++ b/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_temporal.json
@@ -194,6 +194,49 @@
         "Medicare"
       ],
       "title": "UPIN Group File"
+    },
+    {
+      "@type": "dcat:Dataset",
+      "accessLevel": "public",
+      "bureauCode": [
+        "009:38"
+      ],
+      "contactPoint": {
+        "@type": "vcard:Contact",
+        "fn": "Health Data Initiative",
+        "hasEmail": "mailto:cms.data@cms.hhs.gov"
+      },
+      "dataQuality": true,
+      "description": "The Ambulance Fee Schedule public use files for calendar years 2004 through December 31, 2016 are located in the Downloads section below.",
+      "distribution": [
+        {
+          "@type": "dcat:Distribution",
+          "downloadURL": "https://www.cms.gov/Medicare/Medicare-Fee-for-Service-Payment/AmbulanceFeeSchedule/afspuf.html",
+          "mediaType": "text/html",
+          "accessURL": "https://www.cms.gov/Medicare/Medicare-Fee-for-Service-Payment/AmbulanceFeeSchedule/afspuf.html"
+        }
+      ],
+      "identifier": "309",
+      "keyword": [
+        "Publically Available Data File - for download",
+        "Ambulatory",
+        "Providers",
+        "State",
+        "Claims"
+      ],
+      "landingPage": "https://www.cms.gov/Medicare/Medicare-Fee-for-Service-Payment/AmbulanceFeeSchedule/afspuf.html",
+      "modified": "2016-04-07",
+      "programCode": [
+        "009:000"
+      ],
+      "publisher": {
+        "name": "Centers for Medicare & Medicaid Services"
+      },
+      "temporal": "2005-2016",
+      "theme": [
+        "Medicare"
+      ],
+      "title": "Test"
     }
   ]
 }


### PR DESCRIPTION
Harvest sources https://data.cdc.gov/data.json with temporal coverage dates that use dashes as separator are failing with the following error:

```
Error: Call to a member function getTimestamp() on null in       [error]
DatajsonHarvestMigration->prepareRow() (line 201 of
dkan/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc).
Error: Call to a member function getTimestamp() on null in DatajsonHarvestMigration->prepareRow() (line 201 of dkan/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc).
Drush command terminated abnormally due to an unrecoverable error.       [error]
Error: DateTime::__construct(): Failed to parse time string
(1899-2017) at position 6 (0): Unexpected character in
dkan/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc,
line 189
```

This is because dkan_harvest doesn't support temporal coverage values following the format "YYYY-YYYY". As it is a common format, in this PR we are adding support for it, so any harvest source with a temporal coverage value using the format YYYY-YYYY should work correctly just as any other YYYY/YYYY rage dates.

## How to reproduce

1.  Run harvest for a harvest source with temporal coverage values using the format YYYY-YYYY, it should fail with the message above. For example in https://data.cdc.gov/data.json the dataset with identifier https://data.cdc.gov/api/views/66i6-hisz

## QA Steps

- [x] Run harvest for a harvest source with temporal coverage values using the format YYYY-YYYY, it should work correctly, the message from above shouldn't stop the execution of the harvest. For example in https://data.cdc.gov/data.json the dataset with identifier https://data.cdc.gov/api/views/66i6-hisz