### PR TITLE
Change the way we're handling dataset resource updates to changed time

### DIFF
--- a/modules/dkan/dkan_dataset/dkan_dataset.module
+++ b/modules/dkan/dkan_dataset/dkan_dataset.module
@@ -537,33 +537,21 @@ function dkan_dataset_node_update($node) {
       dkan_dataset_sync_groups($node);
       break;
 
-    case 'resource':
+      case 'resource':
       // Add changelog on associated datasets.
       $resource = entity_metadata_wrapper('node', $node);
       $datasets = $resource->field_dataset_ref->raw();
-      if (count($datasets)) {
-        $queue = DrupalQueue::get('dataset_changelog');
-        foreach ($datasets as $dataset) {
-          // Determine if the resource is part of a harvest.
-          // Skip the dataset_changelog update if harvesting since every resource is updated.
-          $harvest = db_select('field_data_field_harvest_source_ref', 'r')
-            ->fields('r', array('entity_id'))
-            ->condition('entity_id', $dataset)
-            ->execute()
-            ->fetchAll();
-          if (!$harvest) {
-            $item = array(
-              'dataset' => $dataset,
-              'message' => 'Update to resource \'' . $resource->title . '\'',
-              'user' => $user->uid,
-            );
-            $queue->createItem($item);
-          }
+      if (empty($datasets)) {
+        break;
+      }
+      foreach ($datasets as $dataset_nid) {
+        $dataset = entity_metadata_wrapper('node', node_load($dataset_nid));
+        if (($resource->changed->value() - $dataset->changed->value() > 60)) {
+          $dataset->revision->set(TRUE);
+          $dataset->log->set(t("Update to resource @resource", array('@resource' => $resource->label())));
+          $dataset->save();
         }
       }
-      break;
-
-    default:
       break;
   }
 }


### PR DESCRIPTION
This PR changes the logic of how DKAN determines whether to create a "revision log" update to a dataset when a resource is changed. We get a lot of extra revisions to datasets based on changes to resources. Rather than trying to check if the update happened during a harvest, this simply checks if the resource revision is more than a minute older than the dataset's updated date. If not, it's not worth recording.

This should provide more consistency and accuracy, and reduce extra revisions created through automated processes. 

Finally, this removes the queue functionality and makes the update immediately. If this creates much longer wait times for harvests to finish we can revisit, but as implemented, the queueing defeats the whole purpose of the revision logging! If the logging is queued and happens hours (or days) later, the updated timestamp will be still inaccurate, just for different reasons.

# QA Steps

I'm not sure how to QA this beyond the tests. Let's discuss if there are concerns!