### PR TITLE
Update titles and help text for fields in metadata form.

### DIFF
--- a/schema/collections/dataset.ui.json
+++ b/schema/collections/dataset.ui.json
@@ -18,15 +18,32 @@
       }
     }
   },
+  "accessLevel": {
+    "ui:options": {
+      "description": "This refers to how the data can be accessed.s"
+    }
+  },
   "spatial": {
     "ui:options": {
       "widget": "textarea",
-      "rows": 5
+      "rows": 5,
+      "title": "Relevant Location",
+      "description": "If your dataset has a spatial component, please provide location such as place name or latitude/longitude pairs."
+    }
+  },
+  "isPartOf": {
+    "ui:options": {
+      "widget": "hidden"
     }
   },
   "publisher": {
     "properties": {
       "@type": {
+        "ui:options": {
+          "widget": "hidden"
+        }
+      },
+      "subOrganizationOf": {
         "ui:options": {
           "widget": "hidden"
         }
@@ -57,6 +74,16 @@
           "extensions": "csv pdf tsv jpg txt xls xlsx",
           "progress_indicator": "bar"
         }
+      }
+    }
+  },
+  "theme": {
+    "ui:options": {
+      "title": "Topics"
+    },
+    "items": {
+      "ui:options": {
+        "title": "Topic"
       }
     }
   },

--- a/schema/collections/dataset.ui.json
+++ b/schema/collections/dataset.ui.json
@@ -20,7 +20,7 @@
   },
   "accessLevel": {
     "ui:options": {
-      "description": "This refers to how the data can be accessed.s"
+      "description": "This refers to how the data can be accessed."
     }
   },
   "spatial": {

--- a/schema/collections/theme.ui.json
+++ b/schema/collections/theme.ui.json
@@ -3,5 +3,10 @@
     "ui:options": {
       "widget": "hidden"
     }
+  },
+  "data": {
+    "ui:options": {
+      "title": "Topic"
+    }
   }
 }


### PR DESCRIPTION
fixes #3403 

## Preparation steps
- Enable the json_form_widget module.
- Go to Structure -> Content types -> Data -> Manage form display, select the widget "JSON Form" for the field "JSON Metadata", make the schema be "dataset" and save the configuration.

## QA Steps
- [ ] Go to Content --> Add content --> Data
- Make sure the following changes are done:
  - [ ] There should be a field called "Relevant Location" instead of "Spatial".
  - [ ] Help text for "Relevant location" should be "If your dataset has a spatial component, please provide location such as place name or latitude/longitude pairs.”
  - [ ] The field "Collection" is not shown.
  - [ ] The field "Parent Organization" is not shown.
  - [ ] There should be a fieldset called "Topics" instead of “Category”, and the textfield inside should read "Topic"
  - [ ] The help text for the "Access Level" field should be "This refers to how the data can be accessed".
