### PR TITLE
Filefetch 'keep_original_filename' configuration defaults to true

### DIFF
--- a/modules/common/src/FileFetcher/Factory.php
+++ b/modules/common/src/FileFetcher/Factory.php
@@ -12,8 +12,8 @@ use FileFetcher\FileFetcher;
 class Factory implements FactoryInterface {
 
   private $factory;
-  private $config_default = [
-    'keep_original_filename' => True,
+  private $configDefault = [
+    'keep_original_filename' => TRUE,
   ];
 
   /**
@@ -29,7 +29,7 @@ class Factory implements FactoryInterface {
    * @inheritdoc
    */
   public function getInstance(string $identifier, array $config = []) {
-    $config = array_merge($this->config_default, $config);
+    $config = array_merge($this->configDefault, $config);
     return FileFetcher::get($identifier, $this->getFileFetcherJobStore(), $config);
   }
 

--- a/modules/common/src/FileFetcher/Factory.php
+++ b/modules/common/src/FileFetcher/Factory.php
@@ -12,6 +12,9 @@ use FileFetcher\FileFetcher;
 class Factory implements FactoryInterface {
 
   private $factory;
+  private $config_default = [
+    'keep_original_filename' => True,
+  ];
 
   /**
    * Constructor.
@@ -26,6 +29,7 @@ class Factory implements FactoryInterface {
    * @inheritdoc
    */
   public function getInstance(string $identifier, array $config = []) {
+    $config = array_merge($this->config_default, $config);
     return FileFetcher::get($identifier, $this->getFileFetcherJobStore(), $config);
   }
 

--- a/modules/metastore/modules/metastore_search/src/ComplexData/Dataset.php
+++ b/modules/metastore/modules/metastore_search/src/ComplexData/Dataset.php
@@ -155,11 +155,10 @@ class Dataset extends ComplexDataFacade {
   private function getArrayValues($property_name) {
     $values = [];
     $matches = [];
-    if (preg_match('/(.*)__item__(.*)/', $property_name, $matches)) {
-      if (is_array($this->data->{$matches[1]})) {
-        foreach ($this->data->{$matches[1]} as $dist) {
-          $values[] = isset($dist->{$matches[2]}) ? $dist->{$matches[2]} : [];
-        }
+    if (preg_match('/(.*)__item__(.*)/', $property_name, $matches)
+      && is_array($this->data->{$matches[1]})) {
+      foreach ($this->data->{$matches[1]} as $dist) {
+        $values[] = isset($dist->{$matches[2]}) ? $dist->{$matches[2]} : [];
       }
     }
     elseif (isset($this->data->{$property_name})) {

--- a/modules/metastore/modules/metastore_search/src/ComplexData/Dataset.php
+++ b/modules/metastore/modules/metastore_search/src/ComplexData/Dataset.php
@@ -156,8 +156,10 @@ class Dataset extends ComplexDataFacade {
     $values = [];
     $matches = [];
     if (preg_match('/(.*)__item__(.*)/', $property_name, $matches)) {
-      foreach ($this->data->{$matches[1]} as $dist) {
-        $values[] = isset($dist->{$matches[2]}) ? $dist->{$matches[2]} : [];
+      if (is_array($this->data->{$matches[1]})) {
+        foreach ($this->data->{$matches[1]} as $dist) {
+          $values[] = isset($dist->{$matches[2]}) ? $dist->{$matches[2]} : [];
+        }
       }
     }
     elseif (isset($this->data->{$property_name})) {


### PR DESCRIPTION
fixes [NuCivic/data-marine-scotland/issues/26]

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Using the FileFetcher component (for example from a harvest) should now produce shorter paths for downloaded assets (for example `public://resources/4a811a0bc52ce3a8671d5f213d47ff9f_1617980199/SamplingInfo_BBICPorOT4_SSASMP.csv`).
- [ ] Bonus fix: Make sure matches are an array before running them through a foreach.
