### PR TITLE
Hide some harvest messages

### DIFF
--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -412,6 +412,7 @@ function dkan_harvest_cache_sources_in_batch(array $harvest_sources = array(), $
  *   The context associated with the batch process.
  */
 function dkan_harvest_migrate_source_batch_op($harvest_source, array $options = array(), array &$context = array()) {
+  $_SESSION['dkan_harvest_running'] = TRUE;
 
   // Load migration.
   $migration = $harvest_source->getMigration();
@@ -488,6 +489,7 @@ function dkan_harvest_migrate_source_batch_op($harvest_source, array $options = 
     dkan_harvest_message_cleanup($harvest_source, $updated_results);
     // Log migration event on log tables.
     $migration->logEvent($updated_results);
+    unset($_SESSION['dkan_harvest_running']);
   }
 }
 

--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -54,6 +54,31 @@ function dkan_harvest_preprocess_page(&$vars) {
 }
 
 /**
+ * Implement hook_preprocess_status_messages().
+ */
+function dkan_harvest_preprocess_status_messages(&$variables) {
+  // Hide messages if running harvest.
+  if ((isset($_SESSION['dkan_harvest_running'])
+      && $_SESSION['dkan_harvest_running'] === TRUE)
+      || current_path() === 'admin/dkan/harvest/dashboard'
+  ) {
+    if (isset($_SESSION['messages'])) {
+      foreach ($_SESSION['messages'] as $type => $messages) {
+        if ($type == 'status') {
+          foreach ($messages as $key => $message) {
+            if (preg_match('/cannot be imported to our datastore/', $message)) {
+              unset($_SESSION['messages'][$type][$key]);
+            } elseif (preg_match('/Groups were updated on/', $message)) {
+              unset($_SESSION['messages'][$type][$key]);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
  * Theme function to create harvest source summary block.
  */
 function theme_dkan_harvest_source_summary(&$vars) {


### PR DESCRIPTION
Hide groups and datastore messages during harvest runs and from the status page right after it finishes, because those messages are not helpful for the user when multiple datasets/resources are added during harvest.

## How to reproduce

1. Create a harvest source from https://open.fda.gov/data.json. Click through to "Harvest Now".
2. Once the harvest has completed, note that there are a large number of messages in green, some of them are related to nodes (like  "Node 43 doesn't have a proper file path.") but some don't have an ID so nothing is actionable from "This filemime type (application/zip) can be added as a resource, but cannot be imported to our datastore." or "Groups were updated on 1 resource(s).".

## QA Steps

- [ ] Create a harvest source from https://open.fda.gov/data.json. Click through to "Harvest Now".
- [ ] While harvest is running, try to load any other pages, you shouldn't see messages like "This filemime type (SOME FILEMIME) can be added as a resource, but cannot be imported to our datastore." or "Groups were updated on X resource(s).".
- [ ] Once the harvest has completed, on the dkan harvest dashboard you shouldn't see messages like "This filemime type (SOME FILEMIME) can be added as a resource, but cannot be imported to our datastore." or "Groups were updated on X resource(s).".
