### PR TITLE
Fix Call to a member function getTimestamp() on null error

### DIFF
--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -209,7 +209,7 @@ class DatajsonHarvestMigration extends HarvestMigration {
         }
         catch (Exception $e) {
           $message = t(
-            'Cannot determine temporal coverage value.'
+            'Cannot determine temporal coverage value. Please review the formatting standards at https://project-open-data.cio.gov/v1.1/schema/#temporal'
           );
           $this->saveMessage($message);
         }

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -203,11 +203,11 @@ class DatajsonHarvestMigration extends HarvestMigration {
             $this->saveMessage($message);
           }
         }
-        
-        try {
+
+        if ($value_date) {
           $value = $value_date->getTimestamp();
         }
-        catch (Exception $e) {
+        else {
           $message = t(
             'Cannot determine temporal coverage value. Please review the formatting standards at https://project-open-data.cio.gov/v1.1/schema/#temporal'
           );

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -203,8 +203,16 @@ class DatajsonHarvestMigration extends HarvestMigration {
             $this->saveMessage($message);
           }
         }
-
-        $value = $value_date->getTimestamp();
+        
+        try {
+          $value = $value_date->getTimestamp();
+        }
+        catch (Exception $e) {
+          $message = t(
+            'Cannot determine temporal coverage value.'
+          );
+          $this->saveMessage($message);
+        }
       }
 
       if (isset($date[0])) {


### PR DESCRIPTION
Nightly harvest failing with `Call to a member function getTimestamp() on null in       [error]
DatajsonHarvestMigration->prepareRow() (line 207 of
/mnt/www/html/healthdatagov/dkan/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc`


## QA Steps

- [ ] nightly harvests complete without errors

test on: https://data.chhs.ca.gov/data.json
identifier: "1e1e2904-1bfb-448c-97e1-cf3e228c9159",
temporal: "7/1/1997 - 06/30/2019",

Proper temporal format is: "1997-07-01/2019-06-30"

> This field should contain an interval of time defined by the start and end dates for which the dataset is applicable. Dates should be formatted as pairs of {start datetime/end datetime} in the ISO 8601 format. ISO 8601 specifies that datetimes can be formatted in a number of ways, including a simple four-digit year (eg. 2013) to a much more specific YYYY-MM-DDTHH:MM:SSZ, where the T specifies a seperator between the date and time and time is expressed in 24 hour notation in the UTC (Zulu) time zone. (e.g., 2011-02-14T12:00:00Z/2013-07-04T19:34:00Z). Use a solidus (“/”) to separate start and end times. If there is a need to define the start or end of applicability using a duration rather than a date, ISO 8601 formatting can account for this with duration based intervals. For instance, applicability starting in January 2010 and continuing for one month could be represented as 2010-01/P1M or 2010-01/2010-02. However, when possible, full dates are preferred for both start and end times.



## Reminders

- [ ] There is test for the issue.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
