### PR TITLE
Show upload progress in distribution form

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       image: circleci/classic:latest
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "composer-project"
+      DKTL_VERSION: "4.2.2"
     steps:
       - checkout:
           path: dkan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       image: circleci/classic:latest
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "4.2.1"
+      DKTL_VERSION: "composer-project"
     steps:
       - checkout:
           path: dkan

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "drupal/config_update": "^1.6",
         "drupal/search_api": "^1.15",
         "drupal/views_bulk_operations": "^3.6",
-        "drush/drush": "^10.2.2",
         "ext-json": "*",
         "ezyang/htmlpurifier" : "^4.11",
         "fmizzell/maquina": "^1.1.0",

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
         "getdkan/file-fetcher" : "^4.0.0",
         "getdkan/harvest": "^1.0.0",
         "getdkan/json-schema-provider": "^0.1.2",
-        "getdkan/mock-chain": "^1.3.0",
         "getdkan/sae" : "^1.1.1",
         "getdkan/sql-parser": "^2.0.0",
         "guzzlehttp/guzzle" : "^6.3",
         "ramsey/uuid" : "^3.8.0",
-        "weitzman/drupal-test-traits": "^1.5",
         "getdkan/rooted-json-data": "^0.0.2"
     },
     "require-dev": {
+        "getdkan/mock-chain": "^1.3.0",
+        "weitzman/drupal-test-traits": "^1.5",
         "phpunit/phpunit": "^7.5"
     },
     "repositories": [

--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -43,7 +43,6 @@ class UploadOrLink extends ManagedFile {
       '#pre_render' => [[$class, 'preRenderManagedFile']],
       '#theme' => 'file_managed_file',
       '#theme_wrappers' => ['form_element'],
-      '#progress_indicator' => 'throbber',
       '#progress_message' => NULL,
       '#upload_validators' => [],
       '#upload_location' => NULL,

--- a/modules/json_form_widget/src/SchemaUiHandler.php
+++ b/modules/json_form_widget/src/SchemaUiHandler.php
@@ -212,6 +212,9 @@ class SchemaUiHandler implements ContainerInjectionInterface {
     if (isset($spec->extensions)) {
       $element['#upload_validators']['file_validate_extensions'][] = $spec->extensions;
     }
+    if (isset($spec->progress_indicator)) {
+      $element['#progress_indicator'] = $spec->progress_indicator;
+    }
     return $element;
   }
 

--- a/schema/collections/dataset.ui.json
+++ b/schema/collections/dataset.ui.json
@@ -50,6 +50,13 @@
           "widget": "textarea",
           "rows": 5
         }
+      },
+      "downloadURL": {
+        "ui:options": {
+          "widget": "upload_or_link",
+          "extensions": "csv pdf tsv jpg txt xls xlsx",
+          "progress_indicator": "bar"
+        }
       }
     }
   },


### PR DESCRIPTION
This allows users to turn on the upload progress bar via ui schema spec, and makes this the default for our datasets out of the box.

## QA Steps

- [ ] Create a new dataset
- [ ] Chose "upload" for the distribution -> downloadURL field and upload a large file.
- [ ] confirm that a progress bar is shown