### PR TITLE
Check accrualPeriodicity against list of valid frequency values.

### DIFF
--- a/modules/dkan/dkan_harvest/includes/HarvestMigration.php
+++ b/modules/dkan/dkan_harvest/includes/HarvestMigration.php
@@ -372,6 +372,22 @@ class HarvestMigration extends MigrateDKAN {
         }
       }
     }
+
+    // Check the accrualPeriodicity field.
+    // If it's in the frequency map as a value, set it to the associated key.
+    // If it's not there, either as a key or value, set it to null.
+    if (isset($row->accrualPeriodicity) && $row->accrualPeriodicity != '') {
+      $frequencies = dkan_dataset_content_types_iso_frecuency_map();
+      if (!isset($frequencies[$row->accrualPeriodicity])) {
+        $frequencies_by_label = array_flip($frequencies);
+        if (isset($frequencies_by_label[$row->accrualPeriodicity])) {
+          $row->accrualPeriodicity = $frequencies_by_label[$row->accrualPeriodicity];
+        }
+        else {
+          $row->accrualPeriodicity = NULL;
+        }
+      }
+    }
   }
 
   /**

--- a/modules/dkan/dkan_harvest/includes/HarvestMigration.php
+++ b/modules/dkan/dkan_harvest/includes/HarvestMigration.php
@@ -372,22 +372,6 @@ class HarvestMigration extends MigrateDKAN {
         }
       }
     }
-
-    // Check the accrualPeriodicity field.
-    // If it's in the frequency map as a value, set it to the associated key.
-    // If it's not there, either as a key or value, set it to null.
-    if (isset($row->accrualPeriodicity) && $row->accrualPeriodicity != '') {
-      $frequencies = dkan_dataset_content_types_iso_frecuency_map();
-      if (!isset($frequencies[$row->accrualPeriodicity])) {
-        $frequencies_by_label = array_flip($frequencies);
-        if (isset($frequencies_by_label[$row->accrualPeriodicity])) {
-          $row->accrualPeriodicity = $frequencies_by_label[$row->accrualPeriodicity];
-        }
-        else {
-          $row->accrualPeriodicity = NULL;
-        }
-      }
-    }
   }
 
   /**

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -255,7 +255,7 @@ class DatajsonHarvestMigration extends HarvestMigration {
         }
         else {
           $message = t(
-            '"@frequency", is not a valid Frequency value',
+            '"@frequency", is not a valid ISO 8601 Repeating Duration value, if the frequency is irregular, simply use "irregular".',
             ['@frequency' => $row->accrualPeriodicity]
           );
           $this->saveMessage($message);

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.migrate.inc
@@ -242,6 +242,27 @@ class DatajsonHarvestMigration extends HarvestMigration {
         $row->dataQuality = 'true';
       }
     }
+
+    // Check the accrualPeriodicity field.
+    // If it's in the frequency map as a value, set it to the associated key.
+    // If it's not there, either as a key or value, set it to null.
+    if (isset($row->accrualPeriodicity) && $row->accrualPeriodicity != '') {
+      $frequencies = dkan_dataset_content_types_iso_frecuency_map();
+      if (!isset($frequencies[$row->accrualPeriodicity])) {
+        $frequencies_by_label = array_flip($frequencies);
+        if (isset($frequencies_by_label[$row->accrualPeriodicity])) {
+          $row->accrualPeriodicity = $frequencies_by_label[$row->accrualPeriodicity];
+        }
+        else {
+          $message = t(
+            '"@frequency", is not a valid Frequency value',
+            ['@frequency' => $row->accrualPeriodicity]
+          );
+          $this->saveMessage($message);
+          $row->accrualPeriodicity = NULL;
+        }
+      }
+    }
   }
 
   /**

--- a/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_accrualPeriodicity.json
+++ b/test/phpunit/dkan_harvest/data/dkan_harvest_datajson_test_accrualPeriodicity.json
@@ -1,0 +1,84 @@
+{
+    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "@id": "http://www.agency.gov/data.json",
+    "@type": "dcat:Catalog",
+    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+    "dataset": [
+      {
+        "@type": "dcat:Dataset",
+        "accessLevel": "public",
+        "contactPoint": {
+          "@type": "vcard:Contact",
+          "fn": "Contact Example",
+          "hasEmail": "mailto:test@test.com"
+        },
+        "dataQuality": true,
+        "description": "Testing accrualPeriodicity value.",
+        "identifier": "1156",
+        "keyword": [
+          "Test"
+        ],
+        "modified": "2016-04-07",
+        "publisher": {
+          "name": "Publisher Name"
+        },
+        "temporal": "2005/2016",
+        "accrualPeriodicity": "R/P1D",
+        "theme": [
+          "dkan"
+        ],
+        "title": "AP test - valid"
+      },
+      {
+        "@type": "dcat:Dataset",
+        "accessLevel": "public",
+        "accrualPeriodicity": "Daily",
+        "contactPoint": {
+          "@type": "vcard:Contact",
+          "fn": "Contact Example",
+          "hasEmail": "mailto:test@test.com"
+        },
+        "dataQuality": true,
+        "description": "Testing accrualPeriodicity value.",
+        "identifier": "1155",
+        "keyword": [
+          "Test"
+        ],
+        "modified": "2016-04-07",
+        "publisher": {
+          "name": "Publisher Name"
+        },
+        "temporal": "2013/2014",
+        "theme": [
+          "dkan"
+        ],
+        "title": "AP test - should also pass"
+      },
+      {
+        "@type": "dcat:Dataset",
+        "accessLevel": "public",
+        "accrualPeriodicity": "whenever",
+        "contactPoint": {
+          "@type": "vcard:Contact",
+          "fn": "Contact Example",
+          "hasEmail": "mailto:test@test.com"
+        },
+        "dataQuality": true,
+        "description": "This one will fail",
+        "identifier": "1154",
+        "keyword": [
+          "Test"
+        ],
+        "modified": "2016-01-06",
+        "publisher": {
+          "name": "Untidy Publisher"
+        },
+        "temporal": "1988-01-01/P1W",
+        "theme": [
+          "dkan"
+        ],
+        "title": "AP test - not going to make it in"
+      }
+    ]
+  }


### PR DESCRIPTION
Checks the validity of the accrualPeriodicity field in `prepareRow()`.

## User story

If a json harvest has an `accrualPeriodicity` value, that value gets saved to the `frequency` field, even if the value isn't valid for the field.

The pr adds a check to prepare row. If the value is a valid key value for field_frequency, there is no change. If it is a valid display value, it is set to the key value. If it is neither, it is set to null.

## How to reproduce

1.  Run a harvest against a harvest cache with an invalid value for `accrualPeriodicity`.
2. Browse to the dataset page. The invalid value will be displayed as the frequency.
3. Edit the page. The select value for the frequency field will be set to '- None -'.

## QA Steps

1. Create/modify three harvest cache files with `accrualPeriodicity`  fields. 
a. Give one a valid Frequency key (e.g. `R/P1D`). 
b. Give another a valid Frequency value (e.g. `Daily`). 
c. Give the third an invalid value
2. Run the harvest.
3. Check the harvested datasets. Frequency should appear with its correct value for the first two on both the dataset page and its edit form. Frequency should not appear on the dataset page for the third.
