### PR TITLE
fix titles on distribution and publisher schema files

### DIFF
--- a/schema/collections/distribution.json
+++ b/schema/collections/distribution.json
@@ -1,6 +1,6 @@
 {
-  "title": "Tags",
-  "description": "Tags (or keywords) help users discover your dataset; please include terms that would be used by technical and non-technical users.",
+  "title": "Distribution",
+  "description": "A container for the array of Distribution objects (data files).",
   "type": "object",
   "required": [
     "identifier",

--- a/schema/collections/publisher.json
+++ b/schema/collections/publisher.json
@@ -1,6 +1,6 @@
 {
-  "title": "Tags",
-  "description": "Tags (or keywords) help users discover your dataset; please include terms that would be used by technical and non-technical users.",
+  "title": "Publisher",
+  "description": "A Dataset Publisher Organization.",
   "type": "object",
   "required": [
     "identifier",


### PR DESCRIPTION
The distribution and publisher schema files are showing "Tags" as the title, this PR updates them to reflect the correct title.