### PR TITLE
Add background color to toggle handle

### DIFF
--- a/themes/nuboot_radix/assets/css/nuboot_radix.style.css
+++ b/themes/nuboot_radix/assets/css/nuboot_radix.style.css
@@ -9625,7 +9625,8 @@ div.datasets-count-preview span {
   font-size: 16px;
   font-weight: normal;
   position: relative;
-  padding: 9px 21px 9px 12px; }
+  padding: 9px 21px 9px 12px;
+  background-color: #0A77BD; }
 
 .node-type-harvest-source .ctools-collapsible-container .ctools-collapsible-handle:after {
   font-family: "fontawesome";

--- a/themes/nuboot_radix/scss/components/_harvest.scss
+++ b/themes/nuboot_radix/scss/components/_harvest.scss
@@ -42,6 +42,7 @@ div.datasets-count-preview span {
     font-weight: normal;
     position: relative;
     padding: 9px 21px 9px 12px;
+    background-color: $brand-primary;
   }
   .ctools-collapsible-container .ctools-collapsible-handle:after {
     font-family: "fontawesome";


### PR DESCRIPTION
## QA steps

1. run a harvest with errors
2. confirm the toggle bar on the error page has a background color

![harvest-errors](https://user-images.githubusercontent.com/314172/59888254-70e0dc80-938c-11e9-9610-04f643dc4776.png)
