### PR TITLE
Use local DKAN in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,10 @@ jobs:
       image: circleci/classic:latest
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "4.0.0"
+      DKTL_VERSION: "localdkan"
     steps:
+      - checkout:
+          path: dkan
       - run:
           name: Setup composer config
           command: |
@@ -20,10 +22,7 @@ jobs:
             echo "export PATH=~/dkan-tools/bin:$PATH" >> $BASH_ENV
       - run:
           name: Initialize Project
-          command: |
-            v=$CIRCLE_BRANCH
-            if [[ $v =~ ^[0-9]. ]]; then v="${v}-dev"; else v="dev-${v}"; fi;
-            v="$v#${CIRCLE_SHA1}" && dktl init --dkan=$v
+          command: dktl init --dkan-local
       - run:
           name: Make DKAN
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,16 @@ jobs:
             dktl drush user-add-role api_user testuser
             dktl dc exec web chmod -R 777 /var/www/docroot/sites/default/files/dkan-tmp
             dktl dkan:test-dredd
+      - run:
+          name: Run frontend cypress tests
+          command: |
+            dktl install
+            dktl install:sample
+            dktl frontend:get
+            dktl frontend:install
+            dktl frontend:build
+            dktl drush cr
+            dktl frontend:test
       - store_artifacts:
           path: docroot/modules/contrib/dkan/cypress/screenshots
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       image: circleci/classic:latest
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "localdkan"
+      DKTL_VERSION: "4.1.0"
     steps:
       - checkout:
           path: dkan

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Search existing issues to make sure the bug has not been reported already.
+
+## Describe the bug
+Be specific! "x is broken" is not helpful. Provide as many details as possible, for example, what version of DKAN/Drupal/PHP are you running? What screen are you on when you get the error. What is the error message?
+
+## Steps To Reproduce
+Replace this line with the exact actions you performed to produce the error.
+
+## Expected behavior

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,12 @@
+---
+name: Enhancement
+about: Suggest a new feature for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## User Story
+
+## Acceptance Criteria

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+fixes [org/repo/issue#]
+
+- [ ] Test coverage exists
+- [ ] Documentation exists
+
+## QA Steps
+
+- [ ] Add manual QA steps in checklist format for a reviewer to perform to confirm that the feature or fix is working. Include as much details as possible so that the reviewer doesn't lose time figuring out how to perform steps.

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "require": {
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.5.0",
-        "drupal/admin_toolbar": "^2.2",
+        "drush/drush": "^10.2.2",
+        "drupal/admin_toolbar": "^2.3",
         "drupal/config_update": "^1.6",
         "drupal/search_api": "^1.15",
         "drupal/views_bulk_operations": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ezyang/htmlpurifier" : "^4.11",
         "fmizzell/maquina": "^1.1.0",
         "getdkan/contracts": "^1.0.0",
-        "getdkan/datastore" : "dev-original-column-names",
+        "getdkan/datastore" : "^5.1.1",
         "getdkan/file-fetcher" : "^3.0.0",
         "getdkan/harvest": "^1.0.0",
         "getdkan/json-schema-provider": "^0.1.2",

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "dkan-frontend": {
             "type": "vcs",
             "url": "https://github.com/GetDKAN/data-catalog-app",
-            "ref": "1.0.1"
+            "ref": "1.0.2"
         }
     }
 }

--- a/modules/common/tests/src/Traits/ServiceCheckTrait.php
+++ b/modules/common/tests/src/Traits/ServiceCheckTrait.php
@@ -112,20 +112,7 @@ trait ServiceCheckTrait {
    * Private.
    */
   private function getRelativeDrupalPath() {
-    $path = __DIR__;
-
-    while (TRUE) {
-      $content = glob($path . "/*");
-      $content = array_map(function ($item) use ($path) {
-        return str_replace($path, "", $item);
-      }, $content);
-
-      if (in_array("/index.php", $content)) {
-        return $path;
-      }
-
-      $path .= "/..";
-    }
+    return "/var/www/docroot";
   }
 
 }

--- a/modules/datastore/src/Drush.php
+++ b/modules/datastore/src/Drush.php
@@ -4,7 +4,6 @@ namespace Drupal\datastore;
 
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Consolidation\OutputFormatters\StructuredData\UnstructuredListData;
-use Drupal\metastore\Reference\Dereferencer;
 use Drush\Commands\DrushCommands;
 
 /**
@@ -44,9 +43,6 @@ class Drush extends DrushCommands {
   public function import($uuid, $deferred = FALSE) {
 
     try {
-      // Load metadata with both identifier and data for this request.
-      drupal_static('metastore_dereference_method', Dereferencer::DEREFERENCE_OUTPUT_REFERENCE_IDS);
-
       $this->datastoreService->import($uuid, $deferred);
     }
     catch (\Exception $e) {
@@ -133,8 +129,6 @@ class Drush extends DrushCommands {
    */
   public function drop($uuid) {
     try {
-      // Load metadata with both identifier and data for this request.
-      drupal_static('metastore_dereference_method', Dereferencer::DEREFERENCE_OUTPUT_REFERENCE_IDS);
       $this->datastoreService->drop($uuid);
     }
     catch (\Exception $e) {

--- a/modules/harvest/src/Drush.php
+++ b/modules/harvest/src/Drush.php
@@ -195,4 +195,58 @@ class Drush extends DrushCommands {
     (new ConsoleOutput())->write("{$result} items reverted for the '{$id}' harvest plan." . PHP_EOL);
   }
 
+  /**
+   * Show status of of a particular harvest run.
+   *
+   * @param string $harvest_id
+   *   The id of the harvest source.
+   * @param string $run_id
+   *   The run's id. Optional. Show the status for the latest run if not
+   *   provided.
+   *
+   * @command dkan:harvest:status
+   *
+   * @usage dkan:harvest:status
+   *   test 1599157120
+   */
+  public function status($harvest_id, $run_id = NULL) {
+    // Validate the harvest id.
+    $harvest_id_all = $this->harvestService->getAllHarvestIds();
+
+    if (array_search($harvest_id, $harvest_id_all) === FALSE) {
+      (new ConsoleOutput())->writeln("<error>harvest id $harvest_id not found.</error>");
+      return DrushCommands::EXIT_FAILURE;
+    }
+
+    // No run_id provided, get the latest run_id.
+    // Validate run_id.
+    $run_id_all = $this->harvestService->getAllHarvestRunInfo($harvest_id);
+
+    if (empty($run_id_all)) {
+      (new ConsoleOutput())->writeln("<error>No Run IDs found for harvest id $harvest_id</error>");
+      return DrushCommands::EXIT_FAILURE;
+    }
+
+    if (empty($run_id)) {
+      $run_id = $run_id_all[0];
+    }
+
+    if (array_search($run_id, $run_id_all) === FALSE) {
+      (new ConsoleOutput())->writeln("<error>Run ID $run_id not found for harvest id $harvest_id</error>");
+      return DrushCommands::EXIT_FAILURE;
+    }
+
+    $run = $this->harvestService
+      ->getHarvestRunInfo($harvest_id, $run_id);
+
+    if (empty($run)) {
+      (new ConsoleOutput())->writeln("<error>No status found for harvest id $harvest_id and run id $run_id</error>");
+      return DrushCommands::EXIT_FAILURE;
+    }
+
+    $run = json_decode($run, TRUE);
+
+    $this->renderStatusTable($harvest_id, $run_id, $run);
+  }
+
 }

--- a/modules/harvest/src/Drush/Helper.php
+++ b/modules/harvest/src/Drush/Helper.php
@@ -63,4 +63,107 @@ trait Helper {
     $table->render();
   }
 
+  /**
+   * Render table for harvest run item status.
+   */
+  private function renderStatusTable($harvest_id, $run_id, $run) {
+    if (empty($run['status']['extracted_items_ids'])) {
+      $extract_status = $run['status']['extract'];
+
+      (new ConsoleOutput())->writeln(
+        ["<warning>harvest id $harvest_id and run id $run_id extract status is $extract_status</warning>",
+          "<warning>No items were extracted.</warning>",
+        ]
+      );
+    }
+    else {
+      $table = new Table(new ConsoleOutput());
+      $table->setHeaders(["item_id", "extract", "transform", "load"]);
+
+      foreach ($run['status']['extracted_items_ids'] as $item_id) {
+        $row = $this->generateItemStatusRow($item_id, $run['status'], $run['errors']);
+        $table->addRow($row);
+      }
+
+      $table->render();
+    }
+  }
+
+  /**
+   * Generate a table row for harvest run item status.
+   */
+  private function generateItemStatusRow($item_id, $status, $errors) {
+    $row = [];
+
+    $row['item_id'] = $item_id;
+
+    /* Extract */
+    $row['extract'] = "[" . $status['extract'] . "]";
+
+    /* transform */
+
+    $row['transform'] = $this->generateItemTransformStatusRow($item_id, $status, $errors);
+
+    /* load */
+    $row['load'] = $this->generateItemLoadStatusRow($item_id, $status, $errors);
+
+    return $row;
+  }
+
+  /**
+   * Return a transform status for a harvest run item.
+   */
+  private function generateItemTransformStatusRow($item_id, $status, $errors) {
+    /* transform */
+    $transform_status = [];
+
+    if (!empty($status['transform'])) {
+      foreach ($status['transform'] as $class => $ids_status) {
+        $transform_status[] = '- ' . $class . ': ' . $ids_status[$item_id];
+      }
+    }
+
+    if (!empty($errors['transform'][$item_id])) {
+      $transform_status[] = 'Errors: ';
+      $transform_status[] = '- ' . $errors['transform'][$item_id];
+    }
+
+    if (!empty($errors['transform']['loading'])) {
+      $transform_status[] = 'Loading Errors: ';
+      $transform_status[] = '- ' . $errors['transform']['loading'];
+    }
+
+    return implode("\n", $transform_status);
+  }
+
+  /**
+   * Return a load status for a harvest run item.
+   */
+  private function generateItemLoadStatusRow($item_id, $status, $errors) {
+    $load_status = [];
+
+    $load_status[] = '[' . $status['load'][$item_id] . ']';
+
+    if ($status['load'][$item_id] == 'FAILURE') {
+
+      $report = json_decode($errors['load'][$item_id], TRUE);
+
+      if (empty($report['errors'])) {
+        // Probably a string and not a json object.
+        $report['errors'] = [
+          [
+            'property' => '',
+            'message' => $errors['load'][$item_id],
+          ],
+        ];
+      }
+
+      foreach ($report['errors'] as $error) {
+        $load_status[] = '- ' . $error['property'] . ': ' . $error['message'];
+      }
+    }
+
+    return implode("\n", $load_status);
+  }
+
 }

--- a/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php
+++ b/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php
@@ -97,18 +97,18 @@ class OrphanReferenceProcessor extends QueueWorkerBase implements ContainerFacto
     }
 
     // Value reference uuid not found in any dataset, therefore safe to delete.
-    $this->deleteReference($metadataProperty, $identifier);
+    $this->unpublishReference($metadataProperty, $identifier);
   }
 
   /**
-   * Deletes a reference.
+   * Unpublish a reference.
    *
    * @param string $property_id
    *   The property id.
    * @param string $uuid
    *   The uuid.
    */
-  protected function deleteReference(string $property_id, string $uuid) {
+  protected function unpublishReference(string $property_id, string $uuid) {
     $references = $this->nodeStorage
       ->loadByProperties(
               [
@@ -117,7 +117,7 @@ class OrphanReferenceProcessor extends QueueWorkerBase implements ContainerFacto
               ]
           );
     if (FALSE !== ($reference = reset($references))) {
-      $reference->delete();
+      $reference->set('moderation_state', 'draft');
     }
   }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.6/phpunit.xsd"
-    bootstrap="../../../../vendor/weitzman/drupal-test-traits/src/bootstrap.php"
+    bootstrap="/var/www/vendor/weitzman/drupal-test-traits/src/bootstrap.php"
     colors="true"
     stopOnFailure="false"
     stopOnError="false"


### PR DESCRIPTION
We're currently grabbing the DKAN branch we're testing from Composer, which lags and doesn't ensure we're actually testing the code we've just pushed. This uses the new "dkan-local" option in GetDKAN/dkan-tools#267 to check out the code using a standard CircleCI step and build from that.