### PR TITLE
Prevent infinite loop in Harvest Source preview page

### DIFF
--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -281,7 +281,7 @@ function dkan_harvest_page_preview($node) {
       $output .= t("<div>Could not connect to <em>@url</em>. Please check the value of 'Source URI' and resubmit.</div>",
           ['@url' => $uri]);
     }
-    elseif (strpos($info->getType(), 'json') === FALSE) {
+    elseif (!empty($info->getType()) && strpos($info->getType(), 'json') === FALSE) {
       $output .= t("<div><em>@url</em> is not a json endpoint. Please check the value of 'Source URI' and resubmit.</div>",
           ['@url' => $uri]);
     }

--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -279,7 +279,7 @@ function dkan_harvest_page_preview($node) {
     $info = new GetRemoteFileInfo($uri, 'test');
     if (!$info->getInfo() ||
         (!empty($info->getType()) && strpos($info->getType(), 'json') === FALSE)) {
-      $output .= t("<div>Unable to harvest from <em>@url</em>. Please check the value of 'Source URI' and confirm that it is publicly accessible and is a json endpoint. Then resubmit.</div>",
+      $output .= t("<div class=\"alert alert-warning\">Unable to harvest from <em>@url</em>. Please check the value of 'Source URI' and confirm that it is publicly accessible and is a json endpoint. Then resubmit.</div>",
           ['@url' => $uri]);
     }
     else {

--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -5,6 +5,8 @@
  * Code for the DKAN Harvest feature.
  */
 
+use dkanDataset\GetRemoteFileInfo;
+
 include_once 'dkan_harvest.features.inc';
 
 // TODO Probably move this to drupal variables.
@@ -273,20 +275,32 @@ function dkan_harvest_page_preview($node) {
 
   if (!$cache_dir) {
     // The cache directory does not exist.
-    // Perform a cache operation.
-    $batch_operations = array();
-    $batch_operations[] = array('dkan_harvest_cache_source_batch_op', array($harvestSource));
+    $uri = $harvestSource->uri;
+    $info = new GetRemoteFileInfo($uri, 'test');
+    if (!$info->getInfo()) {
+      $output .= t("<div>Could not connect to <em>@url</em>. Please check the value of 'Source URI' and resubmit.</div>",
+          ['@url' => $uri]);
+    }
+    elseif (strpos($info->getType(), 'json') === FALSE) {
+      $output .= t("<div><em>@url</em> is not a json endpoint. Please check the value of 'Source URI' and resubmit.</div>",
+          ['@url' => $uri]);
+    }
+    else {
+      // Perform a cache operation.
+      $batch_operations = array();
+      $batch_operations[] = array('dkan_harvest_cache_source_batch_op', array($harvestSource));
 
-    // Setup batch process.
-    $batch = array(
-      'operations' => $batch_operations,
-      'title' => t('Caching source and preparing Harvest preview...'),
-      'init_message' => t('Processed 0%.'),
-      'progress_message' => t('Processed @percentage.'),
-      'error_message' => t('An error ocurred while caching the source.'),
-    );
-    batch_set($batch);
-    batch_process();
+      // Setup batch process.
+      $batch = array(
+          'operations' => $batch_operations,
+          'title' => t('Caching source and preparing Harvest preview...'),
+          'init_message' => t('Processed 0%.'),
+          'progress_message' => t('Processed @percentage.'),
+          'error_message' => t('An error ocurred while caching the source.'),
+      );
+      batch_set($batch);
+      batch_process();
+    }
   }
   else {
     // The cache directory exists. Load the table.

--- a/modules/dkan/dkan_harvest/dkan_harvest.module
+++ b/modules/dkan/dkan_harvest/dkan_harvest.module
@@ -277,12 +277,9 @@ function dkan_harvest_page_preview($node) {
     // The cache directory does not exist.
     $uri = $harvestSource->uri;
     $info = new GetRemoteFileInfo($uri, 'test');
-    if (!$info->getInfo()) {
-      $output .= t("<div>Could not connect to <em>@url</em>. Please check the value of 'Source URI' and resubmit.</div>",
-          ['@url' => $uri]);
-    }
-    elseif (!empty($info->getType()) && strpos($info->getType(), 'json') === FALSE) {
-      $output .= t("<div><em>@url</em> is not a json endpoint. Please check the value of 'Source URI' and resubmit.</div>",
+    if (!$info->getInfo() ||
+        (!empty($info->getType()) && strpos($info->getType(), 'json') === FALSE)) {
+      $output .= t("<div>Unable to harvest from <em>@url</em>. Please check the value of 'Source URI' and confirm that it is publicly accessible and is a json endpoint. Then resubmit.</div>",
           ['@url' => $uri]);
     }
     else {


### PR DESCRIPTION
## Description

When a harvest cache doesn't exist, the harvest source preview page calls a batch to generate it. When the batch is done, it loads the preview page. If the cache can't be created, this creates an infinite loop.

This PR checks that  the Content URI is reachable, and if the header is available, checks that it's a json response. If either check fails, it displays a message instead of triggering the batch

## How to reproduce

1.  Create a harvest source with an invalid source URL. A batch display will keep flashing until you browse away from the page

## QA Steps

- Create a test Harvest Source with an invalid URL and save. Confirm that a message appears and it is appropriate. 
- Change the URL one that goes to a non-json page. Confirm that an appropriate message appears.
- Try valid JSON URLs (including, if possible, one that doesn't return headers). Confirm that caches are generated and the preview page presents a summary of them as before.

