### PR TITLE
Feature/rooted json data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,11 @@
         "getdkan/json-schema-provider": "^0.1.2",
         "getdkan/sql-parser": "^2.0.0",
         "guzzlehttp/guzzle" : "^6.3",
-        "m1x0n/opis-json-schema-error-presenter": "^0.5.2",
         "ramsey/uuid" : "^3.8.0",
         "getdkan/rooted-json-data": "^0.0.2",
         "drupal/select_or_other": "1.x-dev",
         "drupal/select2": "1.x-dev",
         "npm-asset/select2": "^4.0",
-        "ilbee/csv-response": "^1.0",
         "oomphinc/composer-installers-extender": "^2.0",
         "stolt/json-merge-patch": "^1.0"
     },
@@ -35,16 +33,16 @@
         "weitzman/drupal-test-traits": "^1.5",
         "phpunit/phpunit": "^7.5"
     },
-    "repositories": {
-        "drupal": {
+    "repositories": [
+        {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         },
-        "asset": {
+        {
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
-    },
+    ],
     "autoload": {
         "psr-4": {
             "Social\\": "src"

--- a/modules/harvest/src/Load/Dataset.php
+++ b/modules/harvest/src/Load/Dataset.php
@@ -29,7 +29,7 @@ class Dataset extends Load {
     }
 
     $schema_id = 'dataset';
-    $item = $service->getRootedJsonDataFactory()->createRootedJsonData($schema_id, $item);
+    $item = $service->getValidMetadataFactory()->get($schema_id, $item);
     try {
       $service->post($schema_id, $item);
     }

--- a/modules/harvest/src/Load/Dataset.php
+++ b/modules/harvest/src/Load/Dataset.php
@@ -28,12 +28,13 @@ class Dataset extends Load {
       $item = json_encode($item);
     }
 
+    $schema_id = 'dataset';
+    $item = $service->getRootedJsonDataWrapper()->createRootedJsonData($schema_id, $item);
     try {
-      $service->post('dataset', $item);
+      $service->post($schema_id, $item);
     }
     catch (ExistingObjectException $e) {
-      $object = json_decode($item, TRUE);
-      $service->put('dataset', $object['identifier'], $item);
+      $service->put($schema_id, $item->{"$.identifier"}, $item);
     }
   }
 

--- a/modules/harvest/src/Load/Dataset.php
+++ b/modules/harvest/src/Load/Dataset.php
@@ -29,7 +29,7 @@ class Dataset extends Load {
     }
 
     $schema_id = 'dataset';
-    $item = $service->getRootedJsonDataWrapper()->createRootedJsonData($schema_id, $item);
+    $item = $service->getRootedJsonDataFactory()->createRootedJsonData($schema_id, $item);
     try {
       $service->post($schema_id, $item);
     }

--- a/modules/harvest/tests/src/Load/DatasetTest.php
+++ b/modules/harvest/tests/src/Load/DatasetTest.php
@@ -6,7 +6,7 @@ use Contracts\Mock\Storage\Memory;
 use Drupal\Core\DependencyInjection\Container;
 use Drupal\harvest\Load\Dataset;
 use Drupal\metastore\Exception\ExistingObjectException;
-use Drupal\metastore\RootedJsonDataWrapper;
+use Drupal\metastore\RootedJsonDataFactory;
 use Drupal\metastore\Service;
 use Drupal\Tests\metastore\Unit\ServiceTest;
 use MockChain\Chain;
@@ -20,9 +20,9 @@ use PHPUnit\Framework\TestCase;
 class DatasetTest extends TestCase {
 
   /**
-   * The RootedJsonDataWrapper class used for testing.
+   * The RootedJsonDataFactory class used for testing.
    *
-   * @var \Drupal\metastore\RootedJsonDataWrapper|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\metastore\RootedJsonDataFactory|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $rootedJsonDataFactory;
 
@@ -44,8 +44,8 @@ class DatasetTest extends TestCase {
 
     $containerChain = (new Chain($this))
       ->add(Container::class, "get", $containerOptions)
-      ->add(Service::class, "getRootedJsonDataWrapper", RootedJsonDataWrapper::class)
-      ->add(RootedJsonDataWrapper::class, "createRootedJsonData", $expected)
+      ->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class)
+      ->add(RootedJsonDataFactory::class, "createRootedJsonData", $expected)
       ->add(Service::class, "post", "1", 'post');
 
     $container = $containerChain->getMock();
@@ -78,8 +78,8 @@ class DatasetTest extends TestCase {
 
     $containerChain = (new Chain($this))
       ->add(Container::class, "get", $containerOptions)
-      ->add(Service::class, "getRootedJsonDataWrapper", RootedJsonDataWrapper::class)
-      ->add(RootedJsonDataWrapper::class, "createRootedJsonData", $expected)
+      ->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class)
+      ->add(RootedJsonDataFactory::class, "createRootedJsonData", $expected)
       ->add(Service::class, 'post', new ExistingObjectException())
       ->add(Service::class, "put", [], 'put');
 

--- a/modules/harvest/tests/src/Load/DatasetTest.php
+++ b/modules/harvest/tests/src/Load/DatasetTest.php
@@ -6,7 +6,7 @@ use Contracts\Mock\Storage\Memory;
 use Drupal\Core\DependencyInjection\Container;
 use Drupal\harvest\Load\Dataset;
 use Drupal\metastore\Exception\ExistingObjectException;
-use Drupal\metastore\RootedJsonDataFactory;
+use Drupal\metastore\ValidMetadataFactory;
 use Drupal\metastore\Service;
 use Drupal\Tests\metastore\Unit\ServiceTest;
 use MockChain\Chain;
@@ -20,15 +20,15 @@ use PHPUnit\Framework\TestCase;
 class DatasetTest extends TestCase {
 
   /**
-   * The RootedJsonDataFactory class used for testing.
+   * The ValidMetadataFactory class used for testing.
    *
-   * @var \Drupal\metastore\RootedJsonDataFactory|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\metastore\ValidMetadataFactory|\PHPUnit\Framework\MockObject\MockObject
    */
-  protected $rootedJsonDataFactory;
+  protected $validMetadataFactory;
 
   protected function setUp(): void {
     parent::setUp();
-    $this->rootedJsonDataFactory = ServiceTest::getJsonWrapper($this);
+    $this->validMetadataFactory = ServiceTest::getValidMetadataFactory($this);
   }
 
   /**
@@ -40,12 +40,12 @@ class DatasetTest extends TestCase {
       ->index(0);
 
     $object = (object) ["identifier" => "1"];
-    $expected = $this->rootedJsonDataFactory->createRootedJsonData('dummy_schema_id', json_encode($object));
+    $expected = $this->validMetadataFactory->get('dummy_schema_id', json_encode($object));
 
     $containerChain = (new Chain($this))
       ->add(Container::class, "get", $containerOptions)
-      ->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class)
-      ->add(RootedJsonDataFactory::class, "createRootedJsonData", $expected)
+      ->add(Service::class, "getValidMetadataFactory", ValidMetadataFactory::class)
+      ->add(ValidMetadataFactory::class, "get", $expected)
       ->add(Service::class, "post", "1", 'post');
 
     $container = $containerChain->getMock();
@@ -74,12 +74,12 @@ class DatasetTest extends TestCase {
       ->index(0);
 
     $object = (object) ["identifier" => "1"];
-    $expected = $this->rootedJsonDataFactory->createRootedJsonData('dummy_schema_id', json_encode($object));
+    $expected = $this->validMetadataFactory->get('dummy_schema_id', json_encode($object));
 
     $containerChain = (new Chain($this))
       ->add(Container::class, "get", $containerOptions)
-      ->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class)
-      ->add(RootedJsonDataFactory::class, "createRootedJsonData", $expected)
+      ->add(Service::class, "getValidMetadataFactory", ValidMetadataFactory::class)
+      ->add(ValidMetadataFactory::class, "get", $expected)
       ->add(Service::class, 'post', new ExistingObjectException())
       ->add(Service::class, "put", [], 'put');
 

--- a/modules/harvest/tests/src/Load/DatasetTest.php
+++ b/modules/harvest/tests/src/Load/DatasetTest.php
@@ -20,6 +20,18 @@ use PHPUnit\Framework\TestCase;
 class DatasetTest extends TestCase {
 
   /**
+   * The RootedJsonDataWrapper class used for testing.
+   *
+   * @var \Drupal\metastore\RootedJsonDataWrapper|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $rootedJsonDataFactory;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->rootedJsonDataFactory = ServiceTest::getJsonWrapper($this);
+  }
+
+  /**
    *
    */
   public function testNew() {
@@ -28,7 +40,7 @@ class DatasetTest extends TestCase {
       ->index(0);
 
     $object = (object) ["identifier" => "1"];
-    $expected = ServiceTest::getJsonWrapper($this)->createRootedJsonData('dummy_schema_id', json_encode($object));
+    $expected = $this->rootedJsonDataFactory->createRootedJsonData('dummy_schema_id', json_encode($object));
 
     $containerChain = (new Chain($this))
       ->add(Container::class, "get", $containerOptions)
@@ -62,7 +74,7 @@ class DatasetTest extends TestCase {
       ->index(0);
 
     $object = (object) ["identifier" => "1"];
-    $expected = ServiceTest::getJsonWrapper($this)->createRootedJsonData('dummy_schema_id', json_encode($object));
+    $expected = $this->rootedJsonDataFactory->createRootedJsonData('dummy_schema_id', json_encode($object));
 
     $containerChain = (new Chain($this))
       ->add(Container::class, "get", $containerOptions)

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -244,6 +244,7 @@ class WidgetRouter implements ContainerInjectionInterface {
     $options = [];
     $values = $this->metastore->getAll($source->metastoreSchema);
     foreach ($values as $value) {
+      $value = json_decode($value);
       if ($titleProperty) {
         $options[$value->data->{$titleProperty}] = $value->data->{$titleProperty};
       }

--- a/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
@@ -25,9 +25,9 @@ use MockChain\Options;
 class SchemaUiHandlerTest extends TestCase {
 
   /**
-   * The RootedJsonDataWrapper class used for testing.
+   * The RootedJsonDataFactory class used for testing.
    *
-   * @var \Drupal\metastore\RootedJsonDataWrapper|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\metastore\RootedJsonDataFactory|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $rootedJsonDataFactory;
 

--- a/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\json_form_widget\Unit;
 
+use Drupal\Tests\metastore\Unit\ServiceTest;
 use PHPUnit\Framework\TestCase;
 use MockChain\Chain;
 use Drupal\Component\DependencyInjection\Container;
@@ -23,6 +24,18 @@ use stdClass;
  * Test class for SchemaUiHandlerTest.
  */
 class SchemaUiHandlerTest extends TestCase {
+
+  /**
+   * The RootedJsonDataWrapper class used for testing.
+   *
+   * @var \Drupal\metastore\RootedJsonDataWrapper|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $rootedJsonDataFactory;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->rootedJsonDataFactory = ServiceTest::getJsonWrapper($this);
+  }
 
   /**
    * Test.
@@ -878,26 +891,21 @@ class SchemaUiHandlerTest extends TestCase {
    * Dummy list of simple metastore results.
    */
   private function getSimpleMetastoreResults() {
-    $options = [];
-    $options[0] = new stdClass();
-    $options[0]->data = "Option 1";
-    $options[1] = new stdClass();
-    $options[1]->data = "Option 2";
-    return $options;
+    return [
+      $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode(['data' => 'Option 1'])),
+      $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode(['data' => 'Option 2'])),
+    ];
+
   }
 
   /**
    * Dummy list of complex metastore results.
    */
   private function getComplexMetastoreResults() {
-    $options = [];
-    $options[0] = new stdClass();
-    $options[0]->data = new stdClass();
-    $options[0]->data->name = "Option 1";
-    $options[1] = new stdClass();
-    $options[1]->data = new stdClass();
-    $options[1]->data->name = "Option 2";
-    return $options;
+    return [
+      $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode(['data' => ['name' => 'Option 1']])),
+      $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode(['data' => ['name' => 'Option 2']])),
+    ];
   }
 
 }

--- a/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
@@ -25,15 +25,15 @@ use MockChain\Options;
 class SchemaUiHandlerTest extends TestCase {
 
   /**
-   * The RootedJsonDataFactory class used for testing.
+   * The ValidMetadataFactory class used for testing.
    *
-   * @var \Drupal\metastore\RootedJsonDataFactory|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\metastore\ValidMetadataFactory|\PHPUnit\Framework\MockObject\MockObject
    */
-  protected $rootedJsonDataFactory;
+  protected $validMetadataFactory;
 
   protected function setUp(): void {
     parent::setUp();
-    $this->rootedJsonDataFactory = ServiceTest::getJsonWrapper($this);
+    $this->validMetadataFactory = ServiceTest::getValidMetadataFactory($this);
   }
 
   /**
@@ -891,8 +891,8 @@ class SchemaUiHandlerTest extends TestCase {
    */
   private function getSimpleMetastoreResults() {
     return [
-      $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode(['data' => 'Option 1'])),
-      $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode(['data' => 'Option 2'])),
+      $this->validMetadataFactory->get('dataset', json_encode(['data' => 'Option 1'])),
+      $this->validMetadataFactory->get('dataset', json_encode(['data' => 'Option 2'])),
     ];
 
   }
@@ -902,8 +902,8 @@ class SchemaUiHandlerTest extends TestCase {
    */
   private function getComplexMetastoreResults() {
     return [
-      $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode(['data' => ['name' => 'Option 1']])),
-      $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode(['data' => ['name' => 'Option 2']])),
+      $this->validMetadataFactory->get('dataset', json_encode(['data' => ['name' => 'Option 1']])),
+      $this->validMetadataFactory->get('dataset', json_encode(['data' => ['name' => 'Option 2']])),
     ];
   }
 

--- a/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
@@ -18,7 +18,6 @@ use Drupal\json_form_widget\WidgetRouter;
 use Drupal\metastore\SchemaRetriever;
 use Drupal\metastore\Service;
 use MockChain\Options;
-use stdClass;
 
 /**
  * Test class for SchemaUiHandlerTest.

--- a/modules/metastore/metastore.module
+++ b/modules/metastore/metastore.module
@@ -117,7 +117,7 @@ function metastore_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form
     // TODO: use an actual schema id.
     $object = \Drupal::service('dkan.metastore.rooted_json_data_wrapper')->createRootedJsonData(NULL, $json);
     $object = \Drupal\metastore\Service::removeReferences($object);
-    $form['field_json_metadata']['widget'][0]['value']['#default_value'] = $object->pretty();
+    $form['field_json_metadata']['widget'][0]['value']['#default_value'] = $object->__toString();
   }
 }
 
@@ -127,8 +127,8 @@ function metastore_entity_view_alter(array &$build, Drupal\Core\Entity\EntityInt
     if (empty($json)) {
       return;
     }
-    // TODO: use an actual schema id.
-    $object = \Drupal::service('dkan.metastore.rooted_json_data_wrapper')->createRootedJsonData(NULL, $json);
+    $schema_id = $entity->get('field_data_type')->getString();
+    $object = \Drupal::service('dkan.metastore.rooted_json_data_wrapper')->createRootedJsonData($schema_id, $json);
     $object = \Drupal\metastore\Service::removeReferences($object);
     $build['field_json_metadata'][0]['#context']['value'] = $object->pretty();
   }

--- a/modules/metastore/metastore.module
+++ b/modules/metastore/metastore.module
@@ -115,7 +115,7 @@ function metastore_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form
       return;
     }
     // TODO: use an actual schema id.
-    $object = \Drupal::service('dkan.metastore.rooted_json_data_wrapper')->createRootedJsonData(NULL, $json);
+    $object = \Drupal::service('dkan.metastore.valid_metadata')->get(NULL, $json);
     $object = \Drupal\metastore\Service::removeReferences($object);
     $form['field_json_metadata']['widget'][0]['value']['#default_value'] = $object->__toString();
   }
@@ -128,8 +128,8 @@ function metastore_entity_view_alter(array &$build, Drupal\Core\Entity\EntityInt
       return;
     }
     $schema_id = $entity->get('field_data_type')->getString();
-    $object = \Drupal::service('dkan.metastore.rooted_json_data_wrapper')->createRootedJsonData($schema_id, $json);
+    $object = \Drupal::service('dkan.metastore.valid_metadata')->get($schema_id, $json);
     $object = \Drupal\metastore\Service::removeReferences($object);
-    $build['field_json_metadata'][0]['#context']['value'] = $object->pretty();
+    $build['field_json_metadata'][0]['#context']['value'] = $object->__toString();
   }
 }

--- a/modules/metastore/metastore.module
+++ b/modules/metastore/metastore.module
@@ -114,9 +114,10 @@ function metastore_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form
     if (empty($json)) {
       return;
     }
-    $object = json_decode($json);
+    // TODO: use an actual schema id.
+    $object = \Drupal::service('dkan.metastore.rooted_json_data_wrapper')->createRootedJsonData(NULL, $json);
     $object = \Drupal\metastore\Service::removeReferences($object);
-    $form['field_json_metadata']['widget'][0]['value']['#default_value'] = json_encode($object);
+    $form['field_json_metadata']['widget'][0]['value']['#default_value'] = $object->pretty();
   }
 }
 
@@ -126,8 +127,9 @@ function metastore_entity_view_alter(array &$build, Drupal\Core\Entity\EntityInt
     if (empty($json)) {
       return;
     }
-    $object = json_decode($json);
+    // TODO: use an actual schema id.
+    $object = \Drupal::service('dkan.metastore.rooted_json_data_wrapper')->createRootedJsonData(NULL, $json);
     $object = \Drupal\metastore\Service::removeReferences($object);
-    $build['field_json_metadata'][0]['#context']['value'] = json_encode($object);
+    $build['field_json_metadata'][0]['#context']['value'] = $object->pretty();
   }
 }

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -52,6 +52,6 @@ services:
       - '@database'
 
   dkan.metastore.rooted_json_data_wrapper:
-    class: \Drupal\metastore\RootedJsonDataWrapper
+    class: \Drupal\metastore\RootedJsonDataFactory
     arguments:
       - '@dkan.metastore.schema_retriever'

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -4,7 +4,7 @@ services:
     arguments:
       - '@dkan.metastore.schema_retriever'
       - '@dkan.metastore.storage'
-      - '@dkan.metastore.rooted_json_data_wrapper'
+      - '@dkan.metastore.valid_metadata'
 
   dkan.metastore.schema_retriever:
     class: \Drupal\metastore\SchemaRetriever
@@ -51,7 +51,7 @@ services:
     arguments:
       - '@database'
 
-  dkan.metastore.rooted_json_data_wrapper:
-    class: \Drupal\metastore\RootedJsonDataFactory
+  dkan.metastore.valid_metadata:
+    class: \Drupal\metastore\ValidMetadataFactory
     arguments:
       - '@dkan.metastore.schema_retriever'

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -4,6 +4,7 @@ services:
     arguments:
       - '@dkan.metastore.schema_retriever'
       - '@dkan.metastore.storage'
+      - '@dkan.metastore.rooted_json_data_wrapper'
 
   dkan.metastore.schema_retriever:
     class: \Drupal\metastore\SchemaRetriever
@@ -49,3 +50,8 @@ services:
     class: \Drupal\metastore\Storage\ResourceMapperDatabaseTable
     arguments:
       - '@database'
+
+  dkan.metastore.rooted_json_data_wrapper:
+    class: \Drupal\metastore\RootedJsonDataWrapper
+    arguments:
+      - '@dkan.metastore.schema_retriever'

--- a/modules/metastore/modules/metastore_search/src/FacetsFromContentTrait.php
+++ b/modules/metastore/modules/metastore_search/src/FacetsFromContentTrait.php
@@ -130,8 +130,7 @@ trait FacetsFromContentTrait {
 
       foreach ($allFacets as $facet) {
 
-        $facet = $facet->data;
-        $facet = isset($field) ? $facet->{$field} : $facet;
+        $facet = isset($field) ? $facet->{"$.data." . $field} : $facet->{"$.data"};
 
         $facets["{$type}:{$facet}"] = (object) [
           'type' => $type,

--- a/modules/metastore/modules/metastore_search/src/FacetsFromIndexTrait.php
+++ b/modules/metastore/modules/metastore_search/src/FacetsFromIndexTrait.php
@@ -63,7 +63,7 @@ trait FacetsFromIndexTrait {
       $schema = $type;
     }
     foreach ($this->metastoreService->getAll($schema) as $collection) {
-      $facet_name = empty($field) ? $collection->data : $collection->data->{$field};
+      $facet_name = empty($field) ? $collection->{'$.data'} : $collection->{'$.data.' . $field};
       $facets[] = $this->getFacet($type, $facet_name, $query);
     }
 

--- a/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
+++ b/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
@@ -15,6 +15,7 @@ use Drupal\search_api\Query\ConditionGroup;
 use Drupal\search_api\Query\QueryInterface;
 use Drupal\search_api\Query\ResultSet;
 use Drupal\search_api\Utility\QueryHelperInterface;
+use Drupal\Tests\metastore\Unit\ServiceTest;
 use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;
@@ -168,19 +169,21 @@ class SearchTest extends TestCase {
       ->getMock();
 
     if (!isset($collection)) {
-      $collection = (object) [
+      $collection = [
         'title' => 'hello',
         'description' => 'goodbye',
         'publisher__name' => 'Steve',
       ];
     }
 
-    $facet = (object) ['data' => (object) ['name' => 'Steve']];
+    $facet = ['data' => ['name' => 'Steve']];
 
     $getAllOptions = (new Options())
       ->add('keyword', [])
       ->add('theme', [])
-      ->add('publisher', [$facet]);
+      ->add('publisher', [ServiceTest::getJsonWrapper($case)->createRootedJsonData('publisher', json_encode($facet))]);
+
+    $getData = ServiceTest::getJsonWrapper($case)->createRootedJsonData('dummy_schema_id', json_encode($collection));
 
     return (new Chain($case))
       ->add(Container::class, 'get', $services)
@@ -193,7 +196,7 @@ class SearchTest extends TestCase {
       ->add(QueryInterface::class, 'createConditionGroup', ConditionGroup::class)
       ->add(ResultSet::class, 'getResultCount', 1)
       ->add(ResultSet::class, 'getResultItems', [$item])
-      ->add(Metastore::class, 'get', json_encode($collection))
+      ->add(Metastore::class, 'get', $getData)
       ->add(Metastore::class, 'getAll', $getAllOptions);
   }
 

--- a/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
+++ b/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
@@ -181,9 +181,9 @@ class SearchTest extends TestCase {
     $getAllOptions = (new Options())
       ->add('keyword', [])
       ->add('theme', [])
-      ->add('publisher', [ServiceTest::getJsonWrapper($case)->createRootedJsonData('publisher', json_encode($facet))]);
+      ->add('publisher', [ServiceTest::getValidMetadataFactory($case)->get('publisher', json_encode($facet))]);
 
-    $getData = ServiceTest::getJsonWrapper($case)->createRootedJsonData('dummy_schema_id', json_encode($collection));
+    $getData = ServiceTest::getValidMetadataFactory($case)->get('dummy_schema_id', json_encode($collection));
 
     return (new Chain($case))
       ->add(Container::class, 'get', $services)

--- a/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
+++ b/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
@@ -19,11 +19,15 @@ use Symfony\Component\Validator\ConstraintValidator;
 class ProperJsonValidator extends ConstraintValidator implements ContainerInjectionInterface {
 
   /**
+   * Service dkan.metastore.valid_metadata.
+   *
    * @var \Drupal\metastore\ValidMetadataFactory
    */
   protected $validMetadataFactory;
 
   /**
+   * ValidationErrorPresenter.
+   *
    * @var \OpisErrorPresenter\Implementation\ValidationErrorPresenter
    */
   protected $presenter;
@@ -32,7 +36,7 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
    * ProperJsonValidator constructor.
    *
    * @param \Drupal\metastore\ValidMetadataFactory $valid_metadata_factory
-   *   dkan.metastore.valid_metadata service.
+   *   Service dkan.metastore.valid_metadata.
    */
   public function __construct(ValidMetadataFactory $valid_metadata_factory) {
     $this->validMetadataFactory = $valid_metadata_factory;
@@ -73,7 +77,9 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
       catch (InvalidArgumentException $e) {
         $errors[] = $e->getMessage();
       }
-      if (!empty($errors)) $this->addViolations($errors);
+      if (!empty($errors)) {
+        $this->addViolations($errors);
+      }
     }
   }
 
@@ -89,7 +95,7 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
   private function getValidationErrorsMessages(array $errors): array {
     $presented = $this->presenter->present(...$errors);
     return array_map(
-      function($presented_error) {
+      function ($presented_error) {
         return $presented_error->message();
       },
       $presented

--- a/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
+++ b/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
@@ -3,7 +3,7 @@
 namespace Drupal\metastore\Plugin\Validation\Constraint;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\metastore\RootedJsonDataWrapper;
+use Drupal\metastore\RootedJsonDataFactory;
 use InvalidArgumentException;
 use OpisErrorPresenter\Implementation\MessageFormatterFactory;
 use OpisErrorPresenter\Implementation\PresentedValidationErrorFactory;
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 class ProperJsonValidator extends ConstraintValidator implements ContainerInjectionInterface {
 
   /**
-   * @var \Drupal\metastore\RootedJsonDataWrapper
+   * @var \Drupal\metastore\RootedJsonDataFactory
    */
   protected $rootedJsonDataFactory;
 
@@ -31,10 +31,10 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
   /**
    * ProperJsonValidator constructor.
    *
-   * @param \Drupal\metastore\RootedJsonDataWrapper $rooted_json_data_factory
+   * @param \Drupal\metastore\RootedJsonDataFactory $rooted_json_data_factory
    *   dkan.metastore.rooted_json_data_wrapper service.
    */
-  public function __construct(RootedJsonDataWrapper $rooted_json_data_factory) {
+  public function __construct(RootedJsonDataFactory $rooted_json_data_factory) {
     $this->rootedJsonDataFactory = $rooted_json_data_factory;
     $this->presenter = new ValidationErrorPresenter(
       new PresentedValidationErrorFactory(

--- a/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
+++ b/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
@@ -2,13 +2,55 @@
 
 namespace Drupal\metastore\Plugin\Validation\Constraint;
 
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\metastore\RootedJsonDataWrapper;
+use InvalidArgumentException;
+use OpisErrorPresenter\Implementation\MessageFormatterFactory;
+use OpisErrorPresenter\Implementation\PresentedValidationErrorFactory;
+use OpisErrorPresenter\Implementation\ValidationErrorPresenter;
+use RootedData\Exception\ValidationException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
  * Class.
  */
-class ProperJsonValidator extends ConstraintValidator {
+class ProperJsonValidator extends ConstraintValidator implements ContainerInjectionInterface {
+
+  /**
+   * @var \Drupal\metastore\RootedJsonDataWrapper
+   */
+  protected $rootedJsonDataFactory;
+
+  /**
+   * @var \OpisErrorPresenter\Implementation\ValidationErrorPresenter
+   */
+  protected $presenter;
+
+  /**
+   * ProperJsonValidator constructor.
+   *
+   * @param \Drupal\metastore\RootedJsonDataWrapper $rooted_json_data_factory
+   *   dkan.metastore.rooted_json_data_wrapper service.
+   */
+  public function __construct(RootedJsonDataWrapper $rooted_json_data_factory) {
+    $this->rootedJsonDataFactory = $rooted_json_data_factory;
+    $this->presenter = new ValidationErrorPresenter(
+      new PresentedValidationErrorFactory(
+        new MessageFormatterFactory()
+      )
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('dkan.metastore.rooted_json_data_wrapper')
+    );
+  }
 
   /**
    * Inherited.
@@ -21,32 +63,37 @@ class ProperJsonValidator extends ConstraintValidator {
       $schema = $type;
     }
     foreach ($items as $item) {
-      $info = $this->isProper($item->value, $schema);
-      if (!$info['valid']) {
-        $this->addViolations($info['errors']);
+      $errors = [];
+      try {
+        $this->rootedJsonDataFactory->createRootedJsonData($schema, $item->value);
       }
+      catch (ValidationException $e) {
+        $errors = $this->getValidationErrorsMessages($e->getResult()->getErrors());
+      }
+      catch (InvalidArgumentException $e) {
+        $errors[] = $e->getMessage();
+      }
+      if (!empty($errors)) $this->addViolations($errors);
     }
   }
 
   /**
-   * Is proper JSON?
+   * Presents errors.
    *
-   * @param string $value
-   *   Value.
-   * @param string $schema_id
-   *   Schema ID.
+   * @param array $errors
+   *   Validation errors array.
+   *
+   * @return array
+   *   Presented errors array.
    */
-  protected function isProper($value, $schema_id = 'dataset') {
-    // @codeCoverageIgnoreStart
-    $validation_info = \Drupal::service("dkan.metastore.service")->getValidationInfo($schema_id, $value);
-    $validation_info['errors'] = array_map(
+  private function getValidationErrorsMessages(array $errors): array {
+    $presented = $this->presenter->present(...$errors);
+    return array_map(
       function($presented_error) {
         return $presented_error->message();
       },
-      $validation_info['errors']
+      $presented
     );
-    return $validation_info;
-    // @codeCoverageIgnoreEnd
   }
 
   /**
@@ -54,7 +101,7 @@ class ProperJsonValidator extends ConstraintValidator {
    */
   private function addViolations($errors) {
     foreach ($errors as $error) {
-      $this->context->addViolation($error['message']);
+      $this->context->addViolation($error);
     }
   }
 

--- a/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
+++ b/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
@@ -63,9 +63,12 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
    */
   public function validate($items, Constraint $constraint) {
     $schema = 'dataset';
-    if (is_object($items) && $type = $items->getParent()->getEntity()->get('field_data_type')->value) {
-      $schema = $type;
+    if (is_object($items) && $entity = $items->getParent()->getEntity()) {
+      if ($type = $entity->get('field_data_type')->value) {
+        $schema = $type;
+      }
     }
+
     foreach ($items as $item) {
       $errors = [];
       try {

--- a/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
+++ b/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
@@ -3,7 +3,7 @@
 namespace Drupal\metastore\Plugin\Validation\Constraint;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\metastore\RootedJsonDataFactory;
+use Drupal\metastore\ValidMetadataFactory;
 use InvalidArgumentException;
 use OpisErrorPresenter\Implementation\MessageFormatterFactory;
 use OpisErrorPresenter\Implementation\PresentedValidationErrorFactory;
@@ -19,9 +19,9 @@ use Symfony\Component\Validator\ConstraintValidator;
 class ProperJsonValidator extends ConstraintValidator implements ContainerInjectionInterface {
 
   /**
-   * @var \Drupal\metastore\RootedJsonDataFactory
+   * @var \Drupal\metastore\ValidMetadataFactory
    */
-  protected $rootedJsonDataFactory;
+  protected $validMetadataFactory;
 
   /**
    * @var \OpisErrorPresenter\Implementation\ValidationErrorPresenter
@@ -31,11 +31,11 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
   /**
    * ProperJsonValidator constructor.
    *
-   * @param \Drupal\metastore\RootedJsonDataFactory $rooted_json_data_factory
-   *   dkan.metastore.rooted_json_data_wrapper service.
+   * @param \Drupal\metastore\ValidMetadataFactory $valid_metadata_factory
+   *   dkan.metastore.valid_metadata service.
    */
-  public function __construct(RootedJsonDataFactory $rooted_json_data_factory) {
-    $this->rootedJsonDataFactory = $rooted_json_data_factory;
+  public function __construct(ValidMetadataFactory $valid_metadata_factory) {
+    $this->validMetadataFactory = $valid_metadata_factory;
     $this->presenter = new ValidationErrorPresenter(
       new PresentedValidationErrorFactory(
         new MessageFormatterFactory()
@@ -48,7 +48,7 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('dkan.metastore.rooted_json_data_wrapper')
+      $container->get('dkan.metastore.valid_metadata')
     );
   }
 
@@ -65,7 +65,7 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
     foreach ($items as $item) {
       $errors = [];
       try {
-        $this->rootedJsonDataFactory->createRootedJsonData($schema, $item->value);
+        $this->validMetadataFactory->get($schema, $item->value);
       }
       catch (ValidationException $e) {
         $errors = $this->getValidationErrorsMessages($e->getResult()->getErrors());

--- a/modules/metastore/src/RootedJsonDataFactory.php
+++ b/modules/metastore/src/RootedJsonDataFactory.php
@@ -49,9 +49,9 @@ class RootedJsonDataFactory implements ContainerInjectionInterface {
   /**
    * Converts Json string into RootedJsonData object.
    *
-   * @param \Drupal\metastore\string $schema_id
+   * @param string|NULL $schema_id
    *   The {schema_id} slug from the HTTP request.
-   * @param \Drupal\metastore\string $json_string
+   * @param string $json_string
    *   Json string.
    *
    * @return \RootedData\RootedJsonData
@@ -59,8 +59,8 @@ class RootedJsonDataFactory implements ContainerInjectionInterface {
    *
    * @throws \JsonPath\InvalidJsonException
    */
-  public function createRootedJsonData(string $schema_id, string $json_string): RootedJsonData {
-    $schema = $this->getSchemaRetriever()->retrieve($schema_id);
+  public function createRootedJsonData(string $schema_id = NULL, string $json_string): RootedJsonData {
+    $schema = !empty($schema_id) ? $this->getSchemaRetriever()->retrieve($schema_id) : '{}';
     return new RootedJsonData($json_string, $schema);
   }
 

--- a/modules/metastore/src/RootedJsonDataFactory.php
+++ b/modules/metastore/src/RootedJsonDataFactory.php
@@ -3,17 +3,13 @@
 namespace Drupal\metastore;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-//use OpisErrorPresenter\Implementation\MessageFormatterFactory;
-//use OpisErrorPresenter\Implementation\PresentedValidationErrorFactory;
-//use OpisErrorPresenter\Implementation\ValidationErrorPresenter;
 use RootedData\RootedJsonData;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Service.
- * TODO: rename it
  */
-class RootedJsonDataWrapper implements ContainerInjectionInterface {
+class RootedJsonDataFactory implements ContainerInjectionInterface {
 
   /**
    * Schema retriever.
@@ -34,7 +30,7 @@ class RootedJsonDataWrapper implements ContainerInjectionInterface {
   }
 
   /**
-   * RootedJsonDataWrapper constructor.
+   * RootedJsonDataFactory constructor.
    *
    * @param \Drupal\metastore\SchemaRetriever $schemaRetriever
    *   dkan.metastore.schema_retriever service.

--- a/modules/metastore/src/RootedJsonDataWrapper.php
+++ b/modules/metastore/src/RootedJsonDataWrapper.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\metastore;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use OpisErrorPresenter\Implementation\MessageFormatterFactory;
+use OpisErrorPresenter\Implementation\PresentedValidationErrorFactory;
+use OpisErrorPresenter\Implementation\ValidationErrorPresenter;
+use RootedData\RootedJsonData;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Service.
+ */
+class RootedJsonDataWrapper implements ContainerInjectionInterface {
+
+  /**
+   * Schema retriever.
+   *
+   * @var \Drupal\metastore\SchemaRetriever
+   */
+  private $schemaRetriever;
+
+  /**
+   * Inherited.
+   *
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('metastore.schema_retriever'),
+    );
+  }
+
+  /**
+   * RootedJsonDataWrapper constructor.
+   *
+   * @param \Drupal\metastore\SchemaRetriever $schemaRetriever
+   *   dkan.metastore.schema_retriever service.
+   */
+  public function __construct(SchemaRetriever $schemaRetriever) {
+    $this->schemaRetriever = $schemaRetriever;
+  }
+
+  /**
+   * Converts Json string into RootedJsonData object.
+   *
+   * @param \Drupal\metastore\string $schema_id
+   *   The {schema_id} slug from the HTTP request.
+   * @param \Drupal\metastore\string $json_string
+   *   Json string.
+   *
+   * @return \RootedData\RootedJsonData
+   *   RootedJsonData object.
+   *
+   * @throws \JsonPath\InvalidJsonException
+   */
+  public function createRootedJsonData(string $schema_id, string $json_string): RootedJsonData {
+    $schema = $this->schemaRetriever->retrieve($schema_id);
+    return new RootedJsonData($json_string, $schema);
+  }
+
+  /**
+   * Get validation result.
+   *
+   * @param string $schema_id
+   *   The {schema_id} slug from the HTTP request.
+   * @param string $json_data
+   *   Json payload.
+   *
+   * @return array
+   *   The validation result.
+   *
+   * @throws \Exception
+   */
+  public function getValidationInfo(string $schema_id, string $json_string) {
+    $schema = $this->schemaRetriever->retrieve($schema_id);
+    $result = RootedJsonData::validate($json_string, $schema);
+    $presenter = new ValidationErrorPresenter(
+      new PresentedValidationErrorFactory(
+        new MessageFormatterFactory()
+      )
+    );
+    $presented = $presenter->present(...$result->getErrors());
+    return ['valid' => empty($presented), 'errors' => $presented];
+  }
+
+}

--- a/modules/metastore/src/RootedJsonDataWrapper.php
+++ b/modules/metastore/src/RootedJsonDataWrapper.php
@@ -3,14 +3,15 @@
 namespace Drupal\metastore;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use OpisErrorPresenter\Implementation\MessageFormatterFactory;
-use OpisErrorPresenter\Implementation\PresentedValidationErrorFactory;
-use OpisErrorPresenter\Implementation\ValidationErrorPresenter;
+//use OpisErrorPresenter\Implementation\MessageFormatterFactory;
+//use OpisErrorPresenter\Implementation\PresentedValidationErrorFactory;
+//use OpisErrorPresenter\Implementation\ValidationErrorPresenter;
 use RootedData\RootedJsonData;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Service.
+ * TODO: rename it
  */
 class RootedJsonDataWrapper implements ContainerInjectionInterface {
 
@@ -43,6 +44,13 @@ class RootedJsonDataWrapper implements ContainerInjectionInterface {
   }
 
   /**
+   * @return \Drupal\metastore\SchemaRetriever
+   */
+  public function getSchemaRetriever() {
+    return $this->schemaRetriever;
+  }
+
+  /**
    * Converts Json string into RootedJsonData object.
    *
    * @param \Drupal\metastore\string $schema_id
@@ -56,33 +64,8 @@ class RootedJsonDataWrapper implements ContainerInjectionInterface {
    * @throws \JsonPath\InvalidJsonException
    */
   public function createRootedJsonData(string $schema_id, string $json_string): RootedJsonData {
-    $schema = $this->schemaRetriever->retrieve($schema_id);
+    $schema = $this->getSchemaRetriever()->retrieve($schema_id);
     return new RootedJsonData($json_string, $schema);
-  }
-
-  /**
-   * Get validation result.
-   *
-   * @param string $schema_id
-   *   The {schema_id} slug from the HTTP request.
-   * @param string $json_data
-   *   Json payload.
-   *
-   * @return array
-   *   The validation result.
-   *
-   * @throws \Exception
-   */
-  public function getValidationInfo(string $schema_id, string $json_string) {
-    $schema = $this->schemaRetriever->retrieve($schema_id);
-    $result = RootedJsonData::validate($json_string, $schema);
-    $presenter = new ValidationErrorPresenter(
-      new PresentedValidationErrorFactory(
-        new MessageFormatterFactory()
-      )
-    );
-    $presented = $presenter->present(...$result->getErrors());
-    return ['valid' => empty($presented), 'errors' => $presented];
   }
 
 }

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -403,7 +403,7 @@ class Service implements ContainerInjectionInterface {
   /**
    * Private.
    */
-  public static function removeReferences(RootedJsonData $object, $prefix = "%"): RootedJsonData{
+  public static function removeReferences(RootedJsonData $object, $prefix = "%"): RootedJsonData {
     $array = $object->get('$');
 
     foreach ($array as $property => $value) {

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -138,7 +138,7 @@ class Service implements ContainerInjectionInterface {
       function ($jsonString) use ($schema_id) {
         $data = $this->rootedJsonDataWrapper->createRootedJsonData($schema_id, $jsonString);
         try {
-          return json_decode($this->dispatchEvent(self::EVENT_DATA_GET, $data));
+          return $this->dispatchEvent(self::EVENT_DATA_GET, $data);
         }
         catch (\Exception $e) {
           return (object) ["message" => $e->getMessage()];

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -10,9 +10,6 @@ use Drupal\metastore\Exception\ExistingObjectException;
 use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore\Exception\UnmodifiedObjectException;
 use Drupal\metastore\Storage\DataFactory;
-use JsonSchema\Exception\ValidationException;
-use RootedData\RootedJsonData;
-use Rs\Json\Merge\Patch;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -274,9 +271,6 @@ class Service implements ContainerInjectionInterface {
    *   ["identifier" => string, "new" => boolean].
    */
   private function proceedWithPut($schema_id, $identifier, string $data): array {
-    // TODO: abandon the method and use RootedJsonData instead on JSON string.
-    $this->validateJson($schema_id, $data);
-
     if ($this->objectExists($schema_id, $identifier)) {
       $this->getStorage($schema_id)->store($data, $identifier);
       return ['identifier' => $identifier, 'new' => FALSE];
@@ -412,27 +406,6 @@ class Service implements ContainerInjectionInterface {
     }
 
     return $object;
-  }
-
-  /**
-   * Temporary validate method.
-   *
-   * Using RootedJsonData instead of JSON string will make it redundant.
-   *
-   * @param string $schema_id
-   *   The {schema_id} slug from the HTTP request.
-   * @param string $json_data
-   *   Json payload.
-   *
-   * @return bool
-   */
-  private function validateJson(string $schema_id, string $json_data): bool {
-    $schema = $this->schemaRetriever->retrieve($schema_id);
-    $result = RootedJsonData::validate($json_data, $schema);
-    if (!$result->isValid()) {
-      throw new ValidationException("JSON Schema validation failed.", $result);
-    }
-    return TRUE;
   }
 
 }

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -47,9 +47,9 @@ class Service implements ContainerInjectionInterface {
   /**
    * RootedJsonData wrapper.
    *
-   * @var \Drupal\metastore\RootedJsonDataWrapper
+   * @var \Drupal\metastore\RootedJsonDataFactory
    */
-  private $rootedJsonDataWrapper;
+  private $rootedJsonDataFactory;
 
   /**
    * Inherited.
@@ -67,10 +67,10 @@ class Service implements ContainerInjectionInterface {
   /**
    * Constructor.
    */
-  public function __construct(SchemaRetriever $schemaRetriever, DataFactory $factory, RootedJsonDataWrapper $rootedJsonDataWrapper) {
+  public function __construct(SchemaRetriever $schemaRetriever, DataFactory $factory, RootedJsonDataFactory $rootedJsonDataFactory) {
     $this->schemaRetriever = $schemaRetriever;
     $this->storageFactory = $factory;
-    $this->rootedJsonDataWrapper = $rootedJsonDataWrapper;
+    $this->rootedJsonDataFactory = $rootedJsonDataFactory;
   }
 
   /**
@@ -136,7 +136,7 @@ class Service implements ContainerInjectionInterface {
 
     $objects = array_map(
       function ($jsonString) use ($schema_id) {
-        $data = $this->rootedJsonDataWrapper->createRootedJsonData($schema_id, $jsonString);
+        $data = $this->rootedJsonDataFactory->createRootedJsonData($schema_id, $jsonString);
         try {
           return $this->dispatchEvent(self::EVENT_DATA_GET, $data);
         }
@@ -165,7 +165,7 @@ class Service implements ContainerInjectionInterface {
    */
   public function get($schema_id, $identifier): RootedJsonData {
     $json_string = $this->getStorage($schema_id)->retrievePublished($identifier);
-    $data = $this->rootedJsonDataWrapper->createRootedJsonData($schema_id, $json_string);
+    $data = $this->rootedJsonDataFactory->createRootedJsonData($schema_id, $json_string);
 
     $data = $this->dispatchEvent(self::EVENT_DATA_GET, $data);
     return $data;
@@ -186,7 +186,7 @@ class Service implements ContainerInjectionInterface {
    */
   public function getResources($schema_id, $identifier): array {
     $json_string = $this->getStorage($schema_id)->retrieve($identifier);
-    $data = $this->rootedJsonDataWrapper->createRootedJsonData($schema_id, $json_string);
+    $data = $this->rootedJsonDataFactory->createRootedJsonData($schema_id, $json_string);
 
     /* @todo decouple from POD. */
     $resources = $data->{"$.distribution"};;
@@ -195,13 +195,13 @@ class Service implements ContainerInjectionInterface {
   }
 
   /**
-   * Get rootedJsonDataWrapper.
+   * Get RootedJsonDataFactory.
    *
-   * @return \Drupal\metastore\RootedJsonDataWrapper
+   * @return \Drupal\metastore\RootedJsonDataFactory
    *   rootedJsonDataWrapper.
    */
-  public function getRootedJsonDataWrapper() {
-    return $this->rootedJsonDataWrapper;
+  public function getRootedJsonDataFactory() {
+    return $this->rootedJsonDataFactory;
   }
 
   /**
@@ -321,7 +321,7 @@ class Service implements ContainerInjectionInterface {
           json_decode($json_data)
         );
 
-        $new = $this->rootedJsonDataWrapper->createRootedJsonData($schema_id, json_encode($patched));
+        $new = $this->rootedJsonDataFactory->createRootedJsonData($schema_id, json_encode($patched));
 //        $storage->store("$new", "{$identifier}");
         $storage->store($new, "{$identifier}");
         return $identifier;

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -10,10 +10,6 @@ use Drupal\metastore\Exception\ExistingObjectException;
 use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore\Exception\UnmodifiedObjectException;
 use Drupal\metastore\Storage\DataFactory;
-use JsonSchema\Exception\ValidationException;
-use OpisErrorPresenter\Implementation\MessageFormatterFactory;
-use OpisErrorPresenter\Implementation\PresentedValidationErrorFactory;
-use OpisErrorPresenter\Implementation\ValidationErrorPresenter;
 use RootedData\RootedJsonData;
 use Rs\Json\Merge\Patch;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -326,6 +322,7 @@ class Service implements ContainerInjectionInterface {
         );
 
         $new = $this->rootedJsonDataWrapper->createRootedJsonData($schema_id, json_encode($patched));
+//        $storage->store("$new", "{$identifier}");
         $storage->store($new, "{$identifier}");
         return $identifier;
       }
@@ -397,7 +394,7 @@ class Service implements ContainerInjectionInterface {
    * @return bool
    *   TRUE if the metadata is equivalent, false otherwise.
    */
-  private function objectIsEquivalent(string $schema_id, string $identifier, string $metadata) {
+  private function objectIsEquivalent(string $schema_id, string $identifier, RootedJsonData $metadata) {
     $existingMetadata = $this->getStorage($schema_id)->retrieve($identifier);
     $existing = json_decode($existingMetadata);
     $existing = self::removeReferences($existing);

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -322,7 +322,6 @@ class Service implements ContainerInjectionInterface {
         );
 
         $new = $this->rootedJsonDataFactory->createRootedJsonData($schema_id, json_encode($patched));
-//        $storage->store("$new", "{$identifier}");
         $storage->store($new, "{$identifier}");
         return $identifier;
       }
@@ -406,7 +405,6 @@ class Service implements ContainerInjectionInterface {
    * Private.
    */
   public static function removeReferences($object, $prefix = "%") {
-    // TODO: consider using RootedJsonData.
     $array = (array) $object;
     foreach ($array as $property => $value) {
       if (substr_count($property, $prefix) > 0) {

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -10,6 +10,9 @@ use Drupal\metastore\Exception\ExistingObjectException;
 use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore\Exception\UnmodifiedObjectException;
 use Drupal\metastore\Storage\DataFactory;
+use JsonSchema\Exception\ValidationException;
+use RootedData\RootedJsonData;
+use Rs\Json\Merge\Patch;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -271,6 +274,9 @@ class Service implements ContainerInjectionInterface {
    *   ["identifier" => string, "new" => boolean].
    */
   private function proceedWithPut($schema_id, $identifier, string $data): array {
+    // TODO: abandon the method and use RootedJsonData instead on JSON string.
+    $this->validateJson($schema_id, $data);
+
     if ($this->objectExists($schema_id, $identifier)) {
       $this->getStorage($schema_id)->store($data, $identifier);
       return ['identifier' => $identifier, 'new' => FALSE];
@@ -406,6 +412,27 @@ class Service implements ContainerInjectionInterface {
     }
 
     return $object;
+  }
+
+  /**
+   * Temporary validate method.
+   *
+   * Using RootedJsonData instead of JSON string will make it redundant.
+   *
+   * @param string $schema_id
+   *   The {schema_id} slug from the HTTP request.
+   * @param string $json_data
+   *   Json payload.
+   *
+   * @return bool
+   */
+  private function validateJson(string $schema_id, string $json_data): bool {
+    $schema = $this->schemaRetriever->retrieve($schema_id);
+    $result = RootedJsonData::validate($json_data, $schema);
+    if (!$result->isValid()) {
+      throw new ValidationException("JSON Schema validation failed.", $result);
+    }
+    return TRUE;
   }
 
 }

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -80,6 +80,7 @@ class Data implements StorerInterface, RetrieverInterface, BulkRetrieverInterfac
       /** @var \Drupal\node\NodeInterface $node */
       $node = $this->nodeStorage->load($nid);
       if ($node->get('moderation_state')->getString() === 'published') {
+        // TODO: consider transforming to RootedJsonData.
         $all[] = $node->get('field_json_metadata')->getString();
       }
     }
@@ -99,6 +100,7 @@ class Data implements StorerInterface, RetrieverInterface, BulkRetrieverInterfac
     $node = $this->getNodePublishedRevision($uuid);
 
     if ($node && $node->get('moderation_state')->getString() == 'published') {
+      // TODO: consider transforming to RootedJsonData.
       return $node->get('field_json_metadata')->getString();
     }
 
@@ -232,6 +234,8 @@ class Data implements StorerInterface, RetrieverInterface, BulkRetrieverInterfac
    */
   public function store($data, string $uuid = NULL): string {
     $data = json_decode($data);
+
+    // TODO: consider transforming to RootedJsonData.
     $data = $this->filterHtml($data);
 
     $uuid = (!$uuid && isset($data->identifier)) ? $data->identifier : $uuid;

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -80,7 +80,6 @@ class Data implements StorerInterface, RetrieverInterface, BulkRetrieverInterfac
       /** @var \Drupal\node\NodeInterface $node */
       $node = $this->nodeStorage->load($nid);
       if ($node->get('moderation_state')->getString() === 'published') {
-        // TODO: consider transforming to RootedJsonData.
         $all[] = $node->get('field_json_metadata')->getString();
       }
     }
@@ -100,7 +99,6 @@ class Data implements StorerInterface, RetrieverInterface, BulkRetrieverInterfac
     $node = $this->getNodePublishedRevision($uuid);
 
     if ($node && $node->get('moderation_state')->getString() == 'published') {
-      // TODO: consider transforming to RootedJsonData.
       return $node->get('field_json_metadata')->getString();
     }
 
@@ -235,7 +233,6 @@ class Data implements StorerInterface, RetrieverInterface, BulkRetrieverInterfac
   public function store($data, string $uuid = NULL): string {
     $data = json_decode($data);
 
-    // TODO: consider transforming to RootedJsonData.
     $data = $this->filterHtml($data);
 
     $uuid = (!$uuid && isset($data->identifier)) ? $data->identifier : $uuid;

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -313,6 +313,7 @@ class Data implements StorerInterface, RetrieverInterface, BulkRetrieverInterfac
    *   Filtered output.
    */
   private function filterHtml($input) {
+    // TODO: find out if we still need it.
     switch (gettype($input)) {
       case "string":
         return $this->htmlPurifier($input);

--- a/modules/metastore/src/ValidMetadataFactory.php
+++ b/modules/metastore/src/ValidMetadataFactory.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Service.
  */
-class RootedJsonDataFactory implements ContainerInjectionInterface {
+class ValidMetadataFactory implements ContainerInjectionInterface {
 
   /**
    * Schema retriever.
@@ -30,7 +30,7 @@ class RootedJsonDataFactory implements ContainerInjectionInterface {
   }
 
   /**
-   * RootedJsonDataFactory constructor.
+   * ValidMetadataFactory constructor.
    *
    * @param \Drupal\metastore\SchemaRetriever $schemaRetriever
    *   dkan.metastore.schema_retriever service.
@@ -59,7 +59,7 @@ class RootedJsonDataFactory implements ContainerInjectionInterface {
    *
    * @throws \JsonPath\InvalidJsonException
    */
-  public function createRootedJsonData(string $schema_id = NULL, string $json_string): RootedJsonData {
+  public function get(string $schema_id = NULL, string $json_string): RootedJsonData {
     $schema = !empty($schema_id) ? $this->getSchemaRetriever()->retrieve($schema_id) : '{}';
     return new RootedJsonData($json_string, $schema);
   }

--- a/modules/metastore/src/ValidMetadataFactory.php
+++ b/modules/metastore/src/ValidMetadataFactory.php
@@ -33,14 +33,17 @@ class ValidMetadataFactory implements ContainerInjectionInterface {
    * ValidMetadataFactory constructor.
    *
    * @param \Drupal\metastore\SchemaRetriever $schemaRetriever
-   *   dkan.metastore.schema_retriever service.
+   *   Service dkan.metastore.schema_retriever.
    */
   public function __construct(SchemaRetriever $schemaRetriever) {
     $this->schemaRetriever = $schemaRetriever;
   }
 
   /**
+   * Gets schema retriever.
+   *
    * @return \Drupal\metastore\SchemaRetriever
+   *   Service metastore.schema_retriever.
    */
   public function getSchemaRetriever() {
     return $this->schemaRetriever;
@@ -49,7 +52,7 @@ class ValidMetadataFactory implements ContainerInjectionInterface {
   /**
    * Converts Json string into RootedJsonData object.
    *
-   * @param string|NULL $schema_id
+   * @param string|null $schema_id
    *   The {schema_id} slug from the HTTP request.
    * @param string $json_string
    *   Json string.

--- a/modules/metastore/src/WebServiceApi.php
+++ b/modules/metastore/src/WebServiceApi.php
@@ -135,7 +135,7 @@ class WebServiceApi implements ContainerInjectionInterface {
    * Private.
    */
   private function swapReferences(RootedJsonData $object): RootedJsonData {
-    $no_schema_object = $this->service->getRootedJsonDataFactory()->createRootedJsonData(NULL, $object->pretty());
+    $no_schema_object = $this->service->getValidMetadataFactory()->get(NULL, $object->__toString());
     foreach ($no_schema_object->get('$') as $property => $value) {
       if (substr_count($property, "%Ref:") > 0) {
         $no_schema_object = $this->swapReference($property, $value, $no_schema_object);
@@ -187,7 +187,7 @@ class WebServiceApi implements ContainerInjectionInterface {
     try {
       $data = $this->getRequestContent();
       $this->checkIdentifier($data);
-      $data = $this->service->getRootedJsonDataFactory()->createRootedJsonData($schema_id, $data);
+      $data = $this->service->getValidMetadataFactory()->get($schema_id, $data);
       $identifier = $this->service->post($schema_id, $data);
       return $this->getResponse([
         "endpoint" => "{$this->getRequestUri()}/{$identifier}",
@@ -241,7 +241,7 @@ class WebServiceApi implements ContainerInjectionInterface {
     try {
       $data = $this->getRequestContent();
       $this->checkIdentifier($data, $identifier);
-      $data = $this->service->getRootedJsonDataFactory()->createRootedJsonData($schema_id, $data);
+      $data = $this->service->getValidMetadataFactory()->get($schema_id, $data);
       $info = $this->service->put($schema_id, $identifier, $data);
       $code = ($info['new'] == TRUE) ? 201 : 200;
       return $this->getResponse(["endpoint" => $this->getRequestUri(), "identifier" => $info['identifier']], $code);

--- a/modules/metastore/src/WebServiceApi.php
+++ b/modules/metastore/src/WebServiceApi.php
@@ -136,6 +136,7 @@ class WebServiceApi implements ContainerInjectionInterface {
    * Private.
    */
   private function swapReferences($object) {
+    // TODO: use RootedJsonData instead.
     $array = (array) $object;
     foreach ($array as $property => $value) {
       if (substr_count($property, "%Ref:") > 0) {
@@ -325,9 +326,9 @@ class WebServiceApi implements ContainerInjectionInterface {
   /**
    * Private.
    */
-  private function checkData($data, $identifier = NULL) {
+  private function checkData(string $data, $identifier = NULL) {
 
-    // TODO: consider working with RootedJsonData.
+    // TODO: use RootedJsonData.
     if (empty($data)) {
       throw new MissingPayloadException("Empty body");
     }

--- a/modules/metastore/src/WebServiceApi.php
+++ b/modules/metastore/src/WebServiceApi.php
@@ -136,7 +136,6 @@ class WebServiceApi implements ContainerInjectionInterface {
    * Private.
    */
   private function swapReferences($object) {
-    // TODO: use RootedJsonData instead.
     $array = (array) $object;
     foreach ($array as $property => $value) {
       if (substr_count($property, "%Ref:") > 0) {

--- a/modules/metastore/src/WebServiceApi.php
+++ b/modules/metastore/src/WebServiceApi.php
@@ -193,7 +193,7 @@ class WebServiceApi implements ContainerInjectionInterface {
     try {
       $data = $this->getRequestContent();
       $this->checkIdentifier($data);
-      $data = $this->service->getRootedJsonDataWrapper()->createRootedJsonData($schema_id, $data);
+      $data = $this->service->getRootedJsonDataFactory()->createRootedJsonData($schema_id, $data);
       $identifier = $this->service->post($schema_id, $data);
       return $this->getResponse([
         "endpoint" => "{$this->getRequestUri()}/{$identifier}",
@@ -247,7 +247,7 @@ class WebServiceApi implements ContainerInjectionInterface {
     try {
       $data = $this->getRequestContent();
       $this->checkIdentifier($data, $identifier);
-      $data = $this->service->getRootedJsonDataWrapper()->createRootedJsonData($schema_id, $data);
+      $data = $this->service->getRootedJsonDataFactory()->createRootedJsonData($schema_id, $data);
       $info = $this->service->put($schema_id, $identifier, $data);
       $code = ($info['new'] == TRUE) ? 201 : 200;
       return $this->getResponse(["endpoint" => $this->getRequestUri(), "identifier" => $info['identifier']], $code);

--- a/modules/metastore/src/WebServiceApi.php
+++ b/modules/metastore/src/WebServiceApi.php
@@ -81,6 +81,7 @@ class WebServiceApi implements ContainerInjectionInterface {
     $keepRefs = $this->wantObjectWithReferences();
 
     $output = array_map(function ($object) use ($keepRefs) {
+      $object = json_decode($object);
       if ($keepRefs) {
         return $this->swapReferences($object);
       }
@@ -191,6 +192,7 @@ class WebServiceApi implements ContainerInjectionInterface {
     try {
       $data = $this->getRequestContent();
       $this->checkData($data);
+      $data = $this->service->getRootedJsonDataWrapper()->createRootedJsonData($schema_id, $data);
       $identifier = $this->service->post($schema_id, $data);
       return $this->getResponse([
         "endpoint" => "{$this->getRequestUri()}/{$identifier}",
@@ -244,6 +246,7 @@ class WebServiceApi implements ContainerInjectionInterface {
     try {
       $data = $this->getRequestContent();
       $this->checkData($data, $identifier);
+      $data = $this->service->getRootedJsonDataWrapper()->createRootedJsonData($schema_id, $data);
       $info = $this->service->put($schema_id, $identifier, $data);
       $code = ($info['new'] == TRUE) ? 201 : 200;
       return $this->getResponse(["endpoint" => $this->getRequestUri(), "identifier" => $info['identifier']], $code);
@@ -324,6 +327,7 @@ class WebServiceApi implements ContainerInjectionInterface {
    */
   private function checkData($data, $identifier = NULL) {
 
+    // TODO: consider working with RootedJsonData.
     if (empty($data)) {
       throw new MissingPayloadException("Empty body");
     }

--- a/modules/metastore/src/WebServiceApi.php
+++ b/modules/metastore/src/WebServiceApi.php
@@ -150,7 +150,9 @@ class WebServiceApi implements ContainerInjectionInterface {
    */
   private function swapReference($property, $value, RootedJsonData $object): RootedJsonData {
     $original = str_replace("%Ref:", "", $property);
-    if ($object->__isset("$.{$original}")) $object->set("$.{$original}", $value);
+    if ($object->__isset("$.{$original}")) {
+      $object->set("$.{$original}", $value);
+    }
     return $object;
   }
 

--- a/modules/metastore/tests/src/Functional/DatasetSpecificDocsTest.php
+++ b/modules/metastore/tests/src/Functional/DatasetSpecificDocsTest.php
@@ -46,7 +46,7 @@ class DatasetSpecificDocsTest extends ExistingSiteBase {
 
     /** @var \Drupal\metastore\Service $metastore */
     $metastore = \Drupal::service('dkan.metastore.service');
-    $dataset = $metastore->getRootedJsonDataWrapper()->createRootedJsonData('dataset', $dataset);
+    $dataset = $metastore->getRootedJsonDataFactory()->createRootedJsonData('dataset', $dataset);
     $metastore->post('dataset', $dataset);
 
     $webService = WebServiceApiDocs::create(\Drupal::getContainer());

--- a/modules/metastore/tests/src/Functional/DatasetSpecificDocsTest.php
+++ b/modules/metastore/tests/src/Functional/DatasetSpecificDocsTest.php
@@ -46,6 +46,7 @@ class DatasetSpecificDocsTest extends ExistingSiteBase {
 
     /** @var \Drupal\metastore\Service $metastore */
     $metastore = \Drupal::service('dkan.metastore.service');
+    $dataset = $metastore->getRootedJsonDataWrapper()->createRootedJsonData('dataset', $dataset);
     $metastore->post('dataset', $dataset);
 
     $webService = WebServiceApiDocs::create(\Drupal::getContainer());

--- a/modules/metastore/tests/src/Functional/DatasetSpecificDocsTest.php
+++ b/modules/metastore/tests/src/Functional/DatasetSpecificDocsTest.php
@@ -46,7 +46,7 @@ class DatasetSpecificDocsTest extends ExistingSiteBase {
 
     /** @var \Drupal\metastore\Service $metastore */
     $metastore = \Drupal::service('dkan.metastore.service');
-    $dataset = $metastore->getRootedJsonDataFactory()->createRootedJsonData('dataset', $dataset);
+    $dataset = $metastore->getValidMetadataFactory()->get('dataset', $dataset);
     $metastore->post('dataset', $dataset);
 
     $webService = WebServiceApiDocs::create(\Drupal::getContainer());

--- a/modules/metastore/tests/src/Plugin/Validation/Constraint/ProperJsonValidatorTest.php
+++ b/modules/metastore/tests/src/Plugin/Validation/Constraint/ProperJsonValidatorTest.php
@@ -3,7 +3,7 @@
 namespace Drupal\Tests\metastore\Plugin\Validation\Constraint;
 
 use Drupal\metastore\Plugin\Validation\Constraint\ProperJsonValidator;
-use Drupal\metastore\RootedJsonDataFactory;
+use Drupal\metastore\ValidMetadataFactory;
 use Drupal\metastore\SchemaRetriever;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraints\Count;
@@ -23,11 +23,11 @@ class ProperJsonValidatorTest extends TestCase {
   protected $schemaRetriever;
 
   /**
-   * The RootedJsonDataFactory class used for testing.
+   * The ValidMetadataFactory class used for testing.
    *
-   * @var \Drupal\metastore\RootedJsonDataFactory|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\metastore\ValidMetadataFactory|\PHPUnit\Framework\MockObject\MockObject
    */
-  protected $rootedJsonDataFactory;
+  protected $validMetadataFactory;
 
   /**
    * The container used for testing.
@@ -51,11 +51,11 @@ class ProperJsonValidatorTest extends TestCase {
       ->setMethods(["retrieve"])
       ->getMock();
 
-    $this->rootedJsonDataFactory = $this->getMockBuilder(RootedJsonDataFactory::class)
+    $this->validMetadataFactory = $this->getMockBuilder(ValidMetadataFactory::class)
       ->disableOriginalConstructor()
       ->setMethods(["getSchemaRetriever"])
       ->getMock();
-    $this->rootedJsonDataFactory->method('getSchemaRetriever')->willReturn($this->schemaRetriever);
+    $this->validMetadataFactory->method('getSchemaRetriever')->willReturn($this->schemaRetriever);
 
     $this->container = $this->getMockBuilder(ContainerInterface::class)
       ->setMethods(['get'])
@@ -63,8 +63,8 @@ class ProperJsonValidatorTest extends TestCase {
       ->getMockForAbstractClass();
 
     $this->container->method('get')
-      ->with('dkan.metastore.rooted_json_data_wrapper')
-      ->willReturn($this->rootedJsonDataFactory);
+      ->with('dkan.metastore.valid_metadata')
+      ->willReturn($this->validMetadataFactory);
 
     $this->context = $this->getMockBuilder(ExecutionContext::class)
       ->setMethods(["addViolation"])

--- a/modules/metastore/tests/src/Plugin/Validation/Constraint/ProperJsonValidatorTest.php
+++ b/modules/metastore/tests/src/Plugin/Validation/Constraint/ProperJsonValidatorTest.php
@@ -45,6 +45,7 @@ class ProperJsonValidatorTest extends TestCase {
    * {@inheritdoc}
    */
   protected function setUp(): void {
+    parent::setUp();
     $this->schemaRetriever = $this->getMockBuilder(SchemaRetriever::class)
       ->disableOriginalConstructor()
       ->setMethods(["retrieve"])

--- a/modules/metastore/tests/src/Plugin/Validation/Constraint/ProperJsonValidatorTest.php
+++ b/modules/metastore/tests/src/Plugin/Validation/Constraint/ProperJsonValidatorTest.php
@@ -3,7 +3,7 @@
 namespace Drupal\Tests\metastore\Plugin\Validation\Constraint;
 
 use Drupal\metastore\Plugin\Validation\Constraint\ProperJsonValidator;
-use Drupal\metastore\RootedJsonDataWrapper;
+use Drupal\metastore\RootedJsonDataFactory;
 use Drupal\metastore\SchemaRetriever;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraints\Count;
@@ -23,9 +23,9 @@ class ProperJsonValidatorTest extends TestCase {
   protected $schemaRetriever;
 
   /**
-   * The RootedJsonDataWrapper class used for testing.
+   * The RootedJsonDataFactory class used for testing.
    *
-   * @var \Drupal\metastore\RootedJsonDataWrapper|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\metastore\RootedJsonDataFactory|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $rootedJsonDataFactory;
 
@@ -51,7 +51,7 @@ class ProperJsonValidatorTest extends TestCase {
       ->setMethods(["retrieve"])
       ->getMock();
 
-    $this->rootedJsonDataFactory = $this->getMockBuilder(RootedJsonDataWrapper::class)
+    $this->rootedJsonDataFactory = $this->getMockBuilder(RootedJsonDataFactory::class)
       ->disableOriginalConstructor()
       ->setMethods(["getSchemaRetriever"])
       ->getMock();

--- a/modules/metastore/tests/src/Plugin/Validation/Constraint/ProperJsonValidatorTest.php
+++ b/modules/metastore/tests/src/Plugin/Validation/Constraint/ProperJsonValidatorTest.php
@@ -45,12 +45,12 @@ class ProperJsonValidatorTest extends TestCase {
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->schemaRetriever = $schema_retriever = $this->getMockBuilder(SchemaRetriever::class)
+    $this->schemaRetriever = $this->getMockBuilder(SchemaRetriever::class)
       ->disableOriginalConstructor()
       ->setMethods(["retrieve"])
       ->getMock();
 
-    $this->rootedJsonDataFactory = $rooted_json_data_factory = $this->getMockBuilder(RootedJsonDataWrapper::class)
+    $this->rootedJsonDataFactory = $this->getMockBuilder(RootedJsonDataWrapper::class)
       ->disableOriginalConstructor()
       ->setMethods(["getSchemaRetriever"])
       ->getMock();

--- a/modules/metastore/tests/src/Plugin/Validation/Constraint/ProperJsonValidatorTest.php
+++ b/modules/metastore/tests/src/Plugin/Validation/Constraint/ProperJsonValidatorTest.php
@@ -3,6 +3,9 @@
 namespace Drupal\Tests\metastore\Plugin\Validation\Constraint;
 
 use Drupal\metastore\Plugin\Validation\Constraint\ProperJsonValidator;
+use Drupal\metastore\RootedJsonDataWrapper;
+use Drupal\metastore\SchemaRetriever;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Context\ExecutionContext;
 use PHPUnit\Framework\TestCase;
@@ -13,23 +16,74 @@ use PHPUnit\Framework\TestCase;
 class ProperJsonValidatorTest extends TestCase {
 
   /**
-   * Public.
+   * The schema retriever used for testing.
+   *
+   * @var \Drupal\metastore\SchemaRetriever|\PHPUnit\Framework\MockObject\MockObject
    */
-  public function testValidationSuccess() {
-    $validator = $this->getMockBuilder(ProperJsonValidator::class)
-      ->setMethods(["isProper"])
+  protected $schemaRetriever;
+
+  /**
+   * The RootedJsonDataWrapper class used for testing.
+   *
+   * @var \Drupal\metastore\RootedJsonDataWrapper|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $rootedJsonDataFactory;
+
+  /**
+   * The container used for testing.
+   */
+  protected $container;
+
+  /**
+   * The context used for testing.
+   *
+   * @var Symfony\Component\Validator\Context\ExecutionContext|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $context;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    $this->schemaRetriever = $schema_retriever = $this->getMockBuilder(SchemaRetriever::class)
+      ->disableOriginalConstructor()
+      ->setMethods(["retrieve"])
       ->getMock();
 
-    $validator->expects($this->once())->method("isProper")->willReturn(['valid' => TRUE]);
+    $this->rootedJsonDataFactory = $rooted_json_data_factory = $this->getMockBuilder(RootedJsonDataWrapper::class)
+      ->disableOriginalConstructor()
+      ->setMethods(["getSchemaRetriever"])
+      ->getMock();
+    $this->rootedJsonDataFactory->method('getSchemaRetriever')->willReturn($this->schemaRetriever);
 
-    $context = $this->getMockBuilder(ExecutionContext::class)
+    $this->container = $this->getMockBuilder(ContainerInterface::class)
+      ->setMethods(['get'])
+      ->disableOriginalConstructor()
+      ->getMockForAbstractClass();
+
+    $this->container->method('get')
+      ->with('dkan.metastore.rooted_json_data_wrapper')
+      ->willReturn($this->rootedJsonDataFactory);
+
+    $this->context = $this->getMockBuilder(ExecutionContext::class)
       ->setMethods(["addViolation"])
       ->disableOriginalConstructor()
       ->getMock();
+  }
 
-    $context->expects($this->never())->method("addViolation");
+  /**
+   * Public.
+   */
+  public function testValidationSuccess() {
+    $this->schemaRetriever->method('retrieve')->willReturn(
+      json_encode(['foo' => 'bar'])
+    );
 
-    $validator->initialize($context);
+    $validator = ProperJsonValidator::create($this->container);
+
+    $this->context->expects($this->never())->method("addViolation");
+
+    $validator->initialize($this->context);
 
     $validator->validate([(object) ['value' => "{}"]], new Count(['min' => 1, 'max' => 2]));
   }
@@ -38,31 +92,17 @@ class ProperJsonValidatorTest extends TestCase {
    * Public.
    */
   public function testValidationFailure() {
-    $validator = $this->getMockBuilder(ProperJsonValidator::class)
-      ->setMethods(["isProper"])
-      ->getMock();
+    $this->schemaRetriever->method('retrieve')->willReturn(
+      '{"type":"object","properties": {"number":{ "type":"number"}}}'
+    );
 
-    $validator->expects($this->once())
-      ->method("isProper")
-      ->willReturn(
-              [
-                'valid' => FALSE,
-                'errors' => [
-              ['message' => "yep"],
-                ],
-              ]
-          );
+    $validator = ProperJsonValidator::create($this->container);
 
-    $context = $this->getMockBuilder(ExecutionContext::class)
-      ->setMethods(["addViolation"])
-      ->disableOriginalConstructor()
-      ->getMock();
+    $this->context->expects($this->once())->method("addViolation");
 
-    $context->expects($this->once())->method("addViolation");
+    $validator->initialize($this->context);
 
-    $validator->initialize($context);
-
-    $validator->validate([(object) ['value' => "{}"]], new Count(['min' => 1, 'max' => 2]));
+    $validator->validate([(object) ['value' => '{"number":"foo"}']], new Count(['min' => 1, 'max' => 2]));
   }
 
 }

--- a/modules/metastore/tests/src/Unit/ServiceTest.php
+++ b/modules/metastore/tests/src/Unit/ServiceTest.php
@@ -8,7 +8,7 @@ use Drupal\Core\DependencyInjection\Container;
 use Drupal\metastore\Exception\ExistingObjectException;
 use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore\Exception\UnmodifiedObjectException;
-use Drupal\metastore\RootedJsonDataWrapper;
+use Drupal\metastore\RootedJsonDataFactory;
 use Drupal\metastore\Service;
 use Drupal\metastore\SchemaRetriever;
 use Drupal\metastore\Storage\Data;
@@ -25,9 +25,9 @@ use RootedData\RootedJsonData;
 class ServiceTest extends TestCase {
 
   /**
-   * The RootedJsonDataWrapper class used for testing.
+   * The RootedJsonDataFactory class used for testing.
    *
-   * @var \Drupal\metastore\RootedJsonDataWrapper|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\metastore\RootedJsonDataFactory|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $rootedJsonDataFactory;
 
@@ -65,7 +65,7 @@ class ServiceTest extends TestCase {
 
     $container = self::getCommonMockChain($this)
       ->add(Data::class, 'retrieveAll', [json_encode(['foo' => 'bar'])])
-      ->add(RootedJsonDataWrapper::class, 'createRootedJsonData', $expected);
+      ->add(RootedJsonDataFactory::class, 'createRootedJsonData', $expected);
 
     \Drupal::setContainer($container->getMock());
 
@@ -110,7 +110,7 @@ class ServiceTest extends TestCase {
 
     $container = self::getCommonMockChain($this)
       ->add(Data::class, "retrievePublished", json_encode(['foo' => 'bar']))
-      ->add(RootedJsonDataWrapper::class, 'createRootedJsonData', $data);
+      ->add(RootedJsonDataFactory::class, 'createRootedJsonData', $data);
 
     \Drupal::setContainer($container->getMock());
 
@@ -133,7 +133,7 @@ class ServiceTest extends TestCase {
 
     $container = self::getCommonMockChain($this)
       ->add(Data::class, "retrieve", json_encode($dataset))
-      ->add(RootedJsonDataWrapper::class, 'createRootedJsonData', $data);
+      ->add(RootedJsonDataFactory::class, 'createRootedJsonData', $data);
 
     $service = Service::create($container->getMock());
 
@@ -263,7 +263,7 @@ EOF;
     $container = self::getCommonMockChain($this)
       ->add(Data::class, "retrieve", "1")
       ->add(Data::class, "store", "1")
-      ->add(RootedJsonDataWrapper::class, 'createRootedJsonData', RootedJsonData::class);
+      ->add(RootedJsonDataFactory::class, 'createRootedJsonData', RootedJsonData::class);
 
     $service = Service::create($container->getMock());
 
@@ -337,7 +337,7 @@ EOF;
     $container = self::getCommonMockChain($this)
       ->add(SchemaRetriever::class, "retrieve", json_encode($catalog))
       ->add(Data::class, 'retrieveAll', [json_encode($dataset), json_encode($dataset)])
-      ->add(RootedJsonDataWrapper::class, 'createRootedJsonData', $dataset);
+      ->add(RootedJsonDataFactory::class, 'createRootedJsonData', $dataset);
 
     \Drupal::setContainer($container->getMock());
 
@@ -360,7 +360,7 @@ EOF;
     $myServices = [
       'dkan.metastore.schema_retriever' => SchemaRetriever::class,
       'dkan.metastore.storage' => DataFactory::class,
-      'dkan.metastore.rooted_json_data_wrapper' => RootedJsonDataWrapper::class,
+      'dkan.metastore.rooted_json_data_wrapper' => RootedJsonDataFactory::class,
       'event_dispatcher' => ContainerAwareEventDispatcher::class
     ];
 
@@ -388,7 +388,7 @@ EOF;
       ->add(Container::class, "get", $options)
       ->add(SchemaRetriever::class, "retrieve", json_encode(['foo' => 'bar']));
 
-    return RootedJsonDataWrapper::create($container->getMock());
+    return RootedJsonDataFactory::create($container->getMock());
   }
 
 }

--- a/modules/metastore/tests/src/Unit/ServiceTest.php
+++ b/modules/metastore/tests/src/Unit/ServiceTest.php
@@ -8,7 +8,7 @@ use Drupal\Core\DependencyInjection\Container;
 use Drupal\metastore\Exception\ExistingObjectException;
 use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore\Exception\UnmodifiedObjectException;
-use Drupal\metastore\Factory\Sae;
+use Drupal\metastore\RootedJsonDataWrapper;
 use Drupal\metastore\Service;
 use Drupal\metastore\SchemaRetriever;
 use Drupal\metastore\Storage\Data;
@@ -17,7 +17,7 @@ use MockChain\Chain;
 use MockChain\Options;
 use MockChain\Sequence;
 use PHPUnit\Framework\TestCase;
-use Sae\Sae as Engine;
+use RootedData\RootedJsonData;
 
 /**
  *
@@ -49,14 +49,17 @@ class ServiceTest extends TestCase {
    *
    */
   public function testGetAll() {
+    $expected = self::getJsonWrapper($this)->createRootedJsonData('dataset', json_encode(['foo' => 'bar']));
+
     $container = self::getCommonMockChain($this)
-      ->add(Data::class, 'retrieveAll', [json_encode("blah")]);
+      ->add(Data::class, 'retrieveAll', [json_encode(['foo' => 'bar'])])
+      ->add(RootedJsonDataWrapper::class, 'createRootedJsonData', $expected);
 
     \Drupal::setContainer($container->getMock());
 
     $service = Service::create($container->getMock());
 
-    $this->assertEquals(json_encode(["blah"]), json_encode($service->getAll("dataset")));
+    $this->assertEquals([$expected], $service->getAll("dataset"));
   }
 
   public function testGetAllException() {
@@ -91,33 +94,38 @@ class ServiceTest extends TestCase {
    *
    */
   public function testGet() {
+    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', json_encode(['foo' => 'bar']));
+
     $container = self::getCommonMockChain($this)
-      ->add(Data::class, "retrievePublished", json_encode("blah"));
+      ->add(Data::class, "retrievePublished", json_encode(['foo' => 'bar']))
+      ->add(RootedJsonDataWrapper::class, 'createRootedJsonData', $data);
 
     \Drupal::setContainer($container->getMock());
 
     $service = Service::create($container->getMock());
 
-    $this->assertEquals(json_encode("blah"), $service->get("dataset", "1"));
+    $this->assertEquals(json_encode(['foo' => 'bar']), $service->get("dataset", "1"));
   }
 
   /**
    *
    */
   public function testGetResources() {
-    $dataset = (object) [
+    $dataset = [
       "identifier" => "1",
       "distribution" => [
-        (object) ["title" => "hello"],
+        ["title" => "hello"],
       ],
     ];
+    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', json_encode($dataset));
 
     $container = self::getCommonMockChain($this)
-      ->add(Data::class, "retrieve", json_encode($dataset));
+      ->add(Data::class, "retrieve", json_encode($dataset))
+      ->add(RootedJsonDataWrapper::class, 'createRootedJsonData', $data);
 
     $service = Service::create($container->getMock());
 
-    $this->assertEquals(json_encode([(object) ["title" => "hello"]]),
+    $this->assertEquals(json_encode([["title" => "hello"]]),
       json_encode($service->getResources("dataset", "1")));
   }
 
@@ -130,7 +138,8 @@ class ServiceTest extends TestCase {
 
     $service = Service::create($container->getMock());
 
-    $this->assertEquals("1", $service->post("dataset", json_encode("blah")));
+    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', json_encode(['foo' => 'bar']));
+    $this->assertEquals("1", $service->post("dataset", $data));
   }
 
   /**
@@ -143,7 +152,9 @@ class ServiceTest extends TestCase {
     $service = Service::create($container->getMock());
 
     $this->expectException(ExistingObjectException::class);
-    $service->post("dataset", '{"identifier":1,"title":"FooBar"}');
+
+    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', '{"identifier":1,"title":"FooBar"}');
+    $service->post("dataset", $data);
   }
 
   /**
@@ -156,7 +167,9 @@ class ServiceTest extends TestCase {
 
     $service = Service::create($container->getMock());
 
-    $info = $service->put("dataset", "1", json_encode("blah"));
+    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', json_encode(['foo' => 'bar']));
+    $info = $service->put("dataset", "1", $data);
+
     $this->assertEquals("1", $info['identifier']);
   }
 
@@ -173,19 +186,22 @@ class ServiceTest extends TestCase {
     $service = Service::create($container->getMock());
 
     $this->expectExceptionMessage("Identifier cannot be modified");
-    $service->put("dataset", "1", $updating);
+
+    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', $updating);
+    $service->put("dataset", "1", $data);
   }
 
   /**
    *
    */
   public function testPutResultingInNewData() {
-    $data = '{"identifier":"3","title":"FooBar"}';
     $container = self::getCommonMockChain($this)
       ->add(Data::class, "retrieve", new \Exception())
       ->add(Data::class, "store", "3");
 
     $service = Service::create($container->getMock());
+
+    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', '{"identifier":"3","title":"FooBar"}');
     $info = $service->put("dataset", "3", $data);
     $this->assertEquals("3", $info['identifier']);
   }
@@ -201,7 +217,9 @@ class ServiceTest extends TestCase {
 
     $service = Service::create($container->getMock());
     $this->expectException(UnmodifiedObjectException::class);
-    $service->put("dataset", "1", $existing);
+
+    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', $existing);
+    $service->put("dataset", "1", $data);
   }
 
   /**
@@ -221,7 +239,9 @@ EOF;
 
     $service = Service::create($container->getMock());
     $this->expectException(UnmodifiedObjectException::class);
-    $service->put("dataset", "1", $updating);
+
+    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', $updating);
+    $service->put("dataset", "1", $data);
   }
 
   /**
@@ -230,7 +250,8 @@ EOF;
   public function testPatch() {
     $container = self::getCommonMockChain($this)
       ->add(Data::class, "retrieve", "1")
-      ->add(Data::class, "store", "1");
+      ->add(Data::class, "store", "1")
+      ->add(RootedJsonDataWrapper::class, 'createRootedJsonData', RootedJsonData::class);
 
     $service = Service::create($container->getMock());
 
@@ -294,15 +315,17 @@ EOF;
    *
    */
   public function testGetCatalog() {
+    $dataset = self::getJsonWrapper($this)->createRootedJsonData('blah', json_encode(["foo" => "bar"]));
+
     $catalog = (object) [
       "@id" => "http://catalog",
       "dataset" => [],
     ];
-    $dataset = (object) ["foo" => "bar"];
 
     $container = self::getCommonMockChain($this)
       ->add(SchemaRetriever::class, "retrieve", json_encode($catalog))
-      ->add(Data::class, 'retrieveAll', [json_encode($dataset), json_encode($dataset)]);
+      ->add(Data::class, 'retrieveAll', [json_encode($dataset), json_encode($dataset)])
+      ->add(RootedJsonDataWrapper::class, 'createRootedJsonData', $dataset);
 
     \Drupal::setContainer($container->getMock());
 
@@ -325,6 +348,7 @@ EOF;
     $myServices = [
       'dkan.metastore.schema_retriever' => SchemaRetriever::class,
       'dkan.metastore.storage' => DataFactory::class,
+      'dkan.metastore.rooted_json_data_wrapper' => RootedJsonDataWrapper::class,
       'event_dispatcher' => ContainerAwareEventDispatcher::class
     ];
 
@@ -341,6 +365,18 @@ EOF;
       ->add(Container::class, "get", $services)
       ->add(DataFactory::class, 'getInstance', Data::class)
       ->add(SchemaRetriever::class, "retrieve", json_encode(['foo' => 'bar']));
+  }
+
+  public static function getJsonWrapper(TestCase $case) {
+    $options = (new Options())
+      ->add('metastore.schema_retriever', SchemaRetriever::class)
+      ->index(0);
+
+    $container = (new Chain($case))
+      ->add(Container::class, "get", $options)
+      ->add(SchemaRetriever::class, "retrieve", json_encode(['foo' => 'bar']));
+
+    return RootedJsonDataWrapper::create($container->getMock());
   }
 
 }

--- a/modules/metastore/tests/src/Unit/ServiceTest.php
+++ b/modules/metastore/tests/src/Unit/ServiceTest.php
@@ -25,6 +25,18 @@ use RootedData\RootedJsonData;
 class ServiceTest extends TestCase {
 
   /**
+   * The RootedJsonDataWrapper class used for testing.
+   *
+   * @var \Drupal\metastore\RootedJsonDataWrapper|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $rootedJsonDataFactory;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->rootedJsonDataFactory = self::getJsonWrapper($this);
+  }
+
+  /**
    *
    */
   public function testGetSchemas() {
@@ -49,7 +61,7 @@ class ServiceTest extends TestCase {
    *
    */
   public function testGetAll() {
-    $expected = self::getJsonWrapper($this)->createRootedJsonData('dataset', json_encode(['foo' => 'bar']));
+    $expected = $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode(['foo' => 'bar']));
 
     $container = self::getCommonMockChain($this)
       ->add(Data::class, 'retrieveAll', [json_encode(['foo' => 'bar'])])
@@ -94,7 +106,7 @@ class ServiceTest extends TestCase {
    *
    */
   public function testGet() {
-    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', json_encode(['foo' => 'bar']));
+    $data = $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode(['foo' => 'bar']));
 
     $container = self::getCommonMockChain($this)
       ->add(Data::class, "retrievePublished", json_encode(['foo' => 'bar']))
@@ -117,7 +129,7 @@ class ServiceTest extends TestCase {
         ["title" => "hello"],
       ],
     ];
-    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', json_encode($dataset));
+    $data = $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode($dataset));
 
     $container = self::getCommonMockChain($this)
       ->add(Data::class, "retrieve", json_encode($dataset))
@@ -138,7 +150,7 @@ class ServiceTest extends TestCase {
 
     $service = Service::create($container->getMock());
 
-    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', json_encode(['foo' => 'bar']));
+    $data = $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode(['foo' => 'bar']));
     $this->assertEquals("1", $service->post("dataset", $data));
   }
 
@@ -153,7 +165,7 @@ class ServiceTest extends TestCase {
 
     $this->expectException(ExistingObjectException::class);
 
-    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', '{"identifier":1,"title":"FooBar"}');
+    $data = $this->rootedJsonDataFactory->createRootedJsonData('dataset', '{"identifier":1,"title":"FooBar"}');
     $service->post("dataset", $data);
   }
 
@@ -167,7 +179,7 @@ class ServiceTest extends TestCase {
 
     $service = Service::create($container->getMock());
 
-    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', json_encode(['foo' => 'bar']));
+    $data = $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode(['foo' => 'bar']));
     $info = $service->put("dataset", "1", $data);
 
     $this->assertEquals("1", $info['identifier']);
@@ -187,7 +199,7 @@ class ServiceTest extends TestCase {
 
     $this->expectExceptionMessage("Identifier cannot be modified");
 
-    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', $updating);
+    $data = $this->rootedJsonDataFactory->createRootedJsonData('dataset', $updating);
     $service->put("dataset", "1", $data);
   }
 
@@ -201,7 +213,7 @@ class ServiceTest extends TestCase {
 
     $service = Service::create($container->getMock());
 
-    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', '{"identifier":"3","title":"FooBar"}');
+    $data = $this->rootedJsonDataFactory->createRootedJsonData('dataset', '{"identifier":"3","title":"FooBar"}');
     $info = $service->put("dataset", "3", $data);
     $this->assertEquals("3", $info['identifier']);
   }
@@ -218,7 +230,7 @@ class ServiceTest extends TestCase {
     $service = Service::create($container->getMock());
     $this->expectException(UnmodifiedObjectException::class);
 
-    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', $existing);
+    $data = $this->rootedJsonDataFactory->createRootedJsonData('dataset', $existing);
     $service->put("dataset", "1", $data);
   }
 
@@ -240,7 +252,7 @@ EOF;
     $service = Service::create($container->getMock());
     $this->expectException(UnmodifiedObjectException::class);
 
-    $data = self::getJsonWrapper($this)->createRootedJsonData('dataset', $updating);
+    $data = $this->rootedJsonDataFactory->createRootedJsonData('dataset', $updating);
     $service->put("dataset", "1", $data);
   }
 
@@ -315,7 +327,7 @@ EOF;
    *
    */
   public function testGetCatalog() {
-    $dataset = self::getJsonWrapper($this)->createRootedJsonData('blah', json_encode(["foo" => "bar"]));
+    $dataset = $this->rootedJsonDataFactory->createRootedJsonData('blah', json_encode(["foo" => "bar"]));
 
     $catalog = (object) [
       "@id" => "http://catalog",

--- a/modules/metastore/tests/src/Unit/ServiceTest.php
+++ b/modules/metastore/tests/src/Unit/ServiceTest.php
@@ -173,14 +173,19 @@ class ServiceTest extends TestCase {
    *
    */
   public function testPut() {
+    $existing = '{"identifier":"1","title":"Foo"}';
+    $updating = '{"identifier":"1","title":"Bar"}';
+
+    $data_existing = $this->rootedJsonDataFactory->createRootedJsonData('dataset', $existing);
     $container = self::getCommonMockChain($this)
-      ->add(Data::class, "retrieve", "1")
-      ->add(Data::class, "store", "1");
+      ->add(Data::class, "retrieve", $existing)
+      ->add(Data::class, "store", "1")
+      ->add(RootedJsonDataFactory::class, 'createRootedJsonData', $data_existing);
 
     $service = Service::create($container->getMock());
 
-    $data = $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode(['foo' => 'bar']));
-    $info = $service->put("dataset", "1", $data);
+    $data_updating = $this->rootedJsonDataFactory->createRootedJsonData('dataset', $updating);
+    $info = $service->put("dataset", "1", $data_updating);
 
     $this->assertEquals("1", $info['identifier']);
   }
@@ -224,13 +229,14 @@ class ServiceTest extends TestCase {
   public function testPutObjectUnchangedException() {
     $existing = '{"identifier":"1","title":"Foo"}';
 
+    $data = $this->rootedJsonDataFactory->createRootedJsonData('dataset', $existing);
     $container = self::getCommonMockChain($this)
-      ->add(Data::class, "retrieve", $existing);
+      ->add(Data::class, "retrieve", $existing)
+      ->add(RootedJsonDataFactory::class, 'createRootedJsonData', $data);
 
     $service = Service::create($container->getMock());
     $this->expectException(UnmodifiedObjectException::class);
 
-    $data = $this->rootedJsonDataFactory->createRootedJsonData('dataset', $existing);
     $service->put("dataset", "1", $data);
   }
 
@@ -246,14 +252,16 @@ class ServiceTest extends TestCase {
       }
 EOF;
 
+    $data_existing = $this->rootedJsonDataFactory->createRootedJsonData('dataset', $existing);
     $container = self::getCommonMockChain($this)
-      ->add(Data::class, "retrieve", $existing);
+      ->add(Data::class, "retrieve", $existing)
+      ->add(RootedJsonDataFactory::class, 'createRootedJsonData', $data_existing);
 
     $service = Service::create($container->getMock());
     $this->expectException(UnmodifiedObjectException::class);
 
-    $data = $this->rootedJsonDataFactory->createRootedJsonData('dataset', $updating);
-    $service->put("dataset", "1", $data);
+    $data_updating = $this->rootedJsonDataFactory->createRootedJsonData('dataset', $updating);
+    $service->put("dataset", "1", $data_updating);
   }
 
   /**

--- a/modules/metastore/tests/src/Unit/ServiceTest.php
+++ b/modules/metastore/tests/src/Unit/ServiceTest.php
@@ -75,7 +75,7 @@ class ServiceTest extends TestCase {
   }
 
   public function testGetAllException() {
-    $data = "blah";
+    $data = $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode(['foo' => 'bar']));
 
     $event = new Event($data);
     $event->setException(new \Exception("blah"));
@@ -88,8 +88,8 @@ class ServiceTest extends TestCase {
       ->add($event2);
 
     $container = self::getCommonMockChain($this)
-      ->add(Sae::class, "getInstance", Engine::class)
-      ->add(Engine::class, "get", [json_encode($data)])
+      ->add(Data::class, 'retrieveAll', [json_encode(['foo' => 'bar'])])
+      ->add(RootedJsonDataFactory::class, 'createRootedJsonData', $data)
       ->add(ContainerAwareEventDispatcher::class, 'dispatch', $sequence);
 
     \Drupal::setContainer($container->getMock());

--- a/modules/metastore/tests/src/WebServiceApiDocsTest.php
+++ b/modules/metastore/tests/src/WebServiceApiDocsTest.php
@@ -19,22 +19,22 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class WebServiceApiDocsTest extends TestCase {
 
   /**
-   * The RootedJsonDataFactory class used for testing.
+   * The ValidMetadataFactory class used for testing.
    *
-   * @var \Drupal\metastore\RootedJsonDataFactory|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\metastore\ValidMetadataFactory|\PHPUnit\Framework\MockObject\MockObject
    */
-  protected $rootedJsonDataFactory;
+  protected $validMetadataFactory;
 
   protected function setUp(): void {
     parent::setUp();
-    $this->rootedJsonDataFactory = ServiceTest::getJsonWrapper($this);
+    $this->validMetadataFactory = ServiceTest::getValidMetadataFactory($this);
   }
 
   /**
    * Tests dataset-specific docs when SQL endpoint is protected.
    */
   public function testDatasetSpecificDocsWithSqlModifier() {
-    $get = $this->rootedJsonDataFactory->createRootedJsonData('dataset', '{}');
+    $get = $this->validMetadataFactory->get('dataset', '{}');
     $mockChain = $this->getCommonMockChain()
       ->add(Service::class, "get", $get)
       ->add(DataModifierManager::class, 'getDefinitions', [['id' => 'foobar']])

--- a/modules/metastore/tests/src/WebServiceApiDocsTest.php
+++ b/modules/metastore/tests/src/WebServiceApiDocsTest.php
@@ -19,9 +19,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class WebServiceApiDocsTest extends TestCase {
 
   /**
-   * The RootedJsonDataWrapper class used for testing.
+   * The RootedJsonDataFactory class used for testing.
    *
-   * @var \Drupal\metastore\RootedJsonDataWrapper|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\metastore\RootedJsonDataFactory|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $rootedJsonDataFactory;
 

--- a/modules/metastore/tests/src/WebServiceApiDocsTest.php
+++ b/modules/metastore/tests/src/WebServiceApiDocsTest.php
@@ -22,8 +22,9 @@ class WebServiceApiDocsTest extends TestCase {
    * Tests dataset-specific docs when SQL endpoint is protected.
    */
   public function testDatasetSpecificDocsWithSqlModifier() {
+    $get = ServiceTest::getJsonWrapper($this)->createRootedJsonData('dataset', '{}');
     $mockChain = $this->getCommonMockChain()
-      ->add(Service::class, "get", "{}")
+      ->add(Service::class, "get", $get)
       ->add(DataModifierManager::class, 'getDefinitions', [['id' => 'foobar']])
       ->add(DataModifierManager::class, 'createInstance', DataModifierBase::class)
       ->add(DataModifierBase::class, 'requiresModification', TRUE);

--- a/modules/metastore/tests/src/WebServiceApiDocsTest.php
+++ b/modules/metastore/tests/src/WebServiceApiDocsTest.php
@@ -19,10 +19,22 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class WebServiceApiDocsTest extends TestCase {
 
   /**
+   * The RootedJsonDataWrapper class used for testing.
+   *
+   * @var \Drupal\metastore\RootedJsonDataWrapper|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $rootedJsonDataFactory;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->rootedJsonDataFactory = ServiceTest::getJsonWrapper($this);
+  }
+
+  /**
    * Tests dataset-specific docs when SQL endpoint is protected.
    */
   public function testDatasetSpecificDocsWithSqlModifier() {
-    $get = ServiceTest::getJsonWrapper($this)->createRootedJsonData('dataset', '{}');
+    $get = $this->rootedJsonDataFactory->createRootedJsonData('dataset', '{}');
     $mockChain = $this->getCommonMockChain()
       ->add(Service::class, "get", $get)
       ->add(DataModifierManager::class, 'getDefinitions', [['id' => 'foobar']])

--- a/modules/metastore/tests/src/WebServiceApiTest.php
+++ b/modules/metastore/tests/src/WebServiceApiTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\metastore;
 use Drupal\metastore\Exception\ExistingObjectException;
 use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore\Exception\UnmodifiedObjectException;
-use Drupal\metastore\RootedJsonDataFactory;
+use Drupal\metastore\ValidMetadataFactory;
 use Drupal\metastore\Storage\Data;
 use Drupal\metastore\Service;
 use Drupal\metastore\WebServiceApi;
@@ -25,15 +25,15 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class WebServiceApiTest extends TestCase {
 
   /**
-   * The RootedJsonDataFactory class used for testing.
+   * The ValidMetadataFactory class used for testing.
    *
-   * @var \Drupal\metastore\RootedJsonDataFactory|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\metastore\ValidMetadataFactory|\PHPUnit\Framework\MockObject\MockObject
    */
-  protected $rootedJsonDataFactory;
+  protected $validMetadataFactory;
 
   protected function setUp(): void {
     parent::setUp();
-    $this->rootedJsonDataFactory = ServiceTest::getJsonWrapper($this);
+    $this->validMetadataFactory = ServiceTest::getValidMetadataFactory($this);
   }
 
   /**
@@ -41,7 +41,7 @@ class WebServiceApiTest extends TestCase {
    */
   public function testGetAll() {
     $json = ['name' => 'hello'];
-    $object = $this->rootedJsonDataFactory->createRootedJsonData('blah', json_encode($json));
+    $object = $this->validMetadataFactory->get('blah', json_encode($json));
     $mockChain = $this->getCommonMockChain();
     $mockChain->add(Service::class, 'getAll', [$object, $object, $object]);
 
@@ -108,8 +108,8 @@ class WebServiceApiTest extends TestCase {
     $mockChain->add(RequestStack::class, 'getCurrentRequest', Request::class);
     $mockChain->add(Request::class, 'getRequestUri', "http://blah");
     $mockChain->add(Request::class, 'getContent', '{"identifier": "1"}');
-    $mockChain->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class);
-    $mockChain->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class);
+    $mockChain->add(Service::class, "getValidMetadataFactory", ValidMetadataFactory::class);
+    $mockChain->add(ValidMetadataFactory::class, "get", RootedJsonData::class);
     $mockChain->add(Service::class, 'post', "1");
 
     $controller = WebServiceApi::create($mockChain->getMock());
@@ -125,8 +125,8 @@ class WebServiceApiTest extends TestCase {
     $mockChain->add(RequestStack::class, 'getCurrentRequest', Request::class);
     $mockChain->add(Request::class, 'getRequestUri', "http://blah");
     $mockChain->add(Request::class, 'getContent', '{ }');
-    $mockChain->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class);
-    $mockChain->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class);
+    $mockChain->add(Service::class, "getValidMetadataFactory", ValidMetadataFactory::class);
+    $mockChain->add(ValidMetadataFactory::class, "get", RootedJsonData::class);
     $mockChain->add(Service::class, 'post', "1");
 
     $controller = WebServiceApi::create($mockChain->getMock());
@@ -142,8 +142,8 @@ class WebServiceApiTest extends TestCase {
     $mockChain->add(RequestStack::class, 'getCurrentRequest', Request::class);
     $mockChain->add(Request::class, 'getRequestUri', "http://blah");
     $mockChain->add(Request::class, 'getContent', '{ }');
-    $mockChain->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class);
-    $mockChain->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class);
+    $mockChain->add(Service::class, "getValidMetadataFactory", ValidMetadataFactory::class);
+    $mockChain->add(ValidMetadataFactory::class, "get", RootedJsonData::class);
     $mockChain->add(Service::class, 'post', new \Exception("bad"));
 
     $controller = WebServiceApi::create($mockChain->getMock());
@@ -159,8 +159,8 @@ class WebServiceApiTest extends TestCase {
       ->add(RequestStack::class, 'getCurrentRequest', Request::class)
       ->add(Request::class, 'getRequestUri', "http://blah")
       ->add(Request::class, 'getContent', '{"identifier": "1"}')
-      ->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class)
-      ->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class)
+      ->add(Service::class, "getValidMetadataFactory", ValidMetadataFactory::class)
+      ->add(ValidMetadataFactory::class, "get", RootedJsonData::class)
       ->add(Service::class, 'post', new ExistingObjectException("Already exists"));
 
     $controller = WebServiceApi::create($mockChain->getMock());
@@ -176,8 +176,8 @@ class WebServiceApiTest extends TestCase {
     $mockChain->add(RequestStack::class, 'getCurrentRequest', Request::class);
     $mockChain->add(Request::class, 'getContent', "{ }");
     $mockChain->add(Request::class, 'getRequestUri', "http://blah");
-    $mockChain->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class);
-    $mockChain->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class);
+    $mockChain->add(Service::class, "getValidMetadataFactory", ValidMetadataFactory::class);
+    $mockChain->add(ValidMetadataFactory::class, "get", RootedJsonData::class);
     $mockChain->add(Service::class, "put", ["identifier" => "1", "new" => FALSE]);
 
     $controller = WebServiceApi::create($mockChain->getMock());
@@ -227,8 +227,8 @@ EOF;
       ->add(RequestStack::class, 'getCurrentRequest', Request::class)
       ->add(Request::class, 'getContent', $updating)
       ->add(Request::class, 'getRequestUri', "http://blah")
-      ->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class)
-      ->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class)
+      ->add(Service::class, "getValidMetadataFactory", ValidMetadataFactory::class)
+      ->add(ValidMetadataFactory::class, "get", RootedJsonData::class)
       ->add(Service::class, "put", new UnmodifiedObjectException("No changes"));
 
     $controller = WebServiceApi::create($mockChain->getMock());
@@ -258,8 +258,8 @@ EOF;
     $mockChain->add(RequestStack::class, 'getCurrentRequest', Request::class);
     $mockChain->add(Request::class, 'getContent', json_encode($collection));
     $mockChain->add(Request::class, 'getRequestUri', "http://blah");
-    $mockChain->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class);
-    $mockChain->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class);
+    $mockChain->add(Service::class, "getValidMetadataFactory", ValidMetadataFactory::class);
+    $mockChain->add(ValidMetadataFactory::class, "get", RootedJsonData::class);
     $mockChain->add(Service::class, "patch", "1");
 
     $controller = WebServiceApi::create($mockChain->getMock());
@@ -307,8 +307,8 @@ EOF;
     $mockChain = $this->getCommonMockChain()
       ->add(RequestStack::class, 'getCurrentRequest', Request::class)
       ->add(Request::class, 'getContent', '{"identifier":"1","title":"foo"}')
-      ->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class)
-      ->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class)
+      ->add(Service::class, "getValidMetadataFactory", ValidMetadataFactory::class)
+      ->add(ValidMetadataFactory::class, "get", RootedJsonData::class)
       ->add(Service::class, "patch", new MissingObjectException("Not found"));
 
     $controller = WebServiceApi::create($mockChain->getMock());

--- a/modules/metastore/tests/src/WebServiceApiTest.php
+++ b/modules/metastore/tests/src/WebServiceApiTest.php
@@ -188,26 +188,26 @@ class WebServiceApiTest extends TestCase {
   /**
    *
    */
-  public function testPutInvalidJsonException() {
+  public function testPatchInvalidJsonException() {
     $mockChain = $this->getCommonMockChain()
       ->add(RequestStack::class, 'getCurrentRequest', Request::class)
       ->add(Request::class, 'getContent', "{");
 
     $controller = WebServiceApi::create($mockChain->getMock());
-    $response = $controller->put(1, 'dataset');
+    $response = $controller->patch(1, 'dataset');
     $this->assertEquals('{"message":"Invalid JSON"}', $response->getContent());
   }
 
   /**
    *
    */
-  public function testPutMissingPayloadException() {
+  public function testPatchMissingPayloadException() {
     $mockChain = $this->getCommonMockChain()
       ->add(RequestStack::class, 'getCurrentRequest', Request::class)
       ->add(Request::class, 'getContent', "");
 
     $controller = WebServiceApi::create($mockChain->getMock());
-    $response = $controller->put(1, 'dataset');
+    $response = $controller->patch(1, 'dataset');
     $this->assertEquals('{"message":"Empty body"}', $response->getContent());
   }
 

--- a/modules/metastore/tests/src/WebServiceApiTest.php
+++ b/modules/metastore/tests/src/WebServiceApiTest.php
@@ -25,11 +25,23 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class WebServiceApiTest extends TestCase {
 
   /**
+   * The RootedJsonDataWrapper class used for testing.
+   *
+   * @var \Drupal\metastore\RootedJsonDataWrapper|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $rootedJsonDataFactory;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->rootedJsonDataFactory = ServiceTest::getJsonWrapper($this);
+  }
+
+  /**
    *
    */
   public function testGetAll() {
     $json = ['name' => 'hello'];
-    $object = ServiceTest::getJsonWrapper($this)->createRootedJsonData('blah', json_encode($json));
+    $object = $this->rootedJsonDataFactory->createRootedJsonData('blah', json_encode($json));
     $mockChain = $this->getCommonMockChain();
     $mockChain->add(Service::class, 'getAll', [$object, $object, $object]);
 

--- a/modules/metastore/tests/src/WebServiceApiTest.php
+++ b/modules/metastore/tests/src/WebServiceApiTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\metastore;
 use Drupal\metastore\Exception\ExistingObjectException;
 use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore\Exception\UnmodifiedObjectException;
-use Drupal\metastore\RootedJsonDataWrapper;
+use Drupal\metastore\RootedJsonDataFactory;
 use Drupal\metastore\Storage\Data;
 use Drupal\metastore\Service;
 use Drupal\metastore\WebServiceApi;
@@ -25,9 +25,9 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class WebServiceApiTest extends TestCase {
 
   /**
-   * The RootedJsonDataWrapper class used for testing.
+   * The RootedJsonDataFactory class used for testing.
    *
-   * @var \Drupal\metastore\RootedJsonDataWrapper|\PHPUnit\Framework\MockObject\MockObject
+   * @var \Drupal\metastore\RootedJsonDataFactory|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $rootedJsonDataFactory;
 
@@ -108,8 +108,8 @@ class WebServiceApiTest extends TestCase {
     $mockChain->add(RequestStack::class, 'getCurrentRequest', Request::class);
     $mockChain->add(Request::class, 'getRequestUri', "http://blah");
     $mockChain->add(Request::class, 'getContent', '{"identifier": "1"}');
-    $mockChain->add(Service::class, "getRootedJsonDataWrapper", RootedJsonDataWrapper::class);
-    $mockChain->add(RootedJsonDataWrapper::class, "createRootedJsonData", RootedJsonData::class);
+    $mockChain->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class);
+    $mockChain->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class);
     $mockChain->add(Service::class, 'post', "1");
 
     $controller = WebServiceApi::create($mockChain->getMock());
@@ -125,8 +125,8 @@ class WebServiceApiTest extends TestCase {
     $mockChain->add(RequestStack::class, 'getCurrentRequest', Request::class);
     $mockChain->add(Request::class, 'getRequestUri', "http://blah");
     $mockChain->add(Request::class, 'getContent', '{ }');
-    $mockChain->add(Service::class, "getRootedJsonDataWrapper", RootedJsonDataWrapper::class);
-    $mockChain->add(RootedJsonDataWrapper::class, "createRootedJsonData", RootedJsonData::class);
+    $mockChain->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class);
+    $mockChain->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class);
     $mockChain->add(Service::class, 'post', "1");
 
     $controller = WebServiceApi::create($mockChain->getMock());
@@ -142,8 +142,8 @@ class WebServiceApiTest extends TestCase {
     $mockChain->add(RequestStack::class, 'getCurrentRequest', Request::class);
     $mockChain->add(Request::class, 'getRequestUri', "http://blah");
     $mockChain->add(Request::class, 'getContent', '{ }');
-    $mockChain->add(Service::class, "getRootedJsonDataWrapper", RootedJsonDataWrapper::class);
-    $mockChain->add(RootedJsonDataWrapper::class, "createRootedJsonData", RootedJsonData::class);
+    $mockChain->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class);
+    $mockChain->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class);
     $mockChain->add(Service::class, 'post', new \Exception("bad"));
 
     $controller = WebServiceApi::create($mockChain->getMock());
@@ -159,8 +159,8 @@ class WebServiceApiTest extends TestCase {
       ->add(RequestStack::class, 'getCurrentRequest', Request::class)
       ->add(Request::class, 'getRequestUri', "http://blah")
       ->add(Request::class, 'getContent', '{"identifier": "1"}')
-      ->add(Service::class, "getRootedJsonDataWrapper", RootedJsonDataWrapper::class)
-      ->add(RootedJsonDataWrapper::class, "createRootedJsonData", RootedJsonData::class)
+      ->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class)
+      ->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class)
       ->add(Service::class, 'post', new ExistingObjectException("Already exists"));
 
     $controller = WebServiceApi::create($mockChain->getMock());
@@ -176,8 +176,8 @@ class WebServiceApiTest extends TestCase {
     $mockChain->add(RequestStack::class, 'getCurrentRequest', Request::class);
     $mockChain->add(Request::class, 'getContent', "{ }");
     $mockChain->add(Request::class, 'getRequestUri', "http://blah");
-    $mockChain->add(Service::class, "getRootedJsonDataWrapper", RootedJsonDataWrapper::class);
-    $mockChain->add(RootedJsonDataWrapper::class, "createRootedJsonData", RootedJsonData::class);
+    $mockChain->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class);
+    $mockChain->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class);
     $mockChain->add(Service::class, "put", ["identifier" => "1", "new" => FALSE]);
 
     $controller = WebServiceApi::create($mockChain->getMock());
@@ -227,8 +227,8 @@ EOF;
       ->add(RequestStack::class, 'getCurrentRequest', Request::class)
       ->add(Request::class, 'getContent', $updating)
       ->add(Request::class, 'getRequestUri', "http://blah")
-      ->add(Service::class, "getRootedJsonDataWrapper", RootedJsonDataWrapper::class)
-      ->add(RootedJsonDataWrapper::class, "createRootedJsonData", RootedJsonData::class)
+      ->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class)
+      ->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class)
       ->add(Service::class, "put", new UnmodifiedObjectException("No changes"));
 
     $controller = WebServiceApi::create($mockChain->getMock());
@@ -258,8 +258,8 @@ EOF;
     $mockChain->add(RequestStack::class, 'getCurrentRequest', Request::class);
     $mockChain->add(Request::class, 'getContent', json_encode($collection));
     $mockChain->add(Request::class, 'getRequestUri', "http://blah");
-    $mockChain->add(Service::class, "getRootedJsonDataWrapper", RootedJsonDataWrapper::class);
-    $mockChain->add(RootedJsonDataWrapper::class, "createRootedJsonData", RootedJsonData::class);
+    $mockChain->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class);
+    $mockChain->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class);
     $mockChain->add(Service::class, "patch", "1");
 
     $controller = WebServiceApi::create($mockChain->getMock());
@@ -307,8 +307,8 @@ EOF;
     $mockChain = $this->getCommonMockChain()
       ->add(RequestStack::class, 'getCurrentRequest', Request::class)
       ->add(Request::class, 'getContent', '{"identifier":"1","title":"foo"}')
-      ->add(Service::class, "getRootedJsonDataWrapper", RootedJsonDataWrapper::class)
-      ->add(RootedJsonDataWrapper::class, "createRootedJsonData", RootedJsonData::class)
+      ->add(Service::class, "getRootedJsonDataFactory", RootedJsonDataFactory::class)
+      ->add(RootedJsonDataFactory::class, "createRootedJsonData", RootedJsonData::class)
       ->add(Service::class, "patch", new MissingObjectException("Not found"));
 
     $controller = WebServiceApi::create($mockChain->getMock());

--- a/tests/src/Functional/DatasetTest.php
+++ b/tests/src/Functional/DatasetTest.php
@@ -29,7 +29,7 @@ class DatasetTest extends ExistingSiteBase {
   private const S3_PREFIX = 'https://dkan-default-content-files.s3.amazonaws.com/phpunit';
   private const FILENAME_PREFIX = 'dkan_default_content_files_s3_amazonaws_com_phpunit_';
 
-  private $rootedJsonDataFactory;
+  private $validMetadataFactory;
 
   public function setUp(): void {
     parent::setUp();
@@ -43,7 +43,7 @@ class DatasetTest extends ExistingSiteBase {
     $this->setDefaultModerationState();
     $this->changeDatasetsResourceOutputPerspective();
 
-    $this->rootedJsonDataFactory = ServiceTest::getJsonWrapper($this);
+    $this->validMetadataFactory = ServiceTest::getValidMetadataFactory($this);
   }
 
   public function testChangingDatasetResourcePerspectiveOnOutput() {
@@ -243,7 +243,7 @@ class DatasetTest extends ExistingSiteBase {
       $data->distribution[] = $distribution;
     }
 
-    return $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode($data));
+    return $this->validMetadataFactory->get('dataset', json_encode($data));
   }
 
   /**

--- a/tests/src/Functional/DatasetTest.php
+++ b/tests/src/Functional/DatasetTest.php
@@ -12,7 +12,9 @@ use Drupal\metastore_search\Search;
 use Drupal\node\NodeStorage;
 use Drupal\search_api\Entity\Index;
 use Drupal\Tests\common\Traits\CleanUp;
+use Drupal\Tests\metastore\Unit\ServiceTest;
 use Harvest\ETL\Extract\DataJson;
+use RootedData\RootedJsonData;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
 
 /**
@@ -27,6 +29,8 @@ class DatasetTest extends ExistingSiteBase {
   private const S3_PREFIX = 'https://dkan-default-content-files.s3.amazonaws.com/phpunit';
   private const FILENAME_PREFIX = 'dkan_default_content_files_s3_amazonaws_com_phpunit_';
 
+  private $rootedJsonDataFactory;
+
   public function setUp(): void {
     parent::setUp();
     $this->removeHarvests();
@@ -38,6 +42,8 @@ class DatasetTest extends ExistingSiteBase {
     $this->removeDatastoreTables();
     $this->setDefaultModerationState();
     $this->changeDatasetsResourceOutputPerspective();
+
+    $this->rootedJsonDataFactory = ServiceTest::getJsonWrapper($this);
   }
 
   public function testChangingDatasetResourcePerspectiveOnOutput() {
@@ -145,20 +151,20 @@ class DatasetTest extends ExistingSiteBase {
   }
 
   private function datasetPostAndRetrieve(): object {
-    $datasetJson = $this->getData(123, 'Test #1', ['district_centerpoints_small.csv']);
-    $dataset = json_decode($datasetJson);
+    $datasetRootedJsonData = $this->getData(123, 'Test #1', ['district_centerpoints_small.csv']);
+    $dataset = json_decode($datasetRootedJsonData);
 
-    $uuid = $this->getMetastore()->post('dataset', $datasetJson);
+    $uuid = $this->getMetastore()->post('dataset', $datasetRootedJsonData);
 
     $this->assertEquals(
       $dataset->identifier,
       $uuid
     );
 
-    $datasetJson = $this->getMetastore()->get('dataset', $uuid);
-    $this->assertIsString($datasetJson);
+    $datasetRootedJsonData = $this->getMetastore()->get('dataset', $uuid);
+    $this->assertIsString("$datasetRootedJsonData");
 
-    $retrievedDataset = json_decode($datasetJson);
+    $retrievedDataset = json_decode($datasetRootedJsonData);
 
     $this->assertEquals(
       $retrievedDataset->identifier,
@@ -217,7 +223,7 @@ class DatasetTest extends ExistingSiteBase {
    * @return string|false
    *   Json encoded string of this dataset's metadata, or FALSE if error.
    */
-  private function getData(string $identifier, string $title, array $downloadUrls): string {
+  private function getData(string $identifier, string $title, array $downloadUrls): RootedJsonData {
 
     $data = new \stdClass();
     $data->title = $title;
@@ -237,7 +243,7 @@ class DatasetTest extends ExistingSiteBase {
       $data->distribution[] = $distribution;
     }
 
-    return json_encode($data);
+    return $this->rootedJsonDataFactory->createRootedJsonData('dataset', json_encode($data));
   }
 
   /**
@@ -273,8 +279,8 @@ class DatasetTest extends ExistingSiteBase {
    * Store or update a dataset,run datastore_import and resource_purger queues.
    */
   private function storeDatasetRunQueues(string $identifier, string $title, array $filenames, string $method = 'post') {
-    $datasetJson = $this->getData($identifier, $title, $filenames);
-    $this->httpVerbHandler($method, $datasetJson, json_decode($datasetJson));
+    $datasetRootedJsonData = $this->getData($identifier, $title, $filenames);
+    $this->httpVerbHandler($method, $datasetRootedJsonData, json_decode($datasetRootedJsonData));
 
     // Simulate a cron on queues relevant to this scenario.
     $this->runQueues(['datastore_import', 'resource_purger']);
@@ -328,7 +334,7 @@ class DatasetTest extends ExistingSiteBase {
     $this->assertGreaterThan(0, count($results));
   }
 
-  private function httpVerbHandler(string $method, string $json, $dataset) {
+  private function httpVerbHandler(string $method, RootedJsonData $json, $dataset) {
 
     if ($method == 'post') {
       $identifier = $this->getMetastore()->post('dataset', $json);


### PR DESCRIPTION
fixes [GetDKAN/dkan/issues/3372]

Facilitates using [RootedJsonData objects](https://github.com/GetDKAN/RootedJsonData) instead of a JSON string in the metastore controller, service and storage.

- [ ] All tests pass
- [ ] All API requests work the same way as before the change
- [ ] JSON data is validated

## QA Steps

- [ ] Run all the tests
- [ ] Run various API requests
