### PR TITLE
 Adding an easier way to dispatch events, and generating events around API metatstore/get and search capabilities

### DIFF
--- a/modules/common/src/DatasetInfo.php
+++ b/modules/common/src/DatasetInfo.php
@@ -162,7 +162,7 @@ class DatasetInfo implements ContainerInjectionInterface {
   /**
    * Get distributions info.
    *
-   * @param \stdClass $metadata
+   * @param object $metadata
    *   Dataset metadata object.
    *
    * @return array
@@ -185,7 +185,7 @@ class DatasetInfo implements ContainerInjectionInterface {
   /**
    * Get resources information.
    *
-   * @param \stdClass $distribution
+   * @param object $distribution
    *   A distribution object extracted from dataset metadata.
    *
    * @return array

--- a/modules/common/src/EventDispatcherTrait.php
+++ b/modules/common/src/EventDispatcherTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\common;
+
+use Drupal\common\Events\Event;
+
+/**
+ * Trait EventDispatcherTrait.
+ *
+ * @package Drupal\common
+ */
+trait EventDispatcherTrait {
+
+  /**
+   * Dispatch and event and give back any modified data from the listeners.
+   *
+   * @param mixed $eventName
+   *   The name of the event.
+   * @param mixed $data
+   *   The data that will be given to the listeners/subscribers.
+   *
+   * @return mixed
+   *   The data returned by the listeners/subscribers.
+   *
+   * @throws \Exception
+   *   If any of the subscribers registered and Exception it is thrown.
+   */
+  private function dispatchEvent($eventName, $data) {
+    /* @var ContainerAwareEventDispatcher $dispatcher */
+    $dispatcher = \Drupal::service('event_dispatcher');
+
+    /* @var \Drupal\common\Events\Event $event */
+    if ($event = $dispatcher->dispatch($eventName, new Event($data))) {
+      if ($e = $event->getException()) {
+        throw $e;
+      }
+
+      $data = $event->getData();
+    }
+
+    return $data;
+  }
+
+}

--- a/modules/common/src/Events/Event.php
+++ b/modules/common/src/Events/Event.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\common\Events;
+
+use Symfony\Component\EventDispatcher\Event as SymfonyEvent;
+
+/**
+ * Class Event.
+ *
+ * @package Drupal\common\Events
+ */
+class Event extends SymfonyEvent {
+  private $data;
+  private $exception;
+
+  /**
+   * Constructor.
+   */
+  public function __construct($data) {
+    $this->data = $data;
+    $this->exception = NULL;
+  }
+
+  /**
+   * Getter.
+   */
+  public function getData() {
+    return $this->data;
+  }
+
+  /**
+   * Setter.
+   */
+  public function setData($data): void {
+    $this->data = $data;
+  }
+
+  /**
+   * Getter.
+   */
+  public function getException(): ?\Exception {
+    return $this->exception;
+  }
+
+  /**
+   * Setter.
+   */
+  public function setException(\Exception $exception): void {
+    $this->exception = $exception;
+  }
+
+}

--- a/modules/common/src/FileFetcher/Factory.php
+++ b/modules/common/src/FileFetcher/Factory.php
@@ -33,7 +33,7 @@ class Factory implements FactoryInterface {
    * Private.
    */
   private function getFileFetcherJobStore() {
-    /** @var \Drupal\common\Storage\JobStoreFactory $jobStoreFactory */
+    /* @var \Drupal\common\Storage\JobStoreFactory $jobStoreFactory */
     $jobStoreFactory = $this->factory;
     return $jobStoreFactory->getInstance(FileFetcher::class);
   }

--- a/modules/common/src/Resource.php
+++ b/modules/common/src/Resource.php
@@ -226,10 +226,10 @@ class Resource implements \JsonSerializable {
    * Private.
    */
   private static function getDistribution($identifier) {
-    /** @var \Drupal\metastore\Storage\DataFactory $factory */
+    /* @var \Drupal\metastore\Storage\DataFactory $factory */
     $factory = \Drupal::service('dkan.metastore.storage');
 
-    /** @var \Drupal\metastore\Storage\Data $storage */
+    /* @var \Drupal\metastore\Storage\Data $storage */
     $storage = $factory->getInstance('distribution');
 
     $distroJson = $storage->retrieve($identifier);

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -62,12 +62,12 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   public function retrieve(string $id) {
     $this->setTable();
 
-    /** @var \Drupal\Core\Database\Query\Select $select */
+    /* @var \Drupal\Core\Database\Query\Select $select */
     $select = $this->connection->select($this->getTableName(), 't')
       ->fields('t', array_keys($this->getSchema()['fields']))
       ->condition($this->primaryKey(), $id);
 
-    /** @var \Drupal\Core\Database\StatementInterface $statement */
+    /* @var \Drupal\Core\Database\StatementInterface $statement */
     $statement = $select->execute();
 
     // The docs do not mention it, but fetch can return false.

--- a/modules/common/tests/src/Commands/CommonCommandsTest.php
+++ b/modules/common/tests/src/Commands/CommonCommandsTest.php
@@ -5,8 +5,14 @@ use Drupal\common\DatasetInfo;
 use MockChain\Chain;
 use PHPUnit\Framework\TestCase;
 
+/**
+ *
+ */
 class CommonCommandsTest extends TestCase {
 
+  /**
+   *
+   */
   public function testDatasetInfo() {
 
     $datasetInfo = (new Chain($this))

--- a/modules/common/tests/src/DatasetInfoTest.php
+++ b/modules/common/tests/src/DatasetInfoTest.php
@@ -12,8 +12,14 @@ use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;
 
+/**
+ *
+ */
 class DatasetInfoTest extends TestCase {
 
+  /**
+   *
+   */
   public function testMetastoreNotEnabled() {
     $datasetInfo = DatasetInfo::create($this->getCommonChain()->getMock());
 
@@ -25,6 +31,9 @@ class DatasetInfoTest extends TestCase {
     $this->assertEquals($expected, $result);
   }
 
+  /**
+   *
+   */
   public function testUuidNotFound() {
     $mockStorage = (new Chain($this))
       ->add(DataFactory::class, 'getInstance', Data::class)
@@ -47,6 +56,9 @@ class DatasetInfoTest extends TestCase {
     $this->assertEquals($expected, $result);
   }
 
+  /**
+   *
+   */
   private function getCommonChain() {
     $options = (new Options())
       ->index(0);

--- a/modules/common/tests/src/Storage/SelectFactoryTest.php
+++ b/modules/common/tests/src/Storage/SelectFactoryTest.php
@@ -9,6 +9,9 @@ use MockChain\Chain;
 use PHPUnit\Framework\TestCase;
 use Drupal\Tests\common\Unit\Connection;
 
+/**
+ *
+ */
 class SelectFactoryTest extends TestCase {
   private $query;
   private $selectFactory;
@@ -29,10 +32,16 @@ class SelectFactoryTest extends TestCase {
     }
   }
 
+  /**
+   *
+   */
   private function getSelectFactory() {
     return new SelectFactory($this->getConnection());
   }
 
+  /**
+   *
+   */
   private function getConnection() {
     return (new Chain($this))
       ->add(
@@ -43,17 +52,27 @@ class SelectFactoryTest extends TestCase {
       ->getMock();
   }
 
+  /**
+   *
+   */
   private function selectToString(Select $select): string {
     return preg_replace("/\n/", " ", "$select");
   }
 
+  /**
+   *
+   */
   private function queryDebug() {
     print_r($this->query);
     print "\n" . $this->selectToString($this->selectFactory->create($this->query));
   }
 
+  /**
+   *
+   */
   public function setUp() {
     $this->query = new Query();
     $this->selectFactory = $this->getSelectFactory();
   }
+
 }

--- a/modules/common/tests/src/Traits/CleanUp.php
+++ b/modules/common/tests/src/Traits/CleanUp.php
@@ -14,7 +14,7 @@ trait CleanUp {
    *
    */
   private function removeHarvests() {
-    /* @var $service \Drupal\harvest\Service */
+    /* @var \Drupal\harvest\Service $service */
     $service = \Drupal::service('dkan.harvest.service');
     foreach ($service->getAllHarvestIds() as $id) {
       $service->deregisterHarvest($id);
@@ -35,7 +35,7 @@ trait CleanUp {
    *
    */
   private function removeAllMappedFiles() {
-    /** @var \Drupal\metastore\Storage\ResourceMapperDatabaseTable $filemappertable */
+    /* @var \Drupal\metastore\Storage\ResourceMapperDatabaseTable $filemappertable */
     $filemappertable = \Drupal::service('dkan.metastore.resource_mapper_database_table');
     foreach ($filemappertable->retrieveAll() as $id) {
       $filemappertable->remove($id);
@@ -46,10 +46,10 @@ trait CleanUp {
    *
    */
   private function removeAllFileFetchingJobs() {
-    /** @var \Drupal\common\Storage\JobStoreFactory $jobStoreFactory */
+    /* @var \Drupal\common\Storage\JobStoreFactory $jobStoreFactory */
     $jobStoreFactory = \Drupal::service('dkan.common.job_store');
 
-    /** @var \Drupal\common\Storage\JobStore $jobStore */
+    /* @var \Drupal\common\Storage\JobStore $jobStore */
     $jobStore = $jobStoreFactory->getInstance(FileFetcher::class);
     foreach ($jobStore->retrieveAll() as $id) {
       $jobStore->remove($id);
@@ -62,7 +62,7 @@ trait CleanUp {
   private function flushQueues() {
     $dkanQueues = ['orphan_reference_processor', 'datastore_import', 'resource_purger'];
     foreach ($dkanQueues as $queueName) {
-      /** @var \Drupal\Core\Queue\QueueFactory $queueFactory */
+      /* @var \Drupal\Core\Queue\QueueFactory $queueFactory */
       $queueFactory = \Drupal::service('queue');
       $queue = $queueFactory->get($queueName);
       $queue->deleteQueue();
@@ -87,7 +87,7 @@ trait CleanUp {
    *
    */
   private function removeDatastoreTables() {
-    /** @var \Drupal\Core\Database\Connection $connection */
+    /* @var \Drupal\Core\Database\Connection $connection */
     $connection = \Drupal::service('database');
     $tables = $connection->schema()->findTables("datastore_%");
     foreach ($tables as $table) {

--- a/modules/common/tests/src/Unit/Storage/QueryDataProvider.php
+++ b/modules/common/tests/src/Unit/Storage/QueryDataProvider.php
@@ -20,6 +20,9 @@ class QueryDataProvider {
   const SQL = 2;
   const EXCEPTION = 3;
 
+  /**
+   *
+   */
   public function getAllData($return) {
     $tests = [
       'noPropertiesQuery',
@@ -52,6 +55,9 @@ class QueryDataProvider {
     return $data;
   }
 
+  /**
+   *
+   */
   public static function noPropertiesQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -66,6 +72,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function propertiesQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -81,6 +90,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function badPropertyQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -97,6 +109,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function unsafePropertyQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -113,6 +128,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function expressionQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -140,7 +158,7 @@ class QueryDataProvider {
           (object) [
             "property" => "add_one",
             "order" => "asc",
-          ]
+          ],
         ];
         return $query;
 
@@ -152,6 +170,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function nestedExpressionQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -188,6 +209,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function badExpressionOperandQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -212,6 +236,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function conditionQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -233,7 +260,9 @@ class QueryDataProvider {
     }
   }
 
-
+  /**
+   *
+   */
   public static function likeConditionQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -256,7 +285,9 @@ class QueryDataProvider {
     }
   }
 
-
+  /**
+   *
+   */
   public static function arrayConditionQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -279,6 +310,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function nestedConditionGroupQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -307,7 +341,7 @@ class QueryDataProvider {
                     "value" => "value3",
                   ],
                 ],
-              ]
+              ],
             ],
           ],
         ];
@@ -321,6 +355,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function sortQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -352,6 +389,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function badSortQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -368,6 +408,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function offsetQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -383,6 +426,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function limitOffsetQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -399,6 +445,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function joinsQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -413,7 +462,7 @@ class QueryDataProvider {
               "value" => (object) [
                 "collection" => "l",
                 "property" => "field1",
-              ]
+              ],
             ],
           ],
         ];
@@ -427,6 +476,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function joinWithPropertiesFromBothQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:
@@ -462,6 +514,9 @@ class QueryDataProvider {
     }
   }
 
+  /**
+   *
+   */
   public static function countQuery($return) {
     switch ($return) {
       case self::QUERY_OBJECT:

--- a/modules/datastore/src/Service.php
+++ b/modules/datastore/src/Service.php
@@ -202,7 +202,7 @@ class Service implements ContainerInjectionInterface {
    *   The importer list object.
    */
   public function list() {
-    /** @var \Drupal\datastore\Service\Info\ImportInfoList $service */
+    /* @var \Drupal\datastore\Service\Info\ImportInfoList $service */
     $service = \Drupal::service('dkan.datastore.import_info_list');
     return $service->buildList();
   }

--- a/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
+++ b/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
@@ -14,6 +14,9 @@ use Drupal\search_api\Datasource\DatasourcePluginBase;
  *   id = "dkan_dataset",
  *   label = "DKAN Dataset",
  * )
+ *
+ * @todo We should rely more in the metastore instead of direct
+ * entity queries and direct connections to storage classes.
  */
 class DkanDataset extends DatasourcePluginBase {
 

--- a/modules/metastore/modules/metastore_search/src/Search.php
+++ b/modules/metastore/modules/metastore_search/src/Search.php
@@ -19,7 +19,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class Search implements ContainerInjectionInterface {
   use QueryBuilderTrait;
   use FacetsFromIndexTrait;
+  // @todo Use real classes to get proper encapsulation.
   use FacetsFromContentTrait;
+
+  const EVENT_SEARCH = 'dkan_metastore_search_search';
+  const EVENT_SEARCH_PARAMS = 'dkan_metastore_search_search_params';
+
+  // @todo this constant is used by QueryBuilder, maybe we need a class.
+  const EVENT_SEARCH_QUERY_BUILDER_CONDITION = 'dkan_metastore_search_query_builder_condition';
 
   /**
    * The search index.
@@ -94,11 +101,14 @@ class Search implements ContainerInjectionInterface {
    *   Search parameters.
    */
   public function search(array $params = []) {
+    $params = $this->dispatchEvent(self::EVENT_SEARCH_PARAMS, $params);
     $query = $this->getQuery($params, $this->index, $this->queryHelper)[0];
     $result = $query->execute();
 
     $count = $result->getResultCount();
     $data = $this->getData($result);
+
+    $data = $this->dispatchEvent(self::EVENT_SEARCH, $data);
 
     return (object) [
       'total' => $count,

--- a/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
+++ b/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\metastore_search\Unit;
 
+use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Drupal\Core\DependencyInjection\Container;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManager;
@@ -31,7 +32,7 @@ class SearchTest extends TestCase {
    * Test for missing search index.
    */
   public function testNoSearchIndex() {
-    $container = $this->getCommonMockChain()
+    $container = $this->getCommonMockChain($this)
       ->add(EntityStorageInterface::class, 'load', NULL);
 
     $this->expectExceptionMessage('An index named [dkan] does not exist.');
@@ -52,7 +53,11 @@ class SearchTest extends TestCase {
       ],
     ];
 
-    $service = Search::create($this->getCommonMockChain()->getMock());
+    $container = $this->getCommonMockChain($this)->getMock();
+
+    \Drupal::setContainer($container);
+
+    $service = Search::create($container);
 
     $this->assertEquals($expect, $service->search([
       'page' => 1,
@@ -82,7 +87,11 @@ class SearchTest extends TestCase {
     ],
     ];
 
-    $service = Search::create($this->getCommonMockChain()->getMock());
+    $container = $this->getCommonMockChain($this)->getMock();
+
+    \Drupal::setContainer($container);
+
+    $service = Search::create($container);
 
     $this->assertEquals($expect1, $service->facets([]));
 
@@ -97,26 +106,40 @@ class SearchTest extends TestCase {
   }
 
   /**
-   * Common mock chain.
+   *
    */
-  public function getCommonMockChain() {
-    $this->checkService('dkan.metastore.service', 'metastore');
+  public static function getCommonMockChain(TestCase $case, Options $services = NULL, $collection = NULL) {
+    if (!$services) {
+      $services = new Options();
+    }
 
-    $options = (new Options())
-      ->add('dkan.metastore.service', Metastore::class)
-      ->add('entity_type.manager', EntityTypeManager::class)
-      ->add('search_api.query_helper', QueryHelperInterface::class)
-      ->index(0);
+    $myServices = [
+      'dkan.metastore.service' => Metastore::class,
+      'entity_type.manager' => EntityTypeManager::class,
+      'search_api.query_helper' => QueryHelperInterface::class,
+      'event_dispatcher' => ContainerAwareEventDispatcher::class,
+    ];
 
-    $item = (new Chain($this))
+    foreach ($myServices as $serviceName => $class) {
+      $serviceClass = $services->return($serviceName);
+      if (!isset($serviceClass)) {
+        $services->add($serviceName, $class);
+      }
+    }
+
+    $services->index(0);
+
+    $item = (new Chain($case))
       ->add(Item::class, 'getId', 1)
       ->getMock();
 
-    $collection = (object) [
-      'title' => 'hello',
-      'description' => 'goodbye',
-      'publisher__name' => 'Steve',
-    ];
+    if (!isset($collection)) {
+      $collection = (object) [
+        'title' => 'hello',
+        'description' => 'goodbye',
+        'publisher__name' => 'Steve',
+      ];
+    }
 
     $facet = (object) ['data' => (object) ['name' => 'Steve']];
 
@@ -125,8 +148,8 @@ class SearchTest extends TestCase {
       ->add('theme', [])
       ->add('publisher', [$facet]);
 
-    return (new Chain($this))
-      ->add(Container::class, 'get', $options)
+    return (new Chain($case))
+      ->add(Container::class, 'get', $services)
       ->add(EntityTypeManager::class, 'getStorage', EntityStorageInterface::class)
       ->add(EntityStorageInterface::class, 'load', IndexInterface::class)
       ->add(IndexInterface::class, 'getFields', ['description' => 'blah', 'publisher__name' => 'blah'])

--- a/modules/metastore/src/Factory/Sae.php
+++ b/modules/metastore/src/Factory/Sae.php
@@ -65,7 +65,7 @@ class Sae implements FactoryInterface {
   private function getJsonSchema($schema_id) {
     $schemas = $this->schemaRetriever->getAllIds();
 
-    // @Todo: mechanism to validate against additional schemas. For now,
+    // @todo mechanism to validate against additional schemas. For now,
     // validate against the empty object, as it accepts any valid json.
     if (!in_array($schema_id, $schemas)) {
       return '{ }';

--- a/modules/metastore/src/LifeCycle/Data.php
+++ b/modules/metastore/src/LifeCycle/Data.php
@@ -80,7 +80,8 @@ class Data extends AbstractData {
 
     if (isset($downloadUrl) && !filter_var($downloadUrl, FILTER_VALIDATE_URL)) {
       $resourceIdentifier = $downloadUrl;
-      $ref = NULL; $original = NULL;
+      $ref = NULL;
+      $original = NULL;
       [$ref, $original] = $this->retrieveDownloadUrlFromResourceMapper($resourceIdentifier);
 
       $downloadUrl = isset($original) ? $original : "";

--- a/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php
+++ b/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php
@@ -74,7 +74,7 @@ class OrphanReferenceProcessor extends QueueWorkerBase implements ContainerFacto
     $metadataProperty = $data[0];
     $identifier = $data[1];
 
-    // @Todo: Search for uuid directly within the loadByProperties array.
+    // @todo Search for uuid directly within the loadByProperties array.
     // Search datasets using this uuid for this property id.
     $properties = [
       'type' => 'data',

--- a/modules/metastore/src/Reference/Dereferencer.php
+++ b/modules/metastore/src/Reference/Dereferencer.php
@@ -37,7 +37,8 @@ class Dereferencer {
       throw new \Exception("data must be an object.");
     }
     // Cycle through the dataset properties we seek to dereference.
-    $ref = NULL; $actual = NULL;
+    $ref = NULL;
+    $actual = NULL;
     foreach ($this->getPropertyList() as $propertyId) {
       if (isset($data->{$propertyId})) {
         $referenceProperty = "%Ref:{$propertyId}";
@@ -91,7 +92,8 @@ class Dereferencer {
   private function dereferenceMultiple(string $property_id, array $uuids) : array {
     $result = [];
     $reference = [];
-    $ref = NULL; $actual = NULL;
+    $ref = NULL;
+    $actual = NULL;
     foreach ($uuids as $uuid) {
       [$ref, $actual] = $this->dereferenceSingle($property_id, $uuid);
       if (NULL !== $ref && NULL !== $actual) {

--- a/modules/metastore/src/Reference/HelperTrait.php
+++ b/modules/metastore/src/Reference/HelperTrait.php
@@ -29,7 +29,7 @@ trait HelperTrait {
    * @return array
    *   List of dataset properties.
    *
-   * @Todo: consolidate with common RouteProvider's getPropertyList.
+   * @todo consolidate with common RouteProvider's getPropertyList.
    */
   private function getPropertyList() : array {
     if (isset($this->configService)) {

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -77,7 +77,7 @@ class Data implements StorerInterface, RetrieverInterface, BulkRetrieverInterfac
 
     $all = [];
     foreach ($node_ids as $nid) {
-      /* @var $node \Drupal\node\NodeInterface */
+      /** @var \Drupal\node\NodeInterface $node */
       $node = $this->nodeStorage->load($nid);
       if ($node->get('moderation_state')->getString() === 'published') {
         $all[] = $node->get('field_json_metadata')->getString();

--- a/modules/metastore/tests/src/Unit/Reference/DereferencerTest.php
+++ b/modules/metastore/tests/src/Unit/Reference/DereferencerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\metastore\Unit;
+namespace Drupal\Tests\metastore\Unit\Reference;
 
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Config\ImmutableConfig;

--- a/modules/metastore/tests/src/Unit/Reference/OrphanCheckerTest.php
+++ b/modules/metastore/tests/src/Unit/Reference/OrphanCheckerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\metastore\Unit;
+namespace Drupal\Tests\metastore\Unit\Reference;
 
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Config\ImmutableConfig;

--- a/modules/metastore/tests/src/Unit/Reference/ReferencerTest.php
+++ b/modules/metastore/tests/src/Unit/Reference/ReferencerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\Tests\metastore\Unit\Reference;
+
+use Drupal\metastore\Reference\Referencer;
+use MockChain\Chain;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class ReferencerTest extends TestCase {
+
+  public function testHostify() {
+    $container = (new Chain($this))
+      ->add(Container::class, 'get', RequestStack::class)
+      ->add(RequestStack::class, 'getCurrentRequest', Request::class)
+      ->add(Request::class, 'getHost', 'test.test')
+      ->getMock();
+
+    \Drupal::setContainer($container);
+
+    $this->assertEquals(
+      'http://h-o.st/mycsv.txt',
+      Referencer::hostify("http://test.test/mycsv.txt"));
+  }
+
+}

--- a/modules/metastore/tests/src/Unit/ServiceTest.php
+++ b/modules/metastore/tests/src/Unit/ServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\metastore\Unit;
 
+use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Drupal\Core\DependencyInjection\Container;
 use Drupal\metastore\Exception\ExistingObjectException;
 use Drupal\metastore\Exception\MissingObjectException;
@@ -25,7 +26,7 @@ class ServiceTest extends TestCase {
    *
    */
   public function testGetSchemas() {
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(SchemaRetriever::class, "getAllIds", ["1"]);
 
     $service = Service::create($container->getMock());
@@ -36,7 +37,7 @@ class ServiceTest extends TestCase {
    *
    */
   public function testGetSchema() {
-    $container = $this->getCommonMockChain();
+    $container = self::getCommonMockChain($this);
 
     $service = Service::create($container->getMock());
     $this->assertEquals(json_encode("blah"), json_encode($service->getSchema("1")));
@@ -46,9 +47,11 @@ class ServiceTest extends TestCase {
    *
    */
   public function testGetAll() {
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "get", [json_encode("blah")]);
+
+    \Drupal::setContainer($container->getMock());
 
     $service = Service::create($container->getMock());
 
@@ -59,8 +62,10 @@ class ServiceTest extends TestCase {
    *
    */
   public function testGet() {
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Data::class, "retrievePublished", json_encode("blah"));
+
+    \Drupal::setContainer($container->getMock());
 
     $service = Service::create($container->getMock());
 
@@ -78,7 +83,7 @@ class ServiceTest extends TestCase {
       ],
     ];
 
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "get", json_encode($dataset));
 
@@ -92,7 +97,7 @@ class ServiceTest extends TestCase {
    *
    */
   public function testPost() {
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "post", "1");
 
@@ -105,7 +110,7 @@ class ServiceTest extends TestCase {
    *
    */
   public function testPostAlreadyExisting() {
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "get", "1");
 
@@ -119,7 +124,7 @@ class ServiceTest extends TestCase {
    *
    */
   public function testPut() {
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "put", "1")
       ->add(Engine::class, "get", "1");
@@ -137,7 +142,7 @@ class ServiceTest extends TestCase {
     $existing = '{"identifier":"1","title":"Foo"}';
     $updating = '{"identifier":"2","title":"Bar"}';
 
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "get", $existing);
 
@@ -152,7 +157,7 @@ class ServiceTest extends TestCase {
    */
   public function testPutResultingInNewData() {
     $data = '{"identifier":"3","title":"FooBar"}';
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "get", new \Exception())
       ->add(Engine::class, "put", "3")
@@ -169,7 +174,7 @@ class ServiceTest extends TestCase {
   public function testPutObjectUnchangedException() {
     $existing = '{"identifier":"1","title":"Foo"}';
 
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "get", $existing);
 
@@ -190,7 +195,7 @@ class ServiceTest extends TestCase {
       }
 EOF;
 
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "get", $existing);
 
@@ -203,7 +208,7 @@ EOF;
    *
    */
   public function testPatch() {
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "patch", "1")
       ->add(Engine::class, "get", "1");
@@ -219,7 +224,7 @@ EOF;
   public function testPatchObjectNotFoundException() {
     $data = '{"identifier":"1","title":"FooBar"}';
 
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "get", new \Exception());
 
@@ -232,7 +237,7 @@ EOF;
    *
    */
   public function testPublish() {
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "get", "1")
       ->add(Data::class, "publish", "1");
@@ -246,7 +251,7 @@ EOF;
    *
    */
   public function testPublishMissingObjectExpection() {
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "get", new \Exception());
 
@@ -260,7 +265,7 @@ EOF;
    *
    */
   public function testDelete() {
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "delete", "1")
       ->add(Engine::class, "get", "1");
@@ -280,10 +285,12 @@ EOF;
     ];
     $dataset = (object) ["foo" => "bar"];
 
-    $container = $this->getCommonMockChain()
+    $container = self::getCommonMockChain($this)
       ->add(SchemaRetriever::class, "retrieve", json_encode($catalog))
       ->add(Sae::class, "getInstance", Engine::class)
       ->add(Engine::class, "get", [json_encode($dataset), json_encode($dataset)]);
+
+    \Drupal::setContainer($container->getMock());
 
     $service = Service::create($container->getMock());
     $catalog->dataset = [
@@ -296,15 +303,29 @@ EOF;
   /**
    * @return \Drupal\common\Tests\Mock\Chain
    */
-  public function getCommonMockChain() {
-    $options = (new Options())
-      ->add('metastore.schema_retriever', SchemaRetriever::class)
-      ->add('metastore.sae_factory', Sae::class)
-      ->add('dkan.metastore.storage', DataFactory::class)
-      ->index(0);
+  public static function getCommonMockChain(TestCase $case, Options $services = null) {
+    if (!$services) {
+      $services = new Options();
+    }
 
-    return (new Chain($this))
-      ->add(Container::class, "get", $options)
+    $myServices = [
+      'dkan.metastore.schema_retriever' => SchemaRetriever::class,
+      'dkan.metastore.sae_factory' => Sae::class,
+      'dkan.metastore.storage' => DataFactory::class,
+      'event_dispatcher' => ContainerAwareEventDispatcher::class
+    ];
+
+    foreach ($myServices as $serviceName => $class) {
+      $serviceClass = $services->return($serviceName);
+      if (!isset($serviceClass)) {
+        $services->add($serviceName, $class);
+      }
+    }
+
+    $services->index(0);
+
+    return (new Chain($case))
+      ->add(Container::class, "get", $services)
       ->add(DataFactory::class, 'getInstance', Data::class)
       ->add(SchemaRetriever::class, "retrieve", json_encode("blah"));
   }


### PR DESCRIPTION
**User Story:** We would like to restrict some datasets from being viewed by unauthenticated users because the data is licensed in a way that we can not make completely public.

To accomplish this we are creating events at certain points during DKAN activities so subscribers can implement their custom logic without having to modify DKAN.

For our scenario we are generating events during the following actions:

- Get and GetAll metastore actions
- Before and after a Search query is performed

**DEVELOPER NOTES:**
Beyond the new events, we have create a Trait to facilitate dispatching events from any class. This special dispatcher also supports:

- Manipulating some given data (Ex. The parameters of a query)
- An interrupting the flow by registering exception with the event's system