### PR TITLE
Avoid importing/orphaning when cache is not present for unavailable sources.

### DIFF
--- a/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
+++ b/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
@@ -333,7 +333,7 @@ class HarvestMigration extends MigrateDKAN {
    */
   public function processImport(array $options = array()) {
     if (!$this->dkanHarvestSource->getCacheDir()) {
-      $message = t('Looks like source is missing and cache does not exist. No updates can be made at this time.');
+      $message = t('Looks like the source is missing and a cache does not exist. No updates can be made at this time.');
       self::displayMessage($message, 'error');
       $this->reportMessage($message);
       return FALSE;

--- a/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
+++ b/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
@@ -332,6 +332,12 @@ class HarvestMigration extends MigrateDKAN {
    * Add support for harvest migration specific checks and options.
    */
   public function processImport(array $options = array()) {
+    if (!$this->dkanHarvestSource->getCacheDir()) {
+      $message = t('Looks like source is missing and cache does not exist. No updates can be made at this time.');
+      self::displayMessage($message, 'error');
+      $this->reportMessage($message);
+      return FALSE;
+    }
     // Add any extra Harvest Migration Arguments.
     $this->arguments = array_merge($this->arguments, $options);
     return parent::processImport($options);
@@ -1333,7 +1339,7 @@ class HarvestMigration extends MigrateDKAN {
 
   /**
    * {@inheritdoc}
-   * 
+   *
    * Override to make sure to use the mlid for all the log messages being saved
    * from the queue or display in case we don't have the Migration Log ID
    * (mlid).


### PR DESCRIPTION
## Description

On https://github.com/GetDKAN/dkan/pull/2829 we avoided mass-orphaning datasets when the source was not available, but we still have issues for those sources which cache has been deleted for some reason.

## How to reproduce

1. Create a harvest source from https://s3.amazonaws.com/dkan-default-content-files/files/data_harvest_orphan_test.json, and run the harvest, all items should be published.
2. Log in to S3 and make the file private
3. Re-run the harvest, the items should not be imported and they should stay published.
4. Delete the cache for your harvest source, you can do it by deleting the directory of your source inside of dkan-harvest-cache folder inside of files. Re-run the harvest, you'll see all the datasets are unpublished and are shown in an orphaned state on the dashboard.

## QA Steps

- [ ] Create a harvest source from https://s3.amazonaws.com/dkan-default-content-files/files/data_harvest_orphan_test.json, and run the harvest, all items should be published.
- [ ] Log in to S3 and make the file private
- [ ] Re-run the harvest, the items should not be imported and they should stay published.
- [ ] Delete the cache for your harvest source, you can do it by deleting the directory of your source inside of dkan-harvest-cache folder inside of files. Re-run the harvest, note that rather than unpublishing all of the datasets, you only get the error message:

```
Looks like the source is missing and a cache does not exist. No updates can be made at this time.
```