### PR TITLE
Fix dataset update when default moderation state is set to draft

### DIFF
--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -126,7 +126,7 @@ class Data implements StorerInterface, RetrieverInterface, BulkRetrieverInterfac
 
     $this->assertSchema();
 
-    $node = $this->getNodePublishedRevision($uuid);
+    $node = $this->getNodeLatestRevision($uuid);
     if ($node) {
       return $node->get('field_json_metadata')->getString();
     }


### PR DESCRIPTION
`Storage\Data`'s `retrieve()` was incorrectly using the latest published version of the node, rather than its latest revision. This could result in unexpected value when, for example, a published item receives subsequent updates without being published in between.

This PR should address this issue.

Note that by default, the default moderation state is set to `published`. The issue described above exists only when it is set to `draft`.