### PR TITLE
Add file hash option

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -156,7 +156,11 @@ projects:
   filefield_sources:
     version: '1.11'
   filehash:
-    version: '1.6'
+    download:
+      type: git
+      url: https://git.drupal.org/project/filehash.git
+      branch: '7.x-1.x'
+      revision: d36daa759271737f20198240b4aa50280c95af5a
     patch:
       3088648: https://www.drupal.org/files/issues/2019-10-17/add-sha512-3088648-5.patch
       2: patches/filehash-uploaded-files-only-option.patch

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -155,6 +155,11 @@ projects:
     version: '1.5'
   filefield_sources:
     version: '1.11'
+  filehash:
+    version: '1.6'
+    patch:
+      3088648: https://www.drupal.org/files/issues/2019-10-17/add-sha512-3088648-5.patch
+      2: patches/filehash-uploaded-files-only-option.patch
   font_icon_select:
     download:
       type: git

--- a/modules/dkan/dkan_dataset/css/dkan_dataset.css
+++ b/modules/dkan/dkan_dataset/css/dkan_dataset.css
@@ -724,3 +724,21 @@ body .node-dataset #data-and-resources ul.resource-list li .orig {
 .field-name-field-data-dictionary .text-format-wrapper .description {
   margin-bottom: 10px;
 }
+.file-hash {
+  word-wrap: break-word;
+  font-size: 12px;
+  line-height: 1.2;
+  margin: 6px 0;
+  color: #888888;
+}
+.file-hash--content {
+  border-style: solid;
+  width: 80%;
+}
+td .file-hash--content {
+  background-color:inherit;
+  width:100%;
+}
+.file-hash--label {
+  font-weight: bold;
+}

--- a/modules/dkan/dkan_dataset/dkan_dataset.theme.inc
+++ b/modules/dkan/dkan_dataset/dkan_dataset.theme.inc
@@ -101,9 +101,21 @@ function theme_dkan_dataset_resource_view($vars) {
       if (isset($node->field_format) && $node->field_format && $node_wrapper->field_format->value()) {
         $format = $node_wrapper->field_format->value()->name;
       }
+      $hash = '';
       if (isset($node->field_upload[LANGUAGE_NONE])) {
         $type = 'file_upload';
         $file_count++;
+
+        $file = $node_wrapper->field_upload->value();
+        if (!empty($file->filehash)) {
+          foreach ($file->filehash as $hash_type => $hash_value) {
+            if (!empty($hash_value)) {
+              $hash .= '<div class="file-hash"><span class="file-hash--label">' .
+                  strtoupper($hash_type) . ':</span> <input class="file-hash--content" value="'
+                  . $hash_value . '"/></div>';
+            }
+          }
+        }
       }
       elseif (isset($node->field_link_remote_file[LANGUAGE_NONE])) {
         $type = 'link_remote_file';
@@ -111,6 +123,7 @@ function theme_dkan_dataset_resource_view($vars) {
       else {
         $type = 'link_api';
       }
+
       $teaser_link = theme('dkan_dataset_teaser_preview_link', array('node' => $node, 'type' => $type));
       $links[] = theme('dkan_dataset_teaser_link', array(
         'link' => $teaser_link,
@@ -119,6 +132,7 @@ function theme_dkan_dataset_resource_view($vars) {
         'desc' => $desc,
         'format' => $format,
         'type' => $type,
+        'hash' => $hash,
         'node' => $node,
       ));
     }
@@ -167,6 +181,7 @@ function dkan_dataset_resource_direct_link($node) {
 function theme_dkan_dataset_teaser_link($vars) {
 
   $desc = $vars['desc'];
+  $hash = $vars['hash'];
   $output = '<div property="dcat:Distribution">';
   $format = '<span data-toggle="tooltip" data-placement="top" data-original-title="' . $vars['format'] . '" class="format-label" property="dc:format" data-format="' . $vars['format'] . '">' . $vars['format'] . '</span>';
 
@@ -179,7 +194,7 @@ function theme_dkan_dataset_teaser_link($vars) {
     ),
   )
   );
-  $output .= $title . $desc . '<span class="links">' . $vars['link'] . '</span></div>';
+  $output .= $title . $desc . $hash . '<span class="links">' . $vars['link'] . '</span></div>';
 
   return $output;
 }

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.blocks.inc
@@ -146,6 +146,14 @@ function dkan_sitewide_resource_additional_block($nid = '') {
       $file_info[] = array(t('filesize'), $filesize);
       $file_info[] = array(t('resource type'), 'file upload');
       $file_info[] = array(t('timestamp'), date('M d, Y', $file['timestamp']));
+
+      $node_wrapper = entity_metadata_wrapper('node', $node);
+      $file = $node_wrapper->field_upload->value();
+      if (!empty($file->filehash)) {
+        foreach ($file->filehash as $hash_type => $hash_value) {
+          $file_info[] = array(strtoupper($hash_type), '<input class="file-hash--content" value="' . $hash_value . '"/>');
+        }
+      }
       return theme('table',
         array('rows' => $file_info, 'header' => array(t('Field'), t('Value'))));
     }

--- a/patches/filehash-uploaded-files-only-option.patch
+++ b/patches/filehash-uploaded-files-only-option.patch
@@ -1,0 +1,61 @@
+diff --git a/filehash.admin.inc b/filehash.admin.inc
+index 097b8ee..130e825 100644
+--- a/filehash.admin.inc
++++ b/filehash.admin.inc
+@@ -22,6 +22,12 @@ function filehash_settings() {
+     '#title' => t('Disallow duplicate files'),
+     '#type' => 'checkbox',
+   );
++  $form['filehash_local_only'] = array(
++    '#default_value' => variable_get('filehash_local_only', 0),
++    '#description' => t('If checked, only create hashes for files with "public" or "private" uri schemes.'),
++    '#title' => t('Only create hashes for locally uploaded files'),
++    '#type' => 'checkbox',
++  );
+   return system_settings_form($form);
+ }
+ 
+diff --git a/filehash.install b/filehash.install
+index 85505f9..4e86f6f 100644
+--- a/filehash.install
++++ b/filehash.install
+@@ -66,6 +66,7 @@ function filehash_schema() {
+ function filehash_uninstall() {
+   variable_del('filehash_algos');
+   variable_del('filehash_dedupe');
++  variable_del('filehash_local_only');
+ }
+ 
+ /**
+diff --git a/filehash.module b/filehash.module
+index 35a2c27..726af57 100644
+--- a/filehash.module
++++ b/filehash.module
+@@ -186,14 +186,20 @@ function filehash_rss_elements(array $file, $node) {
+  * Calculates and saves the file hashes.
+  */
+ function filehash_save($file) {
+-  $file->filehash = array_fill_keys(array('md5', 'sha1', 'sha256', 'sha512'), NULL);
+-  foreach (filehash_algos() as $algo) {
+-    $file->filehash[$algo] = hash_file($algo, $file->uri);
++  $create_hash = true;
++  if (variable_get('filehash_local_only', 0) && !in_array(parse_url($file->uri, PHP_URL_SCHEME), ['public', 'private'])) {
++    $create_hash = false;
++  }
++  if ($create_hash) {
++    $file->filehash = array_fill_keys(array('md5', 'sha1', 'sha256', 'sha512'), NULL);
++    foreach (filehash_algos() as $algo) {
++      $file->filehash[$algo] = hash_file($algo, $file->uri);
++    }
++    db_merge('filehash')
++      ->key(array('fid' => $file->fid))
++      ->fields($file->filehash)
++      ->execute();
+   }
+-  db_merge('filehash')
+-    ->key(array('fid' => $file->fid))
+-    ->fields($file->filehash)
+-    ->execute();
+ }
+ 
+ /**

--- a/test/dkanextension/src/Drupal/DKANExtension/Context/ResourceContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/ResourceContext.php
@@ -91,4 +91,24 @@ class ResourceContext extends RawDKANEntityContext{
       throw new \InvalidArgumentException(sprintf('Preview of type %s not found on page.', $previewtype));
     }
   }
+
+  /**
+   * @BeforeScenario @add_filehash
+   */
+  public function addFilehash(BeforeScenarioScope $event)
+  {
+    // Enable 'filehash' module.
+    module_enable(array('filehash'));
+    // Set options to hash files with SHA-512
+    variable_set('filehash_algos', ["sha512" => "sha512", "md5" => 0, "sha1" => 0, "sha256" => 0]);
+  }
+
+  /**
+   * @AfterScenario @remove_filehash
+   */
+  public function removeFilehash(AfterScenarioScope $event)
+  {
+    // Disable 'filehash' module.
+    module_disable(array('filehash'));
+  }
 }

--- a/test/features/resource.all.feature
+++ b/test/features/resource.all.feature
@@ -91,3 +91,13 @@ Feature: Resource
     Then I should not see the link "Back to dataset"
     When I click "Edit"
     Then I should see "Groups" in the "content" region
+
+  @resource_all_13 @api @add_filehash @remove_filehash
+  Scenario: View SHA-512 for resource with uploaded file when filehash is enabled and set create SHA-512
+    Given I am logged in as a user with the "content creator" role
+    And I am on "/node/add"
+    And I click "Resource"
+    And I attach the drupal file "dkan/TAB_delimiter_large_raw_number.tsv" to "files[field_upload_und_0]"
+    When I fill in "Title" with "Resource TSV"
+    And I press "Save"
+    Then I should see "SHA512"

--- a/test/phpunit/dkan_dataset/ResourceFileHashTest.php
+++ b/test/phpunit/dkan_dataset/ResourceFileHashTest.php
@@ -1,0 +1,73 @@
+<?php
+
+
+namespace phpunit\dkan_dataset;
+
+/**
+ * Class ResourceFileHashTest
+ */
+class ResourceFileHashTest extends \PHPUnit_Framework_TestCase
+{
+  private $local_resource_node;
+  private $sha512;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function setUpBeforeClass()
+  {
+    module_enable(['filehash']);
+    variable_set('filehash_algos', ["sha512" => "sha512", "md5" => 0, "sha1" => 0, "sha256" => 0]);
+    variable_set('filehash_local_only', 1);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    $filename = 'gold_prices_states.csv';
+    $path = join(DIRECTORY_SEPARATOR, array(__DIR__, 'files', $filename));
+    $this->sha512 = hash_file('sha512', $path);
+    $file = file_save_data(file_get_contents($path), 'public://' . $filename);
+    $this->assertNotEmpty($file->filehash);
+    $this->assertNotEmpty($this->sha512);
+
+    $node = (object) [];
+    $node->title = "Resource Local File Test Object";
+    $node->type = "resource";
+    $node->field_upload['und'][0]['fid'] = $file->fid;
+    $node->status = 1;
+    node_save($node);
+    $this->local_resource_node = node_load($node->nid);
+  }
+
+  /**
+   * Test file hash for uploaded file
+   */
+  public function test() {
+    $node_wrapper = entity_metadata_wrapper('node', $this->local_resource_node);
+    $file = $node_wrapper->field_upload->value();
+    $this->assertNotEmpty($file);
+    $this->assertNotEmpty($file->filehash);
+
+    $hash = $file->filehash;
+    $this->assertNotEmpty($hash['sha512']);
+    $this->assertEquals($hash['sha512'], $this->sha512);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown()
+  {
+    node_delete($this->local_resource_node->nid);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tearDownAfterClass() {
+    // Clean enabled modules.
+    module_disable(['filehash']);
+  }
+}

--- a/test/phpunit/phpunit.xml
+++ b/test/phpunit/phpunit.xml
@@ -26,6 +26,7 @@
             <file>dkan_dataset/getRemoteFileInfoTest.php</file>
             <file>dkan_dataset/reclineEmbedCacheTest.php</file>
             <file>dkan_dataset/ApiTest.php</file>
+            <file>dkan_dataset/ResourceFileHashTest.php</file>
         </testsuite>
         <testsuite name="DKAN Datastore Test Suite">
           <file>dkan_datastore/DkanDatastoreCSVParserTest.php</file>


### PR DESCRIPTION
This gives site admins the option of adding hashes to downloadable files. It adds the Filehash module (https://www.drupal.org/project/filehash) to the dkan build. It also applies two hashes to the Filehash module. One adds SHA-512 to the available hash algorithms. The other adds the option of only hashing uploaded files.

If an admin enables the module and selects one or more hash algorithms, a resource file's hash(es) will be displayed below the file name on dataset pages and in the 'Additional Information' block on  resource pages. The display consists of the name of the algorithm (e.g 'md5', 'sha512'), followed by the hash in an input box. The box contains any overflow and makes it easy to copy the entire hash.

## User story

As the maintainer of an open data portal, I want to give my users the ability to verify their downloads from my site.

## QA Steps

1. Confirm that DKAN, especially Dataset and Resource pages work normally.
2. Enable Filehash module. 
3. Confirm that DKAN, especially Dataset and Resource pages still work normally.
4. Go to /admin/config/media/filehash
5. Check one or more hash algorithms.
6. Go to a dataset page.
7. Resource names should be followed by hashes for the algorithm(s) you selected.
8. Click on a resource and scroll down to 'Additional Information'.
9.Hashes for the algorithm(s) you selected should be displayed there.

