### PR TITLE
Use filename instead of name for id in HarvestList

### DIFF
--- a/modules/dkan/dkan_harvest/includes/HarvestList.php
+++ b/modules/dkan/dkan_harvest/includes/HarvestList.php
@@ -26,7 +26,7 @@ class HarvestList extends MigrateList {
     $this->sourceCacheDir = $source_cache_dir;
     $options = array(
       'recurse' => FALSE,
-      'key' => 'name',
+      'key' => 'filename',
     );
     $this->files = file_scan_directory($this->sourceCacheDir, '/(.*)/', $options);
   }

--- a/modules/dkan/dkan_harvest/includes/HarvestMigration.php
+++ b/modules/dkan/dkan_harvest/includes/HarvestMigration.php
@@ -826,7 +826,7 @@ class HarvestMigration extends MigrateDKAN {
         // This will throw an exception if $this->idListImported is empty. We
         // are doing that check before entring this code but if you are
         // refactoring this code make sure to add the relevent checks.
-        ->condition('sourceid1', $this->getIdList(), 'IN');
+        ->condition('sourceid1', $id_list, 'IN');
       $result = $query->execute();
 
       $rowRestoredSourceList = $result->fetchAllAssoc('destid1');
@@ -899,9 +899,9 @@ class HarvestMigration extends MigrateDKAN {
       ->fields('map')
       ->condition("needs_update", HarvestMigrateSQLMap::STATUS_IGNORED_NO_SOURCE, '<>');
     $id_list = $this->getIdList();
-    if (is_array($this->getIdList()) && !empty($id_list)) {
+    if (is_array($id_list) && !empty($id_list)) {
       foreach ($this->map->getSourceKeyMap() as $key_name) {
-        $query = $query->condition("map.$key_name", $this->getIdList(), 'NOT IN');
+        $query = $query->condition("map.$key_name", $id_list, 'NOT IN');
       }
     }
     $result = $query->execute();


### PR DESCRIPTION
We are using the `name` element from file_scan_directory to create source_ids that are stored in the migrate map tables for harvest. `name` attempts to remove the file extension (specifically, it uses the `basename` element from PHP's `pathinfo()`, so asdf1234.json in the cache would be simply stored as source ID "asdf1234." However, files are not cached with a file extension. In most cases this doesn't matter, but if there is a period (.) in ID, what comes after it can be mistaken for a file extension.

So, source ID `knb-lter-jrn.210001001.61` gets cached the the filename "_public://dkan-harvest-cache/[harvest-machine-name]/knb-lter-jrn.210001001.61_", but when gathered by the `getIdList()` function will then be interpreted as simply the id `knb-lter-jrn.210001001`. Harvest will then think this is an orphaned dataset and unpublish it.

Since we don't cache either JSON or XML files with extensions, using `filename` should remove this problem with no ill effects.

## QA Steps

1. Create a harvest from https://api.jsonbin.io/b/5eb59eb9a47fdd6af15fd015 - it should bring in 4 datasets.
2. Delete one of the datasets
3. Re-run the Harvest. The deleted dataset should come back

## Tests

I did not add a new test for this, it felt like an edge case. Reviewer can lmk if they think a unit test is needed.