### PR TITLE
Avoid proxy file printing.

### DIFF
--- a/modules/dkan/dkan_datastore/dkan_datastore.pages.inc
+++ b/modules/dkan/dkan_datastore/dkan_datastore.pages.inc
@@ -16,33 +16,11 @@ define('MAX_FILE_REMOTE_PROXY_DEFAULT', 1024 * 1024 * 50);
  * Proxy remote resources.
  */
 function dkan_datastore_proxy($node) {
-  $allowed_types = array('csv');
   $node_wrapper = entity_metadata_wrapper('node', $node);
   $remote_file = $node_wrapper->field_link_remote_file->value();
   $uri = $remote_file['uri'];
-  $filename = $remote_file['filename'];
-  $mime = $remote_file['filemime'];
-  $type = recline_get_data_type($remote_file['filemime']);
 
-  if (in_array($type, $allowed_types)) {
-    // dkan_datastore_proxy() loads the file locally which has a big memory footprint.
-    // If the file is too large we don't want to proxy.
-    $max = (int) variable_get('dkan_datastore_max_file_remote_proxy_size', MAX_FILE_REMOTE_PROXY_DEFAULT);
-    $size = isset($node_wrapper->field_link_remote_file->value()['filesize']) ? (int) $node_wrapper->field_link_remote_file->value()['filesize'] : $max;
-
-    if ($size >= $max) {
-      drupal_goto($uri);
-    }
-    else {
-      drupal_add_http_header('Content-Type', $mime);
-      drupal_add_http_header('Content-Disposition', 'attachment; filename=' . $filename);
-      print file_get_contents($uri);
-    }
-  }
-  else {
-    // Not in allowed types, treat the file URI as a normal url.
-    return drupal_goto($uri);
-  }
+  return drupal_goto($uri);
 }
 
 /**


### PR DESCRIPTION
## Issue
When the remote host does not supply a valid content header, namely Content-Length. We cannot get an accurate file size without downloading the file first.
Since we can not reliably determine file size, we end up trying to print large files that are reported as much smaller files. This is causing out of memory errors, so removing the proxy and call to `file_get_contents`.

This will "disable" the data preview for all remote csv files, it can be restored by adding the file to the datastore.

![remote-csv](https://user-images.githubusercontent.com/314172/73376120-8606dd80-4282-11ea-9193-8c05439ba79d.png)


## Steps to test:

- [ ] Whenever you go to `node/%dkan_datastore_resource/data` you should get the file download, wether it is a CSV or not.