### PR TITLE
Add check for data type before building the edit form

### DIFF
--- a/modules/json_form_widget/src/FormBuilder.php
+++ b/modules/json_form_widget/src/FormBuilder.php
@@ -76,8 +76,11 @@ class FormBuilder implements ContainerInjectionInterface {
    *
    * @codeCoverageIgnore
    */
-  public function setSchema($schema_name) {
+  public function setSchema($schema_name, $type = NULL) {
     try {
+      if (!empty($type) && $type !== $schema_name) {
+        $schema_name = $type;
+      }
       $schema = $this->schemaRetriever->retrieve($schema_name);
       $this->schema = json_decode($schema);
       $this->schemaUiHandler->setSchemaUi($schema_name);

--- a/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidget.php
+++ b/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidget.php
@@ -123,7 +123,8 @@ class JsonFormWidget extends WidgetBase {
     foreach ($items as $item) {
       $default_data = json_decode($item->value);
     }
-    $this->builder->setSchema($this->getSetting('schema'));
+    $type = $form_state->getformObject()->getEntity()->get('field_data_type')->value;
+    $this->builder->setSchema($this->getSetting('schema'), $type);
     $json_form = $this->builder->getJsonForm($default_data, $form_state);
 
     if ($json_form) {
@@ -136,11 +137,12 @@ class JsonFormWidget extends WidgetBase {
    */
   public function extractFormValues(FieldItemListInterface $items, array $form, FormStateInterface $form_state) {
     $field_name = $form_state->get('json_form_widget_field');
-    $schema = $form_state->get('json_form_widget_schema');
+    $schema = $this->builder->getSchema();
 
     $data = [];
     $properties = array_keys((array) $schema->properties);
     $values = $form_state->getValue($field_name)[0]['value'];
+
     foreach ($properties as $property) {
       $value = $this->valueHandler->flattenValues($values, $property, $schema->properties->{$property});
       if ($value) {

--- a/modules/metastore/src/Factory/Sae.php
+++ b/modules/metastore/src/Factory/Sae.php
@@ -63,14 +63,15 @@ class Sae implements FactoryInterface {
    *   Json schema.
    */
   private function getJsonSchema($schema_id) {
+    $schemas = $this->schemaRetriever->getAllIds();
 
     // @Todo: mechanism to validate against additional schemas. For now,
     // validate against the empty object, as it accepts any valid json.
-    if ($schema_id != 'dataset') {
+    if (!in_array($schema_id, $schemas)) {
       return '{ }';
     }
 
-    return $this->schemaRetriever->retrieve('dataset');
+    return $this->schemaRetriever->retrieve($schema_id);
   }
 
   /**

--- a/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
+++ b/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
@@ -16,7 +16,10 @@ class ProperJsonValidator extends ConstraintValidator {
    * {@inheritdoc}
    */
   public function validate($items, Constraint $constraint) {
-    $schema = $items->getParent()->getEntity()->get('field_data_type')->value;
+    $schema = 'dataset';
+    if (is_object($items) && $type = $items->getParent()->getEntity()->get('field_data_type')->value) {
+      $schema = $type;
+    }
     foreach ($items as $item) {
       $info = $this->isProper($item->value, $schema);
       if (!$info['valid']) {

--- a/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
+++ b/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
@@ -16,8 +16,9 @@ class ProperJsonValidator extends ConstraintValidator {
    * {@inheritdoc}
    */
   public function validate($items, Constraint $constraint) {
+    $schema = $items->getParent()->getEntity()->get('field_data_type')->value;
     foreach ($items as $item) {
-      $info = $this->isProper($item->value);
+      $info = $this->isProper($item->value, $schema);
       if (!$info['valid']) {
         $this->addViolations($info['errors']);
       }
@@ -30,13 +31,13 @@ class ProperJsonValidator extends ConstraintValidator {
    * @param string $value
    *   Value.
    */
-  protected function isProper($value) {
+  protected function isProper($value, $schema = 'dataset') {
     // @codeCoverageIgnoreStart
     /** @var SaeFactory $saeFactory */
     $saeFactory = \Drupal::service("metastore.sae_factory");
 
     /** @var Sae $engine */
-    $engine = $saeFactory->getInstance('dataset');
+    $engine = $saeFactory->getInstance($schema);
 
     return $engine->validate($value);
     // @codeCoverageIgnoreEnd

--- a/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
+++ b/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
@@ -30,6 +30,8 @@ class ProperJsonValidator extends ConstraintValidator {
    *
    * @param string $value
    *   Value.
+   * @param string $schema
+   *   Schema ID.
    */
   protected function isProper($value, $schema = 'dataset') {
     // @codeCoverageIgnoreStart

--- a/modules/metastore/src/SchemaRetriever.php
+++ b/modules/metastore/src/SchemaRetriever.php
@@ -46,6 +46,14 @@ class SchemaRetriever implements RetrieverInterface, ContainerInjectionInterface
       'catalog',
       'dataset',
       'dataset.ui',
+      'publisher',
+      'publisher.ui',
+      'distribution',
+      'distribution.ui',
+      'theme',
+      'theme.ui',
+      'keyword',
+      'keyword.ui',
     ];
   }
 

--- a/modules/metastore/tests/src/SchemaRetrieverTest.php
+++ b/modules/metastore/tests/src/SchemaRetrieverTest.php
@@ -47,7 +47,20 @@ class SchemaRetrieverTest extends TestCase {
   public function testGetAllIds() {
     $retriever = $this->getSchemaRetriever();
     $ids = $retriever->getAllIds();
-    $this->assertEquals(['catalog', 'dataset', 'dataset.ui'], $ids);
+    $expected = [
+      'catalog',
+      'dataset',
+      'dataset.ui',
+      'publisher',
+      'publisher.ui',
+      'distribution',
+      'distribution.ui',
+      'theme',
+      'theme.ui',
+      'keyword',
+      'keyword.ui',
+    ];
+    $this->assertEquals($expected, $ids);
   }
 
   /**

--- a/schema/collections/distribution.json
+++ b/schema/collections/distribution.json
@@ -2,6 +2,10 @@
   "title": "Tags",
   "description": "Tags (or keywords) help users discover your dataset; please include terms that would be used by technical and non-technical users.",
   "type": "object",
+  "required": [
+    "identifier",
+    "data"
+  ],
   "properties": {
     "identifier": {
       "title": "Identifier",

--- a/schema/collections/distribution.json
+++ b/schema/collections/distribution.json
@@ -1,0 +1,90 @@
+{
+  "title": "Tags",
+  "description": "Tags (or keywords) help users discover your dataset; please include terms that would be used by technical and non-technical users.",
+  "type": "object",
+  "properties": {
+    "identifier": {
+      "title": "Identifier",
+      "type": "string"
+    },
+    "data": {
+      "title": "Project Open Data Distribution",
+      "type": "object",
+      "properties": {
+        "@type": {
+          "title": "Metadata Context",
+          "description": "IRI for the JSON-LD data type. This should be dcat:Distribution for each Distribution.",
+          "default": "dcat:Distribution",
+          "type": "string",
+          "readOnly": true
+        },
+        "title": {
+          "title": "Title",
+          "description": "Human-readable name of the distribution.",
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "title": "Description",
+          "description": "Human-readable description of the distribution.",
+          "type": "string",
+          "minLength": 1
+        },
+        "format": {
+          "title": "Format",
+          "description": "A human-readable description of the file format of a distribution (i.e. csv, pdf, xml, kml, etc.).",
+          "type": "string",
+          "examples": [
+            "arcgis",
+            "csv",
+            "esri rest",
+            "geojson",
+            "json",
+            "kml",
+            "pdf",
+            "tsv",
+            "xls",
+            "xlsx",
+            "xml",
+            "zip"
+          ]
+        },
+        "mediaType": {
+          "title": "Media Type",
+          "description": "The machine-readable file format (<a href=\"https://www.iana.org/assignments/media-types/media-types.xhtml\">IANA Media Type or MIME Type</a>) of the distribution’s downloadURL.",
+          "type": "string"
+        },
+        "downloadURL": {
+          "title": "Download URL",
+          "description": "URL providing direct access to a downloadable file of a dataset.",
+          "type": "string",
+          "format": "uri"
+        },
+        "accessURL": {
+          "title": "Access URL",
+          "description": "URL providing indirect access to a dataset.",
+          "type": "string",
+          "format": "uri"
+        },
+        "conformsTo": {
+          "title": "Data Standard",
+          "description": "URL providing indirect access to a dataset.",
+          "type": "string",
+          "format": "uri"
+        },
+        "describedBy": {
+          "title": "Data Dictionary",
+          "description": "URL to the data dictionary for the distribution found at the downloadURL.",
+          "type": "string",
+          "format": "uri"
+        },
+        "describedByType": {
+          "title": "Data Dictionary Type",
+          "description": "The machine-readable file format (IANA Media Type or MIME Type) of the distribution’s describedBy URL.",
+          "pattern": "^[a-z]+?$",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schema/collections/distribution.ui.json
+++ b/schema/collections/distribution.ui.json
@@ -1,0 +1,27 @@
+{
+  "identifier": {
+    "ui:options": {
+      "widget": "hidden"
+    }
+  },
+  "data": {
+    "properties": {
+      "@type": {
+        "ui:options": {
+          "widget": "hidden"
+        }
+      },
+      "mediaType": {
+        "ui:options": {
+          "widget": "hidden"
+        }
+      },
+      "description": {
+        "ui:options": {
+          "widget": "textarea",
+          "rows": 5
+        }
+      }
+    }
+  }
+}

--- a/schema/collections/keyword.json
+++ b/schema/collections/keyword.json
@@ -2,6 +2,10 @@
   "title": "Tags",
   "description": "Tags (or keywords) help users discover your dataset; please include terms that would be used by technical and non-technical users.",
   "type": "object",
+  "required": [
+    "identifier",
+    "data"
+  ],
   "properties": {
     "identifier": {
       "title": "Identifier",

--- a/schema/collections/keyword.json
+++ b/schema/collections/keyword.json
@@ -1,0 +1,17 @@
+{
+  "title": "Tags",
+  "description": "Tags (or keywords) help users discover your dataset; please include terms that would be used by technical and non-technical users.",
+  "type": "object",
+  "properties": {
+    "identifier": {
+      "title": "Identifier",
+      "type": "string"
+    },
+    "data": {
+      "type": "string",
+      "title": "Tag",
+      "description": "Tags (or keywords) help users discover your dataset; please include terms that would be used by technical and non-technical users.",
+      "minLength": 1
+    }
+  }
+}

--- a/schema/collections/keyword.ui.json
+++ b/schema/collections/keyword.ui.json
@@ -1,0 +1,7 @@
+{
+  "identifier": {
+    "ui:options": {
+      "widget": "hidden"
+    }
+  }
+}

--- a/schema/collections/publisher.json
+++ b/schema/collections/publisher.json
@@ -1,0 +1,39 @@
+{
+  "title": "Tags",
+  "description": "Tags (or keywords) help users discover your dataset; please include terms that would be used by technical and non-technical users.",
+  "type": "object",
+  "properties": {
+    "identifier": {
+      "title": "Identifier",
+      "type": "string"
+    },
+    "data": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
+      "title": "Organization",
+      "description": "A Dataset Publisher Organization.",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "@type": {
+          "title": "Metadata Context",
+          "description": "IRI for the JSON-LD data type. This should be org:Organization for each publisher",
+          "type": "string",
+          "default": "org:Organization"
+        },
+        "name": {
+          "title": "Publisher Name",
+          "description": "",
+          "type": "string",
+          "minLength": 1
+        },
+        "subOrganizationOf": {
+          "title": "Parent Organization",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schema/collections/publisher.json
+++ b/schema/collections/publisher.json
@@ -2,6 +2,10 @@
   "title": "Tags",
   "description": "Tags (or keywords) help users discover your dataset; please include terms that would be used by technical and non-technical users.",
   "type": "object",
+  "required": [
+    "identifier",
+    "data"
+  ],
   "properties": {
     "identifier": {
       "title": "Identifier",

--- a/schema/collections/publisher.ui.json
+++ b/schema/collections/publisher.ui.json
@@ -1,0 +1,16 @@
+{
+  "identifier": {
+    "ui:options": {
+      "widget": "hidden"
+    }
+  },
+  "data": {
+    "properties": {
+      "@type": {
+        "ui:options": {
+          "widget": "hidden"
+        }
+      }
+    }
+  }
+}

--- a/schema/collections/theme.json
+++ b/schema/collections/theme.json
@@ -2,6 +2,10 @@
   "title": "Category",
   "description": "Main thematic category of the dataset.",
   "type": "object",
+  "required": [
+    "identifier",
+    "data"
+  ],
   "properties": {
     "identifier": {
       "title": "Identifier",

--- a/schema/collections/theme.json
+++ b/schema/collections/theme.json
@@ -1,0 +1,17 @@
+{
+  "title": "Category",
+  "description": "Main thematic category of the dataset.",
+  "type": "object",
+  "properties": {
+    "identifier": {
+      "title": "Identifier",
+      "type": "string"
+    },
+    "data": {
+      "type": "string",
+      "title": "Category",
+      "description": "Main thematic category of the dataset.",
+      "minLength": 1
+    }
+  }
+}

--- a/schema/collections/theme.ui.json
+++ b/schema/collections/theme.ui.json
@@ -1,0 +1,7 @@
+{
+  "identifier": {
+    "ui:options": {
+      "widget": "hidden"
+    }
+  }
+}


### PR DESCRIPTION
fixes #3332 

## Preparation steps
- [x] Enable the json_form_widget module.
- [x] Go to Structure -> Content types -> Data -> Manage form display, select the widget "JSON Form" for the field "JSON Metadata", make the schema be "dataset" and save the configuration.
- [x] Make sure you already have datasets in your system in order to test.

## QA Steps

- [x] Go to Content `/admin/content/node`
- [x] Click on the "edit" button for multiple data nodes of different types (publisher, distribution, keyword, theme, dataset)
- [x] The form should be correct in every case, different fields should appear according to the schema
- [x] Try doing changes in all of them, they should all be saved correctly