### PR TITLE
datastore: output debug info only when devel is enabled

### DIFF
--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.module
@@ -407,11 +407,21 @@ function dkan_datastore_api_query($params) {
     return dkan_datastore_api_output($data_select, $results, $table, $params['fields'], $resource_ids, $count, $params['limit']);
   }
   catch (Exception $e) {
-    $info = "";
-    if ($data_select) {
-      $info = dkan_datastore_api_debug($data_select);
+    // If module devel is enabled, provide more information on the error.
+    if (module_exists('devel')) {
+      $info = "";
+      if ($data_select) {
+        $info = dkan_datastore_api_debug($data_select);
+      }
+      return array(
+        'sql' => $info,
+        'error' => array('message' => t('Caught exception: @exception', array('@exception' => $e->getMessage())))
+      );
     }
-    return array('sql' => $info, 'error' => array('message' => 'Caught exception: ' . $e->getMessage()));
+
+    return array(
+      'error' => array('message' => t('Exception Caught, please check logs for more information'))
+    );
   }
 }
 


### PR DESCRIPTION
connects dkan_management#372

Debugging database information was leaking from the datastore when a specific condition was met. Specifically when the datastore table for the queried resource was removed.

This PR hides the debugging output by default, and only available when the `devel` module is enabled on the install.

In addition to the behavior change, the error message is wrapped in a `t()` function to make it translatable.