### PR TITLE
Catch errors which interrupted datastore resource purge-all

### DIFF
--- a/modules/datastore/src/Service/ResourcePurger.php
+++ b/modules/datastore/src/Service/ResourcePurger.php
@@ -295,7 +295,7 @@ class ResourcePurger implements ContainerInjectionInterface {
    *   Array of resource identifiers and versions. Each array element is a
    *   JSON-encoded array containing a resource's identifier and version.
    */
-  private function getResources(NodeInterface $dataset) {
+  private function getResources(NodeInterface $dataset) : array {
     $resources = [];
     $metadata = json_decode($dataset->get('field_json_metadata')->getString());
     $distributions = $metadata->{'%Ref:distribution'};

--- a/modules/datastore/src/Service/ResourcePurger.php
+++ b/modules/datastore/src/Service/ResourcePurger.php
@@ -147,7 +147,12 @@ class ResourcePurger implements ContainerInjectionInterface {
   public function purgeMultiple(array $uuids, bool $prior = FALSE) {
     if ($this->validate()) {
       foreach ($uuids as $vid => $uuid) {
-        $this->purge($vid, $uuid, $prior);
+        try {
+          $this->purge($vid, $uuid, $prior);
+        }
+        catch (\Exception $e) {
+          $this->error("Error purging uuid {$uuid}, revision id {$vid}: " . $e->getMessage());
+        }
       }
     }
   }
@@ -299,13 +304,19 @@ class ResourcePurger implements ContainerInjectionInterface {
    */
   private function delete(string $id, string $version) {
     if ($this->getPurgeFileSetting()) {
-      $this->datastore->getResourceLocalizer()->remove($id, $version);
+      try {
+        $this->datastore->getResourceLocalizer()->remove($id, $version);
+      }
+      catch (\Exception $e) {
+        $this->error("Error removing resource localizer id {$id}, version {$version}: " . $e->getMessage());
+      }
     }
     if ($this->getPurgeTableSetting()) {
       try {
         $this->datastore->getStorage($id, $version)->destroy();
       }
       catch (\Exception $e) {
+        $this->error("Error deleting datastore id {$id}, version {$version}: " . $e->getMessage());
       }
     }
   }

--- a/modules/datastore/tests/src/Service/ResourcePurgerTest.php
+++ b/modules/datastore/tests/src/Service/ResourcePurgerTest.php
@@ -2,11 +2,9 @@
 
 namespace Drupal\Tests\datastore\Service;
 
-use Drupal\common\Resource;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\DependencyInjection\Container;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Queue\QueueInterface;
@@ -15,7 +13,6 @@ use Drupal\datastore\Service\ResourcePurger;
 use Drupal\metastore\Storage\Data;
 use Drupal\metastore\Storage\DataFactory;
 use Drupal\node\Entity\Node;
-use Drupal\node\NodeInterface;
 use Drupal\node\NodeStorageInterface;
 use MockChain\Chain;
 use MockChain\Options;


### PR DESCRIPTION
Drush command `dan:datastore:purge-all` was being interrupted by at least a couple different errors (one SQLSTATE related, one wrapper-related).

This PR addresses the above by adding some try..catch statements.