### PR TITLE
Eliminate drush dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       image: circleci/classic:latest
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "4.2.1"
+      DKTL_VERSION: "dev-project-drush"
     steps:
       - checkout:
           path: dkan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       image: circleci/classic:latest
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "dev-project-drush"
+      DKTL_VERSION: "project-drush"
     steps:
       - checkout:
           path: dkan

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "drupal/config_update": "^1.6",
         "drupal/search_api": "^1.15",
         "drupal/views_bulk_operations": "^3.6",
-        "drush/drush": "^10.2.2",
         "ext-json": "*",
         "ezyang/htmlpurifier" : "^4.11",
         "fmizzell/maquina": "^1.1.0",
@@ -23,10 +22,10 @@
         "getdkan/sql-parser": "^2.0.0",
         "guzzlehttp/guzzle" : "^6.3",
         "ramsey/uuid" : "^3.8.0",
-        "weitzman/drupal-test-traits": "^1.5",
         "getdkan/rooted-json-data": "^0.0.2"
     },
     "require-dev": {
+        "weitzman/drupal-test-traits": "^1.5",
         "phpunit/phpunit": "^7.5"
     },
     "repositories": [


### PR DESCRIPTION
It doesn't really make sense to have drush as a module dependency for DKAN, it should be managed at the project level. This removes it from composer.json

## Merging instructions

1. Merge GetDKAN/dkan-tools#287
2. New DKAN tools release
3. Change dktl version to new release in this branch's circleci config
4. Merge if all still passes