### PR TITLE
Harvest Drush commands tweaks

### DIFF
--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -160,7 +160,7 @@ class HarvestCommands extends DrushCommands {
         ->getAllHarvestRunInfo($id);
       $table = new Table(new ConsoleOutput());
       $table->setHeaders(["{$id} runs"]);
-      foreach (array_keys($runs) as $run_id) {
+      foreach ($runs as $run_id) {
         $table->addRow([$run_id]);
       }
       $table->render();

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -254,9 +254,7 @@ class HarvestCommands extends DrushCommands {
       return DrushCommands::EXIT_FAILURE;
     }
 
-    $run = json_decode($run, TRUE);
-
-    $this->renderStatusTable($harvest_id, $run_id, $run);
+    $this->renderStatusTable($harvest_id, $run_id, json_decode($run, TRUE));
   }
 
   /**

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -228,7 +228,9 @@ class HarvestCommands extends DrushCommands {
     }
 
     if (empty($run_id)) {
-      $run_id = $run_id_all[0];
+      // Get the last run_id from the array.
+      $run_id = end($run_id_all);
+      reset($run_id_all);
     }
 
     if (array_search($run_id, $run_id_all) === FALSE) {

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -118,7 +118,13 @@ class HarvestCommands extends DrushCommands {
     $result = $this->harvestService
       ->runHarvest($id);
 
-    $this->renderResult($result);
+    // Fetch run_id from the harvest service.
+    $run_ids = $this->harvestService
+      ->getAllHarvestRunInfo($id);
+
+    $this->renderHarvestRunsInfo([
+      [end($run_ids), $result],
+    ]);
   }
 
   /**
@@ -154,24 +160,26 @@ class HarvestCommands extends DrushCommands {
    * @deprecated dkan-harvest:info is deprecated and will be removed in a future Dkan release. Use dkan:harvest:info instead.
    */
   public function info($id, $run_id = NULL) {
+    $run_ids = [];
 
     if (!isset($run_id)) {
-      $runs = $this->harvestService
+      $run_ids = $this->harvestService
         ->getAllHarvestRunInfo($id);
-      $table = new Table(new ConsoleOutput());
-      $table->setHeaders(["{$id} runs"]);
-      foreach ($runs as $run_id) {
-        $table->addRow([$run_id]);
-      }
-      $table->render();
     }
     else {
-      $run = $this->harvestService
-        ->getHarvestRunInfo($id, $run_id);
-      $result = json_decode($run);
-      print_r($result);
+      $run_ids = [$run_id];
     }
 
+    $run_infos = [];
+    foreach ($run_ids as $run_id) {
+      $run = $this->harvestService
+        ->getHarvestRunInfo($id, $run_id);
+      $result = json_decode($run, TRUE);
+
+      $run_infos[] = [$run_id, $result];
+    }
+
+    $this->renderHarvestRunsInfo($run_infos);
   }
 
   /**

--- a/modules/harvest/src/Commands/Helper.php
+++ b/modules/harvest/src/Commands/Helper.php
@@ -47,7 +47,7 @@ trait Helper {
   }
 
   /**
-   *
+   * Return Processed, Created, Updated, Failed counts from Harvest Run Result.
    */
   private function getResultCounts($result) {
     $interpreter = new ResultInterpreter($result);
@@ -72,7 +72,6 @@ trait Helper {
 
     foreach ($runInfos as $runInfo) {
       list($run_id, $result) = $runInfo;
-      $interpreter = new ResultInterpreter($result);
 
       $row = array_merge(
         [$run_id],

--- a/modules/harvest/src/Commands/Helper.php
+++ b/modules/harvest/src/Commands/Helper.php
@@ -89,17 +89,19 @@ trait Helper {
    * Render table for harvest run item status.
    */
   private function renderStatusTable($harvest_id, $run_id, $run) {
+    $consoleOutput = new ConsoleOutput();
+
     if (empty($run['status']['extracted_items_ids'])) {
       $extract_status = $run['status']['extract'];
 
-      (new ConsoleOutput())->writeln(
+      $consoleOutput->writeln(
         ["<warning>harvest id $harvest_id and run id $run_id extract status is $extract_status</warning>",
           "<warning>No items were extracted.</warning>",
         ]
       );
     }
     else {
-      $table = new Table(new ConsoleOutput());
+      $table = new Table($consoleOutput);
       $table->setHeaders(["item_id", "extract", "transform", "load"]);
 
       foreach ($run['status']['extracted_items_ids'] as $item_id) {
@@ -107,6 +109,9 @@ trait Helper {
         $table->addRow($row);
       }
 
+      $consoleOutput->writeln(
+        ["<info>$harvest_id run id $run_id status </info>"]
+      );
       $table->render();
     }
   }

--- a/modules/harvest/src/Commands/Helper.php
+++ b/modules/harvest/src/Commands/Helper.php
@@ -47,19 +47,41 @@ trait Helper {
   }
 
   /**
-   * Private..
+   *
    */
-  private function renderResult($result) {
+  private function getResultCounts($result) {
     $interpreter = new ResultInterpreter($result);
 
-    $table = new Table(new ConsoleOutput());
-    $table->setHeaders(['processed', 'created', 'updated', 'errors']);
-    $table->addRow([
+    return [
       $interpreter->countProcessed(),
       $interpreter->countCreated(),
       $interpreter->countUpdated(),
       $interpreter->countFailed(),
-    ]);
+    ];
+  }
+
+  /**
+   * Display a list of [runIds, runInfo].
+   *
+   * @param array $runInfos
+   *   Array of run Ids and HarvesterRunInfo association.
+   */
+  private function renderHarvestRunsInfo(array $runInfos) {
+    $table = new Table(new ConsoleOutput());
+    $table->setHeaders(['run_id', 'processed', 'created', 'updated', 'errors']);
+
+    foreach ($runInfos as $runInfo) {
+      list($run_id, $result) = $runInfo;
+      $interpreter = new ResultInterpreter($result);
+
+      $row = array_merge(
+        [$run_id],
+        $this->getResultCounts($result)
+      );
+
+      $table->addRow($row);
+    }
+
     $table->render();
   }
 

--- a/modules/sample_content/src/Drush.php
+++ b/modules/sample_content/src/Drush.php
@@ -21,8 +21,8 @@ class Drush extends DrushCommands {
     $this->createJson();
     $harvester = $this->getHarvester("sample_content");
     $result = $harvester->harvest();
-    $this->renderResult($result);
-    print_r($result);
+
+    $this->renderHarvestRunsInfo([['sample_content', $result]]);
   }
 
   /**


### PR DESCRIPTION
fixes [org/repo/issue#]

- [ ] Test coverage exists
- [ ] Documentation exists

## Description
**dkan:harvest:status**
1. Fix `drush dkan:harvest:status [harvest_plan_id]` returning the first harvest run and not the last as stated in the description.

![image](https://user-images.githubusercontent.com/1914306/105898291-8b277580-6019-11eb-8f61-6f8953226919.png)


**dkan:harvest:info**
1. Fix `drush dkan:harvest:info [harvest_plan_id]` not returning actual run ids.
2. `drush dkan:harvest:info [harvest_plan_id]` will show run result stats from all or provided harvest runId.

![image](https://user-images.githubusercontent.com/1914306/105897169-20c20580-6018-11eb-9bbf-6145e11fba28.png)

**dktl install:sample**
1. Use the harvest run info render helper method instead of `print_r` call.
![image](https://user-images.githubusercontent.com/1914306/106169408-a0261500-618f-11eb-8e27-d00561bb9c21.png)

## QA Steps

- [x] Run command to notice the difference and make sure they work as advertised.
