### PR TITLE
Revisit use-case of default moderation set to draft

### DIFF
--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -126,7 +126,13 @@ class Data implements StorerInterface, RetrieverInterface, BulkRetrieverInterfac
 
     $this->assertSchema();
 
-    $node = $this->getNodePublishedRevision($uuid);
+    if ($this->getDefaultModerationState() === 'published') {
+      $node = $this->getNodePublishedRevision($uuid);
+    }
+    else {
+      $node = $this->getNodeLatestRevision($uuid);
+    }
+
     if ($node) {
       return $node->get('field_json_metadata')->getString();
     }

--- a/modules/metastore/tests/src/Storage/DataTest.php
+++ b/modules/metastore/tests/src/Storage/DataTest.php
@@ -92,9 +92,33 @@ class DataTest extends TestCase {
   /**
    *
    */
-  public function testRetrieve() {
+  public function testRetrieveModerationPublished() {
     $this->node1 = $this->setNodeMock('1', '{"foo":"bar"}', "");
-    $data = new Data($this->getEntityTypeManager()->getMock());
+
+    $etm = $this->getEntityTypeManager()
+      ->add(ContentModeration::class, 'getConfiguration', [
+      'default_moderation_state' => 'published',
+    ]);
+    $data = new Data($etm->getMock());
+    $data->setSchema('dataset');
+
+    $expected = '{"foo":"bar"}';
+    $result = $data->retrieve('1');
+
+    $this->assertEquals($expected, $result);
+  }
+
+  /**
+   *
+   */
+  public function testRetrieveModerationDraft() {
+    $this->node1 = $this->setNodeMock('1', '{"foo":"bar"}', "");
+
+    $etm = $this->getEntityTypeManager()
+      ->add(ContentModeration::class, 'getConfiguration', [
+        'default_moderation_state' => 'draft',
+      ]);
+    $data = new Data($etm->getMock());
     $data->setSchema('dataset');
 
     $expected = '{"foo":"bar"}';
@@ -107,11 +131,14 @@ class DataTest extends TestCase {
    *
    */
   public function testRetrieveNotFound() {
-    $entityTypeManager = $this->getEntityTypeManager()
+    $etm = $this->getEntityTypeManager()
+      ->add(ContentModeration::class, 'getConfiguration', [
+        'default_moderation_state' => 'draft',
+      ])
       ->add(QueryInterface::class, 'execute', []);
-
-    $data = new Data($entityTypeManager->getMock());
+    $data = new Data($etm->getMock());
     $data->setSchema('dataset');
+
     $this->expectExceptionMessage('No data with that identifier was found.');
     $data->retrieve('4');
   }


### PR DESCRIPTION
Revisiting my previous PR #3148 which passed testing prior to being merged but, once failed afterwards (https://github.com/GetDKAN/dkan/commit/bc6a32b1557d08771c91605826757d8b932f4a17) and was reverted (https://github.com/GetDKAN/dkan/commit/3cc832e68eecae4d031c2f9802d9689fa4b1dfd2).

As expected it's passing again this time, but a bit reluctant to proceed again, unsure if I missed something in my code, or whether it was a fluke in CI. Any thoughts?