### PR TITLE
Save dates in correct format ISO 8601

### DIFF
--- a/modules/json_form_widget/src/Element/DateRange.php
+++ b/modules/json_form_widget/src/Element/DateRange.php
@@ -65,21 +65,8 @@ class DateRange extends Datetime {
   public static function valueCallback(&$element, $input, FormStateInterface $form_state) {
     $element += ['#date_timezone' => date_default_timezone_get()];
     if ($input !== FALSE) {
-      $input['date_range'] = '';
-      $date_format = $element['#date_date_element'] != 'none' ? static::getHtml5DateFormat($element) : '';
-      $time_format = $element['#date_time_element'] != 'none' ? static::getHtml5TimeFormat($element) : '';
-      $date_time_format = trim($date_format . ' ' . $time_format);
-
-      $start = '';
-      if (!empty($input['start_date']['date'])) {
-        $start_time = static::getFormattedTime($input['start_date']['time']);
-        $start = static::getDateTimeElement($input['start_date']['date'], $start_time, $date_time_format, $element['#date_timezone']);
-      }
-      $end = '';
-      if (!empty($input['end_date']['date'])) {
-        $end_time = static::getFormattedTime($input['end_date']['time']);
-        $end = static::getDateTimeElement($input['end_date']['date'], $end_time, $date_time_format, $element['#date_timezone']);
-      }
+      $start = static::getDateValue('start_date', $element, $input);
+      $end = static::getDateValue('end_date', $element, $input);
       $range = (empty($start) && empty($end)) ? '' : $start . '/' . $end;
       $input = [
         'start' => $start,
@@ -88,6 +75,32 @@ class DateRange extends Datetime {
       ];
     }
     return $input;
+  }
+
+  /**
+   * Get date value for date sub element.
+   *
+   * @param string $date_field
+   *   The name of the date field (for example: start_date or end_date).
+   * @param array $element
+   *   The element.
+   * @param array $input
+   *   Input to take the value from.
+   *
+   * @return string
+   *   Date element formatted as string.
+   */
+  public static function getDateValue($date_field, array $element, array $input) {
+    $input['date_range'] = '';
+    $date_format = $element['#date_date_element'] != 'none' ? static::getHtml5DateFormat($element) : '';
+    $time_format = $element['#date_time_element'] != 'none' ? static::getHtml5TimeFormat($element) : '';
+    $date_time_format = trim($date_format . ' ' . $time_format);
+
+    if (!empty($input[$date_field]['date'])) {
+      $time = static::getFormattedTime($input[$date_field]['time']);
+      return static::getDateTimeElement($input[$date_field]['date'], $time, $date_time_format, $element['#date_timezone']);
+    }
+    return '';
   }
 
   /**

--- a/modules/json_form_widget/src/Element/DateRange.php
+++ b/modules/json_form_widget/src/Element/DateRange.php
@@ -80,10 +80,11 @@ class DateRange extends Datetime {
         $end_time = static::getFormattedTime($input['end_date']['time']);
         $end = static::getDateTimeElement($input['end_date']['date'], $end_time, $date_time_format, $element['#date_timezone']);
       }
+      $range = (empty($start) && empty($end)) ? '' : $start . '/' . $end;
       $input = [
         'start' => $start,
         'end' => $end,
-        'date_range' => $start . '/' . $end,
+        'date_range' => $range,
       ];
     }
     return $input;

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -36,7 +36,7 @@ class ValueHandler {
    */
   public function handleStringValues($formValues, $property) {
     if (isset($formValues[$property]) && $formValues[$property] instanceof DrupalDateTime) {
-      return $formValues[$property]->__toString();
+      return $formValues[$property]->format('c', ['timezone' => 'UTC']);
     }
     if (!empty($formValues[$property]) && isset($formValues[$property]['date_range'])) {
       return $formValues[$property]['date_range'];

--- a/modules/json_form_widget/tests/src/Unit/ValueHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/ValueHandlerTest.php
@@ -220,7 +220,7 @@ class ValueHandlerTest extends TestCase {
     $formValues = [
       'modified' => $date,
     ];
-    $expected = $date->__toString();
+    $expected = $date->format('c', ['timezone' => 'UTC']);
     $result = $value_handler->handleStringValues($formValues, 'modified');
     $this->assertEquals($result, $expected);
 


### PR DESCRIPTION
fixes #3540 
Date widgets within json metadata field are saving dates in the incorrect format.
I'm also fixing a bug with the DateRange element where if the user doesn't fill those values, the field gets the value of "/" and the next time you load the form you see the current date as start and end date.

## QA Steps

- Create a new data node using the form and fill in the "Last updated" field. Save the node and check:
  - [ ] confirm the value for the "Last Updated" (modified) field is in the format `2021-06-27T00:00:00+00:00` (you can check it in the database or in the API api/1/metastore/schemas/dataset/items).
  - [ ] confirm the value for the "temporal" field is empty (or the field doesn't exist at all).
- Edit the node, add a value for the "temporal" field and save:
  - [ ] confirm the value is in the format `start/end`, similar to `2021-06-27T00:00:00+00:00/2021-07-15T00:00:00+00:00`
