### PR TITLE
Remove user field on unpublished nodes tab on workbench moderation UI.

### DIFF
--- a/modules/dkan/dkan_workflow/views/workbench_moderation.view.inc
+++ b/modules/dkan/dkan_workflow/views/workbench_moderation.view.inc
@@ -128,7 +128,7 @@ $handler->display->display_options['filters']['is_current']['id'] = 'is_current'
 $handler->display->display_options['filters']['is_current']['table'] = 'workbench_moderation_node_history';
 $handler->display->display_options['filters']['is_current']['field'] = 'is_current';
 
-/* Display: Drafts page */
+/* Display: Unpublished nodes page */
 $handler = $view->new_display('page', 'Unpublished nodes page', 'unpublished_node_drafts_page');
 $handler->display->display_options['defaults']['title'] = FALSE;
 $handler->display->display_options['title'] = 'Unpublished nodes';
@@ -190,13 +190,6 @@ $handler->display->display_options['fields']['vid']['relationship'] = 'nid';
 $handler->display->display_options['fields']['vid']['exclude'] = TRUE;
 $handler->display->display_options['defaults']['filter_groups'] = FALSE;
 $handler->display->display_options['defaults']['filters'] = FALSE;
-/* Filter criterion: User: Current */
-$handler->display->display_options['filters']['uid_current']['id'] = 'uid_current';
-$handler->display->display_options['filters']['uid_current']['table'] = 'users';
-$handler->display->display_options['filters']['uid_current']['field'] = 'uid_current';
-$handler->display->display_options['filters']['uid_current']['relationship'] = 'uid_1';
-$handler->display->display_options['filters']['uid_current']['value'] = '1';
-$handler->display->display_options['filters']['uid_current']['group'] = 1;
 /* Filter criterion: Workbench Moderation: Current */
 $handler->display->display_options['filters']['is_current']['id'] = 'is_current';
 $handler->display->display_options['filters']['is_current']['table'] = 'workbench_moderation_node_history';
@@ -1016,12 +1009,6 @@ $handler->display->display_options['filters']['state']['value'] = array(
   'draft' => 'draft',
 );
 $handler->display->display_options['filters']['state']['group'] = 1;
-/* Filter criterion: User: Current */
-$handler->display->display_options['filters']['uid_current']['id'] = 'uid_current';
-$handler->display->display_options['filters']['uid_current']['table'] = 'users';
-$handler->display->display_options['filters']['uid_current']['field'] = 'uid_current';
-$handler->display->display_options['filters']['uid_current']['relationship'] = 'uid';
-$handler->display->display_options['filters']['uid_current']['value'] = '1';
 /* Filter criterion: Content: Published */
 $handler->display->display_options['filters']['status']['id'] = 'status';
 $handler->display->display_options['filters']['status']['table'] = 'node';


### PR DESCRIPTION
As part of https://github.com/GetDKAN/dkan/pull/2879 we included a new tab in the workbench UI to delete current revisions for unpublished nodes (deleting the nodes completely). It has an issue because there is a user filter being applied so the administrators can't moderate them. In this PR we are removing the filter.

## How to reproduce

1. Log in as an administrator
2. Make sure there is at least one unpublished node with a revision in the site.
3. The tab "Unpublished nodes draft" in admin/workbench shows 0 items.

## QA Steps

- [x] Log in as an administrator
- [x] Make sure there is at least one unpublished node with a revision in the site.
- [x] The tab "Unpublished nodes draft" in admin/workbench should have the list of unpublished nodes with revisions, it should reflect the right amount of items.
- [x] Log in as an editor/workbench moderator, you shouldn't see non-group nodes in this list.