### PR TITLE
Add release script and Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ import groovy.json.JsonOutput
  *
  * @param version The tag in DKAN we're building against
  * @param date A timestamp for the new version
- * @param username The username for github
+ * @param username The username for github.
  * 
  */
 void createDropsPr(String version, String date, String username) {
@@ -18,8 +18,8 @@ void createDropsPr(String version, String date, String username) {
             head: branch,
             base: "master"
         ]
-	    def payload = JsonOutput.toJson(data)
-	    sh "curl -v -u ${username}:${GITHUB_TOKEN} -H ${header} -X POST ${url} -d '${payload}'"
+	def payload = JsonOutput.toJson(data)
+	sh "curl -v -u ${username}:${GITHUB_TOKEN} -H ${header} -X POST ${url} -d '${payload}'"
     }
 }
 
@@ -28,6 +28,12 @@ void createDropsPr(String version, String date, String username) {
  *
  * Create tarballs with version info and without dev artifacts,
  * and create a PR for a DKAN-DROPS-7 (Pantheon) release.
+ *
+ * - Uses the GitHub API to create pull requests
+ * - Uses Credentials Binding Plugin
+ * - Expects a private access token for Github stored in "dkanuploadassets"
+ * - Depends on the pantheon-system and GetDKAN/dkan-drops-7 repos
+ * - Uses the getdkan/dkan-docker:php72-cli image
  */
 pipeline {
     agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,9 @@ pipeline {
     //     USER = 'jenkins'
     // }
     stages {
+        stage('Test') {
+            sh "ls -la"
+        }
         stage('Setup') {
             when { buildingTag() }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,25 @@
+pipeline {
+    agent any
+    options {
+        ansiColor 'xterm'
+    }
+    // environment {
+    //     PATH = "$WORKSPACE/dkan-tools/bin:$PATH"
+    //     USER = 'jenkins'
+    // }
+    stages {
+        stage('Setup') {
+            when { tag() }
+            steps {
+              sh "curl -O -L https://github.com/GetDKAN/dkan-tools/archive/master.zip"
+              sh "unzip master.zip && mv dkan-tools-master dkan-tools && rm master.zip"
+            }
+        }
+        stage('Upload assets') {
+            when { tag() }
+            steps {
+                sh "ls -la"
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,16 @@
 import groovy.json.JsonOutput
 
-void createDropsPr(String branch, String version, String date) {
-    withCredentials([usernamePassword(credentialsId: 'nucivicmachine', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+/**
+ * Create a pull request on DKAN-DROPS-7 against a branch.
+ *
+ * @param version The tag in DKAN we're building against
+ * @param date A timestamp for the new version
+ * @param username The username for github
+ * 
+ */
+void createDropsPr(String version, String date, String username) {
+    withCredentials([string(credentialsId: 'dkanuploadassets', variable: 'GITHUB_TOKEN')]) {
+        def branch = "proposed_release_for_${TAG_NAME}_${DATE}"
         def url = "https://api.github.com/repos/GetDKAN/dkan-drops-7/pulls"
         def header = 'Content-Type: application/json'
         def data = [
@@ -10,17 +19,24 @@ void createDropsPr(String branch, String version, String date) {
             base: "master"
         ]
 	    def payload = JsonOutput.toJson(data)
-	    sh "curl -v -u ${GIT_USERNAME}:${GIT_PASSWORD} -H ${header} -X POST ${url} -d '${payload}'"
+	    sh "curl -v -u ${username}:${GITHUB_TOKEN} -H ${header} -X POST ${url} -d '${payload}'"
     }
 }
 
+/**
+ * Release tasks for DKAN.
+ *
+ * Create tarballs with version info and without dev artifacts,
+ * and create a PR for a DKAN-DROPS-7 (Pantheon) release.
+ */
 pipeline {
     agent {
         docker { image 'getdkan/dkan-docker:php72-cli' }
     }
     environment {
-        GITHUB_TOKEN = credentials('dkanuploadassets')
         DATE = sh(script: 'date +%s', returnStdout: true).trim()
+        GITHUB_USERNAME = "nucivicmachine"
+        GITHUB_TOKEN = credentials('dkanuploadassets')
     }
     stages {
         stage('Upload assets') {
@@ -36,25 +52,23 @@ pipeline {
         stage('Build DROPS') {
             when { buildingTag() }
             steps {
-                withCredentials([usernamePassword(credentialsId: 'nucivicmachine', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
-                    sh('git clone https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/GetDKAN/dkan-drops-7 --tags')
-                    dir('dkan-drops-7') {
-                        sh "git checkout -b proposed_release_for_${TAG_NAME}_${DATE}"
-                        sh "git remote add pantheon git://github.com/pantheon-systems/drops-7.git"
-                        sh "git fetch pantheon && git merge pantheon/master -X theirs"
-                        sh "rm -rf profiles/dkan && mv ../dkan-${TAG_NAME} ./profiles/dkan"
-                    }
-                    dir('dkan-drops-7/profiles/dkan') {
-                        sh "rm -rf .git .gitignore modules/contrib themes/contrib libraries/"
-                        sh "drush -y make --no-core --contrib-destination=. drupal-org.make --no-recursion"
-                        sh "find . -type f -name .gitignore -exec rm -rf {} \\;"
-                    }
-                    dir ('dkan-drops-7') {
-                        sh "git add . -A && git commit -m '${TAG_NAME} release'"
-                        sh "git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/GetDKAN/dkan-drops-7 proposed_release_for_${TAG_NAME}_${DATE}"
-                    }
+                sh("git clone https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/GetDKAN/dkan-drops-7 --tags")
+                dir('dkan-drops-7') {
+                    sh "git checkout -b proposed_release_for_${TAG_NAME}_${DATE}"
+                    sh "git remote add pantheon git://github.com/pantheon-systems/drops-7.git"
+                    sh "git fetch pantheon && git merge pantheon/master -X theirs"
+                    sh "rm -rf profiles/dkan && mv ../dkan-${TAG_NAME} ./profiles/dkan"
                 }
-                createDropsPr("proposed_release_for_${TAG_NAME}_${DATE}", TAG_NAME, DATE)
+                dir('dkan-drops-7/profiles/dkan') {
+                    sh "rm -rf .git .gitignore modules/contrib themes/contrib libraries/"
+                    sh "drush -y make --no-core --contrib-destination=. drupal-org.make --no-recursion"
+                    sh "find . -type f -name .gitignore -exec rm -rf {} \\;"
+                }
+                dir ('dkan-drops-7') {
+                    sh "git add . -A && git commit -m '${TAG_NAME} release'"
+                    sh "git push https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/GetDKAN/dkan-drops-7 proposed_release_for_${TAG_NAME}_${DATE}"
+                }
+                createDropsPr(TAG_NAME, DATE, GITHUB_USERNAME)
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,27 +1,60 @@
-pipeline {
-    agent any
-    options {
-        ansiColor 'xterm'
+import groovy.json.JsonOutput
+
+void createDropsPr(String branch, String version, String date) {
+    withCredentials([usernamePassword(credentialsId: 'nucivicmachine', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+        def url = "https://api.github.com/repos/GetDKAN/dkan-drops-7/pulls"
+        def header = 'Content-Type: application/json'
+        def data = [
+            title: "${date}: Proposed release for ${version}",
+            head: branch,
+            base: "master"
+        ]
+	    def payload = JsonOutput.toJson(data)
+	    sh "curl -v -u ${GIT_USERNAME}:${GIT_PASSWORD} -H ${header} -X POST ${url} -d '${payload}'"
     }
-    // environment {
-    //     PATH = "$WORKSPACE/dkan-tools/bin:$PATH"
-    //     USER = 'jenkins'
-    // }
+}
+
+pipeline {
+    agent {
+        docker { image 'getdkan/dkan-docker:php72-cli' }
+    }
+    environment {
+        GITHUB_TOKEN = credentials('dkanuploadassets')
+        DATE = sh(script: 'date +%s', returnStdout: true).trim()
+    }
     stages {
-        stage('Test') {
-            sh "ls -la"
-        }
-        stage('Setup') {
-            when { buildingTag() }
-            steps {
-              sh "curl -O -L https://github.com/GetDKAN/dkan-tools/archive/master.zip"
-              sh "unzip master.zip && mv dkan-tools-master dkan-tools && rm master.zip"
-            }
-        }
         stage('Upload assets') {
             when { buildingTag() }
             steps {
-                sh "ls -la"
+                sh "cd .. && mv workspace dkan-${TAG_NAME} && mkdir workspace"
+                sh "mv ../dkan-${TAG_NAME} ./"
+                sh "mv dkan-${TAG_NAME}/scripts/release-upload-assets.php ./"
+                sh "cd dkan-${TAG_NAME} && rm -rf Jenkinsfile docs scripts .circleci .github .git"
+                sh "php ./release-upload-assets.php"
+            }
+        }
+        stage('Build DROPS') {
+            when { buildingTag() }
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'nucivicmachine', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+                    sh('git clone https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/GetDKAN/dkan-drops-7 --tags')
+                    dir('dkan-drops-7') {
+                        sh "git checkout -b proposed_release_for_${TAG_NAME}_${DATE}"
+                        sh "git remote add pantheon git://github.com/pantheon-systems/drops-7.git"
+                        sh "git fetch pantheon && git merge pantheon/master -X theirs"
+                        sh "rm -rf profiles/dkan && mv ../dkan-${TAG_NAME} ./profiles/dkan"
+                    }
+                    dir('dkan-drops-7/profiles/dkan') {
+                        sh "rm -rf .git .gitignore modules/contrib themes/contrib libraries/"
+                        sh "drush -y make --no-core --contrib-destination=. drupal-org.make --no-recursion"
+                        sh "find . -type f -name .gitignore -exec rm -rf {} \\;"
+                    }
+                    dir ('dkan-drops-7') {
+                        sh "git add . -A && git commit -m '${TAG_NAME} release'"
+                        sh "git push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/GetDKAN/dkan-drops-7 proposed_release_for_${TAG_NAME}_${DATE}"
+                    }
+                }
+                createDropsPr("proposed_release_for_${TAG_NAME}_${DATE}", TAG_NAME, DATE)
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,14 +9,14 @@ pipeline {
     // }
     stages {
         stage('Setup') {
-            when { tag() }
+            when { buildingTag() }
             steps {
               sh "curl -O -L https://github.com/GetDKAN/dkan-tools/archive/master.zip"
               sh "unzip master.zip && mv dkan-tools-master dkan-tools && rm master.zip"
             }
         }
         stage('Upload assets') {
-            when { tag() }
+            when { buildingTag() }
             steps {
                 sh "ls -la"
             }

--- a/scripts/release-upload-assets.php
+++ b/scripts/release-upload-assets.php
@@ -1,0 +1,215 @@
+<?php
+
+/**
+ * @file
+ * Zip up code for release and delete unneeded files.
+ */
+
+// Get latest release name.
+$handler = curl_init('https://api.github.com/repos/GetDKAN/dkan/releases/latest');
+curl_setopt($handler, CURLOPT_RETURNTRANSFER, 1);
+curl_setopt($handler, CURLOPT_HTTPHEADER, [
+  'User-Agent: DKAN Jenkins',
+  'Accept: application/vnd.github.v3+json',
+]);
+$result = json_decode(curl_exec($handler));
+curl_close($handler);
+$dkan_version = $result->tag_name;
+
+$file_name = "{$dkan_version}.zip";
+
+if (!file_exists($file_name)) {
+  `wget -O {$file_name} https://github.com/GetDKAN/dkan/archive/{$file_name}`;
+}
+else {
+  echo "Already got the file {$file_name}" . PHP_EOL;
+}
+
+$folder_name = "dkan-{$dkan_version}";
+if (!file_exists($folder_name)) {
+  "Extracting {$file_name}" . PHP_EOL;
+  `unzip {$file_name}`;
+  echo "{$file_name} was extracted" . PHP_EOL;
+}
+else {
+  echo "The file {$file_name} has already been extracted to {$folder_name}" . PHP_EOL;
+}
+
+$readme = file_get_contents("{$folder_name}/README.md");
+if (substr_count($readme, $dkan_version) == 0) {
+  echo "Adding version to README file" . PHP_EOL;
+  $new_readme = str_replace("# DKAN Open Data Platform", "# DKAN Open Data Platform ({$dkan_version})", $readme);
+  file_put_contents("{$folder_name}/README.md", $new_readme);
+  echo "Added version to README file" . PHP_EOL;
+}
+else {
+  echo "Version has already been added to the README file" . PHP_EOL;
+}
+
+$files = get_all_files_with_extension($folder_name, "info");
+foreach ($files as $file) {
+  add_version_to_info_file($file, $dkan_version);
+}
+
+$tar_file_name = "{$dkan_version}.tar.gz";
+if (!file_exists($tar_file_name)) {
+  echo "Compressing {$folder_name}" . PHP_EOL;
+  `zip -9 -r {$file_name} {$folder_name}`;
+  `tar -zcvf {$tar_file_name} {$folder_name}`;
+  echo "{$folder_name} zip and tar.gz archives were created" . PHP_EOL;
+}
+else {
+  echo "{$folder_name} has already been compressed";
+}
+
+// Upload assets to release.
+upload_assets($dkan_version, $file_name, 'application/zip');
+upload_assets($dkan_version, $tar_file_name, 'application/gzip');
+
+function add_version_to_info_file($path, $version) {
+  $content = file_get_contents($path);
+  if (substr_count($content, "version") == 0) {
+    echo "Adding version number to {$path}" . PHP_EOL;
+    $content = trim($content);
+    $content .= PHP_EOL . "version = {$version}" . PHP_EOL;
+    file_put_contents($path, $content);
+    echo "Adding version number to {$path}" . PHP_EOL;
+
+  }
+  else {
+    echo "Version number already added to {$path}" . PHP_EOL;
+  }
+}
+
+function get_all_files_with_extension($path, $ext) {
+  $files_with_extension = [];
+  $subs = get_all_subdirectories($path);
+  foreach ($subs as $sub) {
+    $files = get_files_with_extension($sub, $ext);
+    $files_with_extension = array_merge($files_with_extension, $files);
+  }
+  return $files_with_extension;
+}
+
+function get_files_with_extension($path, $ext) {
+  $files_with_extension = [];
+  $files = get_files($path);
+  foreach ($files as $file) {
+    $e = pathinfo($file, PATHINFO_EXTENSION);
+    if ($ext == $e) {
+      $files_with_extension[] = $file;
+    }
+  }
+  return $files_with_extension;
+}
+
+function get_all_subdirectories($path) {
+  $all_subs = [];
+  $stack = [$path];
+  while (!empty($stack)) {
+    $sub = array_shift($stack);
+    $all_subs[] = $sub;
+    $subs = get_subdirectories($sub);
+    $stack = array_merge($stack, $subs);
+  }
+  return $all_subs;
+}
+
+function get_subdirectories($path) {
+  $directories_info = shell_table_to_array(`ls {$path} -lha | grep '^dr'`);
+  $subs = [];
+  foreach ($directories_info as $di) {
+    if (isset($di[8])) {
+      $dir = trim($di[8]);
+      if ($dir != "." && $dir != "..") {
+        $subs[] = "{$path}/{$dir}";
+      }
+    }
+  }
+  return $subs;
+}
+
+function get_files($path) {
+  $files_info = shell_table_to_array(`ls {$path} -lha | grep -v '^dr'`);
+  $files = [];
+  foreach ($files_info as $fi) {
+    if (isset($fi[8])) {
+      $file = trim($fi[8]);
+      $files[] = "{$path}/{$file}";
+    }
+  }
+  return $files;
+}
+
+function shell_table_to_array($shell_table) {
+  $final = [];
+  $lines = explode(PHP_EOL, $shell_table);
+
+  foreach ($lines as $line) {
+    $parts = preg_split('/\s+/', $line);
+    if (!empty($parts)) {
+      $final[] = $parts;
+    }
+  }
+
+  return $final;
+}
+
+function upload_assets($tag, $file_name, $content_type) {
+  echo "Uploading asset {$file_name} for DKAN release {$tag}..." . PHP_EOL;
+
+  // Request to get the release upload_url.
+  $handler = curl_init('https://api.github.com/repos/GetDKAN/dkan/releases/tags/' . $tag);
+  curl_setopt($handler, CURLOPT_RETURNTRANSFER, 1);
+  curl_setopt($handler, CURLOPT_HTTPHEADER, [
+    'User-Agent: DKAN Jenkins',
+    'Accept: application/vnd.github.v3+json',
+  ]);
+  $result = json_decode(curl_exec($handler));
+  curl_close($handler);
+
+  // Get real upload_url.
+  $upload_url = $result->upload_url;
+  $matches = [];
+  if (preg_match('/(.*){\?name,label}/', $upload_url, $matches)) {
+    $upload_url = $matches[1];
+  } else {
+    throw new \Exception("The upload URL is invalid.");
+  }
+
+  // Get filepath.
+  $path = realpath($file_name);
+
+  // Set params for POST to upload_url.
+  $params = [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_ENCODING => "",
+    CURLOPT_MAXREDIRS => 10,
+    CURLOPT_TIMEOUT => 600,
+    CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+    CURLOPT_CUSTOMREQUEST => "POST",
+    CURLOPT_HTTPHEADER => array(
+      "accept: application/vnd.github.v3+json",
+      "authorization: token " . getenv('JENKINS_GITHUB_TOKEN'),
+      "cache-control: no-cache",
+      "content-type: " . $content_type,
+    ),
+    CURLOPT_POSTFIELDS => file_get_contents($path),
+    CURLOPT_VERBOSE => 1,
+  ];
+  $real_upload_url = $upload_url . '?name=' . $file_name;
+  echo "Uploading asset to {$real_upload_url}" . PHP_EOL;
+
+  // POST file to upload_url.
+  $handler = curl_init($real_upload_url);
+  curl_setopt_array($handler, $params);
+  $result = curl_exec($handler);
+  $status_code = curl_getinfo($handler, CURLINFO_HTTP_CODE);
+  curl_close($handler);
+
+  if ($status_code >= 200 && $status_code < 300) {
+    echo "Asset uploaded correctly." . PHP_EOL;
+  } else {
+    throw new \Exception("The asset was not uploaded.");
+  }
+}


### PR DESCRIPTION
To start doing automatic packaging of DKAN on releases, adding a Jenkinsfile and php packaging script. Adds version info and removes scripts and docs for a downloadable release. (Note: removing the docs is new; we can remove this but I don't think we really need to be distributing them with the releases.)

Also creates a PR for a DROPS release

## QA Steps

The asset files uploaded to the [jenkins20](https://github.com/GetDKAN/dkan/releases/tag/jenkins20) release were automatically generated and uploaded. Check the files and confirm they look as expected.

Check GetDKAN/dkan-drops-7#95, generated by the same tag

## Merging instructions

Delete any "jenkins*" releases and tags from the github repo.
Delete GetDKAN/dkan-drops-7#95