### PR TITLE
GET endpoint for datastore query API

### DIFF
--- a/modules/common/src/Util/RequestParamNormalizer.php
+++ b/modules/common/src/Util/RequestParamNormalizer.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\common\Util;
+
+use JsonSchema\Validator;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class DkanRequestNormalizer.
+ *
+ * This class provides public static functions to normalize different HTTP
+ * request types into valid JSON data. Provides type casting from a JSON Schema
+ * to avoid data loss from conversion between query string and JSON.
+ *
+ * @package Drupal\common\Util
+ */
+class RequestParamNormalizer {
+
+  /**
+   * Get the JSON string from the request, with type coercion applied.
+   *
+   * @param Symfony\Component\HttpFoundation\Request $request
+   *   The HTTP request.
+   * @param string $schema
+   *   Optional JSON schema string, used to cast data types.
+   *
+   * @return string
+   *   Normalized and type-casted JSON string.
+   */
+  public static function getFixedJson(Request $request, string $schema = NULL) {
+    $json = self::getJson($request);
+    if ($schema) {
+      $json = self::fixTypes($json, $schema);
+    }
+    return $json;
+  }
+
+  /**
+   * Just get the JSON string from the request.
+   *
+   * @param Symfony\Component\HttpFoundation\Request $request
+   *   Symfony HTTP request object.
+   *
+   * @return string
+   *   JSON string.
+   *
+   * @throws UnexpectedValueException
+   *   When an unsupported HTTP method is passed.
+   */
+  public static function getJson(Request $request) {
+    $method = $request->getRealMethod();
+    switch ($method) {
+      case "POST":
+      case "PUT":
+      case "PATCH":
+        return $request->getContent();
+
+      case "GET":
+        return json_encode($request->query->all());
+
+      default:
+        throw new \UnexpectedValueException("Only POST, PUT, PATCH and GET requests can be normalized.");
+    }
+  }
+
+  /**
+   * Cast data types in the JSON object according to a schema.
+   *
+   * @param string $json
+   *   JSON string.
+   * @param string $schema
+   *   JSON Schema string.
+   *
+   * @return string
+   *   JSON string with type coercion applied.
+   */
+  public static function fixTypes($json, $schema) {
+    $data = json_decode($json);
+    $validator = new Validator();
+    $validator->coerce($data, json_decode($schema));
+    return json_encode($data, JSON_PRETTY_PRINT);
+  }
+
+}

--- a/modules/common/src/Util/RequestParamNormalizer.php
+++ b/modules/common/src/Util/RequestParamNormalizer.php
@@ -6,7 +6,7 @@ use JsonSchema\Validator;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Class DkanRequestNormalizer.
+ * Class RequestParamNormalizer.
  *
  * This class provides public static functions to normalize different HTTP
  * request types into valid JSON data. Provides type casting from a JSON Schema

--- a/modules/common/tests/files/query.json
+++ b/modules/common/tests/files/query.json
@@ -1,0 +1,27 @@
+{
+    "conditions": [
+        {
+            "property": "state",
+            "value": "AL",
+            "operator": "="
+        },
+        {
+            "property": "record_number",
+            "value": "%1%",
+            "operator": "LIKE"
+        }
+    ],
+    "sort": [
+        {
+            "property": "record_number",
+            "order": "asc"
+        },
+        {
+            "property": "state",
+            "order": "desc"
+        }
+    ],
+    "limit": 50,
+    "offset": 25,
+    "results": true
+}

--- a/modules/common/tests/files/querySchema.json
+++ b/modules/common/tests/files/querySchema.json
@@ -1,0 +1,80 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://getdkan.com/api/datastore.test.query.json",
+    "title": "Query",
+    "description": "Simplified schema for testing pseudo DKAN database queries",
+    "type": "object",
+    "properties": {
+        "conditions": {
+            "type": "array",
+            "description": "Conditions or groups of conditions for the query, bound by 'and' operator.",
+            "items": { "$ref": "#/definitions/condition" }
+        },
+        "limit": {
+            "type": "integer",
+            "maximum": 500,
+            "description": "Limit for maximum number of records returned. Pass zero for no limit (may be restricted by user permissions).",
+            "default": 500
+        },
+        "offset": {
+            "type": "integer",
+            "description": "Number of records to offset by or skip before returning first record.",
+            "default": 0
+        },
+        "sorts": {
+            "type": "array",
+            "description": "Result sorting directives.",
+            "items": {"$ref": "#/definitions/sort"}
+        },
+        "results": {
+            "description": "Return the result set. Set to false and set count to true to receive only a count of matches.",
+            "type": "boolean",
+            "default": true
+        }
+    },
+    "definitions": {
+        "condition": {
+            "type": "object",
+            "title": "Condition",
+            "description": "Condition object including property, value and operator. If querying only one resource, the \"resource\" does not need to be specified.",
+            "properties": {
+                "property": { "type": "string" },
+                "value": {
+                    "anyOf": [
+                        { "type": "string" },
+                        { "type": "number" },
+                        { 
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    { "type": "string" },
+                                    { "type": "number" }            
+                                ]
+                            }
+                        }
+                    ],
+                    "description": "The value to filter against."
+                 },
+                 "operator": {
+                     "type": "string",
+                     "description": "Condition operator",
+                     "enum": [ "=", "<>", "<", "<=", ">", ">=", "like", "between", "in", "not in" ],
+                     "default": "="
+                 }
+            },
+            "required": [ "property", "value" ]            
+        },
+        "sort": {
+            "type": "object",
+            "description": "Properties to sort by in a particular order.",
+            "properties": { 
+                "property": { "type": "string" },
+                "order": {
+                    "type": "string",
+                    "description": "Order to sort in, lowercase.",
+                    "enum": ["asc", "desc"]
+                }
+            }
+        }
+    }
+}

--- a/modules/common/tests/src/Util/RequestParamNormalizerTest.php
+++ b/modules/common/tests/src/Util/RequestParamNormalizerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\Tests\common\Util;
+
+use Drupal\common\Util\RequestParamNormalizer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ *
+ */
+class RequestParamNormalizerTest extends TestCase {
+
+  /**
+   * Make sure we get what we expect with a GET
+   */
+  public function testGetNormalizer() {
+    $schema = $this->getSampleSchema();
+    $queryString = "conditions[0][property]=state&conditions[0][value]=AL&conditions[0][operator]==&conditions[1][property]=record_number&conditions[1][value]=%1%&conditions[1][operator]=LIKE&sort[0][property]=record_number&sort[0][order]=asc&sort[1][property]=state&sort[1][order]=desc&limit=50&offset=25&results=true";
+
+    $request = Request::create("http://example.com?$queryString", "GET");
+    $requestJson = RequestParamNormalizer::getFixedJson($request, $schema);
+    $this->assertEquals($requestJson, $this->getSampleJson());
+  }
+
+  /**
+   * Make sure we get what we expect with a post
+   */
+  public function testPostNormalizer() {
+    $sampleJson = $this->getSampleJson();
+    $schema = $this->getSampleSchema();
+    $request = Request::create("http://example.com", "POST", [], [], [], [], $sampleJson);
+    $requestJson = RequestParamNormalizer::getFixedJson($request, $schema);
+    $this->assertEquals($requestJson, $sampleJson);
+  }
+
+  /**
+   * Make sure we get what we expect with a patch
+   */
+  public function testPatchNormalizer() {
+    $sampleJson = $this->getSampleJson();
+    $schema = $this->getSampleSchema();
+
+    $request = Request::create("http://example.com", "PATCH", [], [], [], [], $sampleJson);
+    $requestJson = RequestParamNormalizer::getFixedJson($request, $schema);
+    $this->assertEquals($requestJson, $sampleJson);
+  }
+
+  /**
+   * Make sure we get what we expect with a put
+   */
+  public function testPutNormalizer() {
+    $sampleJson = $this->getSampleJson();
+    $schema = $this->getSampleSchema();
+
+    $request = Request::create("http://example.com", "PUT", [], [], [], [], $sampleJson);
+    $requestJson = RequestParamNormalizer::getFixedJson($request, $schema);
+    $this->assertEquals($requestJson, $sampleJson);
+  }
+
+
+  private function getSampleJson() {
+    return file_get_contents(__DIR__ . "/../../files/query.json");
+  }
+
+  private function getSampleSchema() {
+    return file_get_contents(__DIR__ . "/../../files/querySchema.json");
+  }
+
+}

--- a/modules/common/tests/src/Util/RequestParamNormalizerTest.php
+++ b/modules/common/tests/src/Util/RequestParamNormalizerTest.php
@@ -58,6 +58,18 @@ class RequestParamNormalizerTest extends TestCase {
     $this->assertEquals($requestJson, $sampleJson);
   }
 
+  /**
+   * Make sure we get what we expect with a delete
+   */
+  public function testDeleteNormalizer() {
+    $this->expectExceptionMessage("Only POST, PUT, PATCH and GET requests can be normalized");
+    $sampleJson = $this->getSampleJson();
+    $schema = $this->getSampleSchema();
+
+    $request = Request::create("http://example.com", "DELETE");
+    $requestJson = RequestParamNormalizer::getFixedJson($request, $schema);
+  }
+
 
   private function getSampleJson() {
     return file_get_contents(__DIR__ . "/../../files/query.json");

--- a/modules/datastore/datastore.routing.yml
+++ b/modules/datastore/datastore.routing.yml
@@ -69,9 +69,29 @@ datastore.1.query.post:
   options:
     _auth: ['basic_auth', 'cookie']
 
+datastore.1.query.get:
+  path: '/api/1/datastore/query'
+  methods: [GET]
+  defaults:
+    _controller: '\Drupal\datastore\WebServiceApi::query'
+  requirements:
+    _permission: 'access content'
+  options:
+    _auth: ['basic_auth', 'cookie']
+
 datastore.1.query.id.post:
   path: '/api/1/datastore/query/{identifier}'
   methods: [POST]
+  defaults:
+    _controller: '\Drupal\datastore\WebServiceApi::queryResource'
+  requirements:
+    _permission: 'access content'
+  options:
+    _auth: ['basic_auth', 'cookie']
+
+datastore.1.query.id.get:
+  path: '/api/1/datastore/query/{identifier}'
+  methods: [GET]
   defaults:
     _controller: '\Drupal\datastore\WebServiceApi::queryResource'
   requirements:


### PR DESCRIPTION
Using POST for any datastore query is a pain. This adds an equivalent GET endpoint for datastore queries that can accept the same JSON request types, but encoded for a query string. 

The new RequestParamNormalizer class can hopefully be used to apply this pattern to other parts of the API in the future.

Note: If RootedJsonData used justinrainbow instead of Opis for JSON validation, we could move the type casting logic into RootedJsonData and simplify the controller and normalizer logic from this PR. Would be a nice future improvement if it doesn't break anything RootedJsonData is doing elsewhere.

## QA Steps

- [ ] Stand up a site with sample data
- [ ] Get the distribution ID for bike lane data at api/1/metastore/schemas/dataset/items?show-reference-ids
- [ ] Load api/1/datastore/query/[ID]?results=true&conditions[0][property]=record_number&conditions[0][value]=2 in a browser