### PR TITLE
3506 api dataset creation no identifier

### DIFF
--- a/modules/harvest/src/Load/Dataset.php
+++ b/modules/harvest/src/Load/Dataset.php
@@ -29,7 +29,7 @@ class Dataset extends Load {
     }
 
     $schema_id = 'dataset';
-    $item = $service->getValidMetadataFactory()->get($schema_id, $item);
+    $item = $service->getValidMetadataFactory()->get($item, $schema_id);
     try {
       $service->post($schema_id, $item);
     }

--- a/modules/harvest/tests/src/Load/DatasetTest.php
+++ b/modules/harvest/tests/src/Load/DatasetTest.php
@@ -40,7 +40,7 @@ class DatasetTest extends TestCase {
       ->index(0);
 
     $object = (object) ["identifier" => "1"];
-    $expected = $this->validMetadataFactory->get('dummy_schema_id', json_encode($object));
+    $expected = $this->validMetadataFactory->get(json_encode($object), 'dummy_schema_id');
 
     $containerChain = (new Chain($this))
       ->add(Container::class, "get", $containerOptions)
@@ -74,7 +74,7 @@ class DatasetTest extends TestCase {
       ->index(0);
 
     $object = (object) ["identifier" => "1"];
-    $expected = $this->validMetadataFactory->get('dummy_schema_id', json_encode($object));
+    $expected = $this->validMetadataFactory->get(json_encode($object), 'dummy_schema_id');
 
     $containerChain = (new Chain($this))
       ->add(Container::class, "get", $containerOptions)

--- a/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
@@ -921,8 +921,8 @@ class SchemaUiHandlerTest extends TestCase {
    */
   private function getSimpleMetastoreResults() {
     return [
-      $this->validMetadataFactory->get('dataset', json_encode(['data' => 'Option 1'])),
-      $this->validMetadataFactory->get('dataset', json_encode(['data' => 'Option 2'])),
+      $this->validMetadataFactory->get(json_encode(['data' => 'Option 1']), 'dataset'),
+      $this->validMetadataFactory->get(json_encode(['data' => 'Option 2']), 'dataset'),
     ];
 
   }
@@ -932,8 +932,8 @@ class SchemaUiHandlerTest extends TestCase {
    */
   private function getComplexMetastoreResults() {
     return [
-      $this->validMetadataFactory->get('dataset', json_encode(['data' => ['name' => 'Option 1']])),
-      $this->validMetadataFactory->get('dataset', json_encode(['data' => ['name' => 'Option 2']])),
+      $this->validMetadataFactory->get(json_encode(['data' => ['name' => 'Option 1']]), 'dataset'),
+      $this->validMetadataFactory->get(json_encode(['data' => ['name' => 'Option 2']]), 'dataset'),
     ];
   }
 

--- a/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
+++ b/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
@@ -181,9 +181,9 @@ class SearchTest extends TestCase {
     $getAllOptions = (new Options())
       ->add('keyword', [])
       ->add('theme', [])
-      ->add('publisher', [ServiceTest::getValidMetadataFactory($case)->get('publisher', json_encode($facet))]);
+      ->add('publisher', [ServiceTest::getValidMetadataFactory($case)->get(json_encode($facet), 'publisher')]);
 
-    $getData = ServiceTest::getValidMetadataFactory($case)->get('dummy_schema_id', json_encode($collection));
+    $getData = ServiceTest::getValidMetadataFactory($case)->get(json_encode($collection), 'dummy_schema_id');
 
     return (new Chain($case))
       ->add(Container::class, 'get', $services)

--- a/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
+++ b/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
@@ -105,7 +105,7 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
   private function doValidate(string $schema_id, $item): array {
     $errors = [];
     try {
-      $this->validMetadataFactory->get($schema_id, $item->value);
+      $this->validMetadataFactory->get($item->value, $schema_id);
     }
     catch (ValidationException $e) {
       $errors = $this->getValidationErrorsMessages($e->getResult()->getErrors());

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -136,7 +136,7 @@ class Service implements ContainerInjectionInterface {
 
     $objects = array_map(
       function ($jsonString) use ($schema_id) {
-        $data = $this->validMetadataFactory->get($schema_id, $jsonString);
+        $data = $this->validMetadataFactory->get($jsonString, $schema_id);
         try {
           return $this->dispatchEvent(self::EVENT_DATA_GET, $data, function ($data) {
             return $data instanceof RootedJsonData;
@@ -174,7 +174,7 @@ class Service implements ContainerInjectionInterface {
    */
   public function get($schema_id, $identifier): RootedJsonData {
     $json_string = $this->getStorage($schema_id)->retrievePublished($identifier);
-    $data = $this->validMetadataFactory->get($schema_id, $json_string);
+    $data = $this->validMetadataFactory->get($json_string, $schema_id);
 
     $data = $this->dispatchEvent(self::EVENT_DATA_GET, $data);
     return $data;
@@ -195,7 +195,7 @@ class Service implements ContainerInjectionInterface {
    */
   public function getResources($schema_id, $identifier): array {
     $json_string = $this->getStorage($schema_id)->retrieve($identifier);
-    $data = $this->validMetadataFactory->get($schema_id, $json_string);
+    $data = $this->validMetadataFactory->get($json_string, $schema_id);
 
     /* @todo decouple from POD. */
     $resources = $data->{"$.distribution"};
@@ -330,7 +330,7 @@ class Service implements ContainerInjectionInterface {
           json_decode($json_data)
         );
 
-        $new = $this->validMetadataFactory->get($schema_id, json_encode($patched));
+        $new = $this->validMetadataFactory->get(json_encode($patched), $schema_id);
         $storage->store($new, "{$identifier}");
         return $identifier;
       }
@@ -404,7 +404,7 @@ class Service implements ContainerInjectionInterface {
    */
   private function objectIsEquivalent(string $schema_id, string $identifier, RootedJsonData $metadata) {
     $existingMetadata = $this->getStorage($schema_id)->retrieve($identifier);
-    $existing = $this->getValidMetadataFactory()->get($schema_id, $existingMetadata);
+    $existing = $this->getValidMetadataFactory()->get($existingMetadata, $schema_id);
     $existing = self::removeReferences($existing);
     return $metadata->get('$') == $existing->get('$');
   }

--- a/modules/metastore/src/ValidMetadataFactory.php
+++ b/modules/metastore/src/ValidMetadataFactory.php
@@ -54,10 +54,10 @@ class ValidMetadataFactory implements ContainerInjectionInterface {
   /**
    * Converts Json string into RootedJsonData object.
    *
-   * @param string|null $schema_id
-   *   The {schema_id} slug from the HTTP request.
    * @param string $json_string
    *   Json string.
+   * @param string|null $schema_id
+   *   The {schema_id} slug from the HTTP request.
    * @param array $options
    *   Options array.
    *
@@ -66,7 +66,7 @@ class ValidMetadataFactory implements ContainerInjectionInterface {
    *
    * @throws \JsonPath\InvalidJsonException
    */
-  public function get($schema_id = NULL, string $json_string, array $options = []): RootedJsonData {
+  public function get(string $json_string, $schema_id = NULL, array $options = []): RootedJsonData {
 
     // Add identifier for new objects if necessary.
     if (isset($options['method']) && $options['method'] == 'POST') {

--- a/modules/metastore/src/ValidMetadataFactory.php
+++ b/modules/metastore/src/ValidMetadataFactory.php
@@ -3,7 +3,7 @@
 namespace Drupal\metastore;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\metastore\Reference\HelperTrait;
+use Drupal\metastore\Service\Uuid5;
 use RootedData\RootedJsonData;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -11,7 +11,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Service.
  */
 class ValidMetadataFactory implements ContainerInjectionInterface {
-  use HelperTrait;
 
   /**
    * Schema retriever.
@@ -93,7 +92,8 @@ class ValidMetadataFactory implements ContainerInjectionInterface {
    */
   private function addIdentifier(string $schema_id, string $json_string): string {
     $json_data = json_decode($json_string);
-    $json_data->identifier = $this->getUuidService()->generate($schema_id, $json_string);
+    $uuid5 = new Uuid5();
+    $json_data->identifier = $uuid5->generate($schema_id, $json_string);
     return json_encode($json_data);
   }
 

--- a/modules/metastore/src/ValidMetadataFactory.php
+++ b/modules/metastore/src/ValidMetadataFactory.php
@@ -3,6 +3,7 @@
 namespace Drupal\metastore;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\metastore\Reference\HelperTrait;
 use RootedData\RootedJsonData;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -10,6 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Service.
  */
 class ValidMetadataFactory implements ContainerInjectionInterface {
+  use HelperTrait;
 
   /**
    * Schema retriever.
@@ -56,15 +58,43 @@ class ValidMetadataFactory implements ContainerInjectionInterface {
    *   The {schema_id} slug from the HTTP request.
    * @param string $json_string
    *   Json string.
+   * @param array $options
+   *   Options array.
    *
    * @return \RootedData\RootedJsonData
    *   RootedJsonData object.
    *
    * @throws \JsonPath\InvalidJsonException
    */
-  public function get(string $schema_id = NULL, string $json_string): RootedJsonData {
+  public function get($schema_id = NULL, string $json_string, $options = []): RootedJsonData {
+
+    // Add identifier for new objects if necessary.
+    if (isset($options['method']) && $options['method'] == 'POST') {
+      $data = json_decode($json_string);
+      if (!isset($data->identifier)) {
+        $json_string = $this->addIdentifier($schema_id, $json_string);
+      }
+    }
+
     $schema = !empty($schema_id) ? $this->getSchemaRetriever()->retrieve($schema_id) : '{}';
     return new RootedJsonData($json_string, $schema);
+  }
+
+  /**
+   * Adds identifier to JSON payload.
+   *
+   * @param string $schema_id
+   *   The {schema_id} slug from the HTTP request.
+   * @param string $json_string
+   *   Json string with no identifier.
+   *
+   * @return string
+   *   Json string with the identifier.
+   */
+  private function addIdentifier(string $schema_id, string $json_string): string {
+    $json_data = json_decode($json_string);
+    $json_data->identifier = $this->getUuidService()->generate($schema_id, $json_string);
+    return json_encode($json_data);
   }
 
 }

--- a/modules/metastore/src/ValidMetadataFactory.php
+++ b/modules/metastore/src/ValidMetadataFactory.php
@@ -66,7 +66,7 @@ class ValidMetadataFactory implements ContainerInjectionInterface {
    *
    * @throws \JsonPath\InvalidJsonException
    */
-  public function get($schema_id = NULL, string $json_string, $options = []): RootedJsonData {
+  public function get($schema_id = NULL, string $json_string, array $options = []): RootedJsonData {
 
     // Add identifier for new objects if necessary.
     if (isset($options['method']) && $options['method'] == 'POST') {

--- a/modules/metastore/src/WebServiceApi.php
+++ b/modules/metastore/src/WebServiceApi.php
@@ -135,7 +135,7 @@ class WebServiceApi implements ContainerInjectionInterface {
    * Private.
    */
   private function swapReferences(RootedJsonData $object): RootedJsonData {
-    $no_schema_object = $this->service->getValidMetadataFactory()->get(NULL, "$object");
+    $no_schema_object = $this->service->getValidMetadataFactory()->get("$object", NULL);
     foreach ($no_schema_object->get('$') as $property => $value) {
       if (substr_count($property, "%Ref:") > 0) {
         $no_schema_object = $this->swapReference($property, $value, $no_schema_object);
@@ -189,7 +189,7 @@ class WebServiceApi implements ContainerInjectionInterface {
     try {
       $data = $this->getRequestContent();
       $this->checkIdentifier($data);
-      $data = $this->service->getValidMetadataFactory()->get($schema_id, $data, ['method' => 'POST']);
+      $data = $this->service->getValidMetadataFactory()->get($data, $schema_id, ['method' => 'POST']);
       $identifier = $this->service->post($schema_id, $data);
       return $this->getResponse([
         "endpoint" => "{$this->getRequestUri()}/{$identifier}",
@@ -243,7 +243,7 @@ class WebServiceApi implements ContainerInjectionInterface {
     try {
       $data = $this->getRequestContent();
       $this->checkIdentifier($data, $identifier);
-      $data = $this->service->getValidMetadataFactory()->get($schema_id, $data);
+      $data = $this->service->getValidMetadataFactory()->get($data, $schema_id);
       $info = $this->service->put($schema_id, $identifier, $data);
       $code = ($info['new'] == TRUE) ? 201 : 200;
       return $this->getResponse(["endpoint" => $this->getRequestUri(), "identifier" => $info['identifier']], $code);

--- a/modules/metastore/src/WebServiceApi.php
+++ b/modules/metastore/src/WebServiceApi.php
@@ -189,7 +189,7 @@ class WebServiceApi implements ContainerInjectionInterface {
     try {
       $data = $this->getRequestContent();
       $this->checkIdentifier($data);
-      $data = $this->service->getValidMetadataFactory()->get($schema_id, $data);
+      $data = $this->service->getValidMetadataFactory()->get($schema_id, $data, ['method' => 'POST']);
       $identifier = $this->service->post($schema_id, $data);
       return $this->getResponse([
         "endpoint" => "{$this->getRequestUri()}/{$identifier}",

--- a/modules/metastore/tests/src/Functional/DatasetSpecificDocsTest.php
+++ b/modules/metastore/tests/src/Functional/DatasetSpecificDocsTest.php
@@ -46,7 +46,7 @@ class DatasetSpecificDocsTest extends ExistingSiteBase {
 
     /** @var \Drupal\metastore\Service $metastore */
     $metastore = \Drupal::service('dkan.metastore.service');
-    $dataset = $metastore->getValidMetadataFactory()->get('dataset', $dataset);
+    $dataset = $metastore->getValidMetadataFactory()->get($dataset, 'dataset');
     $metastore->post('dataset', $dataset);
 
     $webService = WebServiceApiDocs::create(\Drupal::getContainer());

--- a/modules/metastore/tests/src/Functional/OrphanCheckerTest.php
+++ b/modules/metastore/tests/src/Functional/OrphanCheckerTest.php
@@ -40,7 +40,7 @@ class OrphanCheckerTest extends ExistingSiteBase {
   public function test() {
     /* @var $service \Drupal\metastore\Service */
     $service = \Drupal::service('dkan.metastore.service');
-    $dataset = $this->validMetadataFactory->get('dataset', $this->getDataset(123, 'Test #1', ['district_centerpoints_small.csv']));
+    $dataset = $this->validMetadataFactory->get($this->getDataset(123, 'Test #1', ['district_centerpoints_small.csv']), 'dataset');
     $service->post('dataset', $dataset);
     $this->runQueues(['datastore_import']);
     $service->delete('dataset', 123);

--- a/modules/metastore/tests/src/Unit/MetastoreSubscriberTest.php
+++ b/modules/metastore/tests/src/Unit/MetastoreSubscriberTest.php
@@ -41,7 +41,7 @@ class MetastoreSubscriberTest extends TestCase {
     $url = 'http://hello.world/file.csv';
     $resource = new Resource($url, 'text/csv');
     $dist = '{"data":{"%Ref:downloadURL":[{"data":{"identifier":"qwerty","version":"uiop","perspective":"source"}}]}}';
-    $dist = $this->validMetadataFactory->get('distribution', $dist);
+    $dist = $this->validMetadataFactory->get($dist, 'distribution');
     $event = new Event($resource);
 
     $options = (new Options())
@@ -72,7 +72,7 @@ class MetastoreSubscriberTest extends TestCase {
     $url = 'http://hello.world/file.csv';
     $resource = new Resource($url, 'text/csv');
     $dist = '{"data":{"%Ref:downloadURL":[{"data":{"identifier":"qwerty","version":"uiop","perspective":"source"}}]}}';
-    $dist = $this->validMetadataFactory->get('distribution', $dist);
+    $dist = $this->validMetadataFactory->get($dist, 'distribution');
     $event = new Event($resource);
 
     $options = (new Options())

--- a/modules/metastore/tests/src/Unit/ServiceTest.php
+++ b/modules/metastore/tests/src/Unit/ServiceTest.php
@@ -61,7 +61,7 @@ class ServiceTest extends TestCase {
    *
    */
   public function testGetAll() {
-    $expected = $this->validMetadataFactory->get('dataset', json_encode(['foo' => 'bar']));
+    $expected = $this->validMetadataFactory->get(json_encode(['foo' => 'bar']), 'dataset');
 
     $container = self::getCommonMockChain($this)
       ->add(NodeData::class, 'retrieveAll', [json_encode(['foo' => 'bar'])])
@@ -75,7 +75,7 @@ class ServiceTest extends TestCase {
   }
 
   public function testGetAllException() {
-    $data = $this->validMetadataFactory->get('dataset', json_encode(['foo' => 'bar']));
+    $data = $this->validMetadataFactory->get(json_encode(['foo' => 'bar']), 'dataset');
 
     $event = new Event($data);
     $event->setException(new \Exception("blah"));
@@ -106,7 +106,7 @@ class ServiceTest extends TestCase {
    *
    */
   public function testGet() {
-    $data = $this->validMetadataFactory->get('dataset', json_encode(['foo' => 'bar']));
+    $data = $this->validMetadataFactory->get(json_encode(['foo' => 'bar']), 'dataset');
 
     $container = self::getCommonMockChain($this)
       ->add(NodeData::class, "retrievePublished", json_encode(['foo' => 'bar']))
@@ -129,7 +129,7 @@ class ServiceTest extends TestCase {
         ["title" => "hello"],
       ],
     ];
-    $data = $this->validMetadataFactory->get('dataset', json_encode($dataset));
+    $data = $this->validMetadataFactory->get(json_encode($dataset), 'dataset');
 
     $container = self::getCommonMockChain($this)
       ->add(Data::class, "retrieve", json_encode($dataset))
@@ -150,7 +150,7 @@ class ServiceTest extends TestCase {
 
     $service = Service::create($container->getMock());
 
-    $data = $this->validMetadataFactory->get('dataset', json_encode(['foo' => 'bar']));
+    $data = $this->validMetadataFactory->get(json_encode(['foo' => 'bar']), 'dataset');
     $this->assertEquals("1", $service->post("dataset", $data));
   }
 
@@ -165,7 +165,7 @@ class ServiceTest extends TestCase {
 
     $this->expectException(ExistingObjectException::class);
 
-    $data = $this->validMetadataFactory->get('dataset', '{"identifier":1,"title":"FooBar"}');
+    $data = $this->validMetadataFactory->get('{"identifier":1,"title":"FooBar"}', 'dataset');
     $service->post("dataset", $data);
   }
 
@@ -176,7 +176,7 @@ class ServiceTest extends TestCase {
     $existing = '{"identifier":"1","title":"Foo"}';
     $updating = '{"identifier":"1","title":"Bar"}';
 
-    $data_existing = $this->validMetadataFactory->get('dataset', $existing);
+    $data_existing = $this->validMetadataFactory->get($existing, 'dataset');
     $container = self::getCommonMockChain($this)
       ->add(NodeData::class, "retrieve", $existing)
       ->add(NodeData::class, "store", "1")
@@ -184,7 +184,7 @@ class ServiceTest extends TestCase {
 
     $service = Service::create($container->getMock());
 
-    $data_updating = $this->validMetadataFactory->get('dataset', $updating);
+    $data_updating = $this->validMetadataFactory->get($updating, 'dataset');
     $info = $service->put("dataset", "1", $data_updating);
 
     $this->assertEquals("1", $info['identifier']);
@@ -204,7 +204,7 @@ class ServiceTest extends TestCase {
 
     $this->expectExceptionMessage("Identifier cannot be modified");
 
-    $data = $this->validMetadataFactory->get('dataset', $updating);
+    $data = $this->validMetadataFactory->get($updating, 'dataset');
     $service->put("dataset", "1", $data);
   }
 
@@ -218,7 +218,7 @@ class ServiceTest extends TestCase {
 
     $service = Service::create($container->getMock());
 
-    $data = $this->validMetadataFactory->get('dataset', '{"identifier":"3","title":"FooBar"}');
+    $data = $this->validMetadataFactory->get('{"identifier":"3","title":"FooBar"}', 'dataset');
     $info = $service->put("dataset", "3", $data);
     $this->assertEquals("3", $info['identifier']);
   }
@@ -229,7 +229,7 @@ class ServiceTest extends TestCase {
   public function testPutObjectUnchangedException() {
     $existing = '{"identifier":"1","title":"Foo"}';
 
-    $data = $this->validMetadataFactory->get('dataset', $existing);
+    $data = $this->validMetadataFactory->get($existing, 'dataset');
     $container = self::getCommonMockChain($this)
       ->add(Data::class, "retrieve", $existing)
       ->add(ValidMetadataFactory::class, 'get', $data);
@@ -252,7 +252,7 @@ class ServiceTest extends TestCase {
       }
 EOF;
 
-    $data_existing = $this->validMetadataFactory->get('dataset', $existing);
+    $data_existing = $this->validMetadataFactory->get($existing, 'dataset');
     $container = self::getCommonMockChain($this)
       ->add(Data::class, "retrieve", $existing)
       ->add(ValidMetadataFactory::class, 'get', $data_existing);
@@ -260,7 +260,7 @@ EOF;
     $service = Service::create($container->getMock());
     $this->expectException(UnmodifiedObjectException::class);
 
-    $data_updating = $this->validMetadataFactory->get('dataset', $updating);
+    $data_updating = $this->validMetadataFactory->get($updating, 'dataset');
     $service->put("dataset", "1", $data_updating);
   }
 
@@ -335,7 +335,7 @@ EOF;
    *
    */
   public function testGetCatalog() {
-    $dataset = $this->validMetadataFactory->get('blah', json_encode(["foo" => "bar"]));
+    $dataset = $this->validMetadataFactory->get(json_encode(["foo" => "bar"]), 'blah');
 
     $catalog = (object) [
       "@id" => "http://catalog",

--- a/modules/metastore/tests/src/Unit/ValidMetadataFactoryTest.php
+++ b/modules/metastore/tests/src/Unit/ValidMetadataFactoryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\Tests\metastore\Unit;
+
+use Drupal\Component\DependencyInjection\Container;
+use Drupal\metastore\SchemaRetriever;
+use Drupal\metastore\ValidMetadataFactory;
+use MockChain\Chain;
+use MockChain\Options;
+use PHPUnit\Framework\TestCase;
+use RootedData\Exception\ValidationException;
+
+/**
+ *
+ */
+class ValidMetadataFactoryTest extends TestCase {
+
+  public function testGetNoIdentifierException() {
+    $validMetadataFactory = ValidMetadataFactory::create($this->getCommonMockChain()->getMock());
+    $this->expectException(ValidationException::class);
+    $validMetadataFactory->get('dataset', json_encode(['title' => 'blah']));
+  }
+
+  public function testGetNoIdentifier() {
+    $validMetadataFactory = ValidMetadataFactory::create($this->getCommonMockChain()->getMock());
+    $result = $validMetadataFactory->get('dataset', json_encode(['title' => 'blah']), ['method' => 'POST']);
+    $this->assertTrue(isset($result->{'$.identifier'}));
+  }
+
+  /**
+   * Private.
+   */
+  private function getCommonMockChain() {
+    $options = (new Options)
+      ->add('metastore.schema_retriever', SchemaRetriever::class)
+      ->index(0);
+
+    $shortDatasetSchema = [
+      'title' => 'Project Open Data Dataset',
+      'required' => [
+        'title',
+        'identifier',
+      ],
+      'properties' => [
+        'title' => [
+          'title' => 'Title',
+          'description' => 'Human-readable name of the asset. Should be in plain English and include sufficient detail to facilitate search and discovery.',
+          'type' => 'string',
+          'minLength' => 1,
+        ],
+        'identifier' => [
+          'title' => 'Unique Identifier',
+          'description' => 'A unique identifier for the dataset or API as maintained within an Agency catalog or database.',
+          'type' => 'string',
+          'minLength' => 1,
+        ],
+      ],
+    ];
+
+    return (new Chain($this))
+      ->add(Container::class, "get", $options)
+      ->add(SchemaRetriever::class, "retrieve", json_encode($shortDatasetSchema));
+  }
+
+}

--- a/modules/metastore/tests/src/Unit/ValidMetadataFactoryTest.php
+++ b/modules/metastore/tests/src/Unit/ValidMetadataFactoryTest.php
@@ -18,12 +18,12 @@ class ValidMetadataFactoryTest extends TestCase {
   public function testGetNoIdentifierException() {
     $validMetadataFactory = ValidMetadataFactory::create($this->getCommonMockChain()->getMock());
     $this->expectException(ValidationException::class);
-    $validMetadataFactory->get('dataset', json_encode(['title' => 'blah']));
+    $validMetadataFactory->get(json_encode(['title' => 'blah']), 'dataset');
   }
 
   public function testGetNoIdentifier() {
     $validMetadataFactory = ValidMetadataFactory::create($this->getCommonMockChain()->getMock());
-    $result = $validMetadataFactory->get('dataset', json_encode(['title' => 'blah']), ['method' => 'POST']);
+    $result = $validMetadataFactory->get(json_encode(['title' => 'blah']), 'dataset', ['method' => 'POST']);
     $this->assertTrue(isset($result->{'$.identifier'}));
   }
 

--- a/modules/metastore/tests/src/WebServiceApiDocsTest.php
+++ b/modules/metastore/tests/src/WebServiceApiDocsTest.php
@@ -34,7 +34,7 @@ class WebServiceApiDocsTest extends TestCase {
    * Tests dataset-specific docs when SQL endpoint is protected.
    */
   public function testDatasetSpecificDocsWithSqlModifier() {
-    $get = $this->validMetadataFactory->get('dataset', '{}');
+    $get = $this->validMetadataFactory->get('{}', 'dataset');
     $mockChain = $this->getCommonMockChain()
       ->add(Service::class, "get", $get)
       ->add(DataModifierManager::class, 'getDefinitions', [['id' => 'foobar']])

--- a/modules/metastore/tests/src/WebServiceApiTest.php
+++ b/modules/metastore/tests/src/WebServiceApiTest.php
@@ -42,7 +42,7 @@ class WebServiceApiTest extends TestCase {
   public function testGetAll() {
     $data = ['name' => 'hello'];
     $dataWithRefs = ["name" => "hello", '%Ref:name' => ["identifier" => "123", "data" => "hello"]];
-    $objectWithRefs = $this->validMetadataFactory->get('blah', json_encode($dataWithRefs));
+    $objectWithRefs = $this->validMetadataFactory->get(json_encode($dataWithRefs), 'blah');
     $mockChain = $this->getCommonMockChain();
     $mockChain->add(Service::class, 'getAll', [$objectWithRefs, $objectWithRefs]);
     $mockChain->add(Service::class, "getValidMetadataFactory", ValidMetadataFactory::class);
@@ -55,7 +55,7 @@ class WebServiceApiTest extends TestCase {
   public function testGetAllRefs() {
     $dataWithRefs = ["name" => "hello", '%Ref:name' => ["identifier" => "123", "data" => "hello"]];
     $dataWithSwappedRefs = ["name" => ["identifier" => "123", "data" => "hello"]];
-    $objectWithRefs = $this->validMetadataFactory->get('blah', json_encode($dataWithRefs));
+    $objectWithRefs = $this->validMetadataFactory->get(json_encode($dataWithRefs), 'blah');
 
     $mockChain = $this->getCommonMockChain();
     $mockChain->add(Service::class, 'getAll', [$objectWithRefs, $objectWithRefs]);

--- a/tests/src/Functional/DatasetTest.php
+++ b/tests/src/Functional/DatasetTest.php
@@ -244,7 +244,7 @@ class DatasetTest extends ExistingSiteBase {
       $data->distribution[] = $distribution;
     }
 
-    return $this->validMetadataFactory->get('dataset', json_encode($data));
+    return $this->validMetadataFactory->get(json_encode($data), 'dataset');
   }
 
   /**


### PR DESCRIPTION
fixes [GetDKAN/dkan/issues/3506]

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Create a dataset with the Metastore API `POST` endpoint - `/api/1/metastore/schemas/dataset/items`
- [ ] Do not include `identifier` in your JSON payload, e.g.
```
{
  "title": "Dummy title",
  "description": "Dummy description",
  "accessLevel": "public",
  "modified": "2020-02-02",
  "keyword": [
    "test"
  ],
  "publisher": {
    "@type": "org:Organization",
    "name": "State Economic Council"
  },
  "distribution": [
    {
      "downloadURL": "file:///var/www/docroot/modules/contrib/dkan/modules/sample_content/files/Bike_Lane.csv",
      "mediaType": "text/csv",
      "format": "csv",
      "title": "Florida Bike Lanes"
    }
  ]
}
```
- [ ] Make sure that a new dataset has been created