### PR TITLE
add delete queue for orphaned content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ composer.lock
 docs
 .vscode
 coverage
+cypress/screenshots
 cypress/videos
 package-lock.json
 tagfile

--- a/cypress/integration/09_admin_links.spec.js
+++ b/cypress/integration/09_admin_links.spec.js
@@ -11,7 +11,8 @@ context('Administration pages', () => {
         cy.wrap($el).contains('DKAN').next('.toolbar-menu').then($el=>{
           cy.wrap($el).invoke('show')
           cy.wrap($el).contains('Dataset properties').click()
-          cy.get('.fieldset-legend').should('have.text', 'List of dataset properties with referencing and API endpoint')
+          cy.get('.fieldset-legend').first().should('have.text', 'List of dataset properties with referencing and API endpoint')
+          cy.get('.fieldset-legend').last().should('have.text', 'Orphaned content processing')
         })
     })
   })

--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -108,6 +108,7 @@ dkan.metastore.config_properties:
   path: '/admin/config/dkan/properties'
   defaults:
     _form: '\Drupal\metastore\Form\DkanDataSettingsForm'
+    _title: 'Metastore configuration'
   requirements:
     _permission: 'access administration pages'
   options:

--- a/modules/metastore/src/Form/DkanDataSettingsForm.php
+++ b/modules/metastore/src/Form/DkanDataSettingsForm.php
@@ -42,11 +42,25 @@ class DkanDataSettingsForm extends ConfigFormBase {
     $config = $this->config('metastore.settings');
     $options = $this->retrieveSchemaProperties();
     $default_values = $config->get('property_list');
+    $default_processing = $config->get('orphan_processing') ? $config->get('orphan_processing') : 0;
     $form['property_list'] = [
       '#type' => 'checkboxes',
       '#title' => $this->t('List of dataset properties with referencing and API endpoint'),
+      '#description_display' => 'before',
+      '#description' => $this->t("Break out specific sub-elements of the dataset schema so that these elements can be worked with as individual objects. Each element is assigned a unique identifier in addition to it's original schema values."),
       '#options' => $options,
       '#default_value' => $default_values,
+    ];
+    $form['orphan_processing'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Orphaned content processing'),
+      '#description_display' => 'before',
+      '#description' => $this->t("Define how to process data content that is no longer assocciated with a dataset."),
+      '#default_value' => $default_processing,
+      '#options' => [
+        0 => $this->t('Delete'),
+        1 => $this->t('Unpublish'),
+      ],
     ];
     return parent::buildForm($form, $form_state);
   }
@@ -87,6 +101,7 @@ class DkanDataSettingsForm extends ConfigFormBase {
 
     $this->config('metastore.settings')
       ->set('property_list', $form_state->getValue('property_list'))
+      ->set('orphan_processing', $form_state->getValue('orphan_processing'))
       ->save();
 
     // Rebuild routes, without clearing all caches.

--- a/modules/sample_content/sample_content.install
+++ b/modules/sample_content/sample_content.install
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * Implements hook_uninstall()
+ */
+function sample_content_uninstall() {
+  \Drupal::database()->schema()->dropTable('harvest_sample_content_hash');
+}


### PR DESCRIPTION
- add a config option for ‘delete’ rather than unpublish orhpaned content
- restore the 'deleteReference' function

## QA Steps
Start with a fresh build with no content.
- [ ] create harvest 1 
    ```
    dktl drush dkan:harvest:register '{"identifier":"test","extract":{"type":"\\Harvest\\ETL\\Extract\\DataJson","uri":"https://dkan-default-content-files.s3.amazonaws.com/data.json"},"transforms":[],"load":{"type":"\\Drupal\\harvest\\Load\\Dataset"}}'
    ```
- [ ] create harvest 2 
    ```
    dktl drush dkan:harvest:register '{"identifier":"test2","extract":{"type":"\\Harvest\\ETL\\Extract\\DataJson","uri":"https://dkan-default-content-files.s3.amazonaws.com/harvest-test.json"},"transforms":[],"load":{"type":"\\Drupal\\harvest\\Load\\Dataset"}}'
    ```
- [ ] Run each harvest 
    ```
    dktl drush dkan:harvest:run test
    dktl drush dkan:harvest:run test2
    ```
- [ ] Visit `admin/content/node` and confirm that you have two datasets and the keyword, theme, distribution, and publisher content. 
- [ ] Select "delete" option for Orphaned Content Processing at `admin/config/dkan/properties` or 
   ```
   dktl drush config:set "metastore.settings" orphan_processing 0 -y
   ```
- [ ] Revert the first harvest: 
   ```
   dktl drush dkan:harvest:revert test
   ```
- [ ] Run the queue 
    ```
    dktl drush queue:run orphan_reference_processor
    ``` 
- [ ] Go to `admin/content/node` and confirm that the dataset, distribution, and keyword content from the _test_ harvest are gone, and the shared theme and publisher remain.
- [ ] Now revert harvest 2 
    ```
    dktl drush dkan:harvest:revert test2
    ```
- [ ] Run the queue 
    ```
    dktl drush queue:run orphan_reference_processor
    ``` 
- [ ] Return to `admin/content/node` and confirm all content has been removed.

---

- [ ] run one of the harvests again 
    ```
    dktl drush dkan:harvest:run test
    ```
- [ ] switch orphan processing to Unpublish 
    ```
    dktl drush config:set "metastore.settings" orphan_processing 1 -y
    ```
- [ ] revert the harvest 
    ```
    dktl drush dkan:harvest:revert test
    ```
- [ ] run the queue 
   ```
   dktl drush queue:run orphan_reference_processor
   ``` 
- [ ] visit `admin/content/node` and confirm the dataset is gone but the extra nodes still persist
- [ ] view the **content_moderation_state_field_revision** table and confirm there is a revision for each set to draft

To Do: the unpublish option should make the draft revisions === the current revision