### PR TITLE
Use jquery 1.12 by default

### DIFF
--- a/dkan.install
+++ b/dkan.install
@@ -886,3 +886,10 @@ function dkan_update_7040() {
     module_enable(array('dkan_dataset_search'));
   }
 }
+
+/**
+ * User newer jquery
+ */
+function dkan_update_7041() {
+  variable_set('jquery_update_jquery_version', '1.12');
+}

--- a/dkan.install
+++ b/dkan.install
@@ -892,4 +892,5 @@ function dkan_update_7040() {
  */
 function dkan_update_7041() {
   variable_set('jquery_update_jquery_version', '1.12');
+  variable_set('jquery_update_jquery_migrate_enable', '1');
 }

--- a/dkan.profile
+++ b/dkan.profile
@@ -318,7 +318,7 @@ function dkan_misc_variables_set(array &$context) {
   variable_set('page_manager_node_view_disabled', FALSE);
   variable_set('page_manager_node_edit_disabled', FALSE);
   variable_set('page_manager_user_view_disabled', FALSE);
-  variable_set('jquery_update_jquery_version', '1.10');
+  variable_set('jquery_update_jquery_version', '1.12');
   // Disable selected views enabled by contributed modules.
   $views_disable = array(
     'og_extras_nodes' => TRUE,

--- a/dkan.profile
+++ b/dkan.profile
@@ -318,7 +318,7 @@ function dkan_misc_variables_set(array &$context) {
   variable_set('page_manager_node_view_disabled', FALSE);
   variable_set('page_manager_node_edit_disabled', FALSE);
   variable_set('page_manager_user_view_disabled', FALSE);
-  variable_set('jquery_update_jquery_version', '1.12');
+  variable_set('jquery_update_jquery_version', '3.1');
   // Disable selected views enabled by contributed modules.
   $views_disable = array(
     'og_extras_nodes' => TRUE,

--- a/dkan.profile
+++ b/dkan.profile
@@ -318,7 +318,7 @@ function dkan_misc_variables_set(array &$context) {
   variable_set('page_manager_node_view_disabled', FALSE);
   variable_set('page_manager_node_edit_disabled', FALSE);
   variable_set('page_manager_user_view_disabled', FALSE);
-  variable_set('jquery_update_jquery_version', '3.1');
+  variable_set('jquery_update_jquery_version', '1.12');
   // Disable selected views enabled by contributed modules.
   $views_disable = array(
     'og_extras_nodes' => TRUE,

--- a/dkan.profile
+++ b/dkan.profile
@@ -319,6 +319,7 @@ function dkan_misc_variables_set(array &$context) {
   variable_set('page_manager_node_edit_disabled', FALSE);
   variable_set('page_manager_user_view_disabled', FALSE);
   variable_set('jquery_update_jquery_version', '1.12');
+  variable_set('jquery_update_jquery_migrate_enable', '1');
   // Disable selected views enabled by contributed modules.
   $views_disable = array(
     'og_extras_nodes' => TRUE,

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -173,7 +173,7 @@ projects:
   job_scheduler:
     version: 2.0
   jquery_update:
-    version: '2.7'
+    version: '3.0-alpha5'
   leaflet_draw_widget:
     download:
       type: git


### PR DESCRIPTION
jquery 1.10 contains the security issue reported here. It's fixed in 1.12. See http://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/ 

Let's see how much havoc it would create to switch.