### PR TITLE
Don't cache harvest records for datasets from another HarvestSource.

### DIFF
--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
@@ -348,7 +348,20 @@ function dkan_harvest_datajson_cache_pod_v1_1_json(array $data, HarvestSource $s
   }, $datasets
   );
 
+  $query = "SELECT COUNT(*) FROM {node} n 
+              JOIN {field_data_field_harvest_source_ref} hsr ON n.nid = hsr.entity_id 
+              JOIN {field_data_field_dkan_harvest_machine_name} mn ON hsr.field_harvest_source_ref_target_id = mn.entity_id
+              WHERE n.uuid = :identifier AND mn.field_dkan_harvest_machine_name_machine <> :machine_name";
+
   foreach ($datasets as $dataset) {
+    $identifier_exists = db_query($query, [
+      ':identifier' => $dataset['identifier'],
+      ':machine_name' => $source->machineName,
+    ])->fetchField();
+
+    if ($identifier_exists) {
+      continue;
+    }
     $identifier = dkan_harvest_datajson_prepare_item_id($dataset['identifier']);
     $dataset_file = implode('/', array($source->getCacheDir(), $identifier));
     $data = drupal_json_encode($dataset);

--- a/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
+++ b/modules/dkan/dkan_harvest/modules/dkan_harvest_datajson/dkan_harvest_datajson.module
@@ -360,6 +360,8 @@ function dkan_harvest_datajson_cache_pod_v1_1_json(array $data, HarvestSource $s
     ])->fetchField();
 
     if ($identifier_exists) {
+      drupal_set_message(t('@title with id "@value" already exists from another harvest source so will be skipped.',
+      array('@value' => $dataset['identifier'], '@title' => $dataset['title'])), 'warning', FALSE);
       continue;
     }
     $identifier = dkan_harvest_datajson_prepare_item_id($dataset['identifier']);


### PR DESCRIPTION
## Description
Doesn't create a harvest cache file if the identifier is already being used by a dataset harvested from another harvest source.

### Notes
- This only checks records harvested from the same source url. `https://example-1.com/27cd-f532` and `https://example-2.com/27cd-f532` are considered different identifiers.
- This won't affect duplicate datasets that have already been harvested.
- It won't affect existing harvest caches either unless they are rerun.
- Because harvest files are excluded only if a dataset with the same identifier already exists, it will still be possible to duplicate datasets by harvesting from drush. If a harvest source is cached before another cached harvest source is migrated, they may contain duplicated content. 


## QA Steps
1. Create a harvest source that excludes at least one record.
2. Run the harvest.
3. Create a second harvest source with the same source url as the first.
4. Go to the preview page of the second harvest sources and confirm that the only records listed are the ones excluded from the first harvest source.