### PR TITLE
Date picker granularity

### DIFF
--- a/cypress/integration/07_admin_dataset_json_form.spec.js
+++ b/cypress/integration/07_admin_dataset_json_form.spec.js
@@ -9,7 +9,7 @@ context('Admin dataset json form', () => {
         cy.get('#edit-field-json-metadata-0-value-title').should('have.attr', 'required', 'required')
         cy.get('#edit-field-json-metadata-0-value-description').should('have.attr', 'required', 'required')
         cy.get('#edit-field-json-metadata-0-value-accesslevel').should('have.attr', 'required', 'required')
-        cy.get('#edit-field-json-metadata-0-value-modified').should('have.attr', 'required', 'required')
+        cy.get('#edit-field-json-metadata-0-value-modified-date').should('have.attr', 'required', 'required')
         cy.get('#edit-field-json-metadata-0-value-publisher-publisher-name').should('have.attr', 'required', 'required')
         cy.get('#edit-field-json-metadata-0-value-contactpoint-contactpoint-fn').should('have.attr', 'required', 'required')
         cy.get('#edit-field-json-metadata-0-value-contactpoint-contactpoint-hasemail').should('have.attr', 'required', 'required')
@@ -29,7 +29,7 @@ context('Admin dataset json form', () => {
         cy.get('#edit-field-json-metadata-0-value-title').type('DKANTEST dataset title', { force:true } )
         cy.get('#edit-field-json-metadata-0-value-description').type('DKANTEST dataset description.', { force:true } )
         cy.get('#edit-field-json-metadata-0-value-accesslevel').select('public', { force:true } )
-        cy.get('#edit-field-json-metadata-0-value-modified').type('2020-02-02', { force:true } )
+        cy.get('#edit-field-json-metadata-0-value-modified-date').type('2020-02-02', { force:true } )
         // Fill select2 field for publisher.
         cy.get('#edit-field-json-metadata-0-value-publisher-publisher-name + .select2')
           .find('.select2-selection')

--- a/cypress/integration/08_admin_views.spec.js
+++ b/cypress/integration/08_admin_views.spec.js
@@ -25,7 +25,7 @@ context('Admin content and dataset views', () => {
         cy.get('#edit-field-json-metadata-0-value-title').type('DKANTEST dataset title', { force: true })
         cy.get('#edit-field-json-metadata-0-value-description').type('DKANTEST dataset description.', { force: true })
         cy.get('#edit-field-json-metadata-0-value-accesslevel').select('public', { force: true })
-        cy.get('#edit-field-json-metadata-0-value-modified').type('2020-02-02', { force: true })
+        cy.get('#edit-field-json-metadata-0-value-modified-date').type('2020-02-02', { force: true })
         // Fill select2 field for publisher.
         cy.get('#edit-field-json-metadata-0-value-publisher-publisher-name + .select2')
         .find('.select2-selection')

--- a/modules/json_form_widget/src/Element/FlexibleDateTime.php
+++ b/modules/json_form_widget/src/Element/FlexibleDateTime.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\json_form_widget\Element;
+
+use Drupal\Core\Datetime\Element\Datetime;
+use Drupal\Core\Datetime\Entity\DateFormat;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a flexible_datetime element.
+ *
+ * @FormElement("flexible_datetime")
+ * @codeCoverageIgnore
+ */
+class FlexibleDateTime extends Datetime {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getInfo() {
+    $date_format = '';
+    $time_format = '';
+    // Date formats cannot be loaded during install or update.
+    if (!defined('MAINTENANCE_MODE')) {
+      if ($date_format_entity = DateFormat::load('html_date')) {
+        /** @var $date_format_entity \Drupal\Core\Datetime\DateFormatInterface */
+        $date_format = $date_format_entity->getPattern();
+      }
+      if ($time_format_entity = DateFormat::load('html_time')) {
+        /** @var $time_format_entity \Drupal\Core\Datetime\DateFormatInterface */
+        $time_format = $time_format_entity->getPattern();
+      }
+    }
+
+    $class = get_class($this);
+
+    // Note that since this information is cached, the #date_timezone property
+    // is not set here, as this needs to vary potentially by-user.
+    return [
+      '#input' => TRUE,
+      '#element_validate' => [
+        [$class, 'validateDatetime'],
+      ],
+      '#process' => [
+        [$class, 'processDatetime'],
+        [$class, 'processAjaxForm'],
+        [$class, 'processGroup'],
+      ],
+      '#pre_render' => [
+        [$class, 'preRenderGroup'],
+      ],
+      '#theme' => 'datetime_form',
+      '#theme_wrappers' => ['datetime_wrapper'],
+      '#date_date_format' => $date_format,
+      '#date_date_element' => 'date',
+      '#date_date_callbacks' => [],
+      '#date_time_format' => $time_format,
+      '#date_time_element' => 'time',
+      '#date_time_callbacks' => [],
+      '#date_year_range' => '1900:2050',
+      '#date_increment' => 1,
+      '#date_time_required' => FALSE,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function valueCallback(&$element, $input, FormStateInterface $form_state) {
+    if (empty($element['#default_value']) && !empty($input['date'])) {
+      $input['time'] = !empty($input['time']) ? $input['time'] : '00:00:00';
+    }
+    return parent::valueCallback($element, $input, $form_state);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function processDatetime(&$element, FormStateInterface $form_state, &$complete_form) {
+    $element = parent::processDatetime($element, $form_state, $complete_form);
+    $element['time']['#required'] = $element['#date_time_required'];
+    return $element;
+  }
+
+}

--- a/modules/json_form_widget/src/Element/FlexibleDateTime.php
+++ b/modules/json_form_widget/src/Element/FlexibleDateTime.php
@@ -3,7 +3,6 @@
 namespace Drupal\json_form_widget\Element;
 
 use Drupal\Core\Datetime\Element\Datetime;
-use Drupal\Core\Datetime\Entity\DateFormat;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -18,49 +17,9 @@ class FlexibleDateTime extends Datetime {
    * {@inheritdoc}
    */
   public function getInfo() {
-    $date_format = '';
-    $time_format = '';
-    // Date formats cannot be loaded during install or update.
-    if (!defined('MAINTENANCE_MODE')) {
-      if ($date_format_entity = DateFormat::load('html_date')) {
-        /** @var $date_format_entity \Drupal\Core\Datetime\DateFormatInterface */
-        $date_format = $date_format_entity->getPattern();
-      }
-      if ($time_format_entity = DateFormat::load('html_time')) {
-        /** @var $time_format_entity \Drupal\Core\Datetime\DateFormatInterface */
-        $time_format = $time_format_entity->getPattern();
-      }
-    }
-
-    $class = get_class($this);
-
-    // Note that since this information is cached, the #date_timezone property
-    // is not set here, as this needs to vary potentially by-user.
-    return [
-      '#input' => TRUE,
-      '#element_validate' => [
-        [$class, 'validateDatetime'],
-      ],
-      '#process' => [
-        [$class, 'processDatetime'],
-        [$class, 'processAjaxForm'],
-        [$class, 'processGroup'],
-      ],
-      '#pre_render' => [
-        [$class, 'preRenderGroup'],
-      ],
-      '#theme' => 'datetime_form',
-      '#theme_wrappers' => ['datetime_wrapper'],
-      '#date_date_format' => $date_format,
-      '#date_date_element' => 'date',
-      '#date_date_callbacks' => [],
-      '#date_time_format' => $time_format,
-      '#date_time_element' => 'time',
-      '#date_time_callbacks' => [],
-      '#date_year_range' => '1900:2050',
-      '#date_increment' => 1,
-      '#date_time_required' => FALSE,
-    ];
+    $info = parent::getInfo();
+    $info['#date_time_required'] = FALSE;
+    return $info;
   }
 
   /**

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\json_form_widget;
 
+use Drupal\Core\Datetime\DrupalDateTime;
+
 /**
  * Class ValueHandler.
  */
@@ -33,6 +35,10 @@ class ValueHandler {
    * Flatten values for string properties.
    */
   public function handleStringValues($formValues, $property) {
+    // Handle datetime elements.
+    if ($formValues[$property] instanceof DrupalDateTime) {
+      return $formValues[$property]->__toString();
+    }
     // Handle select_or_other_select.
     if (isset($formValues[$property]['select'])) {
       return $formValues[$property][0];

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -36,7 +36,7 @@ class ValueHandler {
    */
   public function handleStringValues($formValues, $property) {
     // Handle datetime elements.
-    if ($formValues[$property] instanceof DrupalDateTime) {
+    if (isset($formValues[$property]) && $formValues[$property] instanceof DrupalDateTime) {
       return $formValues[$property]->__toString();
     }
     // Handle select_or_other_select.

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -97,7 +97,7 @@ class WidgetRouter implements ContainerInjectionInterface {
       'upload_or_link' => 'handleUploadOrLinkElement',
       'list' => 'handleListElement',
       'date' => 'handleDateElement',
-      'datetime' => 'handleDatetimeElement',
+      'flexible_datetime' => 'handleDatetimeElement',
     ];
   }
 
@@ -359,8 +359,10 @@ class WidgetRouter implements ContainerInjectionInterface {
   public function handleDateElement($spec, array $element) {
     $element['#type'] = 'date';
     $format = $spec->format ? $spec->format : 'Y-m-d';
-    $date = new DrupalDateTime($element['#default_value']);
-    $element['#default_value'] = $date->format($format);
+    if (isset($element['#default_value'])) {
+      $date = new DrupalDateTime($element['#default_value']);
+      $element['#default_value'] = $date->format($format);
+    }
     $element['#date_date_format'] = $format;
     return $element;
   }
@@ -377,9 +379,14 @@ class WidgetRouter implements ContainerInjectionInterface {
    *   The element configured as date.
    */
   public function handleDatetimeElement($spec, array $element) {
-    $element['#type'] = 'datetime';
-    $date = new DrupalDateTime($element['#default_value']);
-    $element['#default_value'] = $date;
+    $element['#type'] = 'flexible_datetime';
+    if (isset($element['#default_value'])) {
+      $date = new DrupalDateTime($element['#default_value']);
+      $element['#default_value'] = $date;
+      if (isset($spec->timeRequired) && is_bool($spec->timeRequired)) {
+        $element['#date_time_required'] = $spec->timeRequired;
+      }
+    }
     return $element;
   }
 

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -3,6 +3,7 @@
 namespace Drupal\json_form_widget;
 
 use Drupal\Component\Uuid\Php;
+use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\metastore\Service;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -96,6 +97,7 @@ class WidgetRouter implements ContainerInjectionInterface {
       'upload_or_link' => 'handleUploadOrLinkElement',
       'list' => 'handleListElement',
       'date' => 'handleDateElement',
+      'datetime' => 'handleDatetimeElement',
     ];
   }
 
@@ -356,6 +358,28 @@ class WidgetRouter implements ContainerInjectionInterface {
    */
   public function handleDateElement($spec, array $element) {
     $element['#type'] = 'date';
+    $format = $spec->format ? $spec->format : 'Y-m-d';
+    $date = new DrupalDateTime($element['#default_value']);
+    $element['#default_value'] = $date->format($format);
+    $element['#date_date_format'] = $format;
+    return $element;
+  }
+
+  /**
+   * Helper function for getting a datetime element.
+   *
+   * @param mixed $spec
+   *   Element to convert into hidden.
+   * @param array $element
+   *   Object with spec for UI options.
+   *
+   * @return array
+   *   The element configured as date.
+   */
+  public function handleDatetimeElement($spec, array $element) {
+    $element['#type'] = 'datetime';
+    $date = new DrupalDateTime($element['#default_value']);
+    $element['#default_value'] = $date;
     return $element;
   }
 

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -383,9 +383,9 @@ class WidgetRouter implements ContainerInjectionInterface {
     if (isset($element['#default_value'])) {
       $date = new DrupalDateTime($element['#default_value']);
       $element['#default_value'] = $date;
-      if (isset($spec->timeRequired) && is_bool($spec->timeRequired)) {
-        $element['#date_time_required'] = $spec->timeRequired;
-      }
+    }
+    if (isset($spec->timeRequired) && is_bool($spec->timeRequired)) {
+      $element['#date_time_required'] = $spec->timeRequired;
     }
     return $element;
   }

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -358,7 +358,7 @@ class WidgetRouter implements ContainerInjectionInterface {
    */
   public function handleDateElement($spec, array $element) {
     $element['#type'] = 'date';
-    $format = $spec->format ? $spec->format : 'Y-m-d';
+    $format = isset($spec->format) ? $spec->format : 'Y-m-d';
     if (isset($element['#default_value'])) {
       $date = new DrupalDateTime($element['#default_value']);
       $element['#default_value'] = $date->format($format);

--- a/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
@@ -96,6 +96,7 @@ class SchemaUiHandlerTest extends TestCase {
         "#attributes" => [
           "placeholder" => "YYYY-MM-DD",
         ],
+        '#date_date_format' => 'Y-m-d',
       ],
       "disabled" => [
         "#type" => "textfield",

--- a/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
@@ -9,6 +9,9 @@ use Drupal\Component\Uuid\Php;
 use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\json_form_widget\SchemaUiHandler;
 use Drupal\Component\Utility\EmailValidator;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Language\LanguageDefault;
+use Drupal\Core\Language\LanguageManager;
 use Drupal\json_form_widget\StringHelper;
 use Drupal\json_form_widget\WidgetRouter;
 use Drupal\metastore\SchemaRetriever;
@@ -26,12 +29,14 @@ class SchemaUiHandlerTest extends TestCase {
    */
   public function testSchemaUi() {
     $widget_router = $this->getRouter([]);
+    $language_manager = new LanguageManager(new LanguageDefault(['en']));
     $options = (new Options())
       ->add('dkan.metastore.schema_retriever', SchemaRetriever::class)
       ->add('json_form.string_helper', StringHelper::class)
       ->add('logger.factory', LoggerChannelFactory::class)
       ->add('uuid', Php::class)
       ->add('json_form.widget_router', $widget_router)
+      ->add('language_manager', $language_manager)
       ->index(0);
 
     $container_chain = (new Chain($this))
@@ -60,7 +65,7 @@ class SchemaUiHandlerTest extends TestCase {
       "date" => [
         "#type" => "textfield",
         "#title" => "Test field",
-        "#default_value" => NULL,
+        "#default_value" => '2020-05-11T15:06:39.000Z',
         "#required" => FALSE,
       ],
       "disabled" => [
@@ -91,7 +96,7 @@ class SchemaUiHandlerTest extends TestCase {
       "date" => [
         "#type" => "date",
         "#title" => "Test field",
-        "#default_value" => NULL,
+        "#default_value" => '2020-05-11',
         "#required" => FALSE,
         "#attributes" => [
           "placeholder" => "YYYY-MM-DD",
@@ -106,6 +111,69 @@ class SchemaUiHandlerTest extends TestCase {
         "#disabled" => TRUE,
       ],
     ];
+    $this->assertEquals($ui_handler->applySchemaUi($form), $expected);
+
+    // Test flexible datetime without default value.
+    $container_chain->add(SchemaRetriever::class, 'retrieve', '{"modified":{"ui:options":{"widget":"flexible_datetime","timeRequired": true}}}');
+    $container = $container_chain->getMock();
+    \Drupal::setContainer($container);
+    $ui_handler = SchemaUiHandler::create($container);
+    $ui_handler->setSchemaUi('dataset');
+    $form = [
+      "modified" => [
+        "#type" => "textfield",
+        "#title" => "Flexible datetime field",
+        "#default_value" => NULL,
+        "#required" => FALSE,
+      ],
+    ];
+    $expected = [
+      "modified" => [
+        "#type" => "flexible_datetime",
+        "#title" => "Flexible datetime field",
+        "#default_value" => NULL,
+        "#required" => FALSE,
+        "#date_time_required" => TRUE,
+      ],
+    ];
+    $this->assertEquals($ui_handler->applySchemaUi($form), $expected);
+
+    // Test flexible datetime with date format 2020-05-11T15:06:39.000Z.
+    $container_chain->add(SchemaRetriever::class, 'retrieve', '{"modified":{"ui:options":{"widget":"flexible_datetime","timeRequired": false}}}');
+    $container = $container_chain->getMock();
+    \Drupal::setContainer($container);
+    $ui_handler = SchemaUiHandler::create($container);
+    $ui_handler->setSchemaUi('dataset');
+    $form = [
+      "modified" => [
+        "#type" => "textfield",
+        "#title" => "Flexible datetime field",
+        "#default_value" => '2020-05-11T15:06:39.000Z',
+        "#required" => FALSE,
+      ],
+    ];
+    $date = new DrupalDateTime('2020-05-11T15:06:39.000Z');
+    $expected = [
+      "modified" => [
+        "#type" => "flexible_datetime",
+        "#title" => "Flexible datetime field",
+        "#default_value" => $date,
+        "#required" => FALSE,
+        "#date_time_required" => FALSE,
+      ],
+    ];
+    $this->assertEquals($ui_handler->applySchemaUi($form), $expected);
+
+    // Test flexible datetime with date format 2020-05-11 15:06:39.000.
+    $form['modified']['#default_value'] = '2020-05-11 15:06:39.000';
+    $date = new DrupalDateTime('2020-05-11 15:06:39.000');
+    $expected['modified']['#default_value'] = $date;
+    $this->assertEquals($ui_handler->applySchemaUi($form), $expected);
+
+    // Test flexible datetime with date format 2020-05-09.
+    $form['modified']['#default_value'] = '2020-05-09';
+    $date = new DrupalDateTime('2020-05-09');
+    $expected['modified']['#default_value'] = $date;
     $this->assertEquals($ui_handler->applySchemaUi($form), $expected);
 
     // Test dkan_uuid field with already existing value.

--- a/modules/json_form_widget/tests/src/Unit/ValueHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/ValueHandlerTest.php
@@ -2,8 +2,14 @@
 
 namespace Drupal\Tests\json_form_widget\Unit;
 
+use Drupal\Component\DependencyInjection\Container;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Language\LanguageDefault;
+use Drupal\Core\Language\LanguageManager;
 use PHPUnit\Framework\TestCase;
 use Drupal\json_form_widget\ValueHandler;
+use MockChain\Chain;
+use MockChain\Options;
 
 /**
  * Test class for ValueHandlerTest.
@@ -125,6 +131,32 @@ class ValueHandlerTest extends TestCase {
     $result = $value_handler->handleObjectValues(NULL, "publisher", $schema);
     $this->assertEquals($result, FALSE);
 
+  }
+
+  /**
+   * Test values for datetime elements.
+   */
+  public function testDatetimeValues() {
+    $language_manager = new LanguageManager(new LanguageDefault(['en']));
+    $options = (new Options())
+      ->add('language_manager', $language_manager)
+      ->index(0);
+
+    $container_chain = (new Chain($this))
+      ->add(Container::class, 'get', $options);
+
+    $container = $container_chain->getMock();
+    \Drupal::setContainer($container);
+    $value_handler = new ValueHandler();
+
+    // Test flexible_datetime.
+    $date = new DrupalDateTime('2020-05-11T15:06:39.000Z');
+    $formValues = [
+      'modified' => $date,
+    ];
+    $expected = $date->__toString();
+    $result = $value_handler->handleStringValues($formValues, 'modified');
+    $this->assertEquals($result, $expected);
   }
 
   /**

--- a/schema/collections/dataset.ui.json
+++ b/schema/collections/dataset.ui.json
@@ -157,12 +157,13 @@
   },
   "issued": {
     "ui:options": {
-      "widget": "date"
+      "widget": "flexible_datetime"
     }
   },
   "modified": {
     "ui:options": {
-      "widget": "date",
+      "widget": "flexible_datetime",
+      "timeRequired": false,
       "placeholder": "YYYY-MM-DD"
     }
   },

--- a/schema/collections/dataset.ui.json
+++ b/schema/collections/dataset.ui.json
@@ -142,16 +142,6 @@
       }
     }
   },
-  "theme": {
-    "ui:options": {
-      "title": "Topics"
-    },
-    "items": {
-      "ui:options": {
-        "title": "Topic"
-      }
-    }
-  },
   "description": {
     "ui:options": {
       "widget": "textarea",
@@ -183,11 +173,13 @@
   },
   "theme": {
     "ui:options": {
+      "title": "Topics",
       "hideActions": "true",
       "child": "theme"
     },
     "items": {
       "ui:options": {
+        "title": "Topic",
         "widget": "list",
         "type": "autocomplete",
         "allowCreate": "true",


### PR DESCRIPTION
fixes #3440 

## Description
- Added support for date time picker.
- Fixed bug where date pickers wouldn't show the right date if the incoming data included a time.

## Acceptance criteria
- When I harvest a dataset that has in the fields "issued" or "modified" dates with the following formats: 
  - [ ] `2020-05-11T15:06:39.000Z`
  - [ ] `2020-05-11 15:06:39.000`
  - [ ] `2020-05-09`
- And I go to the edit form for the harvested datasets
- Then the date picker for the corresponding field should display the right date.