### PR TITLE
Fixed documentation about hook_update code for changing primary key on datastore tables.

### DIFF
--- a/docs/components/datastore.rst
+++ b/docs/components/datastore.rst
@@ -193,7 +193,7 @@ You have two options:
 
   $tables = db_query("show tables like 'dkan_datastore_%'")->fetchAll();
   foreach($tables as $key => $value) {
-    $table_name = $value->{'Tables_in_drupal (dkan_datastore_%)'};
+    $table_name = reset($value);
     db_drop_primary_key($table_name);
     db_drop_field($table_name, 'feeds_flatstore_entry_id');
     db_add_field($table_name, 'entry_id',


### PR DESCRIPTION
Suggested code for changing primary key on datastore tables was not correct, it was dependant on a specific database name, we're fixing that here.