### PR TITLE
Remove contrib module entity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         "drush/drush": "^10.2.2",
         "drupal/admin_toolbar": "^2.2",
         "drupal/config_update": "^1.6",
-        "drupal/entity": "^1.0.0",
         "drupal/search_api": "^1.15",
         "drupal/views_bulk_operations": "^3.6",
         "fmizzell/maquina": "^1.1.0",


### PR DESCRIPTION
Drupal contrib module entity does not appear to be used anywhere. I suspect it might be a remnant from when Dkan was an installation profile.