### PR TITLE
Workflow moderation issues when publishing via 

### DIFF
--- a/modules/dkan/dkan_workflow/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.module
+++ b/modules/dkan/dkan_workflow/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.module
@@ -67,6 +67,10 @@ function views_dkan_workflow_tree_views_api() {
 function views_dkan_workflow_tree_action_info() {
   $info = array();
   foreach (workbench_moderation_state_labels() as $key => $label) {
+    // When 'behavior' is empty VBO sets 'changes_property' as its default value,
+    // that fires a node_save at the end of the process but it was messing the
+    // workbench moderation functionality so here we need to set it to another
+    // value and let workbench_moderation handle the access check.
     $info['views_dkan_workflow_tree_set_moderation_state_action_' . $key] = array(
       'type' => 'node',
       'label' => t("Workflow set moderation state !state", array('!state' => $label)),
@@ -77,6 +81,7 @@ function views_dkan_workflow_tree_action_info() {
         'workbench_moderation_transition',
       ),
       'callback' => 'views_dkan_workflow_tree_set_state_action',
+      'behavior' => ['update_property'],
       'parameters' => array('state' => $key),
       'configurable' => FALSE,
     );


### PR DESCRIPTION
Specify behavior on dkan workflow moderation set state action to avoid extra node_save.

## How to reproduce

1. Log in as a Workflow Contributor, create a new draft for some node and set its state as "Needs Review".
2. Log in as a Workflow Supervisor, go to "My Workbench" page, go to "Needs Review" tab, you should see the draft created in step 1.
3. As a Workflow Supervisor, from the "My Workbench" page, publish the draft using the vbo button.
4. Go to the node page, the changes made are not visible.
5. If you go to the "Moderate" page of the node you'll see two new revisions, the first one is the one which should be published (it contains the changes made) but the second is the one published and set as current:
![image](https://user-images.githubusercontent.com/2200763/63444353-ad17d400-c3f3-11e9-8696-df991dd4b6b3.png)

## QA Steps

- [ ] Log in as a Workflow Contributor, create a new draft for some node and set its state as "Needs Review".
- [ ] Log in as a Workflow Supervisor, go to "My Workbench" page, go to "Needs Review" tab, you should see the draft created in step 1.
- [ ] As a Workflow Supervisor, from the "My Workbench" page, publish the draft using the vbo button.
- [ ] Go to the node page, the changes made should be visible.
- [ ] Go to the "Moderate" page of the node you'll see two new revisions, the first one should be published and set as current.