### PR TITLE
Improve dataset info

### DIFF
--- a/modules/common/common.services.yml
+++ b/modules/common/common.services.yml
@@ -28,12 +28,11 @@ services:
 
   dkan.common.dataset_info:
     class: \Drupal\common\DatasetInfo
-    arguments:
-      - '@module_handler'
     calls:
       - [setStorage, ['@?dkan.metastore.storage']]
       - [setDatastore, ['@?dkan.datastore.service']]
       - [setResourceMapper, ['@?dkan.metastore.resource_mapper']]
+      - [setImportInfo, ['@?dkan.datastore.import_info']]
 
   plugin.manager.common.data_modifier:
     class: \Drupal\common\Plugin\DataModifierManager

--- a/modules/common/src/DatasetInfo.php
+++ b/modules/common/src/DatasetInfo.php
@@ -128,7 +128,7 @@ class DatasetInfo implements ContainerInjectionInterface {
     $latestRevisionIsDraft = 'draft' === $latest->get('moderation_state')->getString();
     $published = $this->storage->getNodePublishedRevision($uuid);
     if ($latestRevisionIsDraft && $published && 'published' === $published->get('moderation_state')->getString()) {
-      $info['publihed_revision'] = $this->getRevisionInfo($published);
+      $info['published_revision'] = $this->getRevisionInfo($published);
     }
 
     return $info;

--- a/modules/common/tests/src/DatasetInfoTest.php
+++ b/modules/common/tests/src/DatasetInfoTest.php
@@ -2,18 +2,12 @@
 
 namespace Drupal\Tests\common;
 
-use Drupal\common\Resource;
 use Drupal\common\DatasetInfo;
 use Drupal\Core\DependencyInjection\Container;
-use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\datastore\Service as Datastore;
-use Drupal\datastore\Storage\DatabaseTable;
 use Drupal\metastore\ResourceMapper;
-use Drupal\metastore\Service as Metastore;
 use Drupal\metastore\Storage\Data;
 use Drupal\metastore\Storage\DataFactory;
-use Drupal\node\Entity\Node;
 use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;
@@ -24,7 +18,6 @@ class DatasetInfoTest extends TestCase {
     $datasetInfo = DatasetInfo::create($this->getCommonChain()->getMock());
 
     $expected = [
-      'uuid' => 'foo',
       'notice' => 'The DKAN Metastore module is not enabled.',
     ];
     $result = $datasetInfo->gather('foo');
@@ -47,8 +40,7 @@ class DatasetInfoTest extends TestCase {
     $datasetInfo->setResourceMapper($mockResourceMapper->getMock());
 
     $expected = [
-      'uuid' => 'foo',
-      'notice' => 'Not found.',
+      'notice' => 'Not found',
     ];
     $result = $datasetInfo->gather('foo');
 
@@ -57,7 +49,6 @@ class DatasetInfoTest extends TestCase {
 
   private function getCommonChain() {
     $options = (new Options())
-      ->add('module_handler', ModuleHandlerInterface::class)
       ->index(0);
 
     return (new Chain($this))

--- a/modules/metastore/modules/metastore_admin/metastore_admin.install
+++ b/modules/metastore/modules/metastore_admin/metastore_admin.install
@@ -16,7 +16,7 @@ function metastore_admin_install() {
 }
 
 /**
- * Ensable standard content view.
+ * Enable standard content view.
  */
 function metastore_admin_uninstall() {
   $config_factory = \Drupal::configFactory();

--- a/modules/metastore/src/ResourceMapper.php
+++ b/modules/metastore/src/ResourceMapper.php
@@ -196,9 +196,9 @@ class ResourceMapper {
   /**
    * Private.
    */
-  private function exists($identifier, $perspective, $version = NULL) {
+  private function exists($identifier, $perspective, $version = NULL) : bool {
     $item = $this->get($identifier, $perspective, $version);
-    return isset($item) ? TRUE : FALSE;
+    return isset($item);
   }
 
 }

--- a/tests/src/Functional/DatasetTest.php
+++ b/tests/src/Functional/DatasetTest.php
@@ -155,10 +155,10 @@ class DatasetTest extends ExistingSiteBase {
     /** @var \Drupal\common\DatasetInfo $datasetInfo */
     $datasetInfo = \Drupal::service('dkan.common.dataset_info');
     $info = $datasetInfo->gather('111');
-    $this->assertEquals('1.csv', substr($info['latest revision']['distributions'][0]['file path'], -5));
-    $this->assertEquals('5.csv', substr($info['latest revision']['distributions'][1]['file path'], -5));
-    $this->assertEquals('3.csv', substr($info['published revision']['distributions'][0]['file path'], -5));
-    $this->assertEquals('1.csv', substr($info['published revision']['distributions'][1]['file path'], -5));
+    $this->assertEquals('1.csv', substr($info['latest_revision']['distributions'][0]['file_path'], -5));
+    $this->assertEquals('5.csv', substr($info['latest_revision']['distributions'][1]['file_path'], -5));
+    $this->assertEquals('3.csv', substr($info['published_revision']['distributions'][0]['file_path'], -5));
+    $this->assertEquals('1.csv', substr($info['published_revision']['distributions'][1]['file_path'], -5));
 
     // Verify that only the resources associated with the published and the
     // latest revision.


### PR DESCRIPTION
- Mostly, improves the useful information from DatasetInfo to include status and percent complete for both fetching and datastoring. This could also be used in harvest dashboard for draft datasets. The shape of the returned data was tweaked slightly, sticking to rows for the 1 or 2 key revisions found (latest, published if different)
- Simplifies an expression
- Fixes a typo