### PR TITLE
Fixed greetings on workbench email templates.

### DIFF
--- a/modules/dkan/dkan_workflow/dkan_workflow.features.workbench_email.inc
+++ b/modules/dkan/dkan_workflow/dkan_workflow.features.workbench_email.inc
@@ -35,7 +35,7 @@ For assistance or support, please contact a Site Manager or an administrator fro
       'author' => 0,
       'automatic' => 1,
       'subject' => 'Workbench moderation update ([site:name]) - Status of [node:content-type] "[node:title]" has changed.',
-      'message' => '[user:name],
+      'message' => '[workbench-email:name],
 
 The status of the [node:content-type] "[node:title]" has been changed from [workbench-email:email-transition].
 
@@ -56,7 +56,7 @@ For assistance or support, please contact a Site Manager or an administrator fro
       'author' => 0,
       'automatic' => 1,
       'subject' => 'Workbench moderation update ([site:name]) - Status of [node:content-type] "[node:title]" has changed.',
-      'message' => '[user:name],
+      'message' => '[workbench-email:name],
 
 The status of the [node:content-type] "[node:title]" has been changed from [workbench-email:email-transition].
 
@@ -98,7 +98,7 @@ For assistance or support, please contact a Site Manager or an administrator fro
       'author' => 0,
       'automatic' => 1,
       'subject' => 'Workbench moderation update ([site:name]) - Status of [node:content-type] "[node:title]" has changed.',
-      'message' => '[user:name],
+      'message' => '[workbench-email:name],
 
 The status of the [node:content-type] "[node:title]" has been changed from [workbench-email:email-transition].
 
@@ -119,7 +119,7 @@ For assistance or support, please contact a Site Manager or an administrator fro
       'author' => 0,
       'automatic' => 1,
       'subject' => 'Workbench moderation update ([site:name]) - Status of [node:content-type] "[node:title]" has changed.',
-      'message' => '[user:name],
+      'message' => '[workbench-email:name],
 
 The status of the [node:content-type] "[node:title]" has been changed from [workbench-email:email-transition].
 
@@ -161,7 +161,7 @@ For assistance or support, please contact a Site Manager or an administrator fro
       'author' => 0,
       'automatic' => 1,
       'subject' => 'Workbench moderation update ([site:name]) - [node:content-type] "[node:title]" is now published',
-      'message' => '[user:name],
+      'message' => '[workbench-email:name],
 
 The status of the [node:content-type] "[node:title]" has been changed from [workbench-email:email-transition].
 
@@ -182,7 +182,7 @@ For assistance or support, please contact a Site Manager or an administrator fro
       'author' => 0,
       'automatic' => 1,
       'subject' => 'Workbench moderation update ([site:name]) - [node:content-type] "[node:title]" is now published',
-      'message' => '[user:name],
+      'message' => '[workbench-email:name],
 
 The status of the [node:content-type] "[node:title]" has been changed from [workbench-email:email-transition].
 
@@ -224,7 +224,7 @@ For assistance or support, please contact a Site Manager or an administrator fro
       'author' => 0,
       'automatic' => 1,
       'subject' => 'Workbench moderation update ([site:name]) - Status of [node:content-type] "[node:title]" has changed.',
-      'message' => '[user:name],
+      'message' => '[workbench-email:name],
 
 The status of the [node:content-type] "[node:title]" has been changed from [workbench-email:email-transition].
 
@@ -245,7 +245,7 @@ For assistance or support, please contact a Site Manager or an administrator fro
       'author' => 0,
       'automatic' => 1,
       'subject' => 'Workbench moderation update ([site:name]) - Status of [node:content-type] "[node:title]" has changed.',
-      'message' => '[user:name],
+      'message' => '[workbench-email:name],
 
 The status of the [node:content-type] "[node:title]" has been changed from [workbench-email:email-transition].
 


### PR DESCRIPTION
The greeting in the workbench email templates is always addressed to the node author and not to the recipient of the email.
Instead of addressing the greeting to [user:name] we should be using [workbench-email:name].

## QA Steps

- Go to `admin/config/workbench/email` and confirm the following emails are addressed to the email recipient:
- [ ] Draft to Needs Review for Workbench Moderator 
- [ ] Draft to Needs Review for Workflow Supervisor
- [ ] Needs Review to Draft for Workbench Moderator 
- [ ] Needs Review to Draft for Workflow Supervisor
- [ ] Needs Review to Published for Workbench Moderator
- [ ] Needs Review to Published for Workflow Supervisor
- [ ] Published to Needs Review for Workbench Moderator 
- [ ] Published to Needs Review for Workflow Supervisor