### PR TITLE
Add function for cleaning $IDs from select fields.

### DIFF
--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -61,7 +61,7 @@ class ValueHandler {
     foreach ($properties as $sub_property) {
       $value = $this->flattenValues($formValues, $sub_property, $schema->properties->$sub_property);
       if ($value) {
-        $data[$sub_property] = $value;
+        $data[$sub_property] = $this->cleanSelectId($value);
       }
     }
     return $data;
@@ -90,13 +90,29 @@ class ValueHandler {
     $data = [];
     if (is_array($value)) {
       foreach ($value as $item) {
-        $data[] = $item;
+        $data[] = $this->cleanSelectId($item);
       }
     }
     elseif (!empty($value)) {
-      $data[] = $value;
+      $data[] = $this->cleanSelectId($value);
     }
     return $data;
+  }
+
+  /**
+   * Clear item from select2 $ID.
+   *
+   * @param string $value
+   *   Value that we want to clean.
+   *
+   * @return array
+   *   String without $ID:.
+   */
+  private function cleanSelectId($value) {
+    if (substr($value, 0, 4) === "\$ID:") {
+      return substr($value, 4);
+    }
+    return $value;
   }
 
   /**

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -45,7 +45,7 @@ class ValueHandler {
     if (isset($formValues[$property]['select'])) {
       return $formValues[$property][0];
     }
-    return !empty($formValues[$property]) ? $formValues[$property] : FALSE;
+    return !empty($formValues[$property]) ? $this->cleanSelectId($formValues[$property]) : FALSE;
   }
 
   /**
@@ -61,7 +61,7 @@ class ValueHandler {
     foreach ($properties as $sub_property) {
       $value = $this->flattenValues($formValues, $sub_property, $schema->properties->$sub_property);
       if ($value) {
-        $data[$sub_property] = $this->cleanSelectId($value);
+        $data[$sub_property] = $value;
       }
     }
     return $data;

--- a/modules/json_form_widget/tests/src/Unit/ValueHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/ValueHandlerTest.php
@@ -34,7 +34,7 @@ class ValueHandlerTest extends TestCase {
                     "fields" => [
                       0 => [
                         "fields" => [
-                          "name" => "Field name",
+                          "name" => "\$ID:Field name",
                           "title" => "Field title",
                         ],
                       ],


### PR DESCRIPTION
fixes #3481 

## QA Steps

- [ ] Go to node/add/data
- [ ] In the Tags field add a tag that doesn't exist
- [ ] In the Topics field add a topic that doesn't exist
- [ ] In the Publishers field add a publisher that doesn't exist
- [ ] Save the form
- [ ] Go to admin/content/node and confirm new data nodes are created of type keyword, theme and publisher and that none of them have the string $ID: at the beginning.
