### PR TITLE
Expose dataset node changed date

### DIFF
--- a/modules/metastore/metastore.module
+++ b/modules/metastore/metastore.module
@@ -25,7 +25,13 @@ function metastore_node_load(array $entities) {
       // Dereference dataset properties.
       $metadata_obj = json_decode($metadata_string);
       $referencer = Drupal::service("metastore.dereferencer");
-      $metadata_obj = $referencer->dereference($metadata_obj, dereferencing_method());
+      $referencing_method = dereferencing_method();
+      $metadata_obj = $referencer->dereference($metadata_obj, $referencing_method);
+
+      // Expose Dataset node's last modified date.
+      if ($referencing_method == Dereferencer::DEREFERENCE_OUTPUT_REFERENCE_IDS) {
+        $metadata_obj->{'%modified'} = $entity->getChangedTime();
+      }
       $entity->set('field_json_metadata', json_encode($metadata_obj));
     }
 

--- a/modules/metastore/metastore.module
+++ b/modules/metastore/metastore.module
@@ -30,7 +30,9 @@ function metastore_node_load(array $entities) {
 
       // Expose Dataset node's last modified date.
       if ($referencing_method == Dereferencer::DEREFERENCE_OUTPUT_REFERENCE_IDS) {
-        $metadata_obj->{'%modified'} = $entity->getChangedTime();
+        $formatted_changed_date = Drupal::service('date.formatter')
+          ->format($entity->getChangedTime(), 'html_date');
+        $metadata_obj->{'%modified'} = $formatted_changed_date;
       }
       $entity->set('field_json_metadata', json_encode($metadata_obj));
     }


### PR DESCRIPTION
When a user queries the metastore endpoint for a dataset `api/1/metastore/schemas/dataset/items/<UUID>` or all datasets `api/1/metastore/schemas/dataset/items` with the `show-reference-ids` query parameter, the resulting json should include a new `%modified` key showing the day it was last changed, formatted as `YYYY-MM-DD`.