### PR TITLE
Giving more info to the user in the datastore/imports endpoint.

### DIFF
--- a/cypress/integration/05_datastore.spec.js
+++ b/cypress/integration/05_datastore.spec.js
@@ -69,7 +69,7 @@ context('Datastore API', () => {
             expect(response.status).eql(200);
             expect(response.body.numOfRows).eql(2);
             expect(response.body.numOfColumns).eql(6);
-            cy.get('@columns').then((columns) => expect(response.body.columns).eql(columns));
+            cy.get('@columns').then((columns) => expect(Object.keys(response.body.columns)).eql(columns));
           });
       });
   });

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -42,7 +42,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    * Get summary.
    */
   public function getSummary() {
-    $columns = array_keys($this->getSchema()['fields']);
+    $columns = $this->getSchema()['fields'];
     $numOfColumns = count($columns);
     $numOfRows = $this->count();
     return new TableSummary($numOfColumns, $columns, $numOfRows);

--- a/modules/datastore/src/Storage/TableSummary.php
+++ b/modules/datastore/src/Storage/TableSummary.php
@@ -8,9 +8,9 @@ namespace Drupal\datastore\Storage;
  * @todo Use JSON Schema maybe to validate this?
  */
 class TableSummary implements \JsonSerializable {
-  private $numOfColumns;
-  private $columns;
-  private $numOfRows;
+  public $numOfColumns;
+  public $columns;
+  public $numOfRows;
 
   /**
    * Constructor.

--- a/modules/datastore/tests/src/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Storage/DatabaseTableTest.php
@@ -226,12 +226,13 @@ class DatabaseTableTest extends TestCase {
       $connectionChain->getMock(),
       $this->getResource()
     );
-    $this->assertEquals(
-      new TableSummary(
-        3,
-        ["record_number", "first_name", "last_name"],
-        1
-      ), $databaseTable->getSummary());
+
+    $tableSummary = $databaseTable->getSummary();
+
+    $this->assertEquals(3, $tableSummary->numOfColumns);
+    $this->assertEquals(1, $tableSummary->numOfRows);
+    $this->assertEquals(["record_number", "first_name", "last_name"],
+      array_keys($tableSummary->columns));
   }
 
   /**


### PR DESCRIPTION
For compliance with Drupal restrictions around database table structures, the datastore modifies CSV headers when storing.

Currently, there is no easy place to see this information. 

A GET operation on the "datastore/imports" endpoint will give you information about the database table columns, but no information on what the original names were. 

This small change exposes that extra information.