### PR TITLE
Use get_headers as fallback for the file content-type in order to trigger datastore import.

### DIFF
--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -257,6 +257,10 @@ class Referencer {
     if (isset($metadata->data->mediaType)) {
       $mimeType = $metadata->data->mediaType;
     }
+    elseif (isset($metadata->data->downloadURL)) {
+      $headers = get_headers($metadata->data->downloadURL, 1);
+      $mimeType = isset($headers['Content-Type']) ? $headers['Content-Type'] : $mimeType;
+    }
     return $mimeType;
   }
 

--- a/modules/metastore/tests/src/Unit/Reference/ReferencerTest.php
+++ b/modules/metastore/tests/src/Unit/Reference/ReferencerTest.php
@@ -2,9 +2,16 @@
 
 namespace Drupal\Tests\metastore\Unit\Reference;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\metastore\Reference\Referencer;
+use Drupal\metastore\ResourceMapper;
+use Drupal\node\NodeStorage;
 use MockChain\Chain;
+use MockChain\Options;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -25,4 +32,95 @@ class ReferencerTest extends TestCase {
       Referencer::hostify("http://test.test/mycsv.txt"));
   }
 
+  /**
+   *
+   */
+  private function getData($downloadUrl) {
+    $data = '
+    {
+      "title": "Test Dataset No Media Type",
+      "description": "Hi",
+      "identifier": "12345",
+      "accessLevel": "public",
+      "modified": "06-04-2020",
+      "keyword": ["hello"],
+        "distribution": [
+          {
+            "title": "blah",
+            "downloadURL": "' . $downloadUrl . '"
+          }
+        ]
+    }';
+    return json_decode($data);
+  }
+
+  /**
+   *
+   */
+  public function testNoMediaType() {
+    $immutableConfig = (new Chain($this))
+      ->add(ImmutableConfig::class, 'get', $this->getPropertyList())
+      ->getMock();
+
+    $configService = (new Chain($this))
+      ->add(ConfigFactoryInterface::class, 'get', $immutableConfig)
+      ->getMock();
+
+    $node = new class {
+      public function uuid() {
+        return '0398f054-d712-4e20-ad1e-a03193d6ab33';
+      }
+    };
+    $nodeStorage = (new Chain($this))
+      ->add(NodeStorage::class, 'loadByProperties', [$node])
+      ->getMock();
+
+    $options = (new Options())
+      ->add('logger.factory', LoggerChannelFactory::class)
+      ->add('request_stack', RequestStack::class)
+      ->add('dkan.metastore.resource_mapper', ResourceMapper::class)
+      ->index(0);
+
+    $container_chain = (new Chain($this))
+      ->add(Container::class, 'get', $options)
+      ->add(RequestStack::class, 'getCurrentRequest', Request::class)
+      ->add(Request::class, 'getHost', 'test.test')
+      ->add(ResourceMapper::class, 'register', TRUE, 'resource');
+
+    $container = $container_chain->getMock();
+    \Drupal::setContainer($container);
+
+    $referencer = new Referencer($configService, $nodeStorage);
+    $data = $this->getData('https://dkan-default-content-files.s3.amazonaws.com/phpunit/district_centerpoints_small.csv');
+    $metadata = $referencer->reference($data);
+    $this->assertEquals('text/csv', $container_chain->getStoredInput('resource')[0]->getMimeType());
+  }
+
+  /**
+   * Get list of properties.
+   */
+  private function getPropertyList() {
+    return [
+      'theme' => 0,
+      'keyword' => 0,
+      'publisher' => 0,
+      'distribution' => 'distribution',
+      'contactPoint' => 0,
+      '@type' => 0,
+      'title' => 0,
+      'identifier' => 0,
+      'description' => 0,
+      'accessLevel' => 0,
+      'accrualPeriodicity' => 0,
+      'describedBy' => 0,
+      'describedByType' => 0,
+      'issued' => 0,
+      'license' => 0,
+      'modified' => 0,
+      'references' => 0,
+      'spatial' => 0,
+      'temporal' => 0,
+      'isPartOf' => 0,
+    ];
+  }
 }


### PR DESCRIPTION
fixes #3443 

Datastore import was not triggered because we rely on the value of media type to see if the file is a csv, by default the new metadata form has the media type field hidden so the default value assumed was `text/plain`. In this PR we're using the get_headers() function as a fallback when no media type value is found.

## Steps to test

- Create a dataset at node/add/data with a resource (try both, file upload and link to remote)
- Run drush queue:run datastore_import
- [x] Confirm output is "Processed 1 items from the datastore_import queue in XXX sec."
- [x] In dkan_metastore_resource_mapper table we should get 3 perspectives for the same resource.
- [x] If you run `drush dkan:datastore:list`, you can see the import was correct.