### PR TITLE
Fix email validation on json form widget

### DIFF
--- a/modules/json_form_widget/json_form_widget.services.yml
+++ b/modules/json_form_widget/json_form_widget.services.yml
@@ -9,6 +9,7 @@ services:
     class: \Drupal\json_form_widget\ValueHandler
   json_form.string_helper:
     class: \Drupal\json_form_widget\StringHelper
+    arguments: ['@email.validator']
   json_form.object_helper:
     class: \Drupal\json_form_widget\ObjectHelper
   json_form.array_helper:

--- a/modules/json_form_widget/src/StringHelper.php
+++ b/modules/json_form_widget/src/StringHelper.php
@@ -2,14 +2,19 @@
 
 namespace Drupal\json_form_widget;
 
+use Drupal\Component\Utility\EmailValidator;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Class StringHelper.
  */
-class StringHelper {
+class StringHelper implements ContainerInjectionInterface {
   use StringTranslationTrait;
+  use DependencySerializationTrait;
 
   /**
    * Builder object.
@@ -17,6 +22,31 @@ class StringHelper {
    * @var \Drupal\json_form_widget\FieldTypeRouter
    */
   public $builder;
+
+  /**
+   * Email validator service.
+   *
+   * @var \Drupal\Component\Utility\EmailValidator
+   */
+  public $emailValidator;
+
+  /**
+   * Inherited.
+   *
+   * @{inheritdocs}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('email.validator')
+    );
+  }
+
+  /**
+   * Constructor.
+   */
+  public function __construct(EmailValidator $email_validator) {
+    $this->emailValidator = $email_validator;
+  }
 
   /**
    * Set builder.
@@ -119,7 +149,7 @@ class StringHelper {
       return;
     }
 
-    if ($value !== '' && !\Drupal::service('email.validator')->isValid($value) || !filter_var($value, FILTER_VALIDATE_EMAIL)) {
+    if ($value !== '' && !$this->emailValidator->isValid($value) || !filter_var($value, FILTER_VALIDATE_EMAIL)) {
       $form_state->setError($element, $this->t('The email address %mail is not valid.', ['%mail' => $value]));
     }
   }

--- a/modules/json_form_widget/src/StringHelper.php
+++ b/modules/json_form_widget/src/StringHelper.php
@@ -63,13 +63,11 @@ class StringHelper {
     if (isset($property->format) && $property->format == 'uri') {
       return 'url';
     }
-    if (isset($property->enum)) {
+    elseif (isset($property->enum)) {
       return 'select';
     }
-    if (isset($property->pattern)) {
-      if (preg_match('/\^mailto:/', $property->pattern) > 0) {
-        return 'email';
-      }
+    elseif (isset($property->pattern) && preg_match('/\^mailto:/', $property->pattern) > 0) {
+      return 'email';
     }
     return 'textfield';
   }

--- a/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
+++ b/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
@@ -7,6 +7,7 @@ use Drupal\json_form_widget\FormBuilder;
 use Drupal\json_form_widget\ArrayHelper;
 use MockChain\Chain;
 use Drupal\Component\DependencyInjection\Container;
+use Drupal\Component\Utility\EmailValidator;
 use Drupal\Core\Form\FormState;
 use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\Core\StringTranslation\TranslationManager;
@@ -291,7 +292,8 @@ class JsonFormBuilderTest extends TestCase {
    * Return FieldTypeRouter object.
    */
   private function getRouter() {
-    $string_helper = new StringHelper();
+    $email_validator = new EmailValidator();
+    $string_helper = new StringHelper($email_validator);
     $object_helper = new ObjectHelper();
 
     $options = (new Options())

--- a/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
+++ b/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
@@ -162,6 +162,32 @@ class JsonFormBuilderTest extends TestCase {
     $default_data->test = "Some value.";
     $this->assertEquals($form_builder->getJsonForm($default_data), $expected);
 
+    // Test email.
+    $container_chain = (new Chain($this))
+      ->add(Container::class, 'get', $options)
+      ->add(SchemaRetriever::class, 'retrieve', '
+      {
+        "properties":{
+          "hasEmail": {
+            "title": "Email",
+            "description": "Email address for the contact name.",
+            "pattern": "^mailto:",
+            "type": "string"
+          }
+        },
+        "type":"object"
+      }')
+      ->add(SchemaUiHandler::class, 'setSchemaUi');
+
+    $container = $container_chain->getMock();
+    \Drupal::setContainer($container);
+
+    $form_builder = FormBuilder::create($container);
+    $form_builder->setSchema('dataset');
+    $result = $form_builder->getJsonForm($default_data);
+    $this->assertEquals($result["hasEmail"]['#type'], "email");
+    $this->assertArrayHasKey("#element_validate", $result["hasEmail"]);
+
     // Test object.
     $container_chain->add(SchemaRetriever::class, 'retrieve', '{"properties":{"publisher": {
       "$schema": "http://json-schema.org/draft-04/schema#",

--- a/modules/json_form_widget/tests/src/Unit/StringHelperTest.php
+++ b/modules/json_form_widget/tests/src/Unit/StringHelperTest.php
@@ -31,7 +31,7 @@ class StringHelperTest extends TestCase {
     $container = $container_chain->getMock();
     \Drupal::setContainer($container);
 
-    $string_helper = new StringHelper();
+    $string_helper = StringHelper::create($container);
     $element["#parents"] = [];
     $form = [
       "hasEmail" => [

--- a/modules/json_form_widget/tests/src/Unit/StringHelperTest.php
+++ b/modules/json_form_widget/tests/src/Unit/StringHelperTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\Tests\json_form_widget\Unit;
+
+use PHPUnit\Framework\TestCase;
+use MockChain\Chain;
+use Drupal\Component\DependencyInjection\Container;
+use Drupal\Component\Utility\EmailValidator;
+use Drupal\Core\Form\FormState;
+use Drupal\Core\StringTranslation\TranslationManager;
+use Drupal\json_form_widget\StringHelper;
+use MockChain\Options;
+
+/**
+ * Test class for StringHelper.
+ */
+class StringHelperTest extends TestCase {
+
+  /**
+   * Test.
+   */
+  public function testEmailValidate() {
+    $options = (new Options())
+      ->add('string_translation', TranslationManager::class)
+      ->add('email.validator', EmailValidator::class)
+      ->index(0);
+
+    $container_chain = (new Chain($this))
+      ->add(Container::class, 'get', $options)
+      ->add(EmailValidator::class, 'isValid', TRUE);
+    $container = $container_chain->getMock();
+    \Drupal::setContainer($container);
+
+    $string_helper = new StringHelper();
+    $element["#parents"] = [];
+    $form = [
+      "hasEmail" => [
+        "#type" => "email",
+        "#title" => "Email",
+        "#description" => "Email address for the contact name.",
+        "#default_value" => NULL,
+        "#required" => FALSE,
+        "#element_validate" => [StringHelper::class, 'validateEmail'],
+      ],
+    ];
+
+    // Should return nothing.
+    $form_state = new FormState();
+    $element["#value"] = "";
+    $return = $string_helper->validateEmail($element, $form_state, $form);
+    $this->assertEmpty($return);
+
+    // Should raise errors.
+    $form_state = new FormState();
+    $element["#value"] = "test";
+    $string_helper->validateEmail($element, $form_state, $form);
+    $this->assertNotEmpty($form_state->getErrors());
+
+    // Should raise errors.
+    $form_state = new FormState();
+    $element["#value"] = "test@test";
+    $string_helper->validateEmail($element, $form_state, $form);
+    $this->assertNotEmpty($form_state->getErrors());
+
+    // Should not raise errors.
+    $form_state = new FormState();
+    $element["#value"] = "test@test.com";
+    $string_helper->validateEmail($element, $form_state, $form);
+    $this->assertEmpty($form_state->getErrors());
+  }
+
+}


### PR DESCRIPTION
fixes #3312 

## Preparation steps
- [x] Enable the json_form_widget module.
- [x] Go to Structure -> Content types -> Data -> Manage form display, select the widget "JSON Form" for the field "JSON Metadata", make the schema be "dataset" and save the configuration.
- [ ] In the codebase go to the JSON schema UI for dataset `dataset.ui.json` and add a new entry with the following:

```
"identifier": {
    "ui:options": {
      "widget": "dkan_uuid"
    }
  }
```

## QA Steps

- [x] Go to node/add/data
- [x] Fill up the form
- [x] In the field Email (from section Project Open Data Contactpoint VCARD) try the following:
  - [x] Leave the field empty and submit the form, you should get an error saying that field should not be empty
  - [x] Type `test` and submit the form, you should get an error saying that specific field is wrong formatted
  - [x] Type `test@test` and submit the form, you should get an error saying that specific field is wrong formatted
  - [x] Type `test@test.com` and submit the form, the node should be saved correctly without any issues.
