### PR TITLE
Allow query by dataset/distribution-index in addition to distribution for datastore

### DIFF
--- a/modules/datastore/datastore.routing.yml
+++ b/modules/datastore/datastore.routing.yml
@@ -121,6 +121,16 @@ datastore.1.query.id.get:
   options:
     _auth: ['basic_auth', 'cookie']
 
+datastore.1.query.dataset.index.get:
+  path: '/api/1/datastore/query/{dataset}/{index}'
+  methods: [GET]
+  defaults:
+    _controller: '\Drupal\datastore\Controller\QueryController::queryDatasetResource'
+  requirements:
+    _permission: 'access content'
+  options:
+    _auth: ['basic_auth', 'cookie']
+
 datastore.1.query.id.download.get:
   path: '/api/1/datastore/query/{identifier}/download'
   methods: [GET]

--- a/modules/datastore/datastore.routing.yml
+++ b/modules/datastore/datastore.routing.yml
@@ -111,6 +111,16 @@ datastore.1.query.id.post:
   options:
     _auth: ['basic_auth', 'cookie']
 
+datastore.1.query.dataset.index.post:
+  path: '/api/1/datastore/query/{dataset}/{index}'
+  methods: [POST]
+  defaults:
+    _controller: '\Drupal\datastore\Controller\QueryController::queryDatasetResource'
+  requirements:
+    _permission: 'access content'
+  options:
+    _auth: ['basic_auth', 'cookie']
+
 datastore.1.query.id.get:
   path: '/api/1/datastore/query/{identifier}'
   methods: [GET]
@@ -142,11 +152,33 @@ datastore.1.query.id.download.get:
   options:
     _auth: ['basic_auth', 'cookie']
 
+datastore.1.query.dataset.index.download.get:
+  path: '/api/1/datastore/query/{dataset}/{index}/download'
+  methods: [GET]
+  defaults:
+    _controller: '\Drupal\datastore\Controller\QueryController::queryDatasetResource'
+    stream: true
+  requirements:
+    _permission: 'access content'
+  options:
+    _auth: ['basic_auth', 'cookie']
+
 datastore.1.query.id.download.post:
   path: '/api/1/datastore/query/{identifier}/download'
   methods: [POST]
   defaults:
     _controller: '\Drupal\datastore\Controller\QueryController::queryResource'
+    stream: true
+  requirements:
+    _permission: 'access content'
+  options:
+    _auth: ['basic_auth', 'cookie']
+
+datastore.1.query.dataset.index.download.post:
+  path: '/api/1/datastore/query/{dataset}/{index}/download'
+  methods: [POST]
+  defaults:
+    _controller: '\Drupal\datastore\Controller\QueryController::queryDatasetResource'
     stream: true
   requirements:
     _permission: 'access content'

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -276,13 +276,10 @@ class QueryController implements ContainerInjectionInterface {
     if (!isset($metadata['latest_revision'])) {
       return $this->getResponse((object) ['message' => "No dataset found with the identifier $dataset"], 400);
     }
-    if (!isset($metadata['latest_revision']['distributions'][$index])) {
+    if (!isset($metadata['latest_revision']['distributions'][$index]['distribution_uuid'])) {
       return $this->getResponse((object) ['message' => "No resource found at index $index"], 400);
     }
     $identifier = $metadata['latest_revision']['distributions'][$index]['distribution_uuid'];
-    if (!$identifier) {
-      return $this->getResponse((object) ['message' => "Distribution not found."], 400);
-    }
     return $this->queryResource($identifier, $stream);
   }
 

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\datastore\Controller;
 
+use Drupal\common\DatasetInfo;
 use Drupal\datastore\Service\DatastoreQuery;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -36,11 +37,19 @@ class QueryController implements ContainerInjectionInterface {
   private $requestStack;
 
   /**
+   * DatasetInfo Service.
+   *
+   * @var \Drupal\common\DatasetInfo
+   */
+  protected $datasetInfo;
+
+  /**
    * Api constructor.
    */
-  public function __construct(Service $datastoreService, RequestStack $requestStack) {
+  public function __construct(Service $datastoreService, RequestStack $requestStack, DatasetInfo $datasetInfo) {
     $this->datastoreService = $datastoreService;
     $this->requestStack = $requestStack;
+    $this->datasetInfo = $datasetInfo;
   }
 
   /**
@@ -49,7 +58,8 @@ class QueryController implements ContainerInjectionInterface {
   public static function create(ContainerInterface $container) {
     $datastoreService = $container->get('dkan.datastore.service');
     $requestStack = $container->get('request_stack');
-    return new QueryController($datastoreService, $requestStack);
+    $datasetInfo = $container->get('dkan.common.dataset_info');
+    return new QueryController($datastoreService, $requestStack, $datasetInfo);
   }
 
   /**
@@ -246,6 +256,34 @@ class QueryController implements ContainerInjectionInterface {
     }
 
     return $this->formatResponse($datastoreQuery, $result);
+  }
+
+  /**
+   * Perform a query on a single datastore resource.
+   *
+   * @param string $dataset
+   *   The uuid of a dataset.
+   * @param string $index
+   *   The index of the resource in the dataset array.
+   * @param bool $stream
+   *   Whether to return result as a streamed file.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   The json response.
+   */
+  public function queryDatasetResource(string $dataset, string $index, bool $stream = FALSE) {
+    $metadata = $this->datasetInfo->gather($dataset);
+    if (!isset($metadata['latest_revision'])) {
+      return $this->getResponse((object) ['message' => "No dataset found with the identifier $dataset"], 400);
+    }
+    if (!isset($metadata['latest_revision']['distributions'][$index])) {
+      return $this->getResponse((object) ['message' => "No resource found at index $index"], 400);
+    }
+    $identifier = $metadata['latest_revision']['distributions'][$index]['distribution_uuid'];
+    if (!$identifier) {
+      return $this->getResponse((object) ['message' => "Distribution not found."], 400);
+    }
+    return $this->queryResource($identifier, $stream);
   }
 
   /**

--- a/modules/datastore/tests/src/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Controller/QueryControllerTest.php
@@ -221,6 +221,30 @@ class QueryControllerTest extends TestCase {
     $this->assertEquals('1,data', $csv[501]);
   }
 
+  /**
+   * Test streamed resource csv through dataset distribution index.
+   */
+  public function testStreamedResourceQueryCsvDatasetDistIndex() {
+    $data = json_encode([
+      "format" => "csv",
+    ]);
+    // Need 2 json responses which get combined on output.
+    $info['latest_revision']['distributions'][0]['distribution_uuid'] = '123';
+
+    $container = $this->getQueryContainer($data, 'POST', TRUE, $info);
+    $webServiceApi = QueryController::create($container);
+    ob_start(['self', 'getBuffer']);
+    $result = $webServiceApi->queryDatasetResource("2", "0", TRUE);
+    $result->sendContent();
+
+    $csv = explode("\n", $this->buffer);
+    ob_get_clean();
+    $this->assertEquals('record_number,data', $csv[0]);
+    $this->assertEquals('1,data', $csv[1]);
+    $this->assertEquals('50,data', $csv[50]);
+    $this->assertEquals('1,data', $csv[501]);
+  }
+
   public function testQuerySchema() {
     $container = $this->getQueryContainer();
     $webServiceApi = QueryController::create($container);

--- a/modules/datastore/tests/src/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Controller/QueryControllerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Drupal\common\DatasetInfo;
 use MockChain\Options;
 use Drupal\datastore\Service;
 use MockChain\Sequence;
@@ -242,11 +243,13 @@ class QueryControllerTest extends TestCase {
       ->add("dkan.metastore.storage", DataFactory::class)
       ->add("dkan.datastore.service", Service::class)
       ->add("request_stack", RequestStack::class)
+      ->add("dkan.common.dataset_info", DatasetInfo::class)
       ->index(0);
 
     $chain = (new Chain($this))
       ->add(Container::class, "get", $options)
-      ->add(RequestStack::class, 'getCurrentRequest', $request);
+      ->add(RequestStack::class, 'getCurrentRequest', $request)
+      ->add(DatasetInfo::class, "gather", []);
 
     if ($stream) {
       $chain->add(Service::class, "runQuery", $this->addMultipleResponses());


### PR DESCRIPTION
fixes #3514 

## QA Steps

- If you have a dataset with identifier "abc" which contains a single distribution with identifier "xyz" and you query it using the endpoint `/api/1/datastore/query/xyz`, you should also be able to use the endpoint: `/api/1/datastore/query/abc/0` and get the same results. You can try the following URLs:
  - [ ] https://dkan-qa-3528.ci.civicactions.net/api/1/datastore/query/e1f2ebcd-ee23-454f-87b5-df0306658418/0 should return the same set of results than https://dkan-qa-3528.ci.civicactions.net/api/1/datastore/query/5dfd9d60-4f20-5b1d-bcc5-a385a95f7f30
  - [ ] https://dkan-qa-3528.ci.civicactions.net/api/1/datastore/query/e1f2ebcd-ee23-454f-87b5-df0306658418/1 should return the same set of results than https://dkan-qa-3528.ci.civicactions.net/api/1/datastore/query/ca419d8e-8a29-55b0-a323-ad917741ff6a
- If you query the endpoint `/api/1/datastore/query/abc/0` but there isn't a dataset with the identifier abc, then you should get an error. You can try:
  - [ ] https://dkan-qa-3528.ci.civicactions.net/api/1/datastore/query/e1f2ebcd-ee23-454f-87b5-df0306658417/0 should return "No dataset found with the identifier e1f2ebcd-ee23-454f-87b5-df0306658417".
- If you query the endpoint `/api/1/datastore/query/abc/1` but there isn't a distribution in the index 1 for the dataset with the identifier abc, then you should get an error. You can try:
  - [ ] https://dkan-qa-3528.ci.civicactions.net/api/1/datastore/query/e1f2ebcd-ee23-454f-87b5-df0306658418/2 should return "No resource found at index 2".