### PR TITLE
Address notices regarding undefined 'host' index in hostify()

### DIFF
--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -212,7 +212,7 @@ class Referencer {
   public static function hostify($url) {
     $host = \Drupal::request()->getHost();
     $parsedUrl = parse_url($url);
-    if ($parsedUrl['host'] == $host) {
+    if (isset($parsedUrl['host']) && $parsedUrl['host'] == $host) {
       $parsedUrl['host'] = UrlHostTokenResolver::TOKEN;
       $url = self::unparseUrl($parsedUrl);
     }


### PR DESCRIPTION
When visiting the dashboard, our site gets 2 of the following notices per dataset found in a harvest:

```
Error message

    Notice: Undefined index: host in Drupal\metastore\Reference\Referencer::hostify()
    (line 215 of modules/contrib/dkan/modules/metastore/src/Reference/Referencer.php).
```

This attempts to address this.