### PR TITLE
3501 Empty distribution node creation

### DIFF
--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -81,28 +81,24 @@ class ValueHandler {
    *   Processed form values.
    */
   private function processTypeValue(array $formValues): array {
-    $empty = TRUE;
-    foreach ($formValues as $key => $value) {
-      if ($key == '@type') {
-        continue;
-      }
-      $empty = $this->isValueEmpty($value);
-      if (!$empty) {
-        break;
+    // $formValues without the '@type' key.
+    $formValuesNoType = array_diff_key($formValues, array_flip(['@type']));
+
+    foreach ($formValuesNoType as $value) {
+      // If a single value is not empty - return the original $formValues array.
+      if (!$this->isValueEmpty($value)) {
+        return $formValues;
       }
     }
 
-    if ($empty) {
-      $formValues['@type'] = NULL;
-    }
-
-    return $formValues;
+    // All values are empty. '@type' needs to be empty too.
+    return array_merge(['@type' => NULL], $formValuesNoType);
   }
 
   /**
    * Check if a values id empty.
    *
-   * @param $value
+   * @param mixed $value
    *   A form value.
    *
    * @return bool
@@ -111,15 +107,10 @@ class ValueHandler {
   private function isValueEmpty($value): bool {
     if (is_scalar($value)) {
       return empty($value);
-    } else {
-      $value = (array) $value;
-      foreach ($value as $subValue) {
-        if (!$this->isValueEmpty($subValue)) {
-          return FALSE;
-        }
-      }
     }
-    return TRUE;
+
+    $value = (array) $value;
+    return empty(array_filter($value));
   }
 
   /**

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -56,6 +56,10 @@ class ValueHandler {
       return FALSE;
     }
 
+    if (isset($formValues['@type'])) {
+      $formValues = $this->processTypeValue($formValues);
+    }
+
     $properties = array_keys((array) $schema->properties);
     $data = FALSE;
     foreach ($properties as $sub_property) {
@@ -65,6 +69,57 @@ class ValueHandler {
       }
     }
     return $data;
+  }
+
+  /**
+   * Sets '@type' to null if other fields are empty.
+   *
+   * @param array $formValues
+   *   Form values.
+   *
+   * @return array
+   *   Processed form values.
+   */
+  private function processTypeValue(array $formValues): array {
+    $empty = TRUE;
+    foreach ($formValues as $key => $value) {
+      if ($key == '@type') {
+        continue;
+      }
+      $empty = $this->isValueEmpty($value);
+      if (!$empty) {
+        break;
+      }
+    }
+
+    if ($empty) {
+      $formValues['@type'] = NULL;
+    }
+
+    return $formValues;
+  }
+
+  /**
+   * Check if a values id empty.
+   *
+   * @param $value
+   *   A form value.
+   *
+   * @return bool
+   *   TRUE if the value is empty, FALSE if it is not.
+   */
+  private function isValueEmpty($value): bool {
+    if (is_scalar($value)) {
+      return empty($value);
+    } else {
+      $value = (array) $value;
+      foreach ($value as $subValue) {
+        if (!$this->isValueEmpty($subValue)) {
+          return FALSE;
+        }
+      }
+    }
+    return TRUE;
   }
 
   /**

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -43,7 +43,7 @@ class ValueHandler {
     }
     // Handle select_or_other_select.
     if (isset($formValues[$property]['select'])) {
-      return $formValues[$property][0];
+      return isset($formValues[$property][0]) ? $formValues[$property][0] : NULL;
     }
     return !empty($formValues[$property]) ? $this->cleanSelectId($formValues[$property]) : FALSE;
   }

--- a/modules/json_form_widget/tests/src/Unit/ValueHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/ValueHandlerTest.php
@@ -130,7 +130,73 @@ class ValueHandlerTest extends TestCase {
     $schema = json_decode($this->getObjectSchema());
     $result = $value_handler->handleObjectValues(NULL, "publisher", $schema);
     $this->assertEquals($result, FALSE);
+  }
 
+  public function testFlattenValuesEmptyDistribution() {
+    $value_handler = new ValueHandler();
+
+    // Test object where only the '@type' field is not empty.
+    $shortEmptyDistributionSchema = '{
+      "title": "Distribution",
+      "description": "Description.",
+      "type": "array",
+      "items": {
+        "title": "Project Open Data Distribution",
+        "type": "object",
+        "properties": {
+          "@type": {
+            "title": "Metadata Context",
+            "description": "Test Description.",
+            "default": "dcat:Distribution",
+            "type": "string",
+            "readOnly": true
+          },
+          "title": {
+            "title": "Title",
+            "description": "Human-readable name of the distribution.",
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "title": "Description",
+            "description": "Human-readable description of the distribution.",
+            "type": "string",
+            "minLength": 1
+          },
+          "format": {
+            "title": "Format",
+            "description": "A human-readable description of the file format of a distribution (i.e. csv, pdf, xml, kml, etc.).",
+            "type": "string",
+            "examples": [
+              "csv",
+              "json"
+            ]
+          }
+        }
+      }
+    }';
+    $schema = json_decode($shortEmptyDistributionSchema);
+
+    $formValues = [
+      "distribution" => [
+        "distribution" => [
+          0 => [
+            "distribution" => [
+              "@type" => "dcat:Distribution",
+              'title' => '',
+              'description' => '',
+              'format' => [
+                  'select' => '',
+                  'other' => '',
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    $result = $value_handler->flattenValues($formValues, "distribution", $schema);
+    $this->assertEquals([], $result);
   }
 
   /**


### PR DESCRIPTION
fixes [GetDKAN/dkan/issues/3501]

- [ ] Test coverage exists
- [ ] When nothing is submitted for distribution an empty distribution node is not created

## QA Steps

- [ ] Create a dataset with the UI. Leave all distribution fields blank. Make sure an empty distribution node is not created
