### PR TITLE
Change behat context to specifically index the saved entity.

### DIFF
--- a/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
+++ b/test/dkanextension/src/Drupal/DKANExtension/Context/RawDKANEntityContext.php
@@ -522,8 +522,7 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
       }
     }
 
-    // Process any outstanding search items.
-    $this->searchContext->process();
+    $this->indexItem($wrapper->getIdentifier());
 
     // Add the created entity to the array so it can be deleted later.
     $id = $wrapper->getIdentifier();
@@ -638,4 +637,18 @@ class RawDKANEntityContext extends RawDKANContext implements SnippetAcceptingCon
     }
   }
 
+  /**
+   * Add an entity to all indexes
+   *
+   * @param $item
+   *   The entity id of the item to index
+   *
+   * @throws \SearchApiException
+   */
+  public function indexItem($item) {
+    $search_indexes = search_api_index_load_multiple(false);
+    foreach ($search_indexes as $index) {
+      search_api_index_specific_items($index, [$item]);
+    }
+  }
 }


### PR DESCRIPTION
The raw DKAN entity behat context attempts to index new or updated entities using the process() function from SearchAPIContext, which indexes up to 10 entities that haven't yet been indexed. This is fine if the indexes are up-to-date, but if there are enough items that need indexing, it will never get to the one(s) being tested.

This PR solves that problem by explicitly indexing the new/updated entity instead. It may be less efficient, but ensures that test entities will be indexed.

## QA Steps

- [ ] Run behat tests that use the save function from RawDKANEntityContext (e.g. `Given Pages:`, `Given Resources:`, `Given Datasets:`, `Given harvest sources:`). The tests should run correctly.