### PR TITLE
Make group.all.feature not to be a smoketest.

### DIFF
--- a/test/features/group.all.feature
+++ b/test/features/group.all.feature
@@ -1,5 +1,5 @@
 # time:1m1.50s
-@api @smoketest
+@api
 Feature: Site Manager administer groups
 
   Background:


### PR DESCRIPTION
Remove @smoketest tag to group.all.feature as it contains tests that relies on the amount of groups present in the site. This is to be able to have smoketest work correctly in other dkan based sites.