### PR TITLE
Do not index unpublished datasets

### DIFF
--- a/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
+++ b/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
@@ -75,7 +75,10 @@ class DkanDataset extends DatasourcePluginBase {
 
     $items = [];
     foreach ($ids as $id) {
-      $items[$id] = new Dataset($dataStorage->retrieve($id));
+      try {
+        $items[$id] = new Dataset($dataStorage->retrievePublished($id));
+      }
+      catch(\Exception $e) {}
     }
 
     return $items;

--- a/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
+++ b/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
@@ -78,7 +78,9 @@ class DkanDataset extends DatasourcePluginBase {
       try {
         $items[$id] = new Dataset($dataStorage->retrievePublished($id));
       }
-      catch(\Exception $e) {}
+      catch (\Exception $e) {
+
+      }
     }
 
     return $items;

--- a/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
+++ b/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
@@ -79,7 +79,6 @@ class DkanDataset extends DatasourcePluginBase {
         $items[$id] = new Dataset($dataStorage->retrievePublished($id));
       }
       catch (\Exception $e) {
-
       }
     }
 

--- a/modules/metastore/modules/metastore_search/tests/src/Unit/Plugin/search_api/datasource/DkanDatasetTest.php
+++ b/modules/metastore/modules/metastore_search/tests/src/Unit/Plugin/search_api/datasource/DkanDatasetTest.php
@@ -49,7 +49,7 @@ class DkanDatasetTest extends TestCase {
       ->add(QueryInterface::class, 'range', QueryInterface::class)
       ->add(EntityTypeRepository::class, 'getEntityTypeFromClass', NULL)
       ->add(DataFactory::class, 'getInstance', Data::class)
-      ->add(Data::class, 'retrieve', '{}')
+      ->add(Data::class, 'retrievePublished', '{}')
       ->getMock();
 
     \Drupal::setContainer($container);

--- a/tests/src/Functional/DatasetTest.php
+++ b/tests/src/Functional/DatasetTest.php
@@ -175,10 +175,11 @@ class DatasetTest extends ExistingSiteBase {
     $index = Index::load('dkan');
     $index->clear();
     $index->indexItems();
-    // Verify metastore search results contains 111, 222 but not 333.
+    // Verify search results contain the '1.2' version of 111, 222 but not 333.
     $searchResults = $this->getMetastoreSearch()->search();
     $this->assertEquals(2, $searchResults->total);
     $this->assertArrayHasKey('dkan_dataset/111', $searchResults->results);
+    $this->assertEquals('1.2', $searchResults->results['dkan_dataset/111']->title);
     $this->assertArrayHasKey('dkan_dataset/222', $searchResults->results);
     $this->assertArrayNotHasKey('dkan_dataset/333', $searchResults->results);
 

--- a/tests/src/Functional/DatasetTest.php
+++ b/tests/src/Functional/DatasetTest.php
@@ -178,9 +178,9 @@ class DatasetTest extends ExistingSiteBase {
     // Verify metastore search results contains 111, 222 but not 333.
     $searchResults = $this->getMetastoreSearch()->search();
     $this->assertEquals(2, $searchResults->total);
-    $this->assertTrue(isset($searchResults->results['dkan_dataset/111']));
-    $this->assertTrue(isset($searchResults->results['dkan_dataset/222']));
-    $this->assertTrue(!isset($searchResults->results['dkan_dataset/333']));
+    $this->assertArrayHasKey('dkan_dataset/111', $searchResults->results);
+    $this->assertArrayHasKey('dkan_dataset/222', $searchResults->results);
+    $this->assertArrayNotHasKey('dkan_dataset/333', $searchResults->results);
 
     $defaultModerationState->set('type_settings.default_moderation_state', 'published');
     $defaultModerationState->save();


### PR DESCRIPTION
Previously, on sites where the Dkan publishing's default moderation state is 'draft', unpublished datasets were erroneously indexed by the custom search_api plugin. This could cause error in the search's results and total count.

- [x] Test coverage exists