### PR TITLE
Drop metastore_form from metastore_admin deps

### DIFF
--- a/modules/metastore/modules/metastore_admin/metastore_admin.info.yml
+++ b/modules/metastore/modules/metastore_admin/metastore_admin.info.yml
@@ -6,7 +6,6 @@ dependencies:
   - metastore
   - admin_toolbar
   - breakpoint
-  - metastore_form
   - system
   - toolbar
   - user


### PR DESCRIPTION
+ Add the possibility to disable metastore_form module without disabling dkan.

fixes [NuCivic/dkan_management#416]

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform to confirm that the feature or fix is working. Include as much details as possible so that the reviewer doesn't lose time figuring out how to perform steps.
