### PR TITLE
Metastore admin view preprocessing to skip nodes without field_data_type

### DIFF
--- a/modules/metastore/modules/metastore_admin/metastore_admin.module
+++ b/modules/metastore/modules/metastore_admin/metastore_admin.module
@@ -43,6 +43,12 @@ function metastore_admin_preprocess_views_view_field(&$vars) {
     && ($vars['view']->current_display == 'page_1')) {
     // To access current row entity.
     $entity = $vars['row']->_entity;
+
+    // Nodes without field_data_type should be skipped.
+    if (!isset($entity->field_json_metadata)) {
+      return;
+    }
+
     $entity_id = $entity->id();
 
     // Modify data titles to display the metadata title values rather than uuids.


### PR DESCRIPTION
Fixes notices for each non-Data node on admin/content.

```
Notice: Trying to get property 'value' of non-object in metastore_admin_preprocess_views_view_field()
(line 54 of modules/contrib/dkan/modules/metastore/modules/metastore_admin/metastore_admin.module).
```

