### PR TITLE
Upgrade ODSM and enable fast token browser

### DIFF
--- a/dkan.install
+++ b/dkan.install
@@ -828,5 +828,5 @@ function dkan_update_7035() {
  * Enable fast token browser, included with new version of open_data_schema_map.
  */
 function dkan_update_7036() {
-  module_enable('fast_token_browser');
+  module_enable(['fast_token_browser']);
 }

--- a/dkan.install
+++ b/dkan.install
@@ -823,3 +823,10 @@ function dkan_update_7035() {
     drupal_uninstall_modules(array('feeds', 'feeds_field_fetcher', 'feeds_flatstore_processor'));
   }
 }
+
+/**
+ * Enable fast token browser, included with new version of open_data_schema_map.
+ */
+function dkan_update_7036() {
+  module_enable('fast_token_browser');
+}

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -3,7 +3,7 @@ api: '2'
 core: 7.x
 includes:
 - https://raw.githubusercontent.com/GetDKAN/visualization_entity/7.x-2.x/visualization_entity.make
-- https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-2.4/open_data_schema_map.make
+- https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-2.x/open_data_schema_map.make
 - https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/5a5f8faf664aeca02371f6692307580d9fab9116/leaflet_widget.make
 - https://raw.githubusercontent.com/NuCivic/recline/7.x-2.1/recline.make
 projects:
@@ -261,7 +261,7 @@ projects:
     download:
       type: git
       url: https://github.com/GetDKAN/open_data_schema_map.git
-      tag: 7.x-2.4
+      branch: fast-browser
   panelizer:
     version: '3.4'
   panels:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -3,7 +3,7 @@ api: '2'
 core: 7.x
 includes:
 - https://raw.githubusercontent.com/GetDKAN/visualization_entity/7.x-2.x/visualization_entity.make
-- https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-2.x/open_data_schema_map.make
+- https://raw.githubusercontent.com/NuCivic/open_data_schema_map/fast-browser/open_data_schema_map.make
 - https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/5a5f8faf664aeca02371f6692307580d9fab9116/leaflet_widget.make
 - https://raw.githubusercontent.com/NuCivic/recline/7.x-2.1/recline.make
 projects:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -3,7 +3,7 @@ api: '2'
 core: 7.x
 includes:
 - https://raw.githubusercontent.com/GetDKAN/visualization_entity/7.x-2.x/visualization_entity.make
-- https://raw.githubusercontent.com/NuCivic/open_data_schema_map/fast-browser/open_data_schema_map.make
+- https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-2.5/open_data_schema_map.make
 - https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/5a5f8faf664aeca02371f6692307580d9fab9116/leaflet_widget.make
 - https://raw.githubusercontent.com/NuCivic/recline/7.x-2.1/recline.make
 projects:
@@ -261,7 +261,7 @@ projects:
     download:
       type: git
       url: https://github.com/GetDKAN/open_data_schema_map.git
-      branch: fast-browser
+      branch: 7.x-2.5
   panelizer:
     version: '3.4'
   panels:


### PR DESCRIPTION
The current ODSM mapping pages are hard or impossible to load. This cuts out some code that is too recursive and adds [Fast Token Browser](https://www.drupal.org/project/fast_token_browser) to improve page usability and performance. Some documentation of how to use obscure ODSM token hacks may be lost. 

## How to reproduce

1. On current version of DKAN try to edit an ODSM API. Observe poor performance or broken page.

## QA Steps

- [ ] Open one of the ODSM endpoint forms (like POD 1.1). Observe better performance, ajax-based token browser.

## Merge process

- [x] Merge GetDKAN/open_data_schema_map#116
- [x] Tag and release ODSM
- [x] Update drupal-org.make to pull in new release of ODSM
- [ ] Merge this PR.

## Reminders

- [ ] There is test for the issue.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
