### PR TITLE
Reduce unneccesary revisions

### DIFF
--- a/modules/dkan/dkan_dataset/dkan_dataset.module
+++ b/modules/dkan/dkan_dataset/dkan_dataset.module
@@ -806,6 +806,7 @@ function dkan_dataset_update_resource_groups($resources, EntityMetadataWrapper $
     }
     else {
       $wrapper_resource->og_group_ref->set($resource_groups);
+      $wrapper_resource->revision->set(0);
       $wrapper_resource->save();
     }
   }

--- a/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
+++ b/modules/dkan/dkan_harvest/dkan_harvest.migrate.inc
@@ -411,6 +411,7 @@ class HarvestMigration extends MigrateDKAN {
     }
 
     // Save dataset.
+    $dataset->revision = FALSE;
     node_save($dataset);
 
     // Publish dataset and resources if dkan_workflow is enabled.
@@ -431,14 +432,12 @@ class HarvestMigration extends MigrateDKAN {
   private function moderatePublish($dataset) {
     // Publish dataset.
     if (module_exists('dkan_workflow')) {
-      workbench_moderation_moderate($dataset, 'needs_review');
       workbench_moderation_moderate($dataset, 'published');
 
       // Publish resources.
       if (!empty($dataset->field_resources[LANGUAGE_NONE])) {
         foreach ($dataset->field_resources[LANGUAGE_NONE] as $data) {
           $resource = node_load($data['target_id']);
-          workbench_moderation_moderate($resource, 'needs_review');
           workbench_moderation_moderate($resource, 'published');
         }
       }


### PR DESCRIPTION
Stop creating new revisions throughout the dataset creation process in Harvest, so that we have a cleaner history revision history on newly harvested datasets.

## QA Steps

If tests pass, try running an HHS or LKY harvest using this branch to make sure no ill-effects. You should see a reduced number of revisions (actually, just one revision) on new datasets.