### PR TITLE
Add option to keep the file when dropping the datastore

### DIFF
--- a/modules/datastore/drush.services.yml
+++ b/modules/datastore/drush.services.yml
@@ -1,6 +1,6 @@
 services:
   datastore:commands:
-    class: \Drupal\datastore\Drush
+    class: \Drupal\datastore\Commands\DatastoreCommands
     arguments:
       - '@dkan.metastore.service'
       - '@dkan.datastore.service'

--- a/modules/datastore/src/Commands/DatastoreCommands.php
+++ b/modules/datastore/src/Commands/DatastoreCommands.php
@@ -1,13 +1,12 @@
 <?php
 
-namespace Drupal\datastore;
+namespace Drupal\datastore\Commands;
 
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Consolidation\OutputFormatters\StructuredData\UnstructuredListData;
 use Drupal\datastore\Service\ResourceLocalizer;
 use Drupal\datastore\Service as Datastore;
 use Drupal\metastore\Service as Metastore;
-use Drupal\datastore\Drush\Helper;
 use Drush\Commands\DrushCommands;
 
 /**
@@ -15,7 +14,7 @@ use Drush\Commands\DrushCommands;
  *
  * @codeCoverageIgnore
  */
-class Drush extends DrushCommands {
+class DatastoreCommands extends DrushCommands {
   use Helper;
   /**
    * The metastore service.

--- a/modules/datastore/src/Commands/DatastoreCommands.php
+++ b/modules/datastore/src/Commands/DatastoreCommands.php
@@ -158,7 +158,7 @@ class DatastoreCommands extends DrushCommands {
   public function drop($uuid, array $options = ['keepfile' => FALSE]) {
     $keep = $options['keepfile'] ? TRUE : FALSE;
     try {
-      $this->datastoreService->drop($uuid, $keep);
+      $this->datastoreService->drop($uuid, NULL, $keep);
       $this->logger->notice("Successfully dropped the datastore for {$uuid}");
     }
     catch (\Exception $e) {
@@ -183,7 +183,7 @@ class DatastoreCommands extends DrushCommands {
     foreach ($this->metastoreService->getAll('distribution') as $distribution) {
       $uuid = $distribution->data->{"%Ref:downloadURL"}[0]->data->identifier;
       try {
-        $this->datastoreService->drop($uuid);
+        $this->datastoreService->drop($uuid, NULL, $keep);
         $this->logger->notice("Successfully dropped the datastore for {$uuid}");
       }
       catch (\Exception $e) {

--- a/modules/datastore/src/Commands/Helper.php
+++ b/modules/datastore/src/Commands/Helper.php
@@ -10,31 +10,53 @@ namespace Drupal\datastore\Commands;
 trait Helper {
 
   /**
-   * Delete jobstore entries related to a datastore.
+   * Delete jobstore entries related to a datastore import.
    */
-  public function jobstorePrune($uuid, $keep = FALSE) {
+  public function jobstorePruneImporter($uuid) {
     if (!isset($this->resourceLocalizer)) {
       \Drupal::logger('datastore')->error('ResourceLocalizer is not set.');
       return;
     }
     $resource = $this->resourceLocalizer->get($uuid);
-    $ref_uuid = $resource->getUniqueIdentifier();
-    $jobs[] = ["id" => md5($ref_uuid), "table" => "jobstore_dkan_datastore_importer"];
-    if (!$keep) {
-      $jobs[] = [
-        "id" => substr(str_replace('__', '_', $ref_uuid), 0, -11),
-        "table" => "jobstore_filefetcher_filefetcher",
-      ];
-    }
-
-    try {
-      foreach ($jobs as $job) {
-        \Drupal::database()->delete($job['table'])->condition('ref_uuid', $job['id'])->execute();
-        $this->logger('datastore')->notice("Successfully removed the {$job['table']} record for ref_uuid {$job['id']}.");
+    if ($resource) {
+      $ref_uuid = $resource->getUniqueIdentifier();
+      $id = md5($ref_uuid);
+      try {
+        \Drupal::database()->delete('jobstore_dkan_datastore_importer')->condition('ref_uuid', $id)->execute();
+        $this->logger('datastore')->notice("Successfully removed the jobstore record for ref_uuid {$id}.");
+      }
+      catch (\Exception $e) {
+        $this->logger('datastore')->error("Failed to delete the jobstore record for ref_uuid {$id}.", $e->getMessage());
       }
     }
-    catch (\Exception $e) {
-      $this->logger('datastore')->error("Failed to delete the jobstore record for ref_uuid {$job['id']}.", $e->getMessage());
+    else {
+      $this->logger('datastore')->error('Unable to get the unique identifier.');
+    }
+  }
+
+  /**
+   * Delete jobstore entries related to a datastore's local file.
+   */
+  public function jobstorePruneFilefetcher($uuid) {
+    if (!isset($this->resourceLocalizer)) {
+      \Drupal::logger('datastore')->error('ResourceLocalizer is not set.');
+      return;
+    }
+
+    $resource = $this->resourceLocalizer->get($uuid);
+    if ($resource) {
+      $ref_uuid = $resource->getUniqueIdentifier();
+      $id = substr(str_replace('__', '_', $ref_uuid), 0, -11);
+      try {
+        \Drupal::database()->delete('jobstore_filefetcher_filefetcher')->condition('ref_uuid', $id)->execute();
+        $this->logger('datastore')->notice("Successfully removed the jobstore record for ref_uuid {$id}.");
+      }
+      catch (\Exception $e) {
+        $this->logger('datastore')->error("Failed to delete the jobstore record for ref_uuid {$id}.", $e->getMessage());
+      }
+    }
+    else {
+      $this->logger('datastore')->error('Unable to get the unique identifier.');
     }
   }
 

--- a/modules/datastore/src/Commands/Helper.php
+++ b/modules/datastore/src/Commands/Helper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\datastore\Drush;
+namespace Drupal\datastore\Commands;
 
 /**
  * Datastore Trait to assist Drush commands.

--- a/modules/datastore/src/Drush.php
+++ b/modules/datastore/src/Drush.php
@@ -146,8 +146,10 @@ class Drush extends DrushCommands {
    *
    * @param string $uuid
    *   The uuid of a dataset.
+   * @param array $options
+   *   Options.
    *
-   * @options keepfile Keep the local file.
+   * @option keepfile Keep the local file.
    *
    * @command dkan:datastore:drop
    *

--- a/modules/datastore/src/Drush.php
+++ b/modules/datastore/src/Drush.php
@@ -7,6 +7,7 @@ use Consolidation\OutputFormatters\StructuredData\UnstructuredListData;
 use Drupal\datastore\Service\ResourceLocalizer;
 use Drupal\datastore\Service as Datastore;
 use Drupal\metastore\Service as Metastore;
+use Drupal\datastore\Drush\Helper;
 use Drush\Commands\DrushCommands;
 
 /**
@@ -15,7 +16,7 @@ use Drush\Commands\DrushCommands;
  * @codeCoverageIgnore
  */
 class Drush extends DrushCommands {
-  use TableTrait;
+  use Helper;
   /**
    * The metastore service.
    *
@@ -148,11 +149,13 @@ class Drush extends DrushCommands {
    *
    * @command dkan:datastore:drop
    * @aliases dkan-datastore:drop
+   * @options keepfile Keep the local file.
    * @deprecated dkan-datastore:drop is deprecated and will be removed in a future Dkan release. Use dkan:datastore:drop instead.
    */
-  public function drop($uuid) {
+  public function drop($uuid, $options = ['keepfile' => FALSE]) {
+    $keep = $options['keepfile'] ? TRUE : FALSE;
     try {
-      $this->datastoreService->drop($uuid);
+      $this->datastoreService->drop($uuid, $keep);
       $this->logger->notice("Successfully dropped the datastore for {$uuid}");
     }
     catch (\Exception $e) {
@@ -161,7 +164,7 @@ class Drush extends DrushCommands {
       return;
     }
 
-    $this->jobstorePrune($uuid);
+    $this->jobstorePrune($uuid, $keep);
 
   }
 
@@ -169,9 +172,10 @@ class Drush extends DrushCommands {
    * Drop a ALL datastore tables.
    *
    * @command dkan:datastore:drop-all
+   * @options keepfile Keep the local file.
    */
-  public function dropAll() {
-
+  public function dropAll($options = ['keepfile' => FALSE]) {
+    $keep = $options['keepfile'] ? TRUE : FALSE;
     foreach ($this->metastoreService->getAll('distribution') as $distribution) {
       $uuid = $distribution->data->{"%Ref:downloadURL"}[0]->data->identifier;
       try {
@@ -184,7 +188,7 @@ class Drush extends DrushCommands {
         continue;
       }
 
-      $this->jobstorePrune($uuid);
+      $this->jobstorePrune($uuid, $keep);
 
     }
   }

--- a/modules/datastore/src/Drush.php
+++ b/modules/datastore/src/Drush.php
@@ -156,7 +156,7 @@ class Drush extends DrushCommands {
    * @aliases dkan-datastore:drop
    * @deprecated dkan-datastore:drop is deprecated and will be removed in a future Dkan release. Use dkan:datastore:drop instead.
    */
-  public function drop($uuid, $options = ['keepfile' => FALSE]) {
+  public function drop($uuid, array $options = ['keepfile' => FALSE]) {
     $keep = $options['keepfile'] ? TRUE : FALSE;
     try {
       $this->datastoreService->drop($uuid, $keep);

--- a/modules/datastore/src/Drush.php
+++ b/modules/datastore/src/Drush.php
@@ -146,10 +146,9 @@ class Drush extends DrushCommands {
    *
    * @param string $uuid
    *   The uuid of a dataset.
-   *
+   * @options keepfile Keep the local file.
    * @command dkan:datastore:drop
    * @aliases dkan-datastore:drop
-   * @options keepfile Keep the local file.
    * @deprecated dkan-datastore:drop is deprecated and will be removed in a future Dkan release. Use dkan:datastore:drop instead.
    */
   public function drop($uuid, $options = ['keepfile' => FALSE]) {
@@ -171,8 +170,8 @@ class Drush extends DrushCommands {
   /**
    * Drop a ALL datastore tables.
    *
-   * @command dkan:datastore:drop-all
    * @options keepfile Keep the local file.
+   * @command dkan:datastore:drop-all
    */
   public function dropAll($options = ['keepfile' => FALSE]) {
     $keep = $options['keepfile'] ? TRUE : FALSE;

--- a/modules/datastore/src/Drush.php
+++ b/modules/datastore/src/Drush.php
@@ -146,8 +146,11 @@ class Drush extends DrushCommands {
    *
    * @param string $uuid
    *   The uuid of a dataset.
+   *
    * @options keepfile Keep the local file.
+   *
    * @command dkan:datastore:drop
+   *
    * @aliases dkan-datastore:drop
    * @deprecated dkan-datastore:drop is deprecated and will be removed in a future Dkan release. Use dkan:datastore:drop instead.
    */
@@ -171,6 +174,7 @@ class Drush extends DrushCommands {
    * Drop a ALL datastore tables.
    *
    * @options keepfile Keep the local file.
+   *
    * @command dkan:datastore:drop-all
    */
   public function dropAll($options = ['keepfile' => FALSE]) {

--- a/modules/datastore/src/Drush/Helper.php
+++ b/modules/datastore/src/Drush/Helper.php
@@ -19,12 +19,7 @@ trait Helper {
     }
     $resource = $this->resourceLocalizer->get($uuid);
     $ref_uuid = $resource->getUniqueIdentifier();
-    $jobs = [
-      [
-        "id" => md5($ref_uuid),
-        "table" => "jobstore_dkan_datastore_importer",
-      ],
-    ];
+    $jobs[] = ["id" => md5($ref_uuid), "table" => "jobstore_dkan_datastore_importer"];
     if (!$keep) {
       $jobs[] = [
         "id" => substr(str_replace('__', '_', $ref_uuid), 0, -11),

--- a/modules/datastore/src/Drush/Helper.php
+++ b/modules/datastore/src/Drush/Helper.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace Drupal\datastore;
+namespace Drupal\datastore\Drush;
 
 /**
  * Datastore Trait to assist Drush commands.
  *
  * @codeCoverageIgnore
  */
-trait TableTrait {
+trait Helper {
 
   /**
    * Delete jobstore entries related to a datastore.
    */
-  public function jobstorePrune($uuid) {
+  public function jobstorePrune($uuid, $keep = FALSE) {
     if (!isset($this->resourceLocalizer)) {
       \Drupal::logger('datastore')->error('ResourceLocalizer is not set.');
       return;
@@ -21,14 +21,16 @@ trait TableTrait {
     $ref_uuid = $resource->getUniqueIdentifier();
     $jobs = [
       [
-        "id" => substr(str_replace('__', '_', $ref_uuid), 0, -11),
-        "table" => "jobstore_filefetcher_filefetcher",
-      ],
-      [
         "id" => md5($ref_uuid),
         "table" => "jobstore_dkan_datastore_importer",
       ],
     ];
+    if (!$keep) {
+      $jobs[] = [
+        "id" => substr(str_replace('__', '_', $ref_uuid), 0, -11),
+        "table" => "jobstore_filefetcher_filefetcher",
+      ];
+    }
 
     try {
       foreach ($jobs as $job) {

--- a/modules/datastore/src/Service.php
+++ b/modules/datastore/src/Service.php
@@ -159,10 +159,10 @@ class Service implements ContainerInjectionInterface {
    *
    * @param string $identifier
    *   A resource's identifier.
-   * @param bool $keep
-   *   Keep the local file.
    * @param string|null $version
    *   A resource's version.
+   * @param bool $keep
+   *   Keep the local file.
    */
   public function drop(string $identifier, $version = NULL, $keep = FALSE) {
     $storage = $this->getStorage($identifier, $version);

--- a/modules/datastore/src/Service.php
+++ b/modules/datastore/src/Service.php
@@ -164,7 +164,7 @@ class Service implements ContainerInjectionInterface {
    * @param string|null $version
    *   A resource's version.
    */
-  public function drop(string $identifier, $keep = FALSE, $version = NULL) {
+  public function drop(string $identifier, $version = NULL, $keep = FALSE) {
     $storage = $this->getStorage($identifier, $version);
 
     if ($storage) {

--- a/modules/datastore/src/Service.php
+++ b/modules/datastore/src/Service.php
@@ -159,17 +159,20 @@ class Service implements ContainerInjectionInterface {
    *
    * @param string $identifier
    *   A resource's identifier.
+   * @param bool $keep
+   *   Keep the local file.
    * @param string|null $version
    *   A resource's version.
    */
-  public function drop(string $identifier, $version = NULL) {
+  public function drop(string $identifier, $keep = FALSE, $version = NULL) {
     $storage = $this->getStorage($identifier, $version);
 
     if ($storage) {
       $storage->destroy();
     }
-
-    $this->resourceLocalizer->remove($identifier, $version);
+    if (!$keep) {
+      $this->resourceLocalizer->remove($identifier, $version);
+    }
   }
 
   /**

--- a/modules/datastore/src/Service.php
+++ b/modules/datastore/src/Service.php
@@ -161,18 +161,40 @@ class Service implements ContainerInjectionInterface {
    *   A resource's identifier.
    * @param string|null $version
    *   A resource's version.
-   * @param bool $keep
-   *   Keep the local file.
    */
-  public function drop(string $identifier, $version = NULL, $keep = FALSE) {
-    $storage = $this->getStorage($identifier, $version);
+  public function drop(string $identifier, $version = NULL) {
+    $this->dropTable($identifier, $version);
+    $this->dropFile($identifier, $version);
+  }
 
+  /**
+   * Drop a resource's datastore table.
+   *
+   * @param string $identifier
+   *   A resource's identifier.
+   * @param string|null $version
+   *   A resource's version.
+   */
+  public function dropTable(string $identifier, $version = NULL) {
+    $storage = $this->getStorage($identifier, $version);
     if ($storage) {
       $storage->destroy();
     }
-    if (!$keep) {
-      $this->resourceLocalizer->remove($identifier, $version);
+    else {
+      throw new \Exception("no storage");
     }
+  }
+
+  /**
+   * Drop a resource's local file.
+   *
+   * @param string $identifier
+   *   A resource's identifier.
+   * @param string|null $version
+   *   A resource's version.
+   */
+  public function dropFile(string $identifier, $version = NULL) {
+    $this->resourceLocalizer->remove($identifier, $version);
   }
 
   /**


### PR DESCRIPTION
## QA Steps

1. harvest something
2. run `dktl dkan:datastore:drop {id} --keepfile`
3. confirm the filefetcher job stays put and the local file is still in /sites/default/files/resources/{id}/
4. run `dktl dkan:datastore:import {id}`
5. confirm the datastore is imported as expected
6. run `dktl dkan:datastore:drop {id}`
7. confirm the datastore and all jobstore entries for that file are removed