### PR TITLE
Patch facetapi to hide block when facet is empty.

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -101,6 +101,8 @@ projects:
     version: '2.9'
   facetapi:
     version: '1.6'
+    patch:
+      3084250: https://www.drupal.org/files/issues/2019-10-25/hide-block-title-empty-facet-3084250-5.patch
   facetapi_bonus:
     version: '1.3'
   facetapi_pretty_paths:


### PR DESCRIPTION
Bug introduced on facetapi 1.6. 
Facets block titles are shown even when the facet is empty, here we're patching facetapi with https://www.drupal.org/project/facetapi/issues/3084250

## Tests steps:
- Go to datasets search page.
- If a facet is empty, the title shouldn't appear in the sidebar.