### PR TITLE
Datastore char encoding

### DIFF
--- a/modules/dkan/dkan_datastore/dkan_datastore.install
+++ b/modules/dkan/dkan_datastore/dkan_datastore.install
@@ -5,6 +5,9 @@
  * Install file for DKAN Datastore.
  */
 
+use Dkan\Datastore\LockableDrupalVariables;
+use Dkan\Datastore\Manager\CharsetEncoding;
+
 /**
  * Implements hook_install().
  */
@@ -25,4 +28,22 @@ function dkan_datastore_install() {
  */
 function dkan_datastore_update_7001() {
   module_enable(array('field_hidden'));
+}
+
+/**
+ * Add default encoding to existing datastores.
+ */
+function dkan_datastore_update_7002() {
+  $state_storage = new LockableDrupalVariables("dkan_datastore");
+  $bin = $state_storage->borrowBin();
+
+  foreach ($bin as $nid => &$state) {
+    if (!empty($state['configurable_properties'])) {
+      if (empty($state['configurable_properties']['encoding'])) {
+        $state['configurable_properties']['encoding'] = CharsetEncoding::DEST_ENCODING;
+      }
+    }
+  }
+
+  $state_storage->returnBin($bin);
 }

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.module
@@ -24,7 +24,8 @@ function dkan_datastore_fast_import_dkan_datastore_manager() {
   $info = new Info(
     '\Dkan\Datastore\Manager\FastImport\FastImport',
     "fast",
-    "Fast Import"
+    "Fast Import",
+    "MYSQL"
   );
 
   return $info;

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/src/FastImport.php
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/src/FastImport.php
@@ -2,6 +2,7 @@
 
 namespace Dkan\Datastore\Manager\FastImport;
 
+use Dkan\Datastore\Manager\CharsetEncoding;
 use Dkan\Datastore\Manager\Manager;
 use Dkan\Datastore\Resource;
 
@@ -37,15 +38,20 @@ class FastImport extends Manager {
 
     $fields_escaped_by = $properties["escape"];
 
+    $encoding = $properties['encoding']['mysql'];
+
     $load_data_statement = 'LOAD DATA';
 
     $sql = "$load_data_statement INFILE :file_path IGNORE
       INTO TABLE {$this->getTableName()}
+      CHARACTER SET :encoding
       FIELDS TERMINATED BY :delim
       ENCLOSED BY :quote_delimiters";
     $params[':file_path'] = $file_path;
     $params[':delim'] = $delim;
     $params[':quote_delimiters'] = $quote_delimiters;
+    // MySQL manual: 'A character set of binary specifies “no conversion.”'
+    $params[':encoding'] = $encoding === CharsetEncoding::DEST_ENCODING['MYSQL'] ? 'binary' : $encoding;
 
     if ($fields_escaped_by) {
       $sql = $sql . "  ESCAPED BY :fields_escaped_by";

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/src/FastImport.php
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/src/FastImport.php
@@ -38,7 +38,11 @@ class FastImport extends Manager {
 
     $fields_escaped_by = $properties["escape"];
 
-    $encoding = $properties['encoding']['mysql'];
+    $encoding = $properties['encoding']['MYSQL'];
+    // MySQL manual: 'A character set of binary specifies “no conversion.”'
+    if ($encoding === CharsetEncoding::DEST_ENCODING['MYSQL']) {
+      $encoding = 'binary';
+    }
 
     $load_data_statement = 'LOAD DATA';
 
@@ -50,8 +54,7 @@ class FastImport extends Manager {
     $params[':file_path'] = $file_path;
     $params[':delim'] = $delim;
     $params[':quote_delimiters'] = $quote_delimiters;
-    // MySQL manual: 'A character set of binary specifies “no conversion.”'
-    $params[':encoding'] = $encoding === CharsetEncoding::DEST_ENCODING['MYSQL'] ? 'binary' : $encoding;
+    $params[':encoding'] =  $encoding;
 
     if ($fields_escaped_by) {
       $sql = $sql . "  ESCAPED BY :fields_escaped_by";

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_simple_import/dkan_datastore_simple_import.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_simple_import/dkan_datastore_simple_import.module
@@ -24,7 +24,8 @@ function dkan_datastore_simple_import_dkan_datastore_manager() {
   $info = new Info(
     '\Dkan\Datastore\Manager\SimpleImport\SimpleImport',
     "simple",
-    "Simple Import"
+    "Simple Import",
+    "PHP"
   );
 
   return $info;

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_simple_import/src/SimpleImport.php
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_simple_import/src/SimpleImport.php
@@ -47,6 +47,7 @@ class SimpleImport extends Manager {
         break;
       }
       if (time() < $end) {
+        $chunk = $this->fixEncoding($chunk);
         $parser->feed($chunk);
         $counter = $this->getAndStore($parser, $query, $header, $counter, $start);
 

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_simple_import/src/SimpleImport.php
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_simple_import/src/SimpleImport.php
@@ -2,6 +2,7 @@
 
 namespace Dkan\Datastore\Manager\SimpleImport;
 
+use Dkan\Datastore\Manager\CharsetEncoding;
 use Dkan\Datastore\Manager\Manager;
 use Dkan\Datastore\Manager\ManagerInterface;
 use Dkan\Datastore\Parser\Csv;
@@ -39,6 +40,8 @@ class SimpleImport extends Manager {
 
     $h = fopen($this->getResource()->getFilePath(), 'r');
 
+    $encoder = new CharsetEncoding($this);
+
     $finished = TRUE;
     $interrupt = $this->getInterrupt();
     while ($chunk = fread($h, 32)) {
@@ -47,7 +50,12 @@ class SimpleImport extends Manager {
         break;
       }
       if (time() < $end) {
-        $chunk = $this->fixEncoding($chunk);
+        try {
+          $chunk = $encoder->fixEncoding($chunk);
+        }
+        catch (\Exception $exception) {
+          drupal_set_message($exception->getMessage(), 'warning');
+        }
         $parser->feed($chunk);
         $counter = $this->getAndStore($parser, $query, $header, $counter, $start);
 

--- a/modules/dkan/dkan_datastore/src/Manager/CharsetEncoding.php
+++ b/modules/dkan/dkan_datastore/src/Manager/CharsetEncoding.php
@@ -1,0 +1,160 @@
+<?php
+
+
+namespace Dkan\Datastore\Manager;
+
+use \Exception;
+
+/**
+ * Class CharsetEncoding
+ *
+ * Handles the encoding of data that is not in UTF-8.
+ *
+ * @package Dkan\Datastore\Manager
+ */
+class CharsetEncoding {
+
+  /**
+   * Strings representing the destination character set.
+   */
+  const DEST_ENCODING = [
+    'PHP' => 'UTF-8',
+    'MYSQL' => 'utf8'
+  ];
+
+  /** @var \Dkan\Datastore\Manager\ManagerInterface */
+  private $manager;
+
+  public function __construct($manager) {
+    $this->manager = $manager;
+  }
+
+  /**
+   * Gets a list of character sets in the selected naming convention
+   * @param string $type
+   *  The naming convention ('PHP' or 'MYSQL'
+   *
+   * @return array|false|string[]
+   *   Character set names.
+   */
+  public static function getEncodings($type) {
+    $list = [];
+    switch ($type) {
+      case 'PHP':
+        $list = mb_list_encodings();
+        // Make the key/values the same in the array.
+        $list = array_combine($list, $list);
+        break;
+      case 'MYSQL':
+        $list = db_query('SELECT CHARACTER_SET_NAME, DESCRIPTION FROM INFORMATION_SCHEMA.CHARACTER_SETS')->fetchAllKeyed();
+        break;
+    }
+
+    natsort($list);
+    return $list;
+  }
+
+  /**
+   * Select list(s) of encodings, appropriate to available importers.
+   *
+   * @param array $default_value
+   *   The default encoding to use.
+   *
+   * @return array
+   *  Form elements for select lists.
+   */
+  public static function getForm(array $default_value) {
+    $managers_info = dkan_datastore_managers_info();
+    $form = [];
+
+    /* @var $manager_info \Dkan\Datastore\Manager\Info */
+    foreach ($managers_info as $manager_info) {
+      $select_name = "datastore_manager_config_encoding_" . strtolower($manager_info->getImportType());
+
+      $form[$select_name] = [
+        '#type' => 'select',
+        // @codingStandardsIgnoreStart
+        '#title' => t('Character encoding of file'),
+        // @codingStandardsIgnoreEnd
+        '#options' => self::getEncodings($manager_info->getImportType()),
+        '#default_value' => $default_value[$manager_info->getImportType()],
+      ];
+
+      if (count($managers_info) > 1) {
+        $form[$select_name]['#states'] = [
+          'visible' => [
+            ':input[name="datastore_managers_selection"]' => [
+              'value' => $manager_info->getClass()
+            ]
+          ]
+        ];
+      }
+    }
+    return $form;
+  }
+
+  /**
+   * Ensures that a string has the correct encoding
+   *
+   * @param string $data
+   *  A sting in the source charset.
+   *
+   * @return string
+   *  The data string in the destination charset.
+   *
+   * @throws \Exception
+   */
+  public function fixEncoding($data) {
+    $properties = $this->manager->getConfigurableProperties();
+
+    if (mb_check_encoding($data, $properties['encoding']['PHP'])) {
+      if ($properties['encoding']['PHP'] !== self::DEST_ENCODING['PHP']) {
+        // Convert encoding. The conversion is to UTF-8 by default to prevent
+        // SQL errors.
+        $data = mb_convert_encoding($data, self::DEST_ENCODING['PHP'], $properties['encoding']['PHP']);
+      }
+    }
+    else {
+      throw new Exception(t('Source file is not in ":encoding" encoding.', array(':encoding' => $properties['encoding']['PHP'])));
+    }
+
+    return $data;
+  }
+
+  /**
+   * Is this form element part of the 'encoding' property?
+   *
+   * @param $property_name
+   *   The property name to test?
+   *
+   * @return bool
+   *   True if it is an encoding property
+   */
+  static public function isEncodingProperty($property_name) {
+    $prefix = 'encoding_';
+    return strcmp(substr($property_name, 0, strlen($prefix)), $prefix) === 0;
+  }
+
+  /**
+   * Adds or updates an encoding property value.
+   *
+   * @param $configurable_properties
+   *   The properties to update.
+   *
+   * @param $property_name
+   *   The name of the form element.
+   *
+   * @param $value
+   *   The value of the form element.
+   */
+  static public function setEncodingProperty(&$configurable_properties, $property_name, $value) {
+    if (preg_match('/encoding_(.*)/', $property_name, $matches)) {
+      $type = strtoupper($matches[1]);
+      $configurable_properties['encoding'][$type] = $value;
+    }
+    else {
+      $msg = t(':name is not a valid encoding property name', [':name' => $property_name]);
+      drupal_set_message($msg, 'error');
+    }
+  }
+}

--- a/modules/dkan/dkan_datastore/src/Manager/CharsetEncoding.php
+++ b/modules/dkan/dkan_datastore/src/Manager/CharsetEncoding.php
@@ -57,6 +57,10 @@ class CharsetEncoding {
   /**
    * Select list(s) of encodings, appropriate to available importers.
    *
+   * @todo Make Chosen update on #states change.
+   * Everything works fine if only one import manager is enabled, but if
+   * more than one is enabled, Chosen never loads values for the hidden encoding select.
+   *
    * @param array $default_value
    *   The default encoding to use.
    *

--- a/modules/dkan/dkan_datastore/src/Manager/Info.php
+++ b/modules/dkan/dkan_datastore/src/Manager/Info.php
@@ -11,14 +11,16 @@ class Info implements \JsonSerializable {
   private $class;
   private $machineName;
   private $label;
+  private $importType;
 
   /**
    * Info constructor.
    */
-  public function __construct($class, $machine_name, $label) {
+  public function __construct($class, $machine_name, $label, $import_type) {
     $this->class = $class;
     $this->label = $label;
     $this->machineName = $machine_name;
+    $this->importType = $import_type;
   }
 
   /**
@@ -43,6 +45,13 @@ class Info implements \JsonSerializable {
   }
 
   /**
+   * Getter.
+   */
+  public function getImportType() {
+    return $this->importType;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function jsonSerialize() {
@@ -50,6 +59,7 @@ class Info implements \JsonSerializable {
       'class' => $this->class,
       'machine_name' => $this->machineName,
       'label' => $this->label,
+      'import_type' => $this->importType,
     ];
   }
 

--- a/modules/dkan/dkan_datastore/src/Manager/Manager.php
+++ b/modules/dkan/dkan_datastore/src/Manager/Manager.php
@@ -40,7 +40,7 @@ abstract class Manager implements ManagerInterface {
 
     if (!$this->loadState()) {
       $this->setConfigurablePropertiesHelper([
-        'encoding' => self::TO_ENCODING,
+        'encoding' => CharsetEncoding::DEST_ENCODING,
         'delimiter' => ',',
         'quote' => '"',
         'escape' => '\\',
@@ -89,8 +89,7 @@ abstract class Manager implements ManagerInterface {
         $this->configurableProperties['delimiter'],
         $this->configurableProperties['quote'],
         $this->configurableProperties['escape'],
-        ["\r", "\n"],
-        $this->configurableProperties['encoding']
+        ["\r", "\n"]
       );
 
       if (isset($this->configurableProperties['trailing_delimiter']) && $this->configurableProperties['trailing_delimiter'] == TRUE) {
@@ -374,19 +373,4 @@ abstract class Manager implements ManagerInterface {
     $this->saveState();
   }
 
-  protected function fixEncoding($data) {
-    $properties = $this->getConfigurableProperties();
-
-    if (mb_check_encoding($data, $properties['encoding'])) {
-      if ($properties['encoding'] !== self::TO_ENCODING) {
-        // Convert encoding. The conversion is to UTF-8 by default to prevent
-        // SQL errors.
-        $data = mb_convert_encoding($data, self::TO_ENCODING, $properties['encoding']);
-      }
-    }
-    else {
-      drupal_set_message(t('Source file is not in %encoding encoding.', array('%encoding' => $properties['encoding'])));
-    }
-    return $data;
-  }
 }

--- a/modules/dkan/dkan_datastore/src/Manager/ManagerInterface.php
+++ b/modules/dkan/dkan_datastore/src/Manager/ManagerInterface.php
@@ -17,6 +17,8 @@ interface ManagerInterface {
   const DATA_IMPORT_DONE = 6;
   const DATA_IMPORT_ERROR = 7;
 
+  const TO_ENCODING = 'UTF-8';
+
   /**
    * Drops a datastore.
    */

--- a/modules/dkan/dkan_datastore/src/Manager/ManagerInterface.php
+++ b/modules/dkan/dkan_datastore/src/Manager/ManagerInterface.php
@@ -17,8 +17,6 @@ interface ManagerInterface {
   const DATA_IMPORT_DONE = 6;
   const DATA_IMPORT_ERROR = 7;
 
-  const TO_ENCODING = 'UTF-8';
-
   /**
    * Drops a datastore.
    */

--- a/modules/dkan/dkan_datastore/src/Page/Component/ManagerConfiguration.php
+++ b/modules/dkan/dkan_datastore/src/Page/Component/ManagerConfiguration.php
@@ -30,10 +30,34 @@ class ManagerConfiguration {
       '#title' => t('Import options'),
       '#collapsible' => FALSE,
     ];
+
+    // Get the system's list of available encodings.
+    $options = mb_list_encodings();
+    // Make the key/values the same in the array.
+    $options = array_combine($options, $options);
+    // Sort alphabetically not-case sensitive.
+    natcasesort($options);
+
     foreach ($this->datastoreManager->getConfigurableProperties() as $property => $default_value) {
       $propety_label = ucfirst(str_replace("_", " ", $property));
-
-      if ($property == "delimiter") {
+      if ($property == "encoding") {
+        $form['import_options']["datastore_manager_config_{$property}"] = array(
+          '#type' => 'select',
+          // @codingStandardsIgnoreStart
+          '#title' => t('Character encoding of file'),
+          // @codingStandardsIgnoreEnd
+          '#options' => $options,
+          '#states' => [
+            'visible' => [
+              ':input[name="datastore_managers_selection"]' => [
+                '!value' => '\Dkan\Datastore\Manager\FastImport\FastImport'
+              ]
+            ]
+          ],
+          '#default_value' => $default_value,
+        );
+      }
+      elseif ($property == "delimiter") {
         $form['import_options']["datastore_manager_config_{$property}"] = array(
           '#type' => 'select',
           // @codingStandardsIgnoreStart

--- a/modules/dkan/dkan_datastore/src/Page/Component/ManagerConfiguration.php
+++ b/modules/dkan/dkan_datastore/src/Page/Component/ManagerConfiguration.php
@@ -2,6 +2,7 @@
 
 namespace Dkan\Datastore\Page\Component;
 
+use Dkan\Datastore\Manager\CharsetEncoding;
 use Dkan\Datastore\Manager\ManagerInterface;
 
 /**
@@ -31,31 +32,11 @@ class ManagerConfiguration {
       '#collapsible' => FALSE,
     ];
 
-    // Get the system's list of available encodings.
-    $options = mb_list_encodings();
-    // Make the key/values the same in the array.
-    $options = array_combine($options, $options);
-    // Sort alphabetically not-case sensitive.
-    natcasesort($options);
-
     foreach ($this->datastoreManager->getConfigurableProperties() as $property => $default_value) {
       $propety_label = ucfirst(str_replace("_", " ", $property));
+
       if ($property == "encoding") {
-        $form['import_options']["datastore_manager_config_{$property}"] = array(
-          '#type' => 'select',
-          // @codingStandardsIgnoreStart
-          '#title' => t('Character encoding of file'),
-          // @codingStandardsIgnoreEnd
-          '#options' => $options,
-          '#states' => [
-            'visible' => [
-              ':input[name="datastore_managers_selection"]' => [
-                '!value' => '\Dkan\Datastore\Manager\FastImport\FastImport'
-              ]
-            ]
-          ],
-          '#default_value' => $default_value,
-        );
+        $form['import_options'] += CharsetEncoding::getForm($default_value);
       }
       elseif ($property == "delimiter") {
         $form['import_options']["datastore_manager_config_{$property}"] = array(
@@ -105,6 +86,9 @@ class ManagerConfiguration {
         $pname = str_replace("datastore_manager_config_", "", $property_name);
         if ($pname == "trailing_delimiter") {
           $configurable_properties[$pname] = ($v == 1) ? TRUE : FALSE;
+        }
+        elseif (CharsetEncoding::isEncodingProperty($pname)) {
+          CharsetEncoding::setEncodingProperty($configurable_properties, $pname, $v);
         }
         else {
           $configurable_properties[$pname] = $v;

--- a/modules/dkan/dkan_datastore/src/Page/Page.php
+++ b/modules/dkan/dkan_datastore/src/Page/Page.php
@@ -50,7 +50,7 @@ class Page {
       }
 
       $html = t('<p><h3>Datastore:</h3> Import data from a <strong>CSV</strong> or <strong>TSV</strong> file into a database table to make it accessible through an API.</p>
-               <p class="data-explorer-help"><i class="fa fa-info-circle" aria-hidden="true"></i> <strong>Important</strong> Confirm that your column names adhere to the <a href="https://dev.mysql.com/doc/refman/8.0/en/identifiers.html" target="_blank">MySQL idendifier specifications</a> and that your file is UTF8 encoded if your data includes special characters.</p>');
+               <p class="data-explorer-help"><i class="fa fa-info-circle" aria-hidden="true"></i> <strong>Important</strong> Confirm that your column names adhere to the <a href="https://dev.mysql.com/doc/refman/8.0/en/identifiers.html" target="_blank">MySQL identifier specifications</a></p>');
       $this->form['help'] = [
         '#type' => 'item',
         '#markup' => $html,

--- a/test/phpunit/dkan_datastore/DkanDatastoreEncodingTest.php
+++ b/test/phpunit/dkan_datastore/DkanDatastoreEncodingTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Dkan\Datastore\Manager\SimpleImport\SimpleImport;
+use Dkan\Datastore\Resource;
+
+/**
+ * Class DkanDatastoreEncodingTest.
+ */
+class DkanDatastoreEncodingTest extends \PHPUnit_Framework_TestCase {
+
+  private $resource_node;
+
+  protected function setUp() {
+    $node = (object) [];
+    $node->title = "Datastore Resource Test Object 23525";
+    $node->type = "resource";
+    $node->field_link_remote_file['und'][0]['uri'] = "https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv";
+    $node->status = 1;
+    node_save($node);
+    $this->resource_node = node_load($node->nid);
+  }
+
+  public function test() {
+
+    $resource = new Resource($this->resource_node->nid, __DIR__ . "/data/win1252_encoding.csv");
+
+    /* @var $datastore \Dkan\Datastore\Manager\SimpleImport\SimpleImport */
+    $datastore = (new \Dkan\Datastore\Manager\Factory($resource))->get();
+
+    $status = $datastore->getStatus();
+    $this->assertEquals(SimpleImport::STORAGE_UNINITIALIZED, $status['storage']);
+    $this->assertEquals(SimpleImport::DATA_IMPORT_UNINITIALIZED, $status['data_import']);
+
+    $properties = $datastore->getConfigurableProperties();
+    $this->assertEquals($properties['encoding']['PHP'], 'UTF-8');
+    $properties['encoding']['PHP'] = 'Windows-1252';
+    $datastore->setConfigurableProperties($properties);
+
+    $datastore->import();
+
+    $status = $datastore->getStatus();
+    $this->assertEquals(SimpleImport::STORAGE_INITIALIZED, $status['storage']);
+    $this->assertEquals(SimpleImport::DATA_IMPORT_DONE, $status['data_import']);
+
+
+    $query = db_select($datastore->getTableName(), "d");
+    $query->fields("d");
+    $results = $query->execute();
+    $results = $results->fetchAllAssoc("second_column");
+    $json = json_encode($results);
+    $this->assertEquals(
+      "{\"1\":{\"title\":\"\u00a9\u00a5 special characters\",\"second_column\":\"1\",\"entry_id\":\"1\"},\"2\":{\"title\":\"\u00bc \u00bd \u00be special fraction\",\"second_column\":\"2\",\"entry_id\":\"2\"}}",
+      $json);
+
+    $this->assertEquals(2, $datastore->numberOfRecordsImported());
+
+    $status = $datastore->getStatus();
+    $this->assertEquals(SimpleImport::STORAGE_INITIALIZED, $status['storage']);
+    $this->assertEquals(SimpleImport::DATA_IMPORT_DONE, $status['data_import']);
+
+    $datastore->drop();
+    $this->assertFalse(db_table_exists($datastore->getTableName()));
+
+    $status = $datastore->getStatus();
+    $this->assertEquals(SimpleImport::STORAGE_UNINITIALIZED, $status['storage']);
+    $this->assertEquals(SimpleImport::DATA_IMPORT_UNINITIALIZED, $status['data_import']);
+  }
+
+  protected function tearDown() {
+    node_delete($this->resource_node->nid);
+  }
+
+}

--- a/test/phpunit/dkan_datastore/data/win1252_encoding.csv
+++ b/test/phpunit/dkan_datastore/data/win1252_encoding.csv
@@ -1,0 +1,3 @@
+"title","second_column"
+"©¥ special characters",1
+"¼ ½ ¾ special fraction",2

--- a/test/phpunit/phpunit.xml
+++ b/test/phpunit/phpunit.xml
@@ -30,6 +30,7 @@
         </testsuite>
         <testsuite name="DKAN Datastore Test Suite">
           <file>dkan_datastore/DkanDatastoreCSVParserTest.php</file>
+          <file>dkan_datastore/DkanDatastoreEncodingTest.php</file>
           <file>dkan_datastore/DkanDatastoreTest.php</file>
         </testsuite>
         <testsuite name="DKAN Datastore API Test Suite">


### PR DESCRIPTION
fixes #2901

Description. Adds ability to add non UTF-8 files to datastore.

## User story

Currently datastore breaks if the file isn't in UTF-8 . 
This adds a select list of allowed PHP encodings to the datastore form. A user can choose the appropriate encoding for the file.

## QA Steps

1. Create a new resource, uploading /dkan/test/phpunit/dkan_datastore/data/win1252_encoding.csv.
2. Note that the data preview displays bad characters in the 'title' field
2. Go to 'Manage Datastore' and select 'Windows-1252' as the Character encoding.
3. Click 'Import'.
4. Confirm that the file imports successfully and the special characters now display properly in data preview 
