### PR TITLE
Fix unable to deregister a bad harvest plan

### DIFF
--- a/modules/harvest/src/Service.php
+++ b/modules/harvest/src/Service.php
@@ -126,7 +126,11 @@ class Service implements ContainerInjectionInterface {
    *   Boolean.
    */
   public function deregisterHarvest(string $id) {
-    $this->revertHarvest($id);
+    try {
+      $this->revertHarvest($id);
+    }
+    catch (\Exception $e) {
+    }
 
     $plan_store = $this->storeFactory->getInstance("harvest_plans");
 


### PR DESCRIPTION
Fixes #3233

## QA Steps

Recreate @janette's steps to reproduce in https://github.com/GetDKAN/dkan/issues/3233.

The `deregister` command will not output an error message:
```
❯ drush dkan:harvest:deregister notgood
```

The list will no longer show harvest ID "notgood":
```
❯ drush dkan:harvest:list              
+---------+
| plan id |
+---------+
```