### PR TITLE
Add better validation for temporal values

### DIFF
--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_instance.inc
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.features.field_instance.inc
@@ -1368,7 +1368,7 @@ uk-ogl|UK Open Government Licence (OGL)',
         'label' => 'hidden',
         'module' => 'date',
         'settings' => array(
-          'format_type' => 'medium',
+          'format_type' => 'iso_8601_date',
           'fromto' => 'both',
           'multiple_from' => '',
           'multiple_number' => '',

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -147,78 +147,74 @@ class DatajsonHarvestMigration extends HarvestMigration {
       // Validate the value.
       try {
         if ($this->validISO8601Date($row->temporal)) {
-          // Fit the value into the date field.
+          // It's valid. Keep going.
           $date = $row->temporal;
-
           if (strpos($row->temporal, '/')) {
-            // Determine if the value is a range for Start and End dates.
             $date = explode("/", $row->temporal);
-
-            // The first key is the start date of the 'temporal coverage' and the second key is the
-            // end date of the 'temporal coverage'.
-            foreach ($date as $key => &$value) {
-              // Check if this is a time interval on the second Argument.
-              if ($key == 1
-                && preg_match("/P(\d*Y)?(\d*M)?(\d*D)?(\d*W)?T?(\d*H)?(\d*M)?(\d*S)?/", $value)) {
-                try {
-                  $value_diff = new DateInterval($value);
-                  // Get the date from the first segment. This should be represented
-                  // as a timestamp by now.
-                  $value_date = new DateTime();
-                  $value_date->setTimestamp($date[0]);
-                  $value_date->add($value_diff);
-                }
-                catch (Exception $e) {
-                  $message = t(
-                    'Cannot parse temporal coverage interval @value',
-                    array(
-                      '@value' => $value,
-                    ));
-                  $this->saveMessage($message);
-                }
-              }
-              // Support 4 digits year time strings.
-              elseif (preg_match("@^\d{4}$@", $value)) {
+          }
+          elseif (strpos($row->temporal, '-')) {
+            $date = explode("-", $row->temporal);
+          }
+          // The first key is the start date of the 'temporal coverage' and the second key is the
+          // end date of the 'temporal coverage'.
+          foreach ($date as $key => &$value) {
+            // Check if this is a time interval on the second Argument.
+            if ($key == 1
+              && preg_match("/P(\d*Y)?(\d*M)?(\d*D)?(\d*W)?T?(\d*H)?(\d*M)?(\d*S)?/", $value)) {
+              try {
+                $value_diff = new DateInterval($value);
+                // Get the date from the first segment. This should be represented
+                // as a timestamp by now.
                 $value_date = new DateTime();
-
-                // If this is the end date then set it to the last day of the year.
-                if ($key == 1) {
-                  $value_date->setDate($value, 12, 31);
-                }
-                // If this is the start date then set it to the first day of the year.
-                else {
-                  $value_date->setDate($value, 1, 1);
-                }
-
-                $value_date->setTime(0, 0);
+                $value_date->setTimestamp($date[0]);
+                $value_date->add($value_diff);
               }
-              // Fallback to full date/time format.
-              else {
-                try {
-                  $value_date = new DateTime($value);
-                }
-                catch (Exception $e) {
-                  $message = t(
-                    'Cannot parse temporal coverage value @value',
-                    array(
-                      '@value' => $value,
-                    ));
-                  $this->saveMessage($message);
-                }
-              }
-
-              if ($value_date) {
-                $value = $value_date->getTimestamp();
-              }
-              else {
+              catch (Exception $e) {
                 $message = t(
-                  'Cannot determine temporal coverage value. Please review the formatting standards at https://project-open-data.cio.gov/v1.1/schema/#temporal'
-                );
+                  'Cannot parse temporal coverage interval "@value"',
+                  array(
+                    '@value' => $value,
+                  ));
                 $this->saveMessage($message);
               }
             }
+            // Support 4 digits year time strings.
+            elseif (preg_match("@^\d{4}$@", $value)) {
+              $value_date = new DateTime();
+              // If this is the end date then set it to the last day of the year.
+              if ($key == 1) {
+                $value_date->setDate($value, 12, 31);
+              }
+              // If this is the start date then set it to the first day of the year.
+              else {
+                $value_date->setDate($value, 1, 1);
+              }
+              $value_date->setTime(0, 0);
+            }
+            // Fallback to full date/time format.
+            else {
+              try {
+                $value_date = new DateTime($value);
+              }
+              catch (Exception $e) {
+                $message = t(
+                  'Cannot parse temporal coverage value "@value"',
+                  array(
+                    '@value' => $value,
+                  ));
+                $this->saveMessage($message);
+              }
+            }
+            if ($value_date) {
+              $value = $value_date->getTimestamp();
+            }
+            else {
+              $message = t(
+                'Cannot determine temporal coverage value.'
+              );
+              $this->saveMessage($message);
+            }
           }
-
           if (isset($date[0])) {
             $row->temporal_coverage_from = $date[0];
           }
@@ -232,7 +228,7 @@ class DatajsonHarvestMigration extends HarvestMigration {
       }
       catch (Exception $e) {
         $message = t(
-          '"@value" is not a valid temporal format.',
+          '"@value" is not a valid temporal format. Please review the formatting standards at https://project-open-data.cio.gov/v1.1/schema/#temporal',
           array(
             '@value' => $row->temporal,
           ));

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -150,7 +150,7 @@ class DatajsonHarvestMigration extends HarvestMigration {
           // Fit the value into the date field.
           $date = $row->temporal;
 
-          if (strpos($row->temporal, '/') && substr_count($row->temporal, '/') == 1) {
+          if (strpos($row->temporal, '/')) {
             // Determine if the value is a range for Start and End dates.
             $date = explode("/", $row->temporal);
 

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -144,74 +144,90 @@ class DatajsonHarvestMigration extends HarvestMigration {
     // Process Temporal Coverage. The mapping are defined in the base main
     // class, we just need to set the properties.
     if (isset($row->temporal)) {
+      // Validate the value.
+      try {
+        if (validISO8601Date($row->temporal) == FALSE) {
+          throw new Exception();
+        }
+      }
+      catch (Exception $e) {
+        $message = t(
+          '"@value" is not a valid temporal format.',
+          array(
+            '@value' => $row->temporal,
+          ));
+        $this->saveMessage($message);
+      }
+
+      // Fit the value into the date field.
       $date = $row->temporal;
+
       if (strpos($row->temporal, '/')) {
+        // Determine if the value is a range for Start and End dates.
         $date = explode("/", $row->temporal);
-      }
-      elseif (strpos($row->temporal, '-')) {
-        $date = explode("-", $row->temporal);
-      }
-      // The first key is the start date of the 'temporal coverage' and the second key is the
-      // end date of the 'temporal coverage'.
-      foreach ($date as $key => &$value) {
-        // Check if this is a time interval on the second Argument.
-        if ($key == 1
-          && preg_match("/P(\d*Y)?(\d*M)?(\d*D)?(\d*W)?T?(\d*H)?(\d*M)?(\d*S)?/", $value)) {
-          try {
-            $value_diff = new DateInterval($value);
-            // Get the date from the first segment. This should be represented
-            // as a timestamp by now.
+
+        // The first key is the start date of the 'temporal coverage' and the second key is the
+        // end date of the 'temporal coverage'.
+        foreach ($date as $key => &$value) {
+          // Check if this is a time interval on the second Argument.
+          if ($key == 1
+            && preg_match("/P(\d*Y)?(\d*M)?(\d*D)?(\d*W)?T?(\d*H)?(\d*M)?(\d*S)?/", $value)) {
+            try {
+              $value_diff = new DateInterval($value);
+              // Get the date from the first segment. This should be represented
+              // as a timestamp by now.
+              $value_date = new DateTime();
+              $value_date->setTimestamp($date[0]);
+              $value_date->add($value_diff);
+            }
+            catch (Exception $e) {
+              $message = t(
+                'Cannot parse temporal coverage interval @value',
+                array(
+                  '@value' => $value,
+                ));
+              $this->saveMessage($message);
+            }
+          }
+          // Support 4 digits year time strings.
+          elseif (preg_match("@^\d{4}$@", $value)) {
             $value_date = new DateTime();
-            $value_date->setTimestamp($date[0]);
-            $value_date->add($value_diff);
-          }
-          catch (Exception $e) {
-            $message = t(
-              'Cannot parse temporal coverage interval @value',
-              array(
-                '@value' => $value,
-              ));
-            $this->saveMessage($message);
-          }
-        }
-        // Support 4 digits year time strings.
-        elseif (preg_match("@^\d{4}$@", $value)) {
-          $value_date = new DateTime();
 
-          // If this is the end date then set it to the last day of the year.
-          if ($key == 1) {
-            $value_date->setDate($value, 12, 31);
+            // If this is the end date then set it to the last day of the year.
+            if ($key == 1) {
+              $value_date->setDate($value, 12, 31);
+            }
+            // If this is the start date then set it to the first day of the year.
+            else {
+              $value_date->setDate($value, 1, 1);
+            }
+
+            $value_date->setTime(0, 0);
           }
-          // If this is the start date then set it to the first day of the year.
+          // Fallback to full date/time format.
           else {
-            $value_date->setDate($value, 1, 1);
+            try {
+              $value_date = new DateTime($value);
+            }
+            catch (Exception $e) {
+              $message = t(
+                'Cannot parse temporal coverage value @value',
+                array(
+                  '@value' => $value,
+                ));
+              $this->saveMessage($message);
+            }
           }
 
-          $value_date->setTime(0, 0);
-        }
-        // Fallback to full date/time format.
-        else {
-          try {
-            $value_date = new DateTime($value);
+          if ($value_date) {
+            $value = $value_date->getTimestamp();
           }
-          catch (Exception $e) {
+          else {
             $message = t(
-              'Cannot parse temporal coverage value @value',
-              array(
-                '@value' => $value,
-              ));
+              'Cannot determine temporal coverage value. Please review the formatting standards at https://project-open-data.cio.gov/v1.1/schema/#temporal'
+            );
             $this->saveMessage($message);
           }
-        }
-
-        if ($value_date) {
-          $value = $value_date->getTimestamp();
-        }
-        else {
-          $message = t(
-            'Cannot determine temporal coverage value. Please review the formatting standards at https://project-open-data.cio.gov/v1.1/schema/#temporal'
-          );
-          $this->saveMessage($message);
         }
       }
 
@@ -322,6 +338,30 @@ class DatajsonHarvestMigration extends HarvestMigration {
     $group->name = $group_row_data->name;
 
     return $group;
+  }
+
+  /**
+   * Validate temporal key value as valid ISO 8601.
+   */
+  function validISO8601Date($value) {
+    $patterns = array(
+      "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$",
+      "^P(?=\\w*\\d)(?:\\d+Y|Y)?(?:\\d+M|M)?(?:\\d+W|W)?(?:\\d+D|D)?(?:T(?:\\d+H|H)?(?:\\d+M|M)?(?:\\d+(?:\\­.\\d{1,2})?S|S)?)?$",
+      "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?(\\/)([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$",
+      "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?(\\/)P(?=\\w*\\d)(?:\\d+Y|Y)?(?:\\d+M|M)?(?:\\d+W|W)?(?:\\d+D|D)?(?:T(?:\\d+H|H)?(?:\\d+M|M)?(?:\\d+(?:\\­.\\d{1,2})?S|S)?)?$",
+      "^P(?=\\w*\\d)(?:\\d+Y|Y)?(?:\\d+M|M)?(?:\\d+W|W)?(?:\\d+D|D)?(?:T(?:\\d+H|H)?(?:\\d+M|M)?(?:\\d+(?:\\­.\\d{1,2})?S|S)?)?\\/([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$",
+      "^R\\d*\\/([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?\\/P(?=\\w*\\d)(?:\\d+Y|Y)?(?:\\d+M|M)?(?:\\d+W|W)?(?:\\d+D|D)?(?:T(?:\\d+H|H)?(?:\\d+M|M)?(?:\\d+(?:\\­.\\d{1,2})?S|S)?)?$"
+    );
+
+    foreach ($patterns as $pattern) {
+      if (preg_match('/'. $pattern . '/', $value))
+      {
+         return true;
+      }
+    }
+
+    return false;
+
   }
 
 }

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -146,7 +146,87 @@ class DatajsonHarvestMigration extends HarvestMigration {
     if (isset($row->temporal)) {
       // Validate the value.
       try {
-        if (validISO8601Date($row->temporal) == FALSE) {
+        if ($this->validISO8601Date($row->temporal)) {
+          // Fit the value into the date field.
+          $date = $row->temporal;
+
+          if (strpos($row->temporal, '/') && substr_count($row->temporal, '/') == 1) {
+            // Determine if the value is a range for Start and End dates.
+            $date = explode("/", $row->temporal);
+
+            // The first key is the start date of the 'temporal coverage' and the second key is the
+            // end date of the 'temporal coverage'.
+            foreach ($date as $key => &$value) {
+              // Check if this is a time interval on the second Argument.
+              if ($key == 1
+                && preg_match("/P(\d*Y)?(\d*M)?(\d*D)?(\d*W)?T?(\d*H)?(\d*M)?(\d*S)?/", $value)) {
+                try {
+                  $value_diff = new DateInterval($value);
+                  // Get the date from the first segment. This should be represented
+                  // as a timestamp by now.
+                  $value_date = new DateTime();
+                  $value_date->setTimestamp($date[0]);
+                  $value_date->add($value_diff);
+                }
+                catch (Exception $e) {
+                  $message = t(
+                    'Cannot parse temporal coverage interval @value',
+                    array(
+                      '@value' => $value,
+                    ));
+                  $this->saveMessage($message);
+                }
+              }
+              // Support 4 digits year time strings.
+              elseif (preg_match("@^\d{4}$@", $value)) {
+                $value_date = new DateTime();
+
+                // If this is the end date then set it to the last day of the year.
+                if ($key == 1) {
+                  $value_date->setDate($value, 12, 31);
+                }
+                // If this is the start date then set it to the first day of the year.
+                else {
+                  $value_date->setDate($value, 1, 1);
+                }
+
+                $value_date->setTime(0, 0);
+              }
+              // Fallback to full date/time format.
+              else {
+                try {
+                  $value_date = new DateTime($value);
+                }
+                catch (Exception $e) {
+                  $message = t(
+                    'Cannot parse temporal coverage value @value',
+                    array(
+                      '@value' => $value,
+                    ));
+                  $this->saveMessage($message);
+                }
+              }
+
+              if ($value_date) {
+                $value = $value_date->getTimestamp();
+              }
+              else {
+                $message = t(
+                  'Cannot determine temporal coverage value. Please review the formatting standards at https://project-open-data.cio.gov/v1.1/schema/#temporal'
+                );
+                $this->saveMessage($message);
+              }
+            }
+          }
+
+          if (isset($date[0])) {
+            $row->temporal_coverage_from = $date[0];
+          }
+          if (isset($date[1])) {
+            $row->temporal_coverage_to = $date[1];
+          }
+        }
+        else {
           throw new Exception();
         }
       }
@@ -157,85 +237,6 @@ class DatajsonHarvestMigration extends HarvestMigration {
             '@value' => $row->temporal,
           ));
         $this->saveMessage($message);
-      }
-
-      // Fit the value into the date field.
-      $date = $row->temporal;
-
-      if (strpos($row->temporal, '/')) {
-        // Determine if the value is a range for Start and End dates.
-        $date = explode("/", $row->temporal);
-
-        // The first key is the start date of the 'temporal coverage' and the second key is the
-        // end date of the 'temporal coverage'.
-        foreach ($date as $key => &$value) {
-          // Check if this is a time interval on the second Argument.
-          if ($key == 1
-            && preg_match("/P(\d*Y)?(\d*M)?(\d*D)?(\d*W)?T?(\d*H)?(\d*M)?(\d*S)?/", $value)) {
-            try {
-              $value_diff = new DateInterval($value);
-              // Get the date from the first segment. This should be represented
-              // as a timestamp by now.
-              $value_date = new DateTime();
-              $value_date->setTimestamp($date[0]);
-              $value_date->add($value_diff);
-            }
-            catch (Exception $e) {
-              $message = t(
-                'Cannot parse temporal coverage interval @value',
-                array(
-                  '@value' => $value,
-                ));
-              $this->saveMessage($message);
-            }
-          }
-          // Support 4 digits year time strings.
-          elseif (preg_match("@^\d{4}$@", $value)) {
-            $value_date = new DateTime();
-
-            // If this is the end date then set it to the last day of the year.
-            if ($key == 1) {
-              $value_date->setDate($value, 12, 31);
-            }
-            // If this is the start date then set it to the first day of the year.
-            else {
-              $value_date->setDate($value, 1, 1);
-            }
-
-            $value_date->setTime(0, 0);
-          }
-          // Fallback to full date/time format.
-          else {
-            try {
-              $value_date = new DateTime($value);
-            }
-            catch (Exception $e) {
-              $message = t(
-                'Cannot parse temporal coverage value @value',
-                array(
-                  '@value' => $value,
-                ));
-              $this->saveMessage($message);
-            }
-          }
-
-          if ($value_date) {
-            $value = $value_date->getTimestamp();
-          }
-          else {
-            $message = t(
-              'Cannot determine temporal coverage value. Please review the formatting standards at https://project-open-data.cio.gov/v1.1/schema/#temporal'
-            );
-            $this->saveMessage($message);
-          }
-        }
-      }
-
-      if (isset($date[0])) {
-        $row->temporal_coverage_from = $date[0];
-      }
-      if (isset($date[1])) {
-        $row->temporal_coverage_to = $date[1];
       }
     }
 

--- a/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
+++ b/test/phpunit/dkan_harvest/DatajsonHarvestMigrationScenariosTest.php
@@ -564,9 +564,9 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
         'value' => "2000-01-15T00:45:00Z",
         'value2' => "2010-01-15T00:06:00Z",
       ),
-      'Test' => array(
-        'value' => "2005-01-01 00:00:00",
-        'value2' => "2016-12-31 00:00:00",
+      'Test of invalid temporal value' => array(
+        'value' => "",
+        'value2' => "",
       ),
     );
 
@@ -583,10 +583,14 @@ class DatajsonHarvestMigrationScenariosTest extends PHPUnit_Framework_TestCase {
 
     foreach ($dest_ids as $distid) {
       $dataset = entity_metadata_wrapper('node', $distid);
-      $value = new DateTime($expected_temporal[$dataset->label()]['value']);
-      $value2 = new DateTime($expected_temporal[$dataset->label()]['value2']);
-      $this->assertEquals($value->getTimestamp(), $dataset->field_temporal_coverage->value->value());
-      $this->assertEquals($value2->getTimestamp(), $dataset->field_temporal_coverage->value2->value());
+      $value = $expected_temporal[$dataset->label()]['value'] 
+        ? strtotime($expected_temporal[$dataset->label()]['value'])
+        : "";
+      $value2 = $expected_temporal[$dataset->label()]['value2']
+        ? strtotime($expected_temporal[$dataset->label()]['value2'])
+        : "";
+      $this->assertEquals($value, $dataset->field_temporal_coverage->value->value());
+      $this->assertEquals($value2, $dataset->field_temporal_coverage->value2->value());
     }
   }
 

--- a/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_temporal.json
+++ b/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_temporal.json
@@ -28,9 +28,6 @@
       ],
       "identifier": "156",
       "keyword": [
-        "Publically Available Data File - for download",
-        "Ambulatory",
-        "Providers",
         "State",
         "Claims"
       ],
@@ -74,18 +71,7 @@
       "keyword": [
         "Statistics",
         "Hospital",
-        "Inpatient",
-        "Providers",
-        "National",
-        "Quality",
-        "Readmissions",
-        "Admissions",
-        "Claims",
-        "Payments",
-        "Prospective Payment System (PPS)",
-        "Rates",
-        "Publically Available Data File - for download",
-        "Chronic Condition"
+        "Inpatient"
       ],
       "landingPage": "https://www.cms.gov/Medicare/Medicare-Fee-for-Service-Payment/AcuteInpatientPPS/Readmissions-Reduction-Program.html",
       "modified": "2016-04-07",
@@ -125,21 +111,7 @@
       "keyword": [
         "Statistics",
         "Medicare",
-        "Medicare Advantage",
-        "Hospital",
-        "Inpatient",
-        "Part A",
-        "Providers",
-        "National",
-        "Regional",
-        "Research",
-        "Claims",
-        "Eligibility",
-        "Enrollment",
-        "Payments",
-        "Prospective Payment System (PPS)",
-        "Part C",
-        "Disproportionate Share Hospitals (DSH)"
+        "Medicare Advantage"
       ],
       "landingPage": "https://www.cms.gov/Medicare/Medicare-Fee-for-Service-Payment/AcuteInpatientPPS/dsh.html",
       "modified": "2016-01-06",
@@ -236,7 +208,7 @@
       "theme": [
         "Medicare"
       ],
-      "title": "Test"
+      "title": "Test of invalid temporal value"
     }
   ]
 }


### PR DESCRIPTION
## User story

As a data publisher I want to be alerted when the temporal value is not valid.

$d1 = '2000-01-15T00:45:00Z';  //valid
$d2 = '2000-01-01T01:00:00+1200';  //valid
$d3 = '1988-12';  //valid
$d4 = '01/01/2015-12/31/2019';  //not valid
$d5 = '2007- present';  //not valid
$d6 = '2000-01-15T00:45:00Z/2010-01-15T00:06:00Z';  //valid
$d7 = '2000-01-15T00:45:00Z/P1W';  //valid

## How to reproduce

Harvest from https://data.chhs.ca.gov/data.json

## Errors
see https://github.com/NuCivic/healthdata/issues/1156
```
Error: Call to a member function getTimestamp() on null in DatajsonHarvestMigration->prepareRow() (line 207 of ..../dkan/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc)
```


## Reminders

- [ ] There is test for the issue.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
