### PR TITLE
Assign new issues to triage project

### DIFF
--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -1,0 +1,18 @@
+name: Auto Assign to Project(s)
+
+on:
+  issues:
+    types: [opened]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to One Project
+    steps:
+    - name: Assign NEW issues to DKAN Development Board
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/GetDKAN/dkan/projects/1'


### PR DESCRIPTION
Assigns any new issues created in DKAN repo to the issue triage board.