### PR TITLE
Update drupal to 7.70.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+7.x-1.18.5
+----------
+ - #3102 Update Drupal to 7.70.
+
 7.x-1.18.4
 -----------
  - #3045 Wrap datastore strings in t() function

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,15 @@
+7.x-1.18.4
+-----------
+ - #3045 Wrap datastore strings in t() function
+ - #3047 Reduce repo size
+ - #3089 Clean up references to old docs
+ - #3095 Updates for WCAG2AA compliance
+ - #3082 Use filename instead of name for id in HarvestList.
+ - #3041 Update ODSM to version 2.6.
+ - #3037 Update the documentation link to the dkan sites list.
+ - #3033 Remove London Deprivation dataset and fix issue in panelizer.
+ - #3034 Fixing up the formatting of Licensing statement.
+
 7.x-1.18.3
 -----------
  - #3022 Patch og_moderation module to allow users to revert nodes.

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -3,7 +3,7 @@ core: 7.x
 projects:
   drupal:
     type: core
-    version: '7.69'
+    version: '7.70'
     # Use vocabulary machine name for permissions, see http://drupal.org/node/995156
     patch:
       995156: 'https://drupal.org/files/issues/995156-5_portable_taxonomy_permissions.patch'


### PR DESCRIPTION
Drupal security updates [SA-CORE-2020-002](https://www.drupal.org/sa-core-2020-002) and [SA-CORE-2020-003](https://www.drupal.org/sa-core-2020-003).