### PR TITLE
Patch og_moderation module to allow users to revert nodes.

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -242,6 +242,8 @@ projects:
     version: '1.2'
   og_moderation:
     version: '2.3'
+    patch:
+      2447769: https://www.drupal.org/files/issues/revision_access-2447769.patch
   open_data_schema_map:
     download:
       type: git


### PR DESCRIPTION
Adds a patch to `og_moderation` to fix reversion permissions issue.

## How to reproduce

1.  Log in as anyone except User 1 with at least an 'editor' role.
2. Go to the Revisions page of any dataset with more than one revision that you have permission to edit.
3. Click 'revert' on one of the earlier revisions.
4. Confirm that you get an 'Access Denied' message.

## QA Steps

1. Repeat steps 1 - 3 above.
2. Confirm that you see a confirmation page ("Are you sure you want to revert to the revision...")
3. Click the 'Revert' button.
4. Confirm that the dataset was reverted.
