### PR TITLE
Improve facets and drafts behavior 

### DIFF
--- a/modules/metastore/modules/metastore_search/src/FacetsFromContentTrait.php
+++ b/modules/metastore/modules/metastore_search/src/FacetsFromContentTrait.php
@@ -11,7 +11,6 @@ use RootedData\RootedJsonData;
  * @package Drupal\metastore_search
  */
 trait FacetsFromContentTrait {
-  use FacetsCommonTrait;
 
   /**
    * Private.

--- a/modules/metastore/modules/metastore_search/src/FacetsFromIndexTrait.php
+++ b/modules/metastore/modules/metastore_search/src/FacetsFromIndexTrait.php
@@ -11,7 +11,6 @@ use Drupal\search_api\Query\QueryInterface;
  * @package Drupal\metastore_search
  */
 trait FacetsFromIndexTrait {
-  use FacetsCommonTrait;
 
   /**
    * Private.

--- a/modules/metastore/modules/metastore_search/src/Search.php
+++ b/modules/metastore/modules/metastore_search/src/Search.php
@@ -18,6 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class Search implements ContainerInjectionInterface {
   use QueryBuilderTrait;
+  // Both FacetTraits depend on Common, but this makes them collide, we should fix this.
+  use FacetsCommonTrait;
   use FacetsFromIndexTrait;
   // @todo Use real classes to get proper encapsulation.
   use FacetsFromContentTrait;

--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -313,6 +313,7 @@ class Referencer {
     // Create node to store this reference.
     $storage = $this->storageFactory->getInstance($property_id);
     $entity_uuid = $storage->store($json, $data->identifier);
+    $storage->publish($entity_uuid);
     return $entity_uuid;
   }
 

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -100,7 +100,8 @@ abstract class Data implements MetastoreStorageInterface {
     $all = [];
     foreach ($entity_ids as $nid) {
       $entity = $this->entityStorage->load($nid);
-      if ($entity->get('moderation_state')->getString() === 'published') {
+      $moderationState = $entity->get('moderation_state')->getString();
+      if ($moderationState === 'published') {
         $all[] = $entity->get('field_json_metadata')->getString();
       }
     }


### PR DESCRIPTION
There were some issues with the Facets. I believe the first commit addresses that.

But that did not fix all the issues. In a system where we do not publish things by default (things are created as drafts), currently that is affecting the references while previously references were always published.

We can fix this in 2 ways:
1) Bring the previous behavior back and always publish references on creation, or
2) Make it so references are published with the parent

The fact that currently references are not published on creation is breaking facets in those system that allow datasets to be created as drafts.