### PR TITLE
Upgrade to Drupal 7.73.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+7.x-1.18.11
+-----------
+- #3211 Drupal security upgrade to version 7.73.
+
 7.x-1.18.10
 -----------
 - #3179 Added drush command for forcing updates on dkan_periodic_updates.

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -3,7 +3,7 @@ core: 7.x
 projects:
   drupal:
     type: core
-    version: '7.72'
+    version: '7.73'
     # Use vocabulary machine name for permissions, see http://drupal.org/node/995156
     patch:
       995156: 'https://drupal.org/files/issues/995156-5_portable_taxonomy_permissions.patch'

--- a/test/phpunit/dkan_periodic_updates/DkanPeriodicUpdatesTest.php
+++ b/test/phpunit/dkan_periodic_updates/DkanPeriodicUpdatesTest.php
@@ -15,7 +15,7 @@ class DkanPeriodicUpdatesTest extends \PHPUnit_Framework_TestCase {
 
   protected function setUp() {
     // Daily update.
-    $file_url = "https://dkan-default-content-files.s3.amazonaws.com/files/district_centerpoints.csv";
+    $file_url = "https://dkan-default-content-files.s3.amazonaws.com/files/district_centerpoints_0.csv";
     $file = file_save((object)[
       'filename' => drupal_basename($file_url),
       'uri' => $file_url,

--- a/test/phpunit/dkan_periodic_updates/DkanPeriodicUpdatesTest.php
+++ b/test/phpunit/dkan_periodic_updates/DkanPeriodicUpdatesTest.php
@@ -15,7 +15,7 @@ class DkanPeriodicUpdatesTest extends \PHPUnit_Framework_TestCase {
 
   protected function setUp() {
     // Daily update.
-    $file_url = "https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv";
+    $file_url = "https://dkan-default-content-files.s3.amazonaws.com/files/district_centerpoints.csv";
     $file = file_save((object)[
       'filename' => drupal_basename($file_url),
       'uri' => $file_url,

--- a/test/phpunit/dkan_periodic_updates/data/test_manifest.csv
+++ b/test/phpunit/dkan_periodic_updates/data/test_manifest.csv
@@ -1,5 +1,5 @@
 resource_id,frequency,file_url,import_to_datastore
-c65c08d9-43c8-45a4-a49d-29e714ce2ebb,daily,https://s3.amazonaws.com/dkan-default-content-files/district_centerpoints_small.csv,Y
+c65c08d9-43c8-45a4-a49d-29e714ce2ebb,daily,https://dkan-default-content-files.s3.amazonaws.com/files/district_centerpoints_0.csv,Y
 d7ccef48-5c8c-432c-94c8-17cee9c4ed37,weekly,https://s3.amazonaws.com/dkan-default-content-files/files/Polling_Places_Madison_0.csv,n
 fe4b712b-c570-4e0b-aeeb-67d9789a196e,monthly,https://s3.amazonaws.com/dkan-default-content-files/files/last_transactions.xlsx,n
 non-existing-uuid,something,https://s3.amazonaws.com/dkan-default-content-files/files/last_transactions.xlsx,something


### PR DESCRIPTION
Drupal [security upgrade](https://www.drupal.org/sa-core-2020-007) to version 7.73.