### PR TITLE
DM-243 slow queries

### DIFF
--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -401,7 +401,7 @@ function dkan_datastore_api_query($params) {
       dkan_datastore_api_use_indexes($data_select, $table, $params['query']);
     }
 
-    $count = dkan_datastore_api_count($data_select);
+    $count = dkan_datastore_api_count($table);
     $results = $data_select->execute();
 
     return dkan_datastore_api_output($data_select, $results, $table, $params['fields'], $resource_ids, $count, $params['limit']);
@@ -438,10 +438,10 @@ function dkan_datastore_api_multiple_query($queries = NULL) {
 /**
  * Retrieves count given fully query without paging limit.
  */
-function dkan_datastore_api_count($data_select) {
-  $query = clone($data_select);
-  $count = $query->range()->countQuery()->execute()->fetchField();
-  return $count;
+function dkan_datastore_api_count($table) {
+  $query = db_query("select count(*) as total from $table");
+  $total = $query->fetchField();
+  return $total;
 }
 
 /**

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -401,7 +401,7 @@ function dkan_datastore_api_query($params) {
       dkan_datastore_api_use_indexes($data_select, $table, $params['query']);
     }
 
-    $count = dkan_datastore_api_count($table);
+    $count = dkan_datastore_api_count($data_select);
     $results = $data_select->execute();
 
     return dkan_datastore_api_output($data_select, $results, $table, $params['fields'], $resource_ids, $count, $params['limit']);
@@ -438,10 +438,10 @@ function dkan_datastore_api_multiple_query($queries = NULL) {
 /**
  * Retrieves count given fully query without paging limit.
  */
-function dkan_datastore_api_count($table) {
-  $query = db_query("select count(*) as total from $table");
-  $total = $query->fetchField();
-  return $total;
+function dkan_datastore_api_count($data_select) {
+  $query = db_query("select count(*) as total from $data_select");
+  $count = $query->fetchField();
+  return $count;
 }
 
 /**

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -439,8 +439,8 @@ function dkan_datastore_api_multiple_query($queries = NULL) {
  * Retrieves count given fully query without paging limit.
  */
 function dkan_datastore_api_count($data_select) {
-  $query = db_query("select count(*) as total from $data_select");
-  $count = $query->fetchField();
+  $query = clone($data_select);
+  $count = $query->range()->execute()->rowCount();
   return $count;
 }
 

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.module
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.module
@@ -265,15 +265,6 @@ function dkan_sitewide_preprocess_page(&$variables) {
   if (isset($variables['is_front']) && $variables['is_front'] == TRUE) {
     drupal_set_title('');
   }
-  // Redirect 404 to search page.
-  $header = drupal_get_http_header("status");
-  if($header == "404 Not Found") {
-    $message = t('The page you requested does not exist or has moved. Try searching the site.');
-    drupal_set_message($message, 'status', FALSE);
-    $query = str_replace('/', ' ', $_SERVER['REQUEST_URI']);
-    unset($_GET['destination']);
-    drupal_goto('search', array('query' => array('query' => $query)));
-  }
 }
 
 /**

--- a/test/features/search.feature
+++ b/test/features/search.feature
@@ -6,16 +6,16 @@ Feature: Search
   Background:
     Given I am on the homepage
     And pages:
-      | name                      | url                                                |
-      | Dataset Search            | /search/type/dataset                               |
-      | Dataset Results           | /search?query=Dataset%2001                         |
-      | Topics Search             | /search/field_topics                               |
-      | Topics Redirect           | /topics                                            |
-      | Not valid type search     | /search?query=%20search%20type%20notvalid          |
-      | Not valid tags search     | /search?query=%20search%20field_tags%20notvalid    |
-      | Not valid topics search   | /search?query=%20search%20field_topic%20notvalid   |
-      | Not valid resource search | /search?query=%20search%20field_resources%25253Afield_format%20notvalid |
-      | Not valid license search  | /search?query=%20search%20field_license%20notvalid |
+      | name                      | url                                               |
+      | Dataset Search            | /search/type/dataset                              |
+      | Dataset Results           | /search?query=Dataset%2001                        |
+      | Topics Search             | /search/field_topics                              |
+      | Topics Redirect           | /topics                                           |
+      | Not valid type search     | /search/type/notvalid                             |
+      | Not valid tags search     | /search/field_tags/notvalid                       |
+      | Not valid topics search   | /search/field_topic/notvalid                      |
+      | Not valid resource search | /search/field_resources%253Afield_format/notvalid |
+      | Not valid license search  | /search/field_license/notvalid                    |
     Given users:
       | name    | mail                | roles                |
       | Badmin  | admin@example.com   | site manager         |
@@ -105,7 +105,7 @@ Feature: Search
   @search_04
   Scenario Outline: Forbid XSS injection in search
     Given I am on the "<page>" page
-    Then I should see "No results were found. Please try another keyword."
+    Then I should see "Page not found"
     Examples:
     | page                      |
     | Not valid type search     |


### PR DESCRIPTION
see #nucivic/dkan_management#243

- Updates `dkan_datastore_api_count` function to avoid subquery
- Reverts PR #2576 (redirect 404 to search page), using `drupal_set_message` for anon users creates a user session and stops serving cached pages

## Reminders

- [ ] There is test for the issue.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
