### PR TITLE
Add patch for NULL controller class

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -15,3 +15,5 @@ projects:
       2844358: 'https://www.drupal.org/files/issues/drupal_bug_multiple_values_select_states.patch'
       # When trying to create a table that already exists but is empty, recreate the table rather than throwing a DatabaseSchemaObjectExistsException
       1551132: 'https://www.drupal.org/files/issues/1551132-drupal-reinstall-schema-empty-tables-87-D7.patch'
+      # Core entity_get_controller gets a NULL controller class (dkan_management#107)
+      1982810: https://www.drupal.org/files/issues/2018-05-03/1982810-20.patch


### PR DESCRIPTION
Mystery missing home page might be related to 
`Warning: class_parents(): object or string expected in panels_panel_context_render()`


## Reminders

- [ ] There is test for the issue.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
