### PR TITLE
Use node storage over entity type manager

### DIFF
--- a/modules/common/common.services.yml
+++ b/modules/common/common.services.yml
@@ -9,3 +9,7 @@ services:
     arguments:
       - '@module_handler'
       - '@request_stack'
+  dkan.common.node_storage:
+    class: Drupal\node\NodeStorage
+    factory: entity_type.manager:getStorage
+    arguments: ['node']

--- a/modules/frontend/frontend.services.yml
+++ b/modules/frontend/frontend.services.yml
@@ -3,7 +3,7 @@ services:
       class: Drupal\frontend\Page
       arguments:
         - '@app.root'
-        - '@entity_type.manager'
+        - '@dkan.common.node_storage'
       shared: false
   frontend.route_provider:
       class: Drupal\frontend\Routing\RouteProvider

--- a/modules/frontend/src/Page.php
+++ b/modules/frontend/src/Page.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\frontend;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeStorageInterface;
 
 /**
  * Class.
@@ -10,14 +10,14 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 class Page {
 
   private $appRoot;
-  private $entityTypeManager;
+  private $nodeStorage;
 
   /**
    * Constructor.
    */
-  public function __construct(string $appRoot, EntityTypeManagerInterface $entityTypeManager) {
+  public function __construct(string $appRoot, NodeStorageInterface $nodeStorage) {
     $this->appRoot = $appRoot;
-    $this->entityTypeManager = $entityTypeManager;
+    $this->nodeStorage = $nodeStorage;
   }
 
   /**
@@ -47,7 +47,7 @@ class Page {
    */
   public function buildDataset($name) {
     $base_dataset = $this->appRoot . "/data-catalog-frontend/public/dataset/index.html";
-    $node_loaded_by_uuid = $this->entityTypeManager->getStorage('node')->loadByProperties(['uuid' => $name]);
+    $node_loaded_by_uuid = $this->nodeStorage->loadByProperties(['uuid' => $name]);
     $node_loaded_by_uuid = reset($node_loaded_by_uuid);
     $file = $this->appRoot . "/data-catalog-frontend/public/dataset/{$name}/index.html";
 

--- a/modules/frontend/tests/src/Unit/PageTest.php
+++ b/modules/frontend/tests/src/Unit/PageTest.php
@@ -2,7 +2,6 @@
 
 use Drupal\frontend\Page;
 use PHPUnit\Framework\TestCase;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\node\NodeStorageInterface;
 
 /**
@@ -10,21 +9,6 @@ use Drupal\node\NodeStorageInterface;
  */
 class PageTest extends TestCase {
   private $node;
-
-  /**
-   *
-   */
-  private function getEntityTypeManagerMock() {
-    $entityTypeManager = $this->getMockBuilder(EntityTypeManagerInterface::class)
-      ->disableOriginalConstructor()
-      ->setMethods(['getStorage'])
-      ->getMockForAbstractClass();
-
-    $entityTypeManager->method('getStorage')
-      ->willReturn($this->getNodeStorageMock());
-
-    return $entityTypeManager;
-  }
 
   /**
    *
@@ -60,7 +44,7 @@ class PageTest extends TestCase {
    * Test regular page.
    */
   public function test() {
-    $page = new Page(__DIR__ . "/../../app", $this->getEntityTypeManagerMock());
+    $page = new Page(__DIR__ . "/../../app", $this->getNodeStorageMock());
     $content = $page->build('home');
     $this->assertEquals("<h1>Hello World!!!</h1>\n", $content);
 
@@ -72,7 +56,7 @@ class PageTest extends TestCase {
    * Test nonvalid UUID.
    */
   public function testNoDataset() {
-    $page = new Page(__DIR__ . "/../../app", $this->getEntityTypeManagerMock());
+    $page = new Page(__DIR__ . "/../../app", $this->getNodeStorageMock());
     $content = $page->buildDataset('444');
     $this->assertEquals("<h1>!!!Hello World!!!</h1>\n", $content);
   }
@@ -81,7 +65,7 @@ class PageTest extends TestCase {
    * Test valid UUID.
    */
   public function testDataset() {
-    $page = new Page(__DIR__ . "/../../app", $this->getEntityTypeManagerMock());
+    $page = new Page(__DIR__ . "/../../app", $this->getNodeStorageMock());
     $content = $page->buildDataset('123');
     $this->assertEquals("<h1>Hello World!!!</h1>\n", $content);
   }

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -25,14 +25,14 @@ services:
     class: \Drupal\metastore\Reference\Referencer
     arguments:
       - '@config.factory'
-      - '@entity_type.manager'
+      - '@dkan.common.node_storage'
     calls:
       - [setLoggerFactory, ['@logger.factory']]
   dkan.metastore.dereferencer:
     class: \Drupal\metastore\Reference\Dereferencer
     arguments:
       - '@config.factory'
-      - '@entity_type.manager'
+      - '@dkan.common.node_storage'
     calls:
       - [setLoggerFactory, ['@logger.factory']]
   dkan.metastore.orphan_checker:
@@ -70,14 +70,14 @@ services:
     class: \Drupal\metastore\Reference\Referencer
     arguments:
       - '@config.factory'
-      - '@entity_type.manager'
+      - '@dkan.common.node_storage'
     calls:
       - [setLoggerFactory, ['@logger.factory']]
   metastore.dereferencer:
     class: \Drupal\metastore\Reference\Dereferencer
     arguments:
       - '@config.factory'
-      - '@entity_type.manager'
+      - '@dkan.common.node_storage'
     calls:
       - [setLoggerFactory, ['@logger.factory']]
   metastore.orphan_checker:

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -20,7 +20,7 @@ services:
   dkan.metastore.storage:
     class: \Drupal\metastore\Storage\Data
     arguments:
-      - '@entity_type.manager'
+      - '@dkan.common.node_storage'
   dkan.metastore.referencer:
     class: \Drupal\metastore\Reference\Referencer
     arguments:
@@ -65,7 +65,7 @@ services:
   metastore.storage:
     class: \Drupal\metastore\Storage\Data
     arguments:
-      - '@entity_type.manager'
+      - '@dkan.common.node_storage'
   metastore.referencer:
     class: \Drupal\metastore\Reference\Referencer
     arguments:

--- a/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php
+++ b/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php
@@ -69,6 +69,7 @@ class OrphanReferenceProcessor extends QueueWorkerBase implements ContainerFacto
     $property_id = $data[0];
     $uuid = $data[1];
 
+    // @Todo: Search for uuid directly within the loadByProperties array.
     // Search datasets using this uuid for this property id.
     $datasets = $this->nodeStorage
       ->loadByProperties(

--- a/modules/metastore/src/Reference/Dereferencer.php
+++ b/modules/metastore/src/Reference/Dereferencer.php
@@ -3,8 +3,8 @@
 namespace Drupal\metastore\Reference;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\common\LoggerTrait;
+use Drupal\node\NodeStorageInterface;
 use stdClass;
 
 /**
@@ -35,14 +35,14 @@ class Dereferencer {
    */
   private $dereferenceMethod;
 
-  private $entityTypeManager;
+  private $nodeStorage;
 
   /**
    * Constructor.
    */
-  public function __construct(ConfigFactoryInterface $configService, EntityTypeManager $entityTypeManager) {
+  public function __construct(ConfigFactoryInterface $configService, NodeStorageInterface $nodeStorage) {
     $this->setConfigService($configService);
-    $this->entityTypeManager = $entityTypeManager;
+    $this->nodeStorage = $nodeStorage;
   }
 
   /**
@@ -146,8 +146,7 @@ class Dereferencer {
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   private function dereferenceSingle(string $property_id, string $uuid) {
-    $nodes = $this->entityTypeManager
-      ->getStorage('node')
+    $nodes = $this->nodeStorage
       ->loadByProperties([
         'field_data_type' => $property_id,
         'uuid' => $uuid,

--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -3,8 +3,8 @@
 namespace Drupal\metastore\Reference;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\common\LoggerTrait;
+use Drupal\node\NodeStorageInterface;
 use stdClass;
 
 /**
@@ -14,14 +14,14 @@ class Referencer {
   use HelperTrait;
   use LoggerTrait;
 
-  private $entityTypeManager;
+  private $nodeStorage;
 
   /**
    * Constructor.
    */
-  public function __construct(ConfigFactoryInterface $configService, EntityTypeManager $entityTypeManager) {
+  public function __construct(ConfigFactoryInterface $configService, NodeStorageInterface $nodeStorage) {
     $this->setConfigService($configService);
-    $this->entityTypeManager = $entityTypeManager;
+    $this->nodeStorage = $nodeStorage;
   }
 
   /**
@@ -134,8 +134,7 @@ class Referencer {
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   private function checkExistingReference(string $property_id, $data) {
-    $nodes = $this->entityTypeManager
-      ->getStorage('node')
+    $nodes = $this->nodeStorage
       ->loadByProperties([
         'field_data_type' => $property_id,
         'title' => md5(json_encode($data)),
@@ -169,8 +168,7 @@ class Referencer {
     $data->data = $value;
 
     // Create node to store this reference.
-    $node = $this->entityTypeManager
-      ->getStorage('node')
+    $node = $this->nodeStorage
       ->create([
         'title' => md5(json_encode($value)),
         'type' => 'data',

--- a/modules/metastore/tests/src/Reference/DereferencerTest.php
+++ b/modules/metastore/tests/src/Reference/DereferencerTest.php
@@ -2,15 +2,14 @@
 
 namespace Drupal\Tests\metastore\Unit;
 
-use MockChain\Sequence;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Config\ImmutableConfig;
-use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Queue\QueueFactory;
-use Drupal\metastore\Service\Uuid5;
 use Drupal\metastore\Reference\Dereferencer;
+use Drupal\metastore\Service\Uuid5;
+use Drupal\node\NodeStorageInterface;
 use MockChain\Chain;
+use MockChain\Sequence;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -28,9 +27,8 @@ class DereferencerTest extends TestCase {
       ],
     ];
 
-    $entityTypeManager = (new Chain($this))
-      ->add(EntityTypeManager::class, 'getStorage', EntityStorageInterface::class)
-      ->add(EntityStorageInterface::class, 'loadByProperties', [$node])
+    $nodeStorage = (new Chain($this))
+      ->add(NodeStorageInterface::class, 'loadByProperties', [$node])
       ->getMock();
 
     $uuidService = new Uuid5();
@@ -45,7 +43,7 @@ class DereferencerTest extends TestCase {
       ->add(QueueFactory::class, 'blah', NULL)
       ->getMock();
 
-    $valueReferencer = new Dereferencer($configService, $entityTypeManager);
+    $valueReferencer = new Dereferencer($configService, $nodeStorage);
     $referenced = $valueReferencer->dereference((object) ['publisher' => $uuid]);
 
     $this->assertTrue(is_object($referenced));
@@ -72,9 +70,8 @@ class DereferencerTest extends TestCase {
       ->add([$node1])
       ->add([$node2]);
 
-    $entityTypeManager = (new Chain($this))
-      ->add(EntityTypeManager::class, 'getStorage', EntityStorageInterface::class)
-      ->add(EntityStorageInterface::class, 'loadByProperties', $nodes)
+    $nodeStorage = (new Chain($this))
+      ->add(NodeStorageInterface::class, 'loadByProperties', $nodes)
       ->getMock();
 
     $uuidService = new Uuid5();
@@ -88,7 +85,7 @@ class DereferencerTest extends TestCase {
       ->add(QueueFactory::class, 'blah', NULL)
       ->getMock();
 
-    $valueReferencer = new Dereferencer($configService, $entityTypeManager);
+    $valueReferencer = new Dereferencer($configService, $nodeStorage);
     $referenced = $valueReferencer->dereference((object) ['keyword' => ['123456789', '987654321']]);
 
     $this->assertTrue(is_object($referenced));

--- a/modules/metastore/tests/src/Reference/ReferencerTest.php
+++ b/modules/metastore/tests/src/Reference/ReferencerTest.php
@@ -2,11 +2,10 @@
 
 namespace Drupal\Tests\metastore\Unit;
 
+use Drupal\node\NodeStorageInterface;
 use MockChain\Sequence;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Config\ImmutableConfig;
-use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\metastore\Reference\Referencer;
 use Drupal\node\Entity\Node;
 use MockChain\Chain;
@@ -25,9 +24,8 @@ class ReferencerTest extends TestCase {
       ->add(Node::class, "uuid", "123456789")
       ->getMock();
 
-    $entityTypeManager = (new Chain($this))
-      ->add(EntityTypeManager::class, 'getStorage', EntityStorageInterface::class)
-      ->add(EntityStorageInterface::class, 'loadByProperties', [$node])
+    $nodeStorage = (new Chain($this))
+      ->add(NodeStorageInterface::class, 'loadByProperties', [$node])
       ->getMock();
 
     $configService = (new Chain($this))
@@ -35,7 +33,7 @@ class ReferencerTest extends TestCase {
       ->add(ImmutableConfig::class, 'get', ['publisher'])
       ->getMock();
 
-    $valueReferencer = new Referencer($configService, $entityTypeManager);
+    $valueReferencer = new Referencer($configService, $nodeStorage);
     $referenced = $valueReferencer->reference((object) ['publisher' => (object) ['name' => 'Gerardo', 'company' => 'CivicActions']]);
 
     $this->assertTrue(is_object($referenced));
@@ -54,9 +52,8 @@ class ReferencerTest extends TestCase {
       ->add(Node::class, "uuid", $uuids)
       ->getMock();
 
-    $entityTypeManager = (new Chain($this))
-      ->add(EntityTypeManager::class, 'getStorage', EntityStorageInterface::class)
-      ->add(EntityStorageInterface::class, 'loadByProperties', [$node])
+    $nodeStorage = (new Chain($this))
+      ->add(NodeStorageInterface::class, 'loadByProperties', [$node])
       ->getMock();
 
     $configService = (new Chain($this))
@@ -64,7 +61,7 @@ class ReferencerTest extends TestCase {
       ->add(ImmutableConfig::class, 'get', ['keyword'])
       ->getMock();
 
-    $valueReferencer = new Referencer($configService, $entityTypeManager);
+    $valueReferencer = new Referencer($configService, $nodeStorage);
     $referenced = $valueReferencer->reference((object) ['keyword' => ['Gerardo', 'CivicActions']]);
 
     $this->assertTrue(is_object($referenced));

--- a/modules/metastore/tests/src/Storage/DataTest.php
+++ b/modules/metastore/tests/src/Storage/DataTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\common\Unit\Storage;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Field\FieldItemInterface;
 use Drupal\Core\Field\FieldItemListInterface;
@@ -24,7 +23,7 @@ class DataTest extends TestCase {
    *
    */
   public function testRetrieveAll() {
-    $store = new Data($this->getEntityTypeManagerMock());
+    $store = new Data($this->getNodeStorageMock());
     $store->setSchema('dataset');
     $all = $store->retrieveAll();
 
@@ -38,7 +37,7 @@ class DataTest extends TestCase {
    */
   public function testRetrieve() {
     $this->node = $this->getNodeMock();
-    $store = new Data($this->getEntityTypeManagerMock());
+    $store = new Data($this->getNodeStorageMock());
     $store->setSchema('dataset');
     $obj = $store->retrieve(1);
 
@@ -54,7 +53,7 @@ class DataTest extends TestCase {
     $this->node = $this->getNodeMock();
     $object = '{"name":"blah"}';
 
-    $store = new Data($this->getEntityTypeManagerMock());
+    $store = new Data($this->getNodeStorageMock());
     $store->setSchema('dataset');
     $id = $store->store($object, 1);
 
@@ -68,7 +67,7 @@ class DataTest extends TestCase {
     $this->node = NULL;
     $object = '{"name":"blah"}';
 
-    $store = new Data($this->getEntityTypeManagerMock());
+    $store = new Data($this->getNodeStorageMock());
     $store->setSchema('dataset');
     $id = $store->store($object, 1);
 
@@ -80,7 +79,7 @@ class DataTest extends TestCase {
    */
   public function testRemove() {
     $this->node = $this->getNodeMock();
-    $store = new Data($this->getEntityTypeManagerMock());
+    $store = new Data($this->getNodeStorageMock());
     $store->setSchema('dataset');
     $removed = $store->remove(1);
 
@@ -92,7 +91,7 @@ class DataTest extends TestCase {
    */
   public function testRetrieveAllException() {
     $this->expectExceptionMessage("Data schemaId not set in retrieveAll()");
-    $store = new Data($this->getEntityTypeManagerMock());
+    $store = new Data($this->getNodeStorageMock());
     $store->retrieveAll();
   }
 
@@ -101,7 +100,7 @@ class DataTest extends TestCase {
    */
   public function testRetrieveException() {
     $this->expectExceptionMessage("Data schemaId not set in retrieve()");
-    $store = new Data($this->getEntityTypeManagerMock());
+    $store = new Data($this->getNodeStorageMock());
     $store->retrieve(1);
   }
 
@@ -111,23 +110,8 @@ class DataTest extends TestCase {
   public function testStoreException() {
     $this->expectExceptionMessage("Data schemaId not set in store()");
     $object = '{"name":"blah"}';
-    $store = new Data($this->getEntityTypeManagerMock());
+    $store = new Data($this->getNodeStorageMock());
     $store->store($object, 1);
-  }
-
-  /**
-   *
-   */
-  private function getEntityTypeManagerMock() {
-    $entityTypeManager = $this->getMockBuilder(EntityTypeManagerInterface::class)
-      ->disableOriginalConstructor()
-      ->setMethods(['getStorage'])
-      ->getMockForAbstractClass();
-
-    $entityTypeManager->method('getStorage')
-      ->willReturn($this->getNodeStorageMock());
-
-    return $entityTypeManager;
   }
 
   /**


### PR DESCRIPTION
Whenever possible and where intended to be used with `getStorage('node')` (i.e. not in metastore_search), `EntityTypeManager` can be replaced with `NodeStorage` to get us closer to what we actually need, using less custom code hence less mocking in our unit tests.