### PR TITLE
Remove duplicate package in composer require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "require": {
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.5.0",
-        "drush/drush": "^10.2.2",
         "drupal/admin_toolbar": "^2.3",
         "drupal/config_update": "^1.6",
         "drupal/search_api": "^1.15",


### PR DESCRIPTION
When I rebased and fixed the merge conflict in #3174, I did not notice the duplicate `drush/drush` package in the composer's require section. This removes this duplicate.