### PR TITLE
Updates for WCAG2AA compliance

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -122,6 +122,7 @@ projects:
   field_group_table:
     version: '1.6'
     patch:
+      1: patches/field_group_table_accessibilty.patch
       2887897: https://www.drupal.org/files/issues/added_missing_isset_calls-2887897-2.patch
       3016830: https://www.drupal.org/files/issues/2018-11-28/undefined-index-classes-3016830-0.patch
   field_hidden:

--- a/modules/dkan/dkan_dataset/css/dkan_dataset.css
+++ b/modules/dkan/dkan_dataset/css/dkan_dataset.css
@@ -455,7 +455,7 @@ li .heading:hover {
 .label[data-format=HTML],
 .label[data-format=html],
 .label[data-format*=html] {
-  background-color: #55a1ce;
+  background-color: #317daa;
 }
 .label[data-format=jpeg],
 .label[data-format=jpg] {
@@ -464,15 +464,17 @@ li .heading:hover {
 .label[data-format=json],
 .label[data-format*=json],
 .label[data-format=geojson] {
-  background-color: #ef7100;
+  background-color: #d14900;
 }
 .label[data-format=xml],
 .label[data-format*=xml] {
-  background-color: #ef7100;
+  background-color: #d14900;
 }
+.label[data-format=txt],
+.label[data-format*=txt],
 .label[data-format=text],
 .label[data-format*=text] {
-  background-color: #74cbec;
+  background-color: #015924;
 }
 .label[data-format=csv],
 .label[data-format*=csv] {
@@ -480,7 +482,7 @@ li .heading:hover {
 }
 .label[data-format=xls],
 .label[data-format*=xls] {
-  background-color: #2db55d;
+  background-color: #018931;
 }
 .label[data-format=zip],
 .label[data-format*=zip] {
@@ -488,7 +490,7 @@ li .heading:hover {
 }
 .label[data-format=api],
 .label[data-format*=api] {
-  background-color: #ec96be;
+  background-color: #317daa;
 }
 .label[data-format=pdf],
 .label[data-format*=pdf] {
@@ -503,11 +505,7 @@ li .heading:hover {
 }
 .label[data-format=data],
 .label[data-format*=data] {
-  background-color: olive;
-}
-.label[data-format=txt],
-.label[data-format*=txt] {
-  background-color: #70c6e5;
+  background-color: #7a7a00;
 }
 .label[data-format=tsv],
 .label[data-format*=tsv] {

--- a/patches/field_group_table_accessibilty.patch
+++ b/patches/field_group_table_accessibilty.patch
@@ -1,0 +1,23 @@
+diff --git a/field_group_table.module b/field_group_table.module
+index f0ec7d8..ea618ff 100644
+--- a/field_group_table.module
++++ b/field_group_table.module
+@@ -193,8 +193,8 @@ function field_group_table_field_group_pre_render(&$element, $group, &$form) {
+   $header = array();
+   if ($settings['first_column'] || $settings['second_column']) {
+     $header = array(
+-      check_plain($settings['first_column']),
+-      check_plain($settings['second_column']),
++      array('data' => check_plain($settings['first_column']),'scope' => 'col'),
++      array('data' => check_plain($settings['second_column']),'scope' => 'col'),
+     );
+   }
+ 
+@@ -310,6 +310,7 @@ function _field_group_table_row_build($variables) {
+           'data' => $title,
+           'header' => TRUE,
+           'class' => array('field-label'),
++          'scope' => 'row',
+         );
+ 
+         // Do not display the label in the second column.


### PR DESCRIPTION
fixes #3079

- Update data-format colors for contrast
- Add scope attribute to _Additional Info_ table on dataset page

## QA steps
### contrast
- Add dummy resources to a dataset (title and format only) for
  * html
  * geojson
  * xml
  * text
  * xls
  * data
- view the dataset with the search page `search/type/dataset`
- run WCAG2AA test (drag bookmarklet to bookmarks bar https://squizlabs.github.io/HTML_CodeSniffer/)
- confirm you get 0 *errors*

### table cells
- go to a dataset and run the WCAG2AA test
- confirm you do not get errors on the Additional Info table