### PR TITLE
Add helper harvest module

### DIFF
--- a/modules/socrata_harvest/README.md
+++ b/modules/socrata_harvest/README.md
@@ -1,0 +1,11 @@
+## Harvest Source
+
+Register the harvest (replace the uri value with the data.json url of your source):
+```
+drush dkan:harvest:register '{"identifier":"socrata","extract":{"type":"\\Harvest\\ETL\\Extract\\DataJson","uri":"https://YOUR-SOURCE/data.json"},"transforms":["\\Drupal\\socrata_harvest\\Harvest\\Transform\\Socrata", "\\Drupal\\harvest\\Transform\\ResourceImporter"],"load":{"type":"\\Drupal\\harvest\\Load\\Dataset"}}'
+```
+
+Run the harvest:
+```
+drush dkan:harvest:run socrata
+```

--- a/modules/socrata_harvest/socrata_harvest.info.yml
+++ b/modules/socrata_harvest/socrata_harvest.info.yml
@@ -1,0 +1,7 @@
+name: Socrata Harvest
+description: 'Helper module to fill in missing POD values.'
+type: module
+core: 8.x
+dependencies:
+  - harvest
+package: Custom

--- a/modules/socrata_harvest/src/Harvest/Transform/Socrata.php
+++ b/modules/socrata_harvest/src/Harvest/Transform/Socrata.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\socrata_harvest\Harvest\Transform;
+
+use Harvest\ETL\Transform\Transform;
+
+/**
+ * Class Socrata.
+ */
+class Socrata extends Transform {
+  /**
+   * Inherited.
+   *
+   * {@inheritDoc}
+   */
+  public function run($item) {
+    // Convert URL identifier to just the ID.
+    $identifier = $item->identifier;
+    $item->identifier = $this->getIdentifier($identifier);
+
+    // Add a keyword when keywords are null.
+    if (empty($item->keyword)) {
+      $item->keyword = ['No keywords provided'];
+    }
+
+    // Add a description if null.
+    if (empty($item->description)) {
+      $item->description = 'No description provided';
+    }
+
+    // Provide publisher name.
+    $publisher = $item->publisher;
+    if (!isset($publisher->name) && $publisher->source) {
+      $publisher->name = $publisher->source;
+    }
+
+    // Add titles for csv distributions.
+    if ($item->distribution) {
+      foreach ($item->distribution as $key => $dist) {
+        if ($dist->mediaType != "text/csv") {
+          unset($item->distribution[$key]);
+        }
+        else {
+          $dist->title = "{$item->identifier}.csv";
+          $item->distribution[$key] = $dist;
+        }
+      }
+    }
+
+    return $item;
+  }
+
+  /**
+   * Private.
+   */
+  private function getIdentifier($identifier) {
+    $path = parse_url($identifier, PHP_URL_PATH);
+    $path = str_replace('/api/views/', "", $path);
+    return $path;
+  }
+
+}

--- a/modules/socrata_harvest/src/Harvest/Transform/Socrata.php
+++ b/modules/socrata_harvest/src/Harvest/Transform/Socrata.php
@@ -55,7 +55,7 @@ class Socrata extends Transform {
    */
   private function getIdentifier($identifier) {
     $path = parse_url($identifier, PHP_URL_PATH);
-    $path = str_replace('/api/views/', "", $path);
+    $path = str_replace(['/api/views/', '/datasets/'], ["", ""], $path);
     return $path;
   }
 


### PR DESCRIPTION
Optional module to harvest from Socrata catalogs.

## QA Steps (test with Detroit data)
1. enable the Socrata Harvest module
2. ```dktl drush dkan:harvest:register '{"identifier":"socrata","extract":{"type":"\\Harvest\\ETL\\Extract\\DataJson","uri":"https://data.detroitmi.gov/data.json"},"transforms":["\\Drupal\\socrata_harvest\\Harvest\\Transform\\Socrata", "\\Drupal\\harvest\\Transform\\ResourceImporter"],"load":{"type":"\\Drupal\\harvest\\Load\\Dataset"}}' ```
3. ``dktl drush dkan:harvest:run socrata``
4. Review ``admin/content/datasets`` to confirm you have the Detroit datasets