### PR TITLE
Add an opportunity to alter the table schema on creation

### DIFF
--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -5,12 +5,16 @@ namespace Drupal\common\Storage;
 use Dkan\Datastore\Storage\Database\SqlStorageTrait;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\DatabaseExceptionWrapper;
+use Drupal\common\EventDispatcherTrait;
 
 /**
  * AbstractDatabaseTable class.
  */
 abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   use SqlStorageTrait;
+  use EventDispatcherTrait;
+
+  const EVENT_TABLE_CREATE = 'dkan_common_table_create';
 
   /**
    * Drupal DB connection object.
@@ -276,6 +280,8 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    * Create a table given a name and schema.
    */
   private function tableCreate($table_name, $schema) {
+    // Opportunity to alter the schema before table creation.
+    $schema = $this->dispatchEvent(self::EVENT_TABLE_CREATE, $schema);
     $this->connection->schema()->createTable($table_name, $schema);
   }
 


### PR DESCRIPTION
When importing data that contains overly large content in a single field, the standard [data-type](https://www.drupal.org/docs/7/api/schema-api/data-types/data-types-overview) 'text' (16 KB) will not be large enough to hold the data and cause the import to fail.

Adding an event on **tableCreate** will allow users to create an event subscriber to alter the table schema when needed.

For example:
```
public function modifySchema(Event $event) {
    $schema = $event->getData();
    if (isset($schema['fields']['payload'])) {
      $schema['fields']['payload']['type'] = 'text';
      $schema['fields']['payload']['size'] = 'medium';
    }
    $event->setData($schema);
  }
```