### PR TITLE
test against new frontend branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           command: |
             dktl install
             dktl install:sample
-            dktl frontend:get --ref=stubs-tests2
+            dktl frontend:get
             dktl frontend:install
             dktl frontend:build
             dktl drush cr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           command: |
             dktl install
             dktl install:sample
-            dktl frontend:get
+            dktl frontend:get --ref=stubs-tests2
             dktl frontend:install
             dktl frontend:build
             dktl drush cr

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "dkan-frontend": {
             "type": "vcs",
             "url": "https://github.com/GetDKAN/data-catalog-app",
-            "ref": "1.0.0"
+            "ref": "stubs-tests2"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "dkan-frontend": {
             "type": "vcs",
             "url": "https://github.com/GetDKAN/data-catalog-app",
-            "ref": "stubs-tests2"
+            "ref": "1.0.1"
         }
     }
 }


### PR DESCRIPTION
## Merge Process:
- squash merge getdkan/data-catalog-app#39 and cut new release
- update getdkan/dkan#3217 to update the composer.json file to use the new frontend release 

```
"extra": {
        "dkan-frontend": {
            "type": "vcs",
            "url": "https://github.com/GetDKAN/data-catalog-app",
            "ref": "1.0.1"
        }
    }
```

- cut new release of dkan: 2.4.1

