### PR TITLE
Remove resource schema fields from dataset JSON schema.

### DIFF
--- a/schema/collections/dataset.json
+++ b/schema/collections/dataset.json
@@ -301,68 +301,6 @@
             "description": "The machine-readable file format (IANA Media Type or MIME Type) of the distribution’s describedBy URL.",
             "pattern": "^[a-z]+?$",
             "type": "string"
-          },
-          "schema": {
-            "title": "Schema",
-            "description": "Ref of https://frictionlessdata.io/schemas/table-schema.json<p>This is used to specify a data dictionary or schema that defines fields or column headings in the distribution.</p>",
-            "type": "object",
-            "properties": {
-              "fields": {
-                "type": "array",
-                "items": {
-                  "title": "Table Schema Field",
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "title": "Name",
-                      "description": "A name for this field.",
-                      "type": "string"
-                    },
-                    "title": {
-                      "title": "Title",
-                      "description": "A human-readable title.",
-                      "type": "string"
-                    },
-                    "description": {
-                      "title": "Description",
-                      "description": "A text description. Markdown is encouraged.",
-                      "type": "string"
-                    },
-                    "type": {
-                      "description": "The type for the data.",
-                      "type": "string",
-                      "enum": [
-                        "string",
-                        "integer",
-                        "number",
-                        "boolean",
-                        "object",
-                        "array",
-                        "date",
-                        "time",
-                        "datetime",
-                        "year",
-                        "yearmonth",
-                        "duration",
-                        "geopoint",
-                        "geojson"
-                      ]
-                    },
-                    "format": {
-                      "description": "The format keyword options for `string` are `default`, `email`, `uri`, `binary`, and `uuid`.",
-                      "enum": [
-                        "default",
-                        "email",
-                        "uri",
-                        "binary",
-                        "uuid"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
           }
         },
         "minItems": 1,


### PR DESCRIPTION
fixes #3314 

This level of nesting makes the form look very confusing, this is a feature we'd like to revisit some day, but as currently this feature is not fully integrated into DKAN we are deleting it from the schema.

## QA Steps

- [ ] On the dataset creation form we shouldn't have the field for schema under distributions.