### PR TITLE
Adjusted Drupal\metastore_search\FacetsCommonTrait::getValuesFromComm…

### DIFF
--- a/modules/metastore/modules/metastore_search/src/FacetsCommonTrait.php
+++ b/modules/metastore/modules/metastore_search/src/FacetsCommonTrait.php
@@ -19,11 +19,7 @@ trait FacetsCommonTrait {
    *   Values.
    */
   private function getValuesFromCommaSeparatedString(string $string): array {
-    $values = [];
-    foreach (explode(',', $string) as $value) {
-      $values[] = trim($value);
-    }
-    return $values;
+    return array_map('trim', str_getcsv($string));
   }
 
   /**

--- a/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
+++ b/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
@@ -104,6 +104,7 @@ class SearchTest extends TestCase {
       ->add(QueryHelperInterface::class, 'createQuery', QueryInterface::class)
       ->add(QueryInterface::class, 'execute', ResultSet::class)
       ->add(QueryInterface::class, 'createConditionGroup', ConditionGroup::class)
+      ->add(ConditionGroup::class, 'addCondition', null, 'condition_group')
 
       ->add(ResultSet::class, 'getResultItems', [$item])
       ->add(Metastore::class, 'get', json_encode($collection))
@@ -113,13 +114,14 @@ class SearchTest extends TestCase {
 
     $service = Search::create($container->getMock());
 
-    $a = $service->search([
-      'page' => 1,
-      'facets' => true,
-      'page-size' => 10,
-      'publisher__name' => '"Steve, and someone else"',
+    $service->search([
+      'publisher__name' => 'Normal Param, "Steve, and someone else"',
     ]);
 
+    $this->assertEquals(
+      'Steve, and someone else',
+      $container->getStoredInput('condition_group')[1]
+    );
   }
 
   /**

--- a/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
+++ b/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
@@ -77,23 +77,6 @@ class SearchTest extends TestCase {
       ->add('event_dispatcher', ContainerAwareEventDispatcher::class)
       ->index(0);
 
-    $collection = [
-      'title' => 'hello',
-      'description' => 'goodbye',
-      'publisher__name' => 'Steve, and someone else',
-    ];
-
-    $facet = (object) ['data' => (object) ['name' => 'Steve, and someone else']];
-
-    $getAllOptions = (new Options())
-      ->add('keyword', [])
-      ->add('theme', [])
-      ->add('publisher', [$facet]);
-
-    $item = (new Chain($this))
-      ->add(Item::class, 'getId', 1)
-      ->getMock();
-
     $container = (new Chain($this))
       ->add(Container::class, 'get', $options)
       ->add(EntityTypeManager::class, 'getStorage', EntityStorageInterface::class)
@@ -104,11 +87,7 @@ class SearchTest extends TestCase {
       ->add(QueryHelperInterface::class, 'createQuery', QueryInterface::class)
       ->add(QueryInterface::class, 'execute', ResultSet::class)
       ->add(QueryInterface::class, 'createConditionGroup', ConditionGroup::class)
-      ->add(ConditionGroup::class, 'addCondition', null, 'condition_group')
-
-      ->add(ResultSet::class, 'getResultItems', [$item])
-      ->add(Metastore::class, 'get', json_encode($collection))
-      ->add(Metastore::class, 'getAll', $getAllOptions);
+      ->add(ConditionGroup::class, 'addCondition', null, 'condition_group');
 
     \Drupal::setContainer($container->getMock());
 


### PR DESCRIPTION
For example: one, two,"three, four"," five", "term with quotes \" and , in it"