### PR TITLE
Metastore_admin updates

### DIFF
--- a/cypress/integration/08_admin_views.spec.js
+++ b/cypress/integration/08_admin_views.spec.js
@@ -33,7 +33,7 @@ context('Admin content and dataset views', () => {
 
     it('The content table has a column for Data Type', () => {
         cy.visit(baseurl + "/admin/content/node")
-        cy.get('.vbo-table > thead > tr > #view-field-data-type-table-column > a').should('contain','Data Type');
+        cy.get('#view-field-data-type-table-column > a').should('contain','Data Type');
     })
 
     it('The dataset data node titles should link to the REACT dataset page', () => {
@@ -71,6 +71,15 @@ context('Admin content and dataset views', () => {
 
     it('Admin user can delete a dataset', () => {
         cy.visit(baseurl + "/admin/content/datasets")
+        cy.wait(2000)
+        cy.get('#edit-node-bulk-form-0').check({ force:true })
+        cy.get('#edit-submit--2').click({ force:true })
+        cy.get('input[value="Delete"]').click({ force:true })
+        cy.get('.messages').should('contain','Deleted 1 content item.')
+    })
+
+    it('Admin user can delete a data node', () => {
+        cy.visit(baseurl + "/admin/content/node")
         cy.wait(2000)
         cy.get('#edit-node-bulk-form-0').check({ force:true })
         cy.get('#edit-submit--2').click({ force:true })

--- a/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_content.yml
+++ b/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_content.yml
@@ -9,7 +9,7 @@ dependencies:
     - user
     - views_bulk_operations
 _core:
-  default_config_hash: NRDZnPbQCKTmXDMpa6hNSS4dVTbFhvzk2fCeMlZ6y3I
+  default_config_hash: nNi8dFcjVmDJL4brSSIk2j7EZgLP4YAWRfNBctIQmjU
 id: dkan_content
 label: 'DKAN Content'
 module: node
@@ -181,20 +181,8 @@ display:
           clear_on_exposed: true
           action_title: Action
           selected_actions:
-            node_unpromote_action: 0
-            node_unpublish_action: 0
-            node_publish_action: 0
-            node_unpublish_by_keyword_action: 0
-            node_assign_owner_action: 0
-            node_promote_action: 0
-            node_save_action: 0
-            node_make_sticky_action: 0
-            node_make_unsticky_action: 0
-            views_bulk_operations_delete_entity: views_bulk_operations_delete_entity
-            'entity:save_action:node': 0
-            'entity:unpublish_action:node': 'entity:unpublish_action:node'
-            'entity:publish_action:node': 'entity:publish_action:node'
-            'entity:delete_action:node': 0
+            6:
+              action_id: views_bulk_operations_delete_entity
           preconfiguration:
             views_bulk_operations_delete_entity:
               label_override: ''
@@ -555,6 +543,8 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -596,6 +586,8 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -638,6 +630,8 @@ display:
               api_user: '0'
               administrator: '0'
             placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -674,6 +668,8 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Published status'
@@ -723,6 +719,8 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -747,6 +745,9 @@ display:
           plugin_id: node_status
           group: 1
           entity_type: node
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
       sorts: {  }
       title: Content
       empty:

--- a/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_content.yml
+++ b/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_content.yml
@@ -7,7 +7,6 @@ dependencies:
   module:
     - node
     - user
-    - views_bulk_operations
 _core:
   default_config_hash: nNi8dFcjVmDJL4brSSIk2j7EZgLP4YAWRfNBctIQmjU
 id: dkan_content
@@ -126,14 +125,14 @@ display:
       row:
         type: fields
       fields:
-        views_bulk_operations_bulk_form:
-          id: views_bulk_operations_bulk_form
-          table: views
-          field: views_bulk_operations_bulk_form
+        node_bulk_form:
+          id: node_bulk_form
+          table: node
+          field: node_bulk_form
           relationship: none
           group_type: group
           admin_label: ''
-          label: 'Views bulk operations'
+          label: ''
           exclude: false
           alter:
             alter_text: false
@@ -166,7 +165,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: true
+          element_label_colon: false
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -174,23 +173,12 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          batch: false
-          batch_size: 100
-          form_step: true
-          buttons: false
-          clear_on_exposed: true
           action_title: Action
+          include_exclude: include
           selected_actions:
-            6:
-              action_id: views_bulk_operations_delete_entity
-          preconfiguration:
-            views_bulk_operations_delete_entity:
-              label_override: ''
-            'entity:unpublish_action:node':
-              label_override: ''
-            'entity:publish_action:node':
-              label_override: ''
-          plugin_id: views_bulk_operations_bulk_form
+            - node_delete_action
+          entity_type: node
+          plugin_id: node_bulk_form
         title:
           id: title
           table: node_field_data

--- a/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
+++ b/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
@@ -8,7 +8,7 @@ dependencies:
     - node
     - user
 _core:
-  default_config_hash: xG2bEUTQYVqERMnXUOpE00dV04YsQjT4TdFcsmwuuS4
+  default_config_hash: ayMn8Dqvkbh9zfi5TpHKQi1ZV3yGOOTXvEWnhrHwSfQ
 id: dkan_dataset_content
 label: 'DKAN Datasets'
 module: node
@@ -147,16 +147,54 @@ display:
           id: node_bulk_form
           table: node
           field: node_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
           label: ''
           exclude: false
           alter:
             alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
           element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
           element_default_classes: true
           empty: ''
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+          action_title: Action
+          include_exclude: include
+          selected_actions:
+            - node_delete_action
           plugin_id: node_bulk_form
           entity_type: node
         uuid:
@@ -427,6 +465,8 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -465,6 +505,8 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Published status'
@@ -514,6 +556,8 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -538,6 +582,9 @@ display:
           plugin_id: node_status
           group: 1
           entity_type: node
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
         field_data_type_value:
           id: field_data_type_value
           table: node__field_data_type
@@ -562,6 +609,8 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''

--- a/modules/metastore/modules/metastore_admin/metastore_admin.module
+++ b/modules/metastore/modules/metastore_admin/metastore_admin.module
@@ -72,7 +72,7 @@ function metastore_admin_preprocess_views_view_field(&$vars) {
 
         case 'distribution':
           $dist = (array) $title['data'];
-          $mediatype = $entity_id . ' ' . $dist['mediaType'];
+          $mediatype = isset($dist['mediaType']) ? $entity_id . ' ' . $dist['mediaType'] : '';
           $format = $dist['format'] ? $entity_id . ' ' . $dist['format'] : $mediatype;
           $title = $dist['title'] ? $dist['title'] : $format;
 


### PR DESCRIPTION
## Issues
- Fix undefined index error on mediaType.
- Add delete option on dkan_content view.
- Remove publish, unpublish, sticky, promote, etc VBO options from dkan_datasets view. Publishing and Unpublishing via VBO needs work.

## QA Steps

1. Go to `/admin/content/node`, you should be able to use the VBO UI to delete content. And not see any undefined index errors.
2. Go to `/admin/content/datasets`, you should be able to use the VBO UI to delete datasets. And not see any undefined index errors.
3. Confirm that 'delete' is the only VBO option.