### PR TITLE
Update the dkan admin view to filter by dataset by default

### DIFF
--- a/cypress/integration/07_admin_dataset_json_form.spec.js
+++ b/cypress/integration/07_admin_dataset_json_form.spec.js
@@ -44,13 +44,17 @@ context('Admin dataset json form', () => {
         .click({ force: true });
         cy.get('input[aria-controls="select2-edit-field-json-metadata-0-value-keyword-keyword-0-results"]').type('open data{enter}')
         // End filling up keyword.
+        cy.get('#edit-actions').within(() => {
+          cy.get('#edit-preview').should('not.exist')
+        })
         cy.get('#edit-submit').click({ force:true })
         cy.get('.messages--status').should('contain','has been created')
         // Confirm the default dkan admin view is filtered to show only datasets.
         cy.visit(baseurl + "/admin/dkan/datasets")
-        cy.get('tbody td.views-field-field-data-type').each(($el) => {
-            expect($el.text()).to.contains('dataset')
-            return null;
+        cy.get('tbody tr').each(($el) => {
+          cy.wrap($el).within(() => {
+            cy.get('td.views-field-field-data-type').should('contain', 'dataset')
+          })
         })
         // Edit the dataset.
         cy.get('#edit-title').type('DKANTEST dataset title', { force:true } )
@@ -67,6 +71,9 @@ context('Admin dataset json form', () => {
         cy.get('#edit-field-json-metadata-0-value-distribution-distribution-0-distribution-title').type('DKANTEST distribution title text', { force:true })
         cy.get('#edit-field-json-metadata-0-value-distribution-distribution-0-distribution-description').type('DKANTEST distribution description text', { force:true })
         cy.get('#edit-field-json-metadata-0-value-distribution-distribution-0-distribution-format-select').select('csv', { force:true })
+        cy.get('#edit-actions').within(() => {
+          cy.get('#edit-preview').should('not.exist')
+        })
         cy.get('#edit-submit').click({ force:true })
         cy.get('.messages--status').should('contain','has been updated')
         // Delete dataset.
@@ -76,19 +83,6 @@ context('Admin dataset json form', () => {
         cy.get('#edit-submit--2').click({ force:true })
         cy.get('input[value="Delete"]').click({ force:true })
         cy.get('.messages').should('contain','Deleted 1 content item.')
-    })
-    it('User does not see a preview button on the dataset form.', () => {
-        cy.visit(baseurl + "/node/add/data")
-        cy.wait(2000)
-        cy.get('#edit-actions').within(() => {
-          cy.get('#edit-preview').should('not.exist')
-        })
-        cy.visit(baseurl + "/admin/dkan/datasets")
-        cy.wait(2000)
-        cy.get('tbody > tr:first-of-type > .views-field-nothing > a').click({ force:true })
-        cy.get('#edit-actions').within(() => {
-          cy.get('#edit-preview').should('not.exist')
-        })
     })
 
 })

--- a/cypress/integration/07_admin_dataset_json_form.spec.js
+++ b/cypress/integration/07_admin_dataset_json_form.spec.js
@@ -46,8 +46,13 @@ context('Admin dataset json form', () => {
         // End filling up keyword.
         cy.get('#edit-submit').click({ force:true })
         cy.get('.messages--status').should('contain','has been created')
-        // Editing dataset.
+        // Confirm the default dkan admin view is filtered to show only datasets.
         cy.visit(baseurl + "/admin/dkan/datasets")
+        cy.get('tbody td.views-field-field-data-type').each(($el) => {
+            expect($el.text()).to.contains('dataset')
+            return null;
+        })
+        // Edit the dataset.
         cy.get('#edit-title').type('DKANTEST dataset title', { force:true } )
         cy.get('#edit-submit-dkan-dataset-content').click({ force:true })
         cy.get('tbody > tr:first-of-type > .views-field-nothing > a').click({ force:true })

--- a/cypress/integration/08_admin_views.spec.js
+++ b/cypress/integration/08_admin_views.spec.js
@@ -44,8 +44,7 @@ context('Admin content and dataset views', () => {
     it('The default results list only contains datasets.', () => {
         cy.visit(baseurl + "/admin/dkan/datasets")
         cy.get('tbody td.views-field-field-data-type').each(($el, index, $list) => {
-            const CellValue = $el.text();
-            expect(CellValue).to.contains('dataset')
+            expect($el.text()).to.contains('dataset')
         })
     })
 

--- a/cypress/integration/08_admin_views.spec.js
+++ b/cypress/integration/08_admin_views.spec.js
@@ -43,9 +43,9 @@ context('Admin content and dataset views', () => {
 
     it('The default results list only contains datasets.', () => {
         cy.visit(baseurl + "/admin/dkan/datasets")
-        cy.get('tbody td.views-field-field-data-type').each(($el, index, $list) => {
+        cy.get('tbody td.views-field-field-data-type').each(($el) => {
             expect($el.text()).to.contains('dataset')
-            // http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it
+            // Return empty promise.
             return null;
         })
     })

--- a/cypress/integration/08_admin_views.spec.js
+++ b/cypress/integration/08_admin_views.spec.js
@@ -41,13 +41,4 @@ context('Admin content and dataset views', () => {
         cy.get('h1').should('contain.text', 'Edit Data')
     })
 
-    it('The default results list only contains datasets.', () => {
-        cy.visit(baseurl + "/admin/dkan/datasets")
-        cy.get('tbody td.views-field-field-data-type').each(($el) => {
-            expect($el.text()).to.contains('dataset')
-            // Return empty promise.
-            return null;
-        })
-    })
-
   })

--- a/cypress/integration/08_admin_views.spec.js
+++ b/cypress/integration/08_admin_views.spec.js
@@ -45,6 +45,8 @@ context('Admin content and dataset views', () => {
         cy.visit(baseurl + "/admin/dkan/datasets")
         cy.get('tbody td.views-field-field-data-type').each(($el, index, $list) => {
             expect($el.text()).to.contains('dataset')
+            // http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it
+            return null;
         })
     })
 

--- a/cypress/integration/08_admin_views.spec.js
+++ b/cypress/integration/08_admin_views.spec.js
@@ -4,7 +4,6 @@ context('Admin content and dataset views', () => {
         cy.drupalLogin('testeditor', 'testeditor')
     })
 
-    // DKAN Content View.
     it('The admin content screen has an exposed data type filter that contains the values I expect.', () => {
         cy.visit(baseurl + "/admin/dkan/datasets")
         cy.get('h1').should('have.text', 'DKAN Metastore (Datasets)')
@@ -22,43 +21,32 @@ context('Admin content and dataset views', () => {
 
     it('There is a link in the admin menu to the datasets admin screen.', () => {
         cy.visit(baseurl + "/admin/dkan/datasets")
-        cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=>{
+        cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=> {
             cy.wrap($el).invoke('show')
             cy.wrap($el).contains('Datasets')
         })
     })
 
-    // DKAN Dataset view
     it('There is an "Add new dataset" button that takes user to the dataset json form.', () => {
         cy.visit(baseurl + "/admin/dkan/datasets")
         cy.get('h1').should('have.text', 'DKAN Metastore (Datasets)')
         cy.get('.view-header > .form-actions > .button').should('contain', 'Add new dataset').click({ force:true })
+        cy.get('h1').should('have.text', 'Create Data')
     })
 
     it('The dataset edit link should go to the json form.', () => {
         cy.visit(baseurl + "/admin/dkan/datasets")
-        cy.get('.view-header > .form-actions > .button').click({ force: true })
-        cy.get('#edit-field-json-metadata-0-value-title').type('DKANTEST dataset title', { force: true })
-        cy.get('#edit-field-json-metadata-0-value-description').type('DKANTEST dataset description.', { force: true })
-        cy.get('#edit-field-json-metadata-0-value-accesslevel').select('public', { force: true })
-        cy.get('#edit-field-json-metadata-0-value-modified-date').type('2020-02-02', { force: true })
-        // Fill select2 field for publisher.
-        cy.get('#edit-field-json-metadata-0-value-publisher-publisher-name + .select2')
-        .find('.select2-selection')
-        .click({ force: true });
-        cy.get('input[aria-controls="select2-edit-field-json-metadata-0-value-publisher-publisher-name-results"]').type('DKANTEST Publisher{enter}')
-        // End filling up publisher.
-        cy.get('#edit-field-json-metadata-0-value-contactpoint-contactpoint-fn').type('DKANTEST Contact Name', { force: true })
-        cy.get('#edit-field-json-metadata-0-value-contactpoint-contactpoint-hasemail').type('dkantest@test.com', { force: true })
-        // Fill select2 field for keyword.
-        cy.get('#edit-field-json-metadata-0-value-keyword-keyword-0 + .select2')
-        .find('.select2-selection')
-        .click({ force: true });
-        cy.get('input[aria-controls="select2-edit-field-json-metadata-0-value-keyword-keyword-0-results"]').type('open data{enter}')
-        // End filling up keyword.
-        cy.get('#edit-submit').click({ force: true })
-        cy.get('.messages--status').should('contain', 'has been created')
-        cy.get('table .views-field.views-field-nothing > a').invoke('attr', 'href').should('contain', '/edit');
+        cy.get('tbody > :nth-child(1) > .views-field-nothing > a').invoke('attr', 'href').should('contain', '/edit')
+        cy.get('tbody > :nth-child(1) > .views-field-nothing > a').click({ force: true })
+        cy.get('h1').should('contain.text', 'Edit Data')
     })
 
-})
+    it('The default results list only contains datasets.', () => {
+        cy.visit(baseurl + "/admin/dkan/datasets")
+        cy.get('tbody td.views-field-field-data-type').each(($el, index, $list) => {
+            const CellValue = $el.text();
+            expect(CellValue).to.contains('dataset')
+        })
+    })
+
+  })

--- a/cypress/integration/08_admin_views.spec.js
+++ b/cypress/integration/08_admin_views.spec.js
@@ -37,7 +37,28 @@ context('Admin content and dataset views', () => {
 
     it('The dataset edit link should go to the json form.', () => {
         cy.visit(baseurl + "/admin/dkan/datasets")
-        cy.get('tbody > :nth-child(1) > .views-field-nothing > a').invoke('attr', 'href').should('contain', '/edit');
+        cy.get('.view-header > .form-actions > .button').click({ force: true })
+        cy.get('#edit-field-json-metadata-0-value-title').type('DKANTEST dataset title', { force: true })
+        cy.get('#edit-field-json-metadata-0-value-description').type('DKANTEST dataset description.', { force: true })
+        cy.get('#edit-field-json-metadata-0-value-accesslevel').select('public', { force: true })
+        cy.get('#edit-field-json-metadata-0-value-modified-date').type('2020-02-02', { force: true })
+        // Fill select2 field for publisher.
+        cy.get('#edit-field-json-metadata-0-value-publisher-publisher-name + .select2')
+        .find('.select2-selection')
+        .click({ force: true });
+        cy.get('input[aria-controls="select2-edit-field-json-metadata-0-value-publisher-publisher-name-results"]').type('DKANTEST Publisher{enter}')
+        // End filling up publisher.
+        cy.get('#edit-field-json-metadata-0-value-contactpoint-contactpoint-fn').type('DKANTEST Contact Name', { force: true })
+        cy.get('#edit-field-json-metadata-0-value-contactpoint-contactpoint-hasemail').type('dkantest@test.com', { force: true })
+        // Fill select2 field for keyword.
+        cy.get('#edit-field-json-metadata-0-value-keyword-keyword-0 + .select2')
+        .find('.select2-selection')
+        .click({ force: true });
+        cy.get('input[aria-controls="select2-edit-field-json-metadata-0-value-keyword-keyword-0-results"]').type('open data{enter}')
+        // End filling up keyword.
+        cy.get('#edit-submit').click({ force: true })
+        cy.get('.messages--status').should('contain', 'has been created')
+        cy.get('table .views-field.views-field-nothing > a').invoke('attr', 'href').should('contain', '/edit');
     })
 
 })

--- a/cypress/integration/08_admin_views.spec.js
+++ b/cypress/integration/08_admin_views.spec.js
@@ -35,10 +35,35 @@ context('Admin content and dataset views', () => {
     })
 
     it('The dataset edit link should go to the json form.', () => {
+        // Create a dataset.
+        cy.visit(baseurl + "/node/add/data")
+        cy.wait(2000)
+        cy.get('#edit-field-json-metadata-0-value-title').type('DKANTEST dataset title', { force:true } )
+        cy.get('#edit-field-json-metadata-0-value-description').type('DKANTEST dataset description.', { force:true } )
+        cy.get('#edit-field-json-metadata-0-value-accesslevel').select('public', { force:true } )
+        cy.get('#edit-field-json-metadata-0-value-modified-date').type('2020-02-02', { force:true } )
+        // Fill select2 field for publisher.
+        cy.get('#edit-field-json-metadata-0-value-publisher-publisher-name + .select2')
+          .find('.select2-selection')
+          .click({ force:true });
+        cy.get('input[aria-controls="select2-edit-field-json-metadata-0-value-publisher-publisher-name-results"]').type('DKANTEST Publisher{enter}')
+        // End filling up publisher.
+        cy.get('#edit-field-json-metadata-0-value-contactpoint-contactpoint-fn').type('DKANTEST Contact Name', { force:true } )
+        cy.get('#edit-field-json-metadata-0-value-contactpoint-contactpoint-hasemail').type('dkantest@test.com', { force:true } )
+        // Fill select2 field for keyword.
+        cy.get('#edit-field-json-metadata-0-value-keyword-keyword-0 + .select2')
+        .find('.select2-selection')
+        .click({ force: true });
+        cy.get('input[aria-controls="select2-edit-field-json-metadata-0-value-keyword-keyword-0-results"]').type('open data{enter}')
+        // End filling up keyword.
+        cy.get('#edit-submit').click({ force:true })
+        cy.get('.messages--status').should('contain','has been created')
         cy.visit(baseurl + "/admin/dkan/datasets")
+        cy.wait(2000)
         cy.get('tbody > :nth-child(1) > .views-field-nothing > a').invoke('attr', 'href').should('contain', '/edit')
         cy.get('tbody > :nth-child(1) > .views-field-nothing > a').click({ force: true })
         cy.get('h1').should('contain.text', 'Edit Data')
+        cy.get('#edit-delete').click({ force:true })
     })
 
   })

--- a/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
+++ b/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
@@ -9,7 +9,7 @@ dependencies:
     - node
     - user
 _core:
-  default_config_hash: JJ6DPebkL1IQR5zAMGv3XEHJ7DDkhUeD2jgxJ4X7dKU
+  default_config_hash: 0NJOmqzHFD4tr5p2Gh12RsF6qxDspzU4rCD1y12yBgU
 id: dkan_dataset_content
 label: 'DKAN Datasets'
 module: node
@@ -669,7 +669,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: ''
+          value: dataset
           group: 1
           exposed: true
           expose:

--- a/modules/metastore/modules/metastore_admin/metastore_admin.install
+++ b/modules/metastore/modules/metastore_admin/metastore_admin.install
@@ -65,3 +65,17 @@ function metastore_admin_update_8007() {
 
   drupal_flush_all_caches();
 }
+/**
+ * Update default display to filter by datasets.
+ */
+function metastore_admin_update_8008() {
+  $view = \Drupal::service('config.factory')->getEditable('views.view.dkan_dataset_content');
+  $displays = $view->get('display');
+  foreach ($displays as $display_name => $display) {
+    if ($display_name === 'default') {
+      $view->set('display.default.display_options.filters.field_data_type_value.value', 'dataset');
+      $view->save(TRUE);
+    }
+  }
+  drupal_flush_all_caches();
+}


### PR DESCRIPTION
The title of the dkan content view, is 'Datasets' so let's default to show just the datasets by default

## QA Steps

- [ ] Navigate to `/admin/dkan/datasets` and confirm you only see datasets by default and can use the UI to select other options