### PR TITLE
Redirect to datasets list page after saving node add/edit form.

### DIFF
--- a/modules/metastore/modules/metastore_admin/metastore_admin.module
+++ b/modules/metastore/modules/metastore_admin/metastore_admin.module
@@ -116,3 +116,20 @@ function metastore_admin_create_text_link($linkText, $internalUri) {
   $link = Link::fromTextAndUrl(t($linkText), $url);
   return $link->toString();
 }
+
+/**
+ * Add custom submit handler to redirect to datasets page.
+ */
+function metastore_admin_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if ($form_id === "node_data_form" || $form_id === "node_data_edit_form") {
+    $form['actions']['submit']['#submit'][] = 'metastore_admin_form_submit';
+  }
+}
+
+/**
+ * Submit handler to redirect after node save to dkan dataset content page.
+ */
+function metastore_admin_form_submit($form, FormStateInterface &$form_state) {
+  $form_state->setRedirect('view.dkan_dataset_content.page_1');
+  return;
+}


### PR DESCRIPTION
## User story
As a data publisher, I want to know that my dataset has been created and not assume there is an error when I complete inputting all information into the metadata form. 
Note: Currently, when the user completes a metada form for a dataset they are not taken to a list of all the datasets or told that they have successfully created a dataset, instead they see the raw JSON therefore, they may be confused and think there is an error. 	

## Steps to test:
- [ ] When I add a dataset, I am redirected to the list of all the datasets that have been added to the site.