### PR TITLE
Harvest publications continue when handling exceptions

### DIFF
--- a/modules/harvest/harvest.services.yml
+++ b/modules/harvest/harvest.services.yml
@@ -5,6 +5,8 @@ services:
       - '@dkan.harvest.storage.database_table'
       - '@dkan.metastore.service'
       - '@entity_type.manager'
+    calls:
+      - [ setLoggerFactory, [ '@logger.factory' ] ]
   dkan.harvest.storage.database_table:
     class: Drupal\harvest\Storage\DatabaseTableFactory
     arguments:

--- a/modules/harvest/src/Service.php
+++ b/modules/harvest/src/Service.php
@@ -235,11 +235,7 @@ class Service implements ContainerInjectionInterface {
 
     foreach ($lastRunInfoObj->status->extracted_items_ids as $uuid) {
       try {
-        if (isset($lastRunInfoObj->status->load) &&
-          $lastRunInfoObj->status->load->{$uuid} &&
-          $lastRunInfoObj->status->load->{$uuid} != "FAILURE" &&
-          $this->metastore->publish('dataset', $uuid)) {
-
+        if ($this->metastorePublishHelper($lastRunInfoObj->status, $uuid)) {
           $publishedIdentifiers[] = $uuid;
         }
       }
@@ -249,6 +245,16 @@ class Service implements ContainerInjectionInterface {
     }
 
     return $publishedIdentifiers;
+  }
+
+  /**
+   * Private.
+   */
+  private function metastorePublishHelper($runInfoStatus, string $uuid): bool {
+    return isset($runInfoStatus->load)
+      && $runInfoStatus->load->{$uuid}
+      && $runInfoStatus->load->{$uuid} != 'FAILURE'
+      && $this->metastore->publish('dataset', $uuid);
   }
 
   /**

--- a/modules/harvest/src/Service.php
+++ b/modules/harvest/src/Service.php
@@ -249,11 +249,7 @@ class Service implements ContainerInjectionInterface {
 
     foreach ($lastRunStatus->extracted_items_ids as $uuid) {
       try {
-        if (isset($runInfoStatus->load) &&
-          $runInfoStatus->load->{$uuid} &&
-          $runInfoStatus->load->{$uuid} != 'FAILURE' &&
-          $this->metastore->publish('dataset', $uuid)) {
-
+        if ($this->metastorePublishHelper($lastRunStatus, $uuid)) {
           $publishedIdentifiers[] = $uuid;
         }
       }
@@ -263,6 +259,16 @@ class Service implements ContainerInjectionInterface {
     }
 
     return $publishedIdentifiers;
+  }
+
+  /**
+   * Private.
+   */
+  private function metastorePublishHelper($runInfoStatus, string $uuid): bool {
+    return isset($runInfoStatus->load) &&
+      $runInfoStatus->load->{$uuid} &&
+      $runInfoStatus->load->{$uuid} != 'FAILURE' &&
+      $this->metastore->publish('dataset', $uuid);
   }
 
   /**

--- a/modules/harvest/tests/src/ServiceTest.php
+++ b/modules/harvest/tests/src/ServiceTest.php
@@ -5,18 +5,20 @@ namespace Drupal\Tests\harvest;
 use Contracts\FactoryInterface;
 use Contracts\Mock\Storage\Memory;
 use Drupal\Component\DependencyInjection\Container;
-use Drupal\Core\Utility\Error;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Tests\common\Traits\ServiceCheckTrait;
 use Drupal\datastore\Storage\DatabaseTable;
 use Drupal\harvest\Service as HarvestService;
 use Drupal\harvest\Storage\DatabaseTableFactory;
 use Drupal\metastore\Service as Metastore;
 use Drupal\node\NodeStorage;
-use Drupal\Tests\common\Traits\ServiceCheckTrait;
-use Drupal\Core\Entity\EntityTypeManager;
 use Harvest\ETL\Extract\DataJson;
 use Harvest\ETL\Load\Simple;
 use MockChain\Chain;
 use MockChain\Options;
+use MockChain\Sequence;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -221,7 +223,7 @@ class ServiceTest extends TestCase {
    */
   public function testPublish() {
 
-    $datasetUuids = ['abcd-1001', 'abcd-1002', 'abcd-1003'];
+    $datasetUuids = ['abcd-1001', 'abcd-1002', 'abcd-1003', 'abcd-1004'];
     $lastRunInfo = (object) [
       'status' => [
         'extracted_items_ids' => $datasetUuids,
@@ -229,16 +231,36 @@ class ServiceTest extends TestCase {
           'abcd-1001' => "SUCCESS",
           'abcd-1002' => "SUCCESS",
           'abcd-1003' => "SUCCESS",
+          'abcd-1004' => "FAILURE",
         ],
       ],
     ];
 
+    $metastorePublicationResults = (new Sequence())
+      // abcd-1001 will be skipped since already published.
+      ->add(FALSE)
+      // abcd-1002 will be skipped due to exception.
+      ->add(new \Exception('FooBar'))
+      // abcd-1003 should be published without issue.
+      ->add(TRUE);
+
+    $logger = (new Chain($this))
+      ->add(LoggerChannelFactory::class, 'get', LoggerChannelInterface::class)
+      ->add(LoggerChannelInterface::class, 'error', NULL, 'error');
+
     $container = $this->getCommonMockChain()
-      ->add(DatabaseTable::class, "retrieve", json_encode($lastRunInfo));
+      ->add(DatabaseTable::class, "retrieve", json_encode($lastRunInfo))
+      ->add(Metastore::class, 'publish', $metastorePublicationResults);
 
     $service = HarvestService::create($container->getMock());
+    $service->setLoggerFactory($logger->getMock());
     $result = $service->publish('1');
-    $this->assertEquals($result, $datasetUuids);
+
+    $this->assertEquals(['abcd-1003'], $result);
+
+    $loggerResult = $logger->getStoredInput('error')[0];
+    $error = 'Error publishing dataset abcd-1002 in harvest 1: FooBar';
+    $this->assertEquals($error, $loggerResult);
   }
 
   /**


### PR DESCRIPTION
Though #3487 dealt with an exception mistakenly thrown, the harvest publication process could still be interrupted by other exceptions. Ideally, it should catch exceptions and continue looping through all of its datasets and attempt to publish each of them.

- [x] Test coverage exists

Because QA steps or a setup for this would be pretty complicated, the unit test for Harvest's `publish` is augmented to account for various scenarios:
    - Publishing a dataset that's already published
    - Publishing a dataset resulting in an exception thrown
    - Publishing a dataset whose harvest load was 'failure'
    - Publishing a dataset not already published 