### PR TITLE
Drush command to remove datastore config and drop table for resource.

### DIFF
--- a/docs/components/datastore.rst
+++ b/docs/components/datastore.rst
@@ -62,6 +62,13 @@ To remove all records from the datastore:
 3. Click the "Drop" button.
 4. Confirm by clicking the "Drop" button.
 
+Remove Stuck Datastore
+------------------------
+
+If a datastore cannot import correctly, it may be left in a 'stuck' state.
+
+To reset the datastore state and remove any incompletely imported datastore table, run ``drush dkan_datastore_drush_delete [RNID]``. Replace '[RNID]' with the node id of the related resource.
+
 
 .. _fast_import_manager:
 

--- a/modules/dkan/dkan_datastore/dkan_datastore.drush.inc
+++ b/modules/dkan/dkan_datastore/dkan_datastore.drush.inc
@@ -27,6 +27,15 @@ function dkan_datastore_drush_command() {
     'callback' => 'dkan_datastore_drush_drop_orphan_tables',
   );
 
+  $items['dkan-datastore-delete'] = array(
+    'description' => 'Remove datastore store configuration and datastore table for a resource.',
+    'callback' => 'dkan_datastore_drush_delete',
+    'arguments' => array(
+      'resource_nid' => "Resource NID"
+    ),
+  );
+
+
   return $items;
 }
 
@@ -77,4 +86,18 @@ function dkan_datastore_drush_drop_orphan_tables() {
   } else {
     drush_print("There are currently no datastore tables on this site.");
   }
+}
+
+/**
+ * Remove datastore config and table.
+ *
+ * @param $resource_id
+ *  The nid of the resource whose datastore should be removed.
+ */
+function dkan_datastore_drush_delete($resource_id) {
+  $state_storage = new LockableDrupalVariables("dkan_datastore");
+  $state_storage->delete($resource_id);
+
+  $table = 'dkan_datastore_' . $resource_id;
+  $query = db_drop_table($table);
 }


### PR DESCRIPTION
Adds a drush command to remove the datastore config and drop the datastore table for a selected resource

## QA Steps

1. Find the node id of a resource with a file in datastore.
2. Run `drush dkan-datastore-delete [node id]`
3. Go to the datastore page for the resource and confirm that the "Data importing" state is "Ready"
