### PR TITLE
Fix to show 'Add dataset' button when no results

### DIFF
--- a/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
+++ b/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
@@ -608,7 +608,7 @@ display:
           relationship: none
           group_type: group
           admin_label: 'Add dataset button'
-          empty: false
+          empty: true
           tokenize: false
           content: '<div class="form-actions"><a class="button button--primary" href="/admin/dkan/dataset">+ Add new dataset</a></div>'
           plugin_id: text_custom


### PR DESCRIPTION
## QA steps
- build without demo data or delete all datasets
- confirm that you still see the 'Add new dataset' button at `admin/content/datasets`