### PR TITLE
Support import_to_datastore field on manifest for periodic updates.

### DIFF
--- a/docs/components/periodic-updates.rst
+++ b/docs/components/periodic-updates.rst
@@ -30,11 +30,12 @@ If you already have a manifest in the system but need to pause the periodic upda
 
 The manifest is a CSV file in which you define all of the resources that need to be updated periodically in the system, this file should contain the following column names:
 
-``resource_id,frequency,file_url``
+``resource_id,frequency,file_url,import_to_datastore``
 
 :resource_id: is the UUID related to the resource node.
 :frequency: it can be set to `daily`, `weekly` or `monthly`. If you leave it empty or put any other string, then the system asumes it has to be imported daily.
 :file_url: the URL of the remote file that needs to be downloaded or linked and saved to the node.
+:import_to_datastore: if you want the resource to be imported to the datastore, you should set this to "Y", every other value will prevent the file from being imported into the datastore.
 
 Once you upload the manifest and click on "Add file", the file will be recognized by the system.
 
@@ -51,4 +52,5 @@ If the updates are enabled and a valid manifest is uploaded, then you'll see a l
   - the Source File URL,
   - the Update frequency,
   - the Status: this represents the messages generated on each update, it will tell you wether the resource has been updated, if the process finished correctly or if/what errors were produced,
-  - the Last update date: this is the date in which the resource was last updated via periodic updates.
+  - the Last update date: this is the date in which the resource was last updated via periodic updates,
+  - the Import to datastore indicator: it shows wether the file should be imported into the datastore based on what is defined in the manifest.

--- a/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
+++ b/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
@@ -62,7 +62,7 @@ function dkan_periodic_updates_form($form, &$form_state) {
     '#title' => 'Manifest for periodic updates',
   ];
   $form['manifest-file']['info'] = [
-    '#markup' => '<p>' . t('The manifest file should contain the following column names: resource_id, frequency and file_url. The allowed frequency values are daily, weekly, or monthly. If left blank, the frequency will default to daily.') . '</p>',
+    '#markup' => '<p>' . t('The manifest file should contain the following column names: resource_id, frequency, file_url and import_to_datastore. The allowed frequency values are daily, weekly, or monthly. If left blank, the frequency will default to daily.') . '</p>',
   ];
   $form['manifest-file']['manifest'] = [
     '#type' => 'managed_file',
@@ -105,7 +105,7 @@ function dkan_periodic_updates_form($form, &$form_state) {
  * Validate function for periodic updates manifest form.
  */
 function dkan_periodic_updates_form_validate($form, &$form_state) {
-  $standard_headers = ['resource_id', 'frequency', 'file_url'];
+  $standard_headers = ['resource_id', 'frequency', 'file_url', 'import_to_datastore'];
 
   $file = file_load($form_state['values']['manifest']);
   if ($file) {
@@ -214,24 +214,30 @@ function dkan_periodic_updates_get_items_to_update($file) {
         switch ($resource_data['frequency']) {
           case 'monthly':
             if ($time_passed->days >= 28) {
-              $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
+              $to_update[$resource_data['resource_id']]['file_url'] = $resource_data['file_url'];
             }
             break;
           case 'weekly':
             if ($time_passed->days >= 7) {
-              $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
+              $to_update[$resource_data['resource_id']]['file_url'] = $resource_data['file_url'];
             }
             break;
           default:
             if ($time_passed->days >= 1) {
-              $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
+              $to_update[$resource_data['resource_id']]['file_url'] = $resource_data['file_url'];
             }
         }
       }
       // If there is no last update date, then add the resource to list of
       // resource to import.
       else {
-        $to_update[$resource_data['resource_id']] = $resource_data['file_url'];
+        $to_update[$resource_data['resource_id']]['file_url'] = $resource_data['file_url'];
+      }
+
+      // If the resource will be updated, add if it should be imported into the
+      // datastore.
+      if (isset($to_update[$resource_data['resource_id']])) {
+          $to_update[$resource_data['resource_id']]['datastore'] = $resource_data['import_to_datastore'];
       }
     }
     fclose($handle);
@@ -248,8 +254,10 @@ function dkan_periodic_updates_get_items_to_update($file) {
 function dkan_periodic_updates_execute_update($resources) {
   module_load_include('inc', 'dkan_datastore', 'resources/dkan_datastore_resource');
   if (!empty($resources)) {
-    foreach ($resources as $uuid => $file_url) {
+    foreach ($resources as $uuid => $resource) {
       $nids = entity_get_id_by_uuid('node', [$uuid]);
+      $file_url = $resource['file_url'];
+      $datastore = $resource['datastore'] === 'Y' ? TRUE : FALSE;
       if (empty($nids)) {
         watchdog('dkan_periodic_updates', 'There is no node with UUID !uuid.', ['!uuid' => $uuid], WATCHDOG_WARNING);
         variable_set('dkan_periodic_updates_message_' . $uuid, 'No node found for the UUID specified.');
@@ -264,6 +272,7 @@ function dkan_periodic_updates_execute_update($resources) {
               $file = dkan_periodic_updates_create_file($file_url, TRUE, $nid);
               if ($file) {
                 $node->field_upload[LANGUAGE_NONE][0]['fid'] = $file->fid;
+                variable_set('dkan_periodic_updates_message_' . $uuid, '');
               }
               else {
                 watchdog('dkan_periodic_updates', 'File for node !uuid could not be retrieved.', ['!uuid' => $uuid], WATCHDOG_WARNING);
@@ -274,13 +283,14 @@ function dkan_periodic_updates_execute_update($resources) {
               if (!empty($node->field_link_remote_file)) {
                 $file = dkan_periodic_updates_create_file($file_url);
                 $node->field_link_remote_file[LANGUAGE_NONE][0]['fid'] = $file->fid;
+                variable_set('dkan_periodic_updates_message_' . $uuid, '');
               }
             }
             if ($file) {
               dkan_periodic_updates_impersonate_user($node);
               variable_set('dkan_periodic_updates_' . $uuid, new DateTime("now"));
               $updated = TRUE;
-              if ($file->filemime === 'text/csv' || $file->filemime === 'text/tab-separated-values') {
+              if ($datastore && ($file->filemime === 'text/csv' || $file->filemime === 'text/tab-separated-values')) {
                 $proceed_with_import = TRUE;
               }
             }
@@ -326,7 +336,7 @@ function dkan_periodic_updates_state() {
     if ($file) {
       $handle = fopen($file->uri, 'r');
       $headers = fgetcsv($handle, 0, ',');
-      $table_headers = [t('Destination Resource ID'), t('Source File URL'), t('Update frequency'), t('Status'), t('Last update')];
+      $table_headers = [t('Destination Resource ID'), t('Source File URL'), t('Update frequency'), t('Status'), t('Last update'), t('Import to datastore')];
 
       while (($data = fgetcsv($handle, 0, ",")) !== FALSE) {
         $resource_data = array_combine($headers, $data);
@@ -358,7 +368,7 @@ function dkan_periodic_updates_state() {
           default:
             $frequency = 'daily';
         }
-        $table_rows[] = [$destination, $resource_data['file_url'], $frequency, $status, $last_updated];
+        $table_rows[] = [$destination, $resource_data['file_url'], $frequency, $status, $last_updated, $resource_data['import_to_datastore']];
       }
       fclose($handle);
       $output['state'] = [

--- a/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
+++ b/modules/dkan/dkan_periodic_updates/dkan_periodic_updates.module
@@ -237,7 +237,8 @@ function dkan_periodic_updates_get_items_to_update($file) {
       // If the resource will be updated, add if it should be imported into the
       // datastore.
       if (isset($to_update[$resource_data['resource_id']])) {
-          $to_update[$resource_data['resource_id']]['datastore'] = $resource_data['import_to_datastore'];
+        $datastore = $resource_data['import_to_datastore'] === 'Y' ? TRUE : FALSE;
+        $to_update[$resource_data['resource_id']]['datastore'] = $datastore;
       }
     }
     fclose($handle);
@@ -257,7 +258,7 @@ function dkan_periodic_updates_execute_update($resources) {
     foreach ($resources as $uuid => $resource) {
       $nids = entity_get_id_by_uuid('node', [$uuid]);
       $file_url = $resource['file_url'];
-      $datastore = $resource['datastore'] === 'Y' ? TRUE : FALSE;
+      $datastore = $resource['datastore'];
       if (empty($nids)) {
         watchdog('dkan_periodic_updates', 'There is no node with UUID !uuid.', ['!uuid' => $uuid], WATCHDOG_WARNING);
         variable_set('dkan_periodic_updates_message_' . $uuid, 'No node found for the UUID specified.');

--- a/test/phpunit/dkan_periodic_updates/DkanPeriodicUpdatesTest.php
+++ b/test/phpunit/dkan_periodic_updates/DkanPeriodicUpdatesTest.php
@@ -112,6 +112,15 @@ class DkanPeriodicUpdatesTest extends \PHPUnit_Framework_TestCase {
     $this->assertEquals(2, count($to_update));
   }
 
+  public function testImportDatastore() {
+    $to_update = dkan_periodic_updates_get_items_to_update($this->manifest);
+    $this->assertEquals(4, count($to_update));
+    $this->assertTrue($to_update['c65c08d9-43c8-45a4-a49d-29e714ce2ebb']['datastore']);
+    $this->assertFalse($to_update['d7ccef48-5c8c-432c-94c8-17cee9c4ed37']['datastore']);
+    $this->assertFalse($to_update['fe4b712b-c570-4e0b-aeeb-67d9789a196e']['datastore']);
+    $this->assertFalse($to_update['non-existing-uuid']['datastore']);
+  }
+
   public function testUpdatesDisabled() {
     // Updates disabled.
     variable_set('dkan_periodic_updates_status', FALSE);

--- a/test/phpunit/dkan_periodic_updates/data/test_manifest.csv
+++ b/test/phpunit/dkan_periodic_updates/data/test_manifest.csv
@@ -1,5 +1,5 @@
-resource_id,frequency,file_url
-c65c08d9-43c8-45a4-a49d-29e714ce2ebb,daily,https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv
-d7ccef48-5c8c-432c-94c8-17cee9c4ed37,weekly,https://s3.amazonaws.com/dkan-default-content-files/files/Polling_Places_Madison_0.csv
-fe4b712b-c570-4e0b-aeeb-67d9789a196e,monthly,https://s3.amazonaws.com/dkan-default-content-files/files/last_transactions.xlsx
-non-existing-uuid,something,https://s3.amazonaws.com/dkan-default-content-files/files/last_transactions.xlsx
+resource_id,frequency,file_url,import_to_datastore
+c65c08d9-43c8-45a4-a49d-29e714ce2ebb,daily,https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv,Y
+d7ccef48-5c8c-432c-94c8-17cee9c4ed37,weekly,https://s3.amazonaws.com/dkan-default-content-files/files/Polling_Places_Madison_0.csv,n
+fe4b712b-c570-4e0b-aeeb-67d9789a196e,monthly,https://s3.amazonaws.com/dkan-default-content-files/files/last_transactions.xlsx,n
+non-existing-uuid,something,https://s3.amazonaws.com/dkan-default-content-files/files/last_transactions.xlsx,something


### PR DESCRIPTION
Sometimes the CSV files have unescaped quotes or are way to big and the user doesn't want them to be in the datastore, by default, the periodic updates module takes the manifest and tries to import everything so when a resource has an issue in the corresponding CSV the datastore gets stuck, so the idea is to allow the users to decide what elements from their manifest should be imported to the datastore after being updated.

## User story
As a sitemanager I can decide what resources from the periodic updates manifest should be imported to the datastore.

## QA Steps
- [x] Go to admin/dkan/periodic-updates, enable periodic updates and upload a manifest containing a new column name "import_to_datastore", its possible values are "Y" and "N". Confirm you can upload the file correctly.
- [x] Go to "Status" tab, you should see the state of the elements in your manifest.
- [x] Run cron (from drush you can run dktl drush cron run).
- [x] Confirm that the resources that had a "Y" in the field "import_to_datastore" are updated and imported to the datastore. All the others shouldn't be imported to the datastore.