### PR TITLE
ValidMetadata argument order in metadata.module

### DIFF
--- a/modules/metastore/metastore.module
+++ b/modules/metastore/metastore.module
@@ -134,7 +134,7 @@ function metastore_form_alter(&$form, FormStateInterface $form_state, $form_id) 
       return;
     }
     // TODO: use an actual schema id.
-    $object = \Drupal::service('dkan.metastore.valid_metadata')->get(NULL, $json);
+    $object = \Drupal::service('dkan.metastore.valid_metadata')->get($json, NULL);
     $object = \Drupal\metastore\Service::removeReferences($object);
     $form[$fieldName]['widget'][0]['value']['#default_value'] = json_encode($object);
   }
@@ -152,7 +152,7 @@ function metastore_entity_view_alter(array &$build, EntityInterface $entity, Ent
       return;
     }
 
-    $object = \Drupal::service('dkan.metastore.valid_metadata')->get(NULL, $json);
+    $object = \Drupal::service('dkan.metastore.valid_metadata')->get($json, NULL);
     $object = Service::removeReferences($object);
     $build[$fieldName][0]['#context']['value'] = (string) $object;
   }


### PR DESCRIPTION
metadata.module still using old argument order. Also reveals gap in test coverage to be fixed at another time.