### PR TITLE
Update version of data-catalog-app to 1.0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "dkan-frontend": {
             "type": "vcs",
             "url": "https://github.com/GetDKAN/data-catalog-app",
-            "ref": "1.0.2"
+            "ref": "1.0.3"
         }
     }
 }


### PR DESCRIPTION
Broken dataset/x/api page

## QA Steps
1. Go to a dataset page, click the API link in the sidebar
2. Confirm you see the dataset title followed by the api docs component
