### PR TITLE
Implement periodic updates functionality

### DIFF
--- a/docs/components/index.rst
+++ b/docs/components/index.rst
@@ -24,6 +24,7 @@ described inside the Datasets section, all this functionality is provided by the
    federal-extras
    search
    theme
+   Periodic Updates <periodic-updates>
    Roles and Permissions <permissions>
    Storytelling <storytelling>
    Open Data Schema Map <open-data-schema>

--- a/docs/components/periodic-updates.rst
+++ b/docs/components/periodic-updates.rst
@@ -13,7 +13,7 @@ The module requires a CSV file to execute the updates, this file is known as "th
 Periodic Updates Settings
 -------------------------
 
-You can find the periodic updates settings under DKAN --> Periodic Updates (`/admin/dkan/periodic-updates`).
+You can find the periodic updates settings under DKAN --> Periodic Updates --> Settings (`/admin/dkan/periodic-updates`).
 The settings for this module includes:
 
   - Periodic updates state

--- a/docs/components/periodic-updates.rst
+++ b/docs/components/periodic-updates.rst
@@ -1,0 +1,55 @@
+DKAN Periodic Updates
+=====================
+
+The DKAN Periodic Updates module provides the user the ability to execute automated updates on existing resources in a daily, weekly or monthly basis. It also provides a UI in which you can check at the status of the updates.
+The module requires a CSV file to execute the updates, this file is known as "the manifest", when you upload it and enable the updates, this is what happens:
+
+- The manifest is evaluated on every cron run to determine what resources needs to be updated (based on the frequency defined in the manifest and the "last update" date).
+- For each resource that needs an update, the system will:
+  - Download the file URL specified in the manifest (or link it, according to which file field is used on the corresponding resource).
+  - Update the resource node to use the new file.
+  - If the file is a CSV or TSV, then the resource is imported into the datastore.
+
+Periodic Updates Settings
+-------------------------
+
+You can find the periodic updates settings under DKAN --> Periodic Updates (`/admin/dkan/periodic-updates`).
+The settings for this module includes:
+
+  - Periodic updates state
+  - Manifest for periodic updates
+
+1- Periodic updates state
+*************************
+
+To turn periodic updates on you need to be in the Periodic Updates page, once there you should mark the option "Enable periodic updates" and click on "Save settings". You'll also need to upload a valid manifest in the section "Manifest for periodic updates", otherwise the updates cannot be executed.
+If you already have a manifest in the system but need to pause the periodic updates, all you need to do is unmark the option "Enable periodic updates" and save settings.
+
+2- Manifest for periodic updates
+********************************
+
+The manifest is a CSV file in which you define all the resources that need to be updated periodically in the system, this file should contain the following column names:
+
+``resource_id,frequency,file_url``
+
+:resource_id: is the UUID related to the resource node.
+:frequency: it can be set to `daily`, `weekly` or `monthly`. If you leave it empty or put any other string, then the system asumes it has to be imported daily.
+:file_url: the URL of the remote file that needs to be downloaded or linked and saved to the node.
+
+Once you upload the manifest and click on "Add file", the file will be recognized by the system.
+
+Note: for the periodic updates to be executed you need to have uploaded a valid manifest and enabled the periodic updates. If you only have one of these items, the updates will not be executed.
+
+Periodic Updates Status
+-------------------------
+
+The status page can be found under DKAN --> Periodic Updates --> Status (`/admin/dkan/periodic-updates/status`). In this page you'll get information about all the resources specified in the manifest.
+If the "Enable periodic updates" checkbox from Settings is not marked, then you'll get a message saying "Periodic updates are disabled.". If it is marked but no manifest has been uploaded, then you'll get a message saying "No manifest was found.".
+If the updates are enabled and a valid manifest is uploaded, then you'll see a list of the elements included in the manifest file, that list includes:
+
+  - the node UUID,
+  - the File URL,
+  - the Update frequency,
+  - the Status: this represents the messages generated on each update, it will tell you wether the resource has been updated, if the process finished correctly or if/what errors were produced
+  - the Last update date: this is the date in which the resource was last updated via periodic updates
+  - a link to view the resource.

--- a/docs/components/periodic-updates.rst
+++ b/docs/components/periodic-updates.rst
@@ -47,9 +47,8 @@ The status page can be found under DKAN --> Periodic Updates --> Status (`/admin
 If the "Enable periodic updates" checkbox from Settings is not marked, then you'll get a message saying "Periodic updates are disabled.". If it is marked but no manifest has been uploaded, then you'll get a message saying "No manifest was found.".
 If the updates are enabled and a valid manifest is uploaded, then you'll see a list of the elements included in the manifest file, that list includes:
 
-  - the node UUID,
-  - the File URL,
+  - the Destination Resource ID: this shows the resource UUID specified in the manifest but it is also a link to the resource node when applicable,
+  - the Source File URL,
   - the Update frequency,
-  - the Status: this represents the messages generated on each update, it will tell you wether the resource has been updated, if the process finished correctly or if/what errors were produced
-  - the Last update date: this is the date in which the resource was last updated via periodic updates
-  - a link to view the resource.
+  - the Status: this represents the messages generated on each update, it will tell you wether the resource has been updated, if the process finished correctly or if/what errors were produced,
+  - the Last update date: this is the date in which the resource was last updated via periodic updates.

--- a/docs/components/periodic-updates.rst
+++ b/docs/components/periodic-updates.rst
@@ -1,10 +1,10 @@
 DKAN Periodic Updates
 =====================
 
-The DKAN Periodic Updates module provides the user the ability to execute automated updates on existing resources in a daily, weekly or monthly basis. It also provides a UI in which you can check at the status of the updates.
+The DKAN Periodic Updates module provides the user the ability to execute automated updates on existing resources on a daily, weekly or monthly basis. It also provides a UI in which you can check at the status of the updates.
 The module requires a CSV file to execute the updates, this file is known as "the manifest", when you upload it and enable the updates, this is what happens:
 
-- The manifest is evaluated on every cron run to determine what resources needs to be updated (based on the frequency defined in the manifest and the "last update" date).
+- The manifest is evaluated on every cron run to determine which resources need to be updated (based on the frequency defined in the manifest and the "last update" date).
 - For each resource that needs an update, the system will:
   - Download the file URL specified in the manifest (or link it, according to which file field is used on the corresponding resource).
   - Update the resource node to use the new file.
@@ -14,7 +14,7 @@ Periodic Updates Settings
 -------------------------
 
 You can find the periodic updates settings under DKAN --> Periodic Updates --> Settings (`/admin/dkan/periodic-updates`).
-The settings for this module includes:
+The settings for this module include:
 
   - Periodic updates state
   - Manifest for periodic updates
@@ -22,13 +22,13 @@ The settings for this module includes:
 1- Periodic updates state
 *************************
 
-To turn periodic updates on you need to be in the Periodic Updates page, once there you should mark the option "Enable periodic updates" and click on "Save settings". You'll also need to upload a valid manifest in the section "Manifest for periodic updates", otherwise the updates cannot be executed.
-If you already have a manifest in the system but need to pause the periodic updates, all you need to do is unmark the option "Enable periodic updates" and save settings.
+Enable periodic updates by checking the "Enable periodic updates" box on the Periodic Updates page, and click on "Save settings". You'll also need to upload a valid manifest in the section "Manifest for periodic updates", otherwise the updates cannot be executed.
+If you already have a manifest in the system but need to pause the periodic updates, all you need to do is uncheck the option "Enable periodic updates" and save settings.
 
 2- Manifest for periodic updates
 ********************************
 
-The manifest is a CSV file in which you define all the resources that need to be updated periodically in the system, this file should contain the following column names:
+The manifest is a CSV file in which you define all of the resources that need to be updated periodically in the system, this file should contain the following column names:
 
 ``resource_id,frequency,file_url``
 
@@ -43,7 +43,7 @@ Note: for the periodic updates to be executed you need to have uploaded a valid 
 Periodic Updates Status
 -------------------------
 
-The status page can be found under DKAN --> Periodic Updates --> Status (`/admin/dkan/periodic-updates/status`). In this page you'll get information about all the resources specified in the manifest.
+The status page can be found under DKAN --> Periodic Updates --> Status (`/admin/dkan/periodic-updates/status`). In this page you'll get information about the resources specified in the manifest.
 If the "Enable periodic updates" checkbox from Settings is not marked, then you'll get a message saying "Periodic updates are disabled.". If it is marked but no manifest has been uploaded, then you'll get a message saying "No manifest was found.".
 If the updates are enabled and a valid manifest is uploaded, then you'll see a list of the elements included in the manifest file, that list includes:
 

--- a/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.info
+++ b/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.info
@@ -1,0 +1,6 @@
+name = DKAN Periodic Updates
+description = DKAN module for executing periodic updates to resources.
+core = 7.x
+package = DKAN
+dependencies[] = dkan_dataset
+dependencies[] = dkan_datastore

--- a/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
+++ b/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
@@ -183,48 +183,56 @@ function dkan_periodic_updates_cron() {
   $active = variable_get('dkan_periodic_updates_status');
   if ($active) {
     $file = variable_get('dkan_periodic_updates_manifest');
-    $file = file_load($file);
-    if ($file) {
-      $to_update = [];
-      $today = new DateTime("now");
-      $handle = fopen($file->uri, 'r');
-      $headers = fgetcsv($handle, 0, ',');
+    $to_update = dkan_periodic_updates_get_items_to_update($file);
+    if (!empty($to_update)) {
+      dkan_periodic_updates_execute_update($to_update);
+    }
+  }
+}
 
-      while (($data = fgetcsv($handle, 0, ",")) !== FALSE) {
-        $resource_data = array_combine($headers, $data);
-        $last_update = variable_get('dkan_periodic_updates_' . $resource_data['resource_id'], '');
-        // If the last update date is present for the resource, then check for
-        // its frequency to see if it should be updated.
-        if (!empty($last_update)) {
-          $time_passed = $today->diff($last_update);
-          switch ($resource_data['frequency']) {
-            case 'monthly':
-              if ($time_passed->days >= 28) {
-                $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
-              }
-              break;
-            case 'weekly':
-              if ($time_passed->days >= 7) {
-                $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
-              }
-              break;
-            default:
-              if ($time_passed->days >= 1) {
-                $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
-              }
-          }
-        }
-        // If there is no last update date, then add the resource to list of
-        // resource to import.
-        else {
-          $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
+function dkan_periodic_updates_get_items_to_update($file) {
+  $file = file_load($file);
+  if ($file) {
+    $to_update = [];
+    $today = new DateTime("now");
+    $handle = fopen($file->uri, 'r');
+    $headers = fgetcsv($handle, 0, ',');
+
+    while (($data = fgetcsv($handle, 0, ",")) !== FALSE) {
+      $resource_data = array_combine($headers, $data);
+      $last_update = variable_get('dkan_periodic_updates_' . $resource_data['resource_id'], '');
+      // If the last update date is present for the resource, then check for
+      // its frequency to see if it should be updated.
+      if (!empty($last_update)) {
+        $time_passed = $today->diff($last_update);
+        switch ($resource_data['frequency']) {
+          case 'monthly':
+            if ($time_passed->days >= 28) {
+              $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
+            }
+            break;
+          case 'weekly':
+            if ($time_passed->days >= 7) {
+              $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
+            }
+            break;
+          default:
+            if ($time_passed->days >= 1) {
+              $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
+            }
         }
       }
-      fclose($handle);
-      dkan_periodic_updates_execute_update($to_update);
-    } else {
-      watchdog('dkan_periodic_updates', 'No manifest found.');
+      // If there is no last update date, then add the resource to list of
+      // resource to import.
+      else {
+        $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
+      }
     }
+    fclose($handle);
+    return $to_update;
+  } else {
+    watchdog('dkan_periodic_updates', 'No manifest found.');
+    return [];
   }
 }
 

--- a/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
+++ b/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
@@ -1,0 +1,451 @@
+<?php
+
+/**
+ * @file
+ * Code for dkan_periodic_updates module.
+ */
+
+/**
+ * Implements hook_permission().
+ */
+function dkan_periodic_updates_permission()
+{
+  return [
+    'administer periodic updates' => [
+      'title' => t('administer periodic updates')
+    ],
+  ];
+}
+
+/**
+ * Implements hook_menu().
+ */
+function dkan_periodic_updates_menu() {
+  $items = [];
+  $items['admin/dkan/periodic-updates'] = [
+    'title' => t('Periodic updates'),
+    'description' => t('Form for uploading periodic updates manifest.'),
+    'page callback' => 'dkan_periodic_updates',
+    'access arguments' => ['administer periodic updates'],
+    'type' => MENU_NORMAL_ITEM,
+  ];
+  $items['admin/dkan/periodic-updates/manifest'] = [
+    'title' => t('Manifest'),
+    'type' => MENU_DEFAULT_LOCAL_TASK,
+  ];
+  $items['admin/dkan/periodic-updates/status'] = [
+    'title' => t('Status'),
+    'page callback' => 'dkan_periodic_updates_state',
+    'access arguments' => ['administer periodic updates'],
+    'type' => MENU_LOCAL_TASK,
+  ];
+  return $items;
+}
+
+
+/**
+ * Page callback for admin/dkan/periodic-updates.
+ */
+function dkan_periodic_updates() {
+  $output = [];
+  $output['periodic-updates-status'] = drupal_get_form('dkan_periodic_updates_status_form');
+  $output['periodic-updates-manifest'] = drupal_get_form('dkan_periodic_updates_form');
+  return $output;
+}
+
+/**
+ * Form for periodic updates manifest.
+ */
+function dkan_periodic_updates_form($form, &$form_state) {
+  $form['manifest-file'] = [
+    '#type' => 'fieldset',
+    '#title' => 'Manifest for periodic updates',
+  ];
+  $form['manifest-file']['info'] = [
+    '#markup' => '<p>' . t('The manifest file should contain the following column names: resource_id, frequency and file_url. The allowed frequency values are daily, weekly, or monthly. If left blank, the frequency will default to daily.') . '</p>',
+  ];
+  $form['manifest-file']['manifest'] = [
+    '#type' => 'managed_file',
+    '#title' => 'Upload manifest file',
+    '#upload_location' => 'public://manifest/',
+    '#upload_validators' => array(
+      'file_validate_extensions' => array('csv'),
+    ),
+  ];
+  $form['manifest-file']['submit'] = [
+    '#type' => 'submit',
+    '#id' => 'add-manifest-file',
+    '#value' => t('Add file'),
+  ];
+
+  // Current manifest file.
+  $prev_file_name = '- None -';
+  $message = '<p>Current manifest: ' . $prev_file_name . '</p>';
+  $prev_file = variable_get('dkan_periodic_updates_manifest');
+  if ($prev_file) {
+    $file = file_load($prev_file);
+    $prev_file_name = $file->filename;
+    $url = file_create_url($file->uri);
+    $message = '<p>Current manifest: <a href="' . $url . '">' . $prev_file_name . '</a></p>';
+  }
+  $form['manifest-file']['manifest']['text'] = array(
+    '#markup' => $message,
+  );
+
+  return $form;
+}
+
+/**
+ * Validate function for periodic updates manifest form.
+ */
+function dkan_periodic_updates_form_validate($form, &$form_state) {
+  $standard_headers = ['resource_id', 'frequency', 'file_url'];
+
+  $file = file_load($form_state['values']['manifest']);
+  if ($file) {
+    $handle = fopen($file->uri, 'r');
+    $headers = fgetcsv($handle);
+    fclose($handle);
+    foreach ($headers as $header) {
+      if (!in_array($header, $standard_headers)) {
+        $error = $error . '<br> • ' . print_r($header, TRUE);
+      }
+    }
+    if (!empty($error)) {
+      form_set_error('file', 'Your file contains improper headings, please edit the following: ' . $error);
+    }
+  } else {
+    form_set_error('file', 'Please choose a data file to upload.');
+  }
+}
+
+/**
+ * Submit function for periodic updates manifest form.
+ */
+function dkan_periodic_updates_form_submit($form, &$form_state) {
+  $data = new stdClass();
+  $data->file = $form_state['values']['manifest'];
+
+  // Save file permanently. It's saved temporally as a default.
+  $file = file_load($data->file);
+  $file->status = FILE_STATUS_PERMANENT;
+  file_save($file);
+  drupal_set_message($file->filename . ' has been added.', 'status', FALSE);
+  $manifest_file = variable_get('dkan_periodic_updates_manifest');
+  if ($manifest_file) {
+    file_delete(file_load($manifest_file));
+  }
+  variable_set('dkan_periodic_updates_manifest', $data->file);
+}
+
+/**
+ * Form for periodic updates status.
+ */
+function dkan_periodic_updates_status_form($form, &$form_state) {
+  // Activate periodic updates.
+  $form['periodic-updates'] = [
+    '#type' => 'fieldset',
+    '#title' => 'Periodic updates state',
+  ];
+  $form['periodic-updates']['info'] = [
+    '#markup' => '<p>' . t('Once you upload a valid manifest and enable periodic updates, the updates will be evaluated and executed as specified on every cron run.') . '</p>',
+  ];
+  $form['periodic-updates']['periodic_update_status'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Enable periodic updates.'),
+    '#default_value' => variable_get('dkan_periodic_updates_status', 0),
+  ];
+  $form['periodic-updates']['submit'] = [
+    '#type' => 'submit',
+    '#id' => 'save-periodic-updates-settings',
+    '#value' => t('Save settings'),
+  ];
+
+  return $form;
+}
+
+/**
+ * Submit function for periodic updates status form.
+ */
+function dkan_periodic_updates_status_form_submit($form, &$form_state) {
+  variable_set('dkan_periodic_updates_status', $form_state['values']['periodic_update_status']);
+  drupal_set_message(t("Periodic updates settings have been saved."));
+  $manifest = variable_get('dkan_periodic_updates_manifest');
+  if (!$manifest) {
+    drupal_set_message(t('Please upload a valid manifest.'), 'warning');
+  }
+}
+
+/**
+ * Implements hook_cron().
+ */
+function dkan_periodic_updates_cron() {
+  $active = variable_get('dkan_periodic_updates_status');
+  if ($active) {
+    $file = variable_get('dkan_periodic_updates_manifest');
+    $file = file_load($file);
+    if ($file) {
+      $to_update = [];
+      $today = new DateTime("now");
+      $handle = fopen($file->uri, 'r');
+      $headers = fgetcsv($handle, 0, ',');
+
+      while (($data = fgetcsv($handle, 0, ",")) !== FALSE) {
+        $resource_data = array_combine($headers, $data);
+        $last_update = variable_get('dkan_periodic_updates_' . $resource_data['resource_id'], '');
+        // If the last update date is present for the resource, then check for
+        // its frequency to see if it should be updated.
+        if (!empty($last_update)) {
+          $time_passed = $today->diff($last_update);
+          switch ($resource_data['frequency']) {
+            case 'monthly':
+              if ($time_passed->days >= 28) {
+                $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
+              }
+              break;
+            case 'weekly':
+              if ($time_passed->days >= 7) {
+                $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
+              }
+              break;
+            default:
+              if ($time_passed->days >= 1) {
+                $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
+              }
+          }
+        }
+        // If there is no last update date, then add the resource to list of
+        // resource to import.
+        else {
+          $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
+        }
+      }
+      fclose($handle);
+      dkan_periodic_updates_execute_update($to_update);
+    } else {
+      watchdog('dkan_periodic_updates', 'No manifest found.');
+    }
+  }
+}
+
+/**
+ * Helper function to execute periodic update to resources.
+ */
+function dkan_periodic_updates_execute_update($resources) {
+  module_load_include('inc', 'dkan_datastore', 'resources/dkan_datastore_resource');
+  if (!empty($resources)) {
+    foreach ($resources as $uuid => $file_url) {
+      $nids = entity_get_id_by_uuid('node', [$uuid]);
+      if (empty($nids)) {
+        watchdog('dkan_periodic_updates', 'There is no node with UUID !uuid.', ['!uuid' => $uuid], WATCHDOG_WARNING);
+        variable_set('dkan_periodic_updates_message_' . $uuid, 'No node found for the UUID specified.');
+      } else {
+        foreach ($nids as $nid) {
+          $node = node_load($nid);
+          $updated = FALSE;
+          $proceed_with_import = FALSE;
+          if ($node) {
+            $file = FALSE;
+            if (!empty($node->field_upload)) {
+              $file = dkan_periodic_updates_create_file($file_url, TRUE, $nid);
+              if ($file) {
+                $node->field_upload[LANGUAGE_NONE][0]['fid'] = $file->fid;
+              }
+              else {
+                watchdog('dkan_periodic_updates', 'File for node !uuid could not be retrieved.', ['!uuid' => $uuid], WATCHDOG_WARNING);
+                variable_set('dkan_periodic_updates_message_' . $uuid, 'File could not be retrieved.');
+              }
+            }
+            else {
+              if (!empty($node->field_link_remote_file)) {
+                $file = dkan_periodic_updates_create_file($file_url);
+                $node->field_link_remote_file[LANGUAGE_NONE][0]['fid'] = $file->fid;
+              }
+            }
+            if ($file) {
+              dkan_periodic_updates_impersonate_user($node);
+              variable_set('dkan_periodic_updates_' . $uuid, new DateTime("now"));
+              $updated = TRUE;
+              if ($file->filemime === 'text/csv' || $file->filemime === 'text/tab-separated-values') {
+                $proceed_with_import = TRUE;
+              }
+            }
+
+            if ($updated && $proceed_with_import) {
+              variable_set('dkan_periodic_updates_message_' . $uuid, "Importing to datastore.");
+              $import = FALSE;
+              try {
+                _dkan_datastore_resource_drop($node->nid);
+                $import = _dkan_datastore_resource_import($node->nid);
+              } catch (\Exception $e) {
+                $message = 'Error importing to the datastore: ' . htmlspecialchars($e->getMessage());
+                watchdog('error', $message, [], WATCHDOG_ERROR);
+                variable_set('dkan_periodic_updates_message_' . $uuid, $message);
+              }
+              if ($import) {
+                watchdog('dkan_periodic_updates', 'Updated resource with UUID !uuid and nid !nid.', ['!uuid' => $uuid, '!nid' => $nid], WATCHDOG_INFO);
+                variable_del('dkan_periodic_updates_message_' . $uuid);
+              }
+            }
+          } else {
+            watchdog('dkan_periodic_updates', 'Node with nid !nid not found.', ['!nid' => $nid], WATCHDOG_WARNING);
+            variable_set('dkan_periodic_updates_message_' . $uuid, 'Node with nid ' . $nid . ' was not found.');
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Page callback for periodic updates status page.
+ */
+function dkan_periodic_updates_state() {
+  $active = variable_get('dkan_periodic_updates_status');
+  $output = [];
+  $output['info'] = [
+    '#markup' => '<p>' . t('The updates are evaluated on every cron run. If a resource from your manifest hasn\'t been updated yet, it may be updated on the next cron run.') . '</p>',
+  ];
+  if ($active) {
+    $file = variable_get('dkan_periodic_updates_manifest');
+    $file = file_load($file);
+    if ($file) {
+      $handle = fopen($file->uri, 'r');
+      $headers = fgetcsv($handle, 0, ',');
+      $table_headers = [t('UUID'), t('File URL'), t('Update frequency'), t('Status'), t('Last update'), ''];
+
+      while (($data = fgetcsv($handle, 0, ",")) !== FALSE) {
+        $resource_data = array_combine($headers, $data);
+        $last_updated = variable_get('dkan_periodic_updates_' . $resource_data['resource_id'], '');
+        $status = variable_get('dkan_periodic_updates_message_' . $resource_data['resource_id'], '');
+        if (empty($last_updated)) {
+          $last_updated = ' - ';
+          if (empty($status)) {
+            $status = t('Resource hasn\'t been updated.');
+          }
+        }
+        else {
+          $last_updated = date_format($last_updated, 'Y/m/d H:i:s');
+          if (empty($status)) {
+            $status = t('No errors found.');
+          }
+        }
+
+        $nid = entity_get_id_by_uuid('node', [$resource_data['resource_id']]);
+        $link = t('No node could be found.');
+        if ($nid = $nid[$resource_data['resource_id']]) {
+          $link = l(t('View resource.'), 'node/' . $nid);
+        }
+        switch ($resource_data['frequency']) {
+          case 'monthly':
+          case 'weekly':
+            $frequency = $resource_data['frequency'];
+            break;
+          default:
+            $frequency = 'daily';
+        }
+        $table_rows[] = [$resource_data['resource_id'], $resource_data['file_url'], $frequency, $status, $last_updated, $link];
+      }
+      fclose($handle);
+      $output['state'] = [
+        '#theme' => 'table',
+        '#header' => $table_headers,
+        '#rows' => $table_rows,
+      ];
+    } else {
+      $output['state'] = [
+        '#markup' => '<p>' . t('No manifest was found.') . '</p>',
+      ];
+    }
+  }
+  else {
+    $output['state'] = [
+      '#markup' => '<p>' . t('Periodic updates are disabled.') . '</p>',
+    ];
+  }
+
+  return $output;
+}
+
+/**
+ * Helper function to get file contents.
+*/
+function dkan_periodic_updates_curl_get_contents($url, $path) {
+  $url = preg_replace('/ /', '%20', $url);
+  $fp = fopen($path, 'w');
+
+  $ch = curl_init($url);
+  curl_setopt($ch, CURLOPT_FILE, $fp);
+
+  $data = curl_exec($ch);
+
+  curl_close($ch);
+  fclose($fp);
+
+  return $data;
+}
+
+/**
+ * Helper function to create managed files using a file_url.
+ */
+function dkan_periodic_updates_create_file($file_url, $download = FALSE, $nid = '') {
+  if ($download) {
+    $dir = 'public://' . $nid;
+    $option = is_dir($dir) ? FILE_MODIFY_PERMISSIONS : FILE_CREATE_DIRECTORY;
+    if (file_prepare_directory($dir, $option)) {
+      $file_name = drupal_basename($file_url);
+      // Copy file locally.
+      $status = dkan_periodic_updates_curl_get_contents($file_url, $dir . '/' . $file_name);
+      if ($status) {
+        // If copied correctly, create file in database.
+        $match = file_scan_directory($dir, '/' . $file_name . '/');
+        if (!empty($match)) {
+          $file = $match[$dir . '/' . $file_name];
+          $uri = $file->uri;
+
+          $preexisting_files = file_load_multiple(array(), array('uri' => $uri));
+          if ($preexisting_files) {
+            $file = reset($preexisting_files);
+            $file->uri = $uri;
+            return file_save($file);
+          }
+          else {
+            $file->status = FILE_STATUS_PERMANENT;
+            $file->filemime = file_get_mimetype($uri);
+            return file_save($file);
+          }
+        }
+      }
+    }
+  }
+  else {
+    $files = file_load_multiple(array(), array('uri' => $file_url));
+    $file = reset($files);
+    if (!$file) {
+      $file = file_save((object)[
+        'filename' => drupal_basename($file_url),
+        'uri' => $file_url,
+        'status' => FILE_STATUS_PERMANENT,
+        'filemime' => file_get_mimetype($file_url),
+      ]);
+    }
+    return $file;
+  }
+  return FALSE;
+}
+
+/**
+ * Helper function to impersonate node author user before saving node.
+ */
+function dkan_periodic_updates_impersonate_user($node) {
+  global $user;
+  $original_user = $user;
+  $old_state = drupal_save_session();
+  drupal_save_session(FALSE);
+  $user = user_load($node->uid);
+  // Pretend to be node author to save changes.
+  node_save($node);
+  // Go back to original user.
+  $user = $original_user;
+  drupal_save_session($old_state);
+}

--- a/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
+++ b/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
@@ -312,7 +312,7 @@ function dkan_periodic_updates_state() {
     if ($file) {
       $handle = fopen($file->uri, 'r');
       $headers = fgetcsv($handle, 0, ',');
-      $table_headers = [t('UUID'), t('File URL'), t('Update frequency'), t('Status'), t('Last update'), ''];
+      $table_headers = [t('Destination Resource ID'), t('Source File URL'), t('Update frequency'), t('Status'), t('Last update')];
 
       while (($data = fgetcsv($handle, 0, ",")) !== FALSE) {
         $resource_data = array_combine($headers, $data);
@@ -332,9 +332,9 @@ function dkan_periodic_updates_state() {
         }
 
         $nid = entity_get_id_by_uuid('node', [$resource_data['resource_id']]);
-        $link = t('No node could be found.');
+        $destination = $resource_data['resource_id'];
         if ($nid = $nid[$resource_data['resource_id']]) {
-          $link = l(t('View resource.'), 'node/' . $nid);
+          $destination = l($destination, 'node/' . $nid);
         }
         switch ($resource_data['frequency']) {
           case 'monthly':
@@ -344,7 +344,7 @@ function dkan_periodic_updates_state() {
           default:
             $frequency = 'daily';
         }
-        $table_rows[] = [$resource_data['resource_id'], $resource_data['file_url'], $frequency, $status, $last_updated, $link];
+        $table_rows[] = [$destination, $resource_data['file_url'], $frequency, $status, $last_updated];
       }
       fclose($handle);
       $output['state'] = [

--- a/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
+++ b/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
@@ -29,8 +29,8 @@ function dkan_periodic_updates_menu() {
     'access arguments' => ['administer periodic updates'],
     'type' => MENU_NORMAL_ITEM,
   ];
-  $items['admin/dkan/periodic-updates/manifest'] = [
-    'title' => t('Manifest'),
+  $items['admin/dkan/periodic-updates/settings'] = [
+    'title' => t('Settings'),
     'type' => MENU_DEFAULT_LOCAL_TASK,
   ];
   $items['admin/dkan/periodic-updates/status'] = [

--- a/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
+++ b/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
@@ -84,9 +84,15 @@ function dkan_periodic_updates_form($form, &$form_state) {
   $prev_file = variable_get('dkan_periodic_updates_manifest');
   if ($prev_file) {
     $file = file_load($prev_file);
-    $prev_file_name = $file->filename;
-    $url = file_create_url($file->uri);
-    $message = '<p>Current manifest: <a href="' . $url . '">' . $prev_file_name . '</a></p>';
+    if ($file) {
+      $prev_file_name = $file->filename;
+      $url = file_create_url($file->uri);
+      $message = '<p>Current manifest: <a href="' . $url . '">' . $prev_file_name . '</a></p>';
+    }
+    else {
+      $message = '<p>Manifest was removed</p>';
+      variable_del('dkan_periodic_updates_manifest');
+    }
   }
   $form['manifest-file']['manifest']['text'] = array(
     '#markup' => $message,

--- a/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
+++ b/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
@@ -368,13 +368,13 @@ function dkan_periodic_updates_state() {
       ];
     } else {
       $output['state'] = [
-        '#markup' => '<p>' . t('No manifest was found.') . '</p>',
+        '#markup' => '<p class="alert alert-warning">' . t('No manifest was found.') . '</p>',
       ];
     }
   }
   else {
     $output['state'] = [
-      '#markup' => '<p>' . t('Periodic updates are disabled.') . '</p>',
+      '#markup' => '<p class="alert alert-warning">' . t('Periodic updates are disabled.') . '</p>',
     ];
   }
 

--- a/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
+++ b/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
@@ -347,7 +347,7 @@ function dkan_periodic_updates_state() {
 
         $nid = entity_get_id_by_uuid('node', [$resource_data['resource_id']]);
         $destination = $resource_data['resource_id'];
-        if ($nid = $nid[$resource_data['resource_id']]) {
+        if ($nid && $nid = $nid[$resource_data['resource_id']]) {
           $destination = l($destination, 'node/' . $nid);
         }
         switch ($resource_data['frequency']) {

--- a/test/phpunit/dkan_periodic_updates/DkanPeriodicUpdatesTest.php
+++ b/test/phpunit/dkan_periodic_updates/DkanPeriodicUpdatesTest.php
@@ -1,0 +1,166 @@
+<?php
+
+use Dkan\Datastore\Manager\SimpleImport\SimpleImport;
+use Dkan\Datastore\Resource;
+
+/**
+ * Class DkanPeriodicUpdatesTest.
+ */
+class DkanPeriodicUpdatesTest extends \PHPUnit_Framework_TestCase {
+
+  private $resources;
+  private $manifest;
+
+  protected function setUp() {
+    // Daily update.
+    $file_url = "https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv";
+    $file = file_save((object)[
+      'filename' => drupal_basename($file_url),
+      'uri' => $file_url,
+      'status' => FILE_STATUS_PERMANENT,
+      'filemime' => file_get_mimetype($file_url),
+    ]);
+    $node = (object)[];
+    $node->title = "Resource Test Object - Daily Update";
+    $node->type = "resource";
+    $node->field_upload[LANGUAGE_NONE][0]['fid'] = $file->fid;
+    $node->status = 1;
+    $node->uuid = 'c65c08d9-43c8-45a4-a49d-29e714ce2ebb';
+    node_save($node);
+    $this->resources[$node->nid] = node_load($node->nid);
+
+    // Weekly update.
+    $node = (object)[];
+    $node->title = "Resource Test Object - Weekly Update";
+    $node->type = "resource";
+    $node->field_link_remote_file[LANGUAGE_NONE][0]['fid'] = $file->fid;
+    $node->field_link_remote_file[LANGUAGE_NONE][0]['display'] = 1;
+    $node->status = 1;
+    $node->uuid = 'd7ccef48-5c8c-432c-94c8-17cee9c4ed37';
+    node_save($node);
+    $this->resources[$node->nid] = node_load($node->nid);
+
+    // Monthly update.
+    $node = (object)[];
+    $node->title = "Resource Test Object - Monthly Update";
+    $node->type = "resource";
+    $node->field_link_remote_file[LANGUAGE_NONE][0]['fid'] = $file->fid;
+    $node->field_link_remote_file[LANGUAGE_NONE][0]['display'] = 1;
+    $node->status = 1;
+    $node->uuid = 'fe4b712b-c570-4e0b-aeeb-67d9789a196e';
+    node_save($node);
+    $this->resources[$node->nid] = node_load($node->nid);
+
+    // Set manifest.
+    $this->setManifest();
+  }
+
+  protected function setManifest() {
+    $file = file_get_contents(__DIR__ . '/data/test_manifest.csv');
+    $file = file_save_data($file, 'public://test_manifest.csv');
+    $this->manifest = $file->fid;
+  }
+
+  public function testAmountFirstTimeUpdates() {
+    // All elements from manifest should be updated.
+    $to_update = dkan_periodic_updates_get_items_to_update($this->manifest);
+    $this->assertEquals(4, count($to_update));
+  }
+
+  public function testAmountDailyUpdates() {
+    $date = new DateTime("now");
+    // Set last_update date to three hours ago for existing resources.
+    // One element should be updated.
+    variable_set('dkan_periodic_updates_c65c08d9-43c8-45a4-a49d-29e714ce2ebb', $date->modify('-3 hour'));
+    variable_set('dkan_periodic_updates_d7ccef48-5c8c-432c-94c8-17cee9c4ed37', $date->modify('-3 hour'));
+    variable_set('dkan_periodic_updates_fe4b712b-c570-4e0b-aeeb-67d9789a196e', $date->modify('-3 hour'));
+    $to_update = dkan_periodic_updates_get_items_to_update($this->manifest);
+    $this->assertEquals(1, count($to_update));
+
+    // Set last_update date to 1+ day ago to Daily Update Test Object.
+    // Just two element should be updated.
+    variable_set('dkan_periodic_updates_c65c08d9-43c8-45a4-a49d-29e714ce2ebb', $date->modify('-2 day'));
+    $to_update = dkan_periodic_updates_get_items_to_update($this->manifest);
+    $this->assertEquals(2, count($to_update));
+  }
+
+  public function testAmountWeeklyUpdates() {
+    $date = new DateTime("now");
+    // Set last_update date to 7+ day ago to Weekly Update Test Object.
+    // Just two elements should be updated.
+    variable_set('dkan_periodic_updates_c65c08d9-43c8-45a4-a49d-29e714ce2ebb', $date->modify('-3 hour'));
+    $date = new DateTime("now");
+    variable_set('dkan_periodic_updates_d7ccef48-5c8c-432c-94c8-17cee9c4ed37', $date->modify('-8 day'));
+    $date = new DateTime("now");
+    variable_set('dkan_periodic_updates_fe4b712b-c570-4e0b-aeeb-67d9789a196e', $date->modify('-9 day'));
+    $to_update = dkan_periodic_updates_get_items_to_update($this->manifest);
+    $this->assertEquals(2, count($to_update));
+  }
+
+  public function testAmountMonthlyUpdates() {
+    $date = new DateTime("now");
+    // Set last_update date to 29+ day ago to Monthly Update Test Object.
+    // Just two element should be updated.
+    variable_set('dkan_periodic_updates_c65c08d9-43c8-45a4-a49d-29e714ce2ebb', $date->modify('-3 hour'));
+    $date = new DateTime("now");
+    variable_set('dkan_periodic_updates_d7ccef48-5c8c-432c-94c8-17cee9c4ed37', $date->modify('-4 day'));
+    $date = new DateTime("now");
+    variable_set('dkan_periodic_updates_fe4b712b-c570-4e0b-aeeb-67d9789a196e', $date->modify('-30 day'));
+    $to_update = dkan_periodic_updates_get_items_to_update($this->manifest);
+    $this->assertEquals(2, count($to_update));
+  }
+
+  public function testUpdatesDisabled() {
+    // Updates disabled.
+    variable_set('dkan_periodic_updates_status', FALSE);
+    $result = dkan_periodic_updates_state();
+    $message_disabled = '<p>Periodic updates are disabled.</p>';
+    $this->assertEquals($message_disabled, $result['state']['#markup']);
+  }
+
+  public function testUpdatesWithoutManifest() {
+    // Updates enabled, no manifest.
+    variable_set('dkan_periodic_updates_status', TRUE);
+    variable_del('dkan_periodic_updates_manifest');
+    $result = dkan_periodic_updates_state();
+    $message_no_manifest = '<p>No manifest was found.</p>';
+    $this->assertEquals($message_no_manifest, $result['state']['#markup']);
+  }
+
+  public function testUpdates() {
+    variable_set('dkan_periodic_updates_status', TRUE);
+    variable_set('dkan_periodic_updates_manifest', $this->manifest);
+    $to_update = dkan_periodic_updates_get_items_to_update($this->manifest);
+    $this->assertEquals(4, count($to_update));
+    dkan_periodic_updates_execute_update($to_update);
+    $result = dkan_periodic_updates_state();
+
+    // Assert last update is set for daily, weekly and monthly updated resources.
+    // This means the update was executed.
+    $this->assertEquals("No errors found.", $result['state']['#rows'][0][3]);
+    $this->assertNotEquals(" - ", $result['state']['#rows'][0][4]);
+    $this->assertEquals("No errors found.", $result['state']['#rows'][1][3]);
+    $this->assertNotEquals(" - ", $result['state']['#rows'][1][4]);
+    $this->assertEquals("No errors found.", $result['state']['#rows'][2][3]);
+    $this->assertNotEquals(" - ", $result['state']['#rows'][2][4]);
+
+    // Assert empty frequency is shown as daily.
+    $this->assertEquals("daily", $result['state']['#rows'][3][2]);
+    // Assert status about no node found for UUID specified.
+    $this->assertEquals("No node found for the UUID specified.", $result['state']['#rows'][3][3]);
+    // Assert last update is not set for non existing node with UUID specified.
+    $this->assertEquals(" - ", $result['state']['#rows'][3][4]);
+
+    // Try to import again and confirm already imported items don't need to be updated.
+    $to_update = dkan_periodic_updates_get_items_to_update($this->manifest);
+    $this->assertEquals(1, count($to_update));
+  }
+
+  protected function tearDown() {
+    foreach ($this->resources as $resource) {
+      variable_del('dkan_periodic_updates_' . $resource->uuid);
+      variable_del('dkan_periodic_updates_message_' . $resource->uuid);
+    }
+    node_delete_multiple(array_keys($this->resources));
+  }
+}

--- a/test/phpunit/dkan_periodic_updates/DkanPeriodicUpdatesTest.php
+++ b/test/phpunit/dkan_periodic_updates/DkanPeriodicUpdatesTest.php
@@ -116,7 +116,7 @@ class DkanPeriodicUpdatesTest extends \PHPUnit_Framework_TestCase {
     // Updates disabled.
     variable_set('dkan_periodic_updates_status', FALSE);
     $result = dkan_periodic_updates_state();
-    $message_disabled = '<p>Periodic updates are disabled.</p>';
+    $message_disabled = '<p class="alert alert-warning">Periodic updates are disabled.</p>';
     $this->assertEquals($message_disabled, $result['state']['#markup']);
   }
 
@@ -125,7 +125,7 @@ class DkanPeriodicUpdatesTest extends \PHPUnit_Framework_TestCase {
     variable_set('dkan_periodic_updates_status', TRUE);
     variable_del('dkan_periodic_updates_manifest');
     $result = dkan_periodic_updates_state();
-    $message_no_manifest = '<p>No manifest was found.</p>';
+    $message_no_manifest = '<p class="alert alert-warning">No manifest was found.</p>';
     $this->assertEquals($message_no_manifest, $result['state']['#markup']);
   }
 

--- a/test/phpunit/dkan_periodic_updates/DkanPeriodicUpdatesTest.php
+++ b/test/phpunit/dkan_periodic_updates/DkanPeriodicUpdatesTest.php
@@ -3,6 +3,8 @@
 use Dkan\Datastore\Manager\SimpleImport\SimpleImport;
 use Dkan\Datastore\Resource;
 
+module_load_include('module', 'dkan_periodic_updates');
+
 /**
  * Class DkanPeriodicUpdatesTest.
  */

--- a/test/phpunit/dkan_periodic_updates/data/test_manifest.csv
+++ b/test/phpunit/dkan_periodic_updates/data/test_manifest.csv
@@ -1,0 +1,5 @@
+resource_id,frequency,file_url
+c65c08d9-43c8-45a4-a49d-29e714ce2ebb,daily,https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv
+d7ccef48-5c8c-432c-94c8-17cee9c4ed37,weekly,https://s3.amazonaws.com/dkan-default-content-files/files/Polling_Places_Madison_0.csv
+fe4b712b-c570-4e0b-aeeb-67d9789a196e,monthly,https://s3.amazonaws.com/dkan-default-content-files/files/last_transactions.xlsx
+non-existing-uuid,something,https://s3.amazonaws.com/dkan-default-content-files/files/last_transactions.xlsx

--- a/test/phpunit/phpunit.xml
+++ b/test/phpunit/phpunit.xml
@@ -44,6 +44,9 @@
         <testsuite name="Open Data Schema Map Test Suite">
             <file>open_data_schema_map/PodValidationTest.php</file>
         </testsuite>
+        <testsuite name="DKAN Periodic Updates Test Suite">
+            <file>dkan_periodic_updates/DkanPeriodicUpdatesTest.php</file>
+        </testsuite>
     </testsuites>
 
     <php>


### PR DESCRIPTION
Added dkan_periodic_updates module.

As a site manager I can upload a manifest for a periodic import of resources.
There should be an administrative page where user can upload the manifest, which is a csv file with format resource_id,frequency,file_url.
The file_url will be used to download the file in a temporary directory, then that file will be used to update the resource with the resource_id specified.
The frequency can be daily, weekly or monthly.

## Steps to test
- [x] Enable dkan_periodic_updates.
- Go to `admin/dkan/periodic-updates`:
  - [x] Try to upload a file that is not a csv, you should get an error message.
  - [x] Try to upload a csv file with any headers, it should throw a message as it doesn't has the right headers.
  - [x] Upload a CSV files with the columns `resource_id`, `frequency` and `file_url`, it should be saved correctly.
  - [x] Mark the checkbox `Enable periodic updates.` and click on `Save settings`.
- Go to `admin/dkan/periodic-updates/status`:
  - [x] If the "Enable periodic updates" checkbox is not marked, then you should get a message saying "Periodic updates are disabled.".
  - [x] If the "Enable periodic updates" checkbox is marked but no manifest has been uploaded, then you should get a message saying "No manifest was found.".
  - [ ] If the updates are enabled and a valid manifest is uploaded, you should see a list of the elements included in the previously uploaded manifest file, it should include the `UUID`, the `File URL`, the `Update frequency`, `Status` (which represents the update status), `Last update` (which is the date in which the resource was last updated) and a link to see the resource.
- [ ] Once the updates are enabled and there is a valid manifest uploaded, on every cron run the manifest will be evaluated to see what resources needs to be updated based on the last update date and the frequency specified in the manifest (the frequency can be `monthly` or `weekly`, every other value will be applied as `daily`).
- [ ] Run `drush cron run` to trigger the updates and keep checking `admin/dkan/periodic-updates/status` to see the differences in the updates status.
- For every updated resource check:
  - [ ] on each node just one file is loaded
  - [ ] the updated date on the node matches the current date 
  - [ ] make sure the data is imported into the datastore (only time this can change is when the periodic update status page reports an error when importing to the datastore, in these cases, user would need to re-import manually).

Note: documentation as added and also PHP Unit tests.