### PR TITLE
Add support for minItems in arrays.

### DIFF
--- a/modules/json_form_widget/src/ArrayHelper.php
+++ b/modules/json_form_widget/src/ArrayHelper.php
@@ -195,7 +195,9 @@ class ArrayHelper implements ContainerInjectionInterface {
     if (is_array($data) && isset($data[$i])) {
       $element['#default_value'] = $data[$i];
     }
-    if (in_array($definition['name'], $this->builder->getSchema()->required)) {
+    if (isset($this->builder->getSchema()->required)
+      && in_array($definition['name'], $this->builder->getSchema()->required)
+    ) {
       $element = $this->checkMinItems($element, $definition, $i);
     }
     return $element;

--- a/modules/json_form_widget/src/ArrayHelper.php
+++ b/modules/json_form_widget/src/ArrayHelper.php
@@ -195,7 +195,9 @@ class ArrayHelper implements ContainerInjectionInterface {
     if (is_array($data) && isset($data[$i])) {
       $element['#default_value'] = $data[$i];
     }
-    $element = $this->checkMinItems($element, $definition, $i);
+    if (in_array($definition['name'], $this->builder->getSchema()->required)) {
+      $element = $this->checkMinItems($element, $definition, $i);
+    }
     return $element;
   }
 

--- a/modules/json_form_widget/src/ArrayHelper.php
+++ b/modules/json_form_widget/src/ArrayHelper.php
@@ -195,6 +195,19 @@ class ArrayHelper implements ContainerInjectionInterface {
     if (is_array($data) && isset($data[$i])) {
       $element['#default_value'] = $data[$i];
     }
+    $element = $this->checkMinItems($element, $definition, $i);
+    return $element;
+  }
+
+  /**
+   * Helper function to check if array has min items.
+   */
+  private function checkMinItems($element, $definition, $i) {
+    if (isset($definition['schema']->minItems)) {
+      if ($i < $definition['schema']->minItems) {
+        $element['#required'] = TRUE;
+      }
+    }
     return $element;
   }
 

--- a/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
+++ b/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
@@ -286,6 +286,53 @@ class JsonFormBuilderTest extends TestCase {
     $result = $form_builder->getJsonForm([], $form_state);
     unset($result['keyword']['actions']);
     $this->assertEquals($result, $expected);
+
+    // Test array required.
+    $container_chain->add(SchemaRetriever::class, 'retrieve', '
+    {
+      "required": [
+        "keyword"
+      ],
+      "properties":{
+        "keyword": {
+          "title": "Tags",
+          "description": "Tags (or keywords).",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Tag"
+          },
+          "minItems": 1
+        }
+      },
+      "type":"object"
+    }');
+    $container = $container_chain->getMock();
+    \Drupal::setContainer($container);
+
+    $form_builder = FormBuilder::create($container);
+    $form_builder->setSchema('dataset');
+    $expected = [
+      "keyword" => [
+        "#type" => "fieldset",
+        "#title" => "Tags",
+        "#prefix" => '<div id="keyword-fieldset-wrapper">',
+        "#suffix" => "</div>",
+        "#tree" => TRUE,
+        "#description" => "Tags (or keywords).",
+        "keyword" => [
+          0 => [
+            "#type" => "textfield",
+            "#title" => "Tag",
+            "#required" => TRUE,
+          ],
+        ],
+      ],
+    ];
+    $form_state = new FormState();
+    $result = $form_builder->getJsonForm([], $form_state);
+    unset($result['keyword']['actions']);
+    $this->assertEquals($result, $expected);
   }
 
   /**


### PR DESCRIPTION
fixes #3313 

## Background
In the json form, when you fill up the form but don't add a tag and you click on save, you get an error, the problem is the error message is confusing because it says "keyword" instead of "Tags" which is the actual title of the field appearing on the form, also the whole form gets red making it hard for the user to know what should be fixed. The error happens because it is coming from the backend during save time and not during validation, the form is not validating that the item in an array is required that's why it goes all the way through the form.

In this PR I'm checking if the array field is in the list of required fields from the main schema and making its element be required based on the minItems property.

## QA Steps

- [ ] When I create a new dataset using the JSON Form Widget and I don't include tags but I fill out the rest of the fields properly, then I see a clear error message that tells me which field to fix.