### PR TITLE
Fix call to deprecated constant FILE_CREATE_DIRECTORY

### DIFF
--- a/modules/harvest/src/Utility/FileHelperInterface.php
+++ b/modules/harvest/src/Utility/FileHelperInterface.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\harvest\Utility;
 
+use Drupal\Core\File\FileSystemInterface;
+
 /**
  * Interface.
  */
@@ -28,7 +30,7 @@ interface FileHelperInterface {
   /**
    * Public.
    */
-  public function prepareDir(&$directory, $options = FILE_CREATE_DIRECTORY);
+  public function prepareDir(&$directory, $options = FileSystemInterface::CREATE_DIRECTORY);
 
   /**
    * Public.


### PR DESCRIPTION
Deprecated in Drupal 8.7.0, removed 9.0.0, use Drupal\Core\File\FileSystemInterface::CREATE_DIRECTORY instead.