### PR TITLE
Fix exception thrown when publishing an already published dataset

### DIFF
--- a/modules/harvest/src/Service.php
+++ b/modules/harvest/src/Service.php
@@ -234,8 +234,10 @@ class Service implements ContainerInjectionInterface {
     foreach ($lastRunInfoObj->status->extracted_items_ids as $uuid) {
       if (isset($lastRunInfoObj->status->load) &&
         $lastRunInfoObj->status->load->{$uuid} &&
-        $lastRunInfoObj->status->load->{$uuid} != "FAILURE") {
-        $publishedIdentifiers[] = $this->metastore->publish('dataset', $uuid);
+        $lastRunInfoObj->status->load->{$uuid} != "FAILURE" &&
+        $this->metastore->publish('dataset', $uuid)) {
+
+        $publishedIdentifiers[] = $uuid;
       }
     }
 

--- a/modules/harvest/tests/src/ServiceTest.php
+++ b/modules/harvest/tests/src/ServiceTest.php
@@ -238,7 +238,7 @@ class ServiceTest extends TestCase {
 
     $service = HarvestService::create($container->getMock());
     $result = $service->publish('1');
-    $this->assertEquals($result, ['1', '1', '1']);
+    $this->assertEquals($result, $datasetUuids);
   }
 
   /**

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -237,10 +237,10 @@ class Service implements ContainerInjectionInterface {
    * @param string $identifier
    *   Identifier.
    *
-   * @return string
-   *   Identifier.
+   * @return bool Identifier.
+   *   True if the dataset is successfully published, false otherwise.
    */
-  public function publish(string $schema_id, string $identifier) {
+  public function publish(string $schema_id, string $identifier): bool {
     if ($this->objectExists($schema_id, $identifier)) {
       return $this->getStorage($schema_id)->publish($identifier);
     }

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -237,7 +237,7 @@ class Service implements ContainerInjectionInterface {
    * @param string $identifier
    *   Identifier.
    *
-   * @return bool Identifier.
+   * @return bool
    *   True if the dataset is successfully published, false otherwise.
    */
   public function publish(string $schema_id, string $identifier): bool {

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -119,7 +119,7 @@ abstract class Data implements MetastoreStorageInterface {
       return $entity->get('field_json_metadata')->getString();
     }
 
-    throw new \Exception("No data with that identifier was found.");
+    throw new \Exception("Error retrieving published dataset: {$uuid} not found.");
   }
 
   /**
@@ -140,7 +140,7 @@ abstract class Data implements MetastoreStorageInterface {
       return $entity->get('field_json_metadata')->getString();
     }
 
-    throw new \Exception("No data with that identifier was found.");
+    throw new \Exception("Error retrieving dataset: {$uuid} not found.");
   }
 
   /**
@@ -157,7 +157,7 @@ abstract class Data implements MetastoreStorageInterface {
     $entity = $this->getEntityLatestRevision($uuid);
 
     if (!$entity) {
-      throw new \Exception("No data with that identifier was found.");
+      throw new \Exception("Error publishing dataset: {$uuid} not found.");
     }
     elseif ('published' !== $entity->get('moderation_state')) {
       $entity->set('moderation_state', 'published');

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -156,13 +156,17 @@ abstract class Data implements MetastoreStorageInterface {
 
     $entity = $this->getEntityLatestRevision($uuid);
 
-    if ($entity && $entity->get('moderation_state') !== 'published') {
+    if (!$entity) {
+      throw new \Exception("No data with that identifier was found.");
+    }
+    elseif ('published' !== $entity->get('moderation_state')) {
       $entity->set('moderation_state', 'published');
       $entity->save();
-      return $uuid;
+      return TRUE;
     }
-
-    throw new \Exception("No data with that identifier was found.");
+    else {
+      return FALSE;
+    }
   }
 
   /**

--- a/modules/metastore/tests/src/Storage/DataTest.php
+++ b/modules/metastore/tests/src/Storage/DataTest.php
@@ -3,7 +3,9 @@
 namespace Drupal\Tests\metastore\Storage;
 
 use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\metastore\Storage\NodeData;
+use Drupal\node\Entity\Node;
 use Drupal\node\NodeStorage;
 use MockChain\Chain;
 use PHPUnit\Framework\TestCase;
@@ -17,13 +19,62 @@ class DataTest extends TestCase {
 
   public function testGetStorageNode() {
 
-    $etm = (new Chain($this))
-      ->add(EntityTypeManager::class, 'getStorage', NodeStorage::class)
-      ->getMock();
-
-    $data = new NodeData('dataset', $etm);
+    $data = new NodeData('dataset', $this->getEtmChain()->getMock());
     $this->assertInstanceOf(NodeStorage::class, $data->getEntityStorage());
     $this->assertEquals('field_json_metadata', $data->getMetadataField());
+  }
+
+  public function testPublishNonDataset() {
+
+    $this->expectExceptionMessage('Publishing currently only implemented for datasets.');
+    $nodeData = new NodeData('foobar', $this->getEtmChain()->getMock());
+    $nodeData->publish('1');
+  }
+
+  public function testPublishDatasetNotFound() {
+
+    $etmMock = $this->getEtmChain()
+      ->add(QueryInterface::class, 'execute', [])
+      ->getMock();
+
+    $this->expectExceptionMessage('No data with that identifier was found.');
+    $nodeData = new NodeData('dataset', $etmMock);
+    $nodeData->publish('1');
+  }
+
+  public function testPublishDraftDataset() {
+
+    $etmMock = $this->getEtmChain()
+      ->add(Node::class, 'get', 'draft')
+      ->add(Node::class, 'set')
+      ->add(Node::class, 'save')
+      ->getMock();
+
+    $nodeData = new NodeData('dataset', $etmMock);
+    $result = $nodeData->publish('1');
+    $this->assertEquals(TRUE, $result);
+  }
+
+  public function testPublishDatasetAlreadyPublished() {
+
+    $etmMock = $this->getEtmChain()
+      ->add(Node::class, 'get', 'published')
+      ->getMock();
+
+    $nodeData = new NodeData('dataset', $etmMock);
+    $result = $nodeData->publish('1');
+    $this->assertEquals(FALSE, $result);
+  }
+
+  private function getEtmChain() {
+
+    return (new Chain($this))
+      ->add(EntityTypeManager::class, 'getStorage', NodeStorage::class)
+      ->add(NodeStorage::class, 'getQuery', QueryInterface::class)
+      ->add(QueryInterface::class, 'condition', QueryInterface::class)
+      ->add(QueryInterface::class, 'execute', ['1'])
+      ->add(NodeStorage::class, 'getLatestRevisionId', '2')
+      ->addd('loadRevision', Node::class);
   }
 
 }

--- a/modules/metastore/tests/src/Storage/DataTest.php
+++ b/modules/metastore/tests/src/Storage/DataTest.php
@@ -37,7 +37,7 @@ class DataTest extends TestCase {
       ->add(QueryInterface::class, 'execute', [])
       ->getMock();
 
-    $this->expectExceptionMessage('No data with that identifier was found.');
+    $this->expectExceptionMessage('Error publishing dataset: 1 not found.');
     $nodeData = new NodeData('dataset', $etmMock);
     $nodeData->publish('1');
   }


### PR DESCRIPTION
On our test server, we recently noticed publishing was broken. Specifically, publishing a harvest when at least one of its dataset was already published.

We think the issue comes from `modules/metastore/src/Storage/Data.php`'s `publish`:

```
  public function publish(string $uuid) : string {

    if ($this->schemaId !== 'dataset') {      
      throw new \Exception("Publishing currently only implemented for datasets.");
    }

    $entity = $this->getEntityLatestRevision($uuid);

    if ($entity && $entity->get('moderation_state') !== 'published') {
      $entity->set('moderation_state', 'published');
      $entity->save();
      return $uuid;
    }

    throw new \Exception("No data with that identifier was found.");
  }
```

For data nodes that exist and were not already published, it returns the uuid. But for data nodes that exist but were already published, it falls down to the "not found" Exception, which is incorrect.

This PR attempts to address that issue, and largely stem from a discussion with @fmizzell, in which we also decided to change the return value of that function to a boolean. This function's caller already knows the `$uuid` since it's the parameter. My work includes revisiting the consequence of changing the return value, as well as providing code coverage where it was previously missing.

Please let me know if you have any comments or concerns.