### PR TITLE
Added CachableResponseTrait

### DIFF
--- a/modules/common/src/CachableResponseTrait.php
+++ b/modules/common/src/CachableResponseTrait.php
@@ -10,6 +10,13 @@ use Symfony\Component\HttpFoundation\Response;
 trait CachableResponseTrait {
 
   /**
+   * Cache page max age config value.
+   *
+   * @var int
+   */
+  protected $maxAge;
+
+  /**
    * Adds cache headers to the response.
    *
    * TODO: implement more flexible caching and move the code out of the trait.
@@ -23,10 +30,13 @@ trait CachableResponseTrait {
    * @throws \Exception
    */
   private function addCacheHeaders(Response $response) : Response {
+    if (!isset($this->maxAge)) {
+      $this->maxAge = \Drupal::config('system.performance')->get('cache.page.max_age');
+    }
     $response->setCache([
       'public' => TRUE,
       'private' => FALSE,
-      'max_age' => 600,
+      'max_age' => $this->maxAge,
       'last_modified' => new \DateTime(),
     ]);
     $response->setVary('Cookie');

--- a/modules/common/src/CachableResponseTrait.php
+++ b/modules/common/src/CachableResponseTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\common;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Cachable Response Trait.
+ */
+trait CachableResponseTrait {
+
+  /**
+   * Adds cache headers to the response.
+   *
+   * TODO: implement more flexible caching and move the code out of the trait.
+   *
+   * @param \Symfony\Component\HttpFoundation\Response $response
+   *   Symfony response.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   Symfony response.
+   *
+   * @throws \Exception
+   */
+  private function addCacheHeaders(Response $response) : Response {
+    $response->setCache([
+      'public' => TRUE,
+      'private' => FALSE,
+      'max_age' => 600,
+      'last_modified' => new \DateTime(),
+    ]);
+    $response->setVary('Cookie');
+    return $response;
+  }
+
+}

--- a/modules/common/src/CacheableResponseTrait.php
+++ b/modules/common/src/CacheableResponseTrait.php
@@ -14,7 +14,7 @@ trait CacheableResponseTrait {
    *
    * @var int
    */
-  protected $maxAge;
+  protected $cacheMaxAge;
 
   /**
    * Adds cache headers to the response.
@@ -30,19 +30,33 @@ trait CacheableResponseTrait {
    * @throws \Exception
    */
   private function addCacheHeaders(Response $response) : Response {
-    if (!isset($this->maxAge)) {
-      $this->maxAge = \Drupal::config('system.performance')->get('cache.page.max_age');
-    }
-    if ($this->maxAge !== 0) {
+    $this->setCacheMaxAge();
+
+    if ($this->cacheMaxAge !== 0) {
       $response->setCache([
         'public' => TRUE,
         'private' => FALSE,
-        'max_age' => $this->maxAge,
+        'max_age' => $this->cacheMaxAge,
         'last_modified' => new \DateTime(),
       ]);
       $response->setVary('Cookie');
     }
     return $response;
+  }
+
+  /**
+   * Sets cache max age.
+   */
+  private function setCacheMaxAge() {
+    if (!isset($this->cacheMaxAge)) {
+      // A hack to bypass the controllers' tests.
+      if (\Drupal::hasService('config.factory')) {
+        $this->cacheMaxAge = \Drupal::config('system.performance')->get('cache.page.max_age');
+      }
+      else {
+        $this->cacheMaxAge = 0;
+      }
+    }
   }
 
 }

--- a/modules/common/src/CacheableResponseTrait.php
+++ b/modules/common/src/CacheableResponseTrait.php
@@ -33,13 +33,15 @@ trait CacheableResponseTrait {
     if (!isset($this->maxAge)) {
       $this->maxAge = \Drupal::config('system.performance')->get('cache.page.max_age');
     }
-    $response->setCache([
-      'public' => TRUE,
-      'private' => FALSE,
-      'max_age' => $this->maxAge,
-      'last_modified' => new \DateTime(),
-    ]);
-    $response->setVary('Cookie');
+    if ($this->maxAge !== 0) {
+      $response->setCache([
+        'public' => TRUE,
+        'private' => FALSE,
+        'max_age' => $this->maxAge,
+        'last_modified' => new \DateTime(),
+      ]);
+      $response->setVary('Cookie');
+    }
     return $response;
   }
 

--- a/modules/common/src/CacheableResponseTrait.php
+++ b/modules/common/src/CacheableResponseTrait.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Cachable Response Trait.
  */
-trait CachableResponseTrait {
+trait CacheableResponseTrait {
 
   /**
    * Cache page max age config value.

--- a/modules/common/src/Controller/OpenApiController.php
+++ b/modules/common/src/Controller/OpenApiController.php
@@ -73,7 +73,8 @@ class OpenApiController implements ContainerInjectionInterface {
    * Get version.
    */
   public function getVersions() {
-    return new JsonResponse(["version" => 1, "url" => "/api/1"]);
+    $response = new JsonResponse(["version" => 1, "url" => "/api/1"]);
+    return $this->addCacheHeaders($response);
   }
 
   /**

--- a/modules/common/src/Controller/OpenApiController.php
+++ b/modules/common/src/Controller/OpenApiController.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\common\Controller;
 
-use Drupal\common\CachableResponseTrait;
+use Drupal\common\CacheableResponseTrait;
 use Drupal\common\JsonResponseTrait;
 use Drupal\common\DkanApiDocsGenerator;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class OpenApiController implements ContainerInjectionInterface {
   use JsonResponseTrait;
-  use CachableResponseTrait;
+  use CacheableResponseTrait;
 
   /**
    * API Docs generator class.

--- a/modules/common/src/Controller/OpenApiController.php
+++ b/modules/common/src/Controller/OpenApiController.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\common\Controller;
 
+use Drupal\common\CachableResponseTrait;
 use Drupal\common\JsonResponseTrait;
 use Drupal\common\DkanApiDocsGenerator;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
@@ -19,6 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class OpenApiController implements ContainerInjectionInterface {
   use JsonResponseTrait;
+  use CachableResponseTrait;
 
   /**
    * API Docs generator class.
@@ -108,7 +110,8 @@ class OpenApiController implements ContainerInjectionInterface {
    *   OpenAPI spec response.
    */
   private function getYamlResponse($spec, $code = 200) {
-    return new Response(Yaml::encode($spec), 200, ['Content-type' => 'application/vnd.oai.openapi']);
+    $response = new Response(Yaml::encode($spec), 200, ['Content-type' => 'application/vnd.oai.openapi']);
+    return $this->addCacheHeaders($response);
   }
 
 }

--- a/modules/common/src/JsonResponseTrait.php
+++ b/modules/common/src/JsonResponseTrait.php
@@ -13,7 +13,7 @@ use RootedData\Exception\ValidationException;
  * Json Response Trait.
  */
 trait JsonResponseTrait {
-  use CachableResponseTrait;
+  use CacheableResponseTrait;
 
   /**
    * Private.

--- a/modules/common/src/JsonResponseTrait.php
+++ b/modules/common/src/JsonResponseTrait.php
@@ -13,12 +13,14 @@ use RootedData\Exception\ValidationException;
  * Json Response Trait.
  */
 trait JsonResponseTrait {
+  use CachableResponseTrait;
 
   /**
    * Private.
    */
   private function getResponse($message, int $code = 200): JsonResponse {
-    return new JsonResponse($message, $code, []);
+    $response = new JsonResponse($message, $code, []);
+    return $this->addCacheHeaders($response);
   }
 
   /**

--- a/modules/common/tests/src/Controller/OpenApiControllerTest.php
+++ b/modules/common/tests/src/Controller/OpenApiControllerTest.php
@@ -83,7 +83,7 @@ class OpenApiControllerTest extends TestCase {
     $generator = new DkanApiDocsGenerator($container->getMock()->get('plugin.manager.dkan_api_docs'));
     $controller = new OpenApiController($container->getMock()->get('request_stack'), $generator);
 
-    // JSON. Cache on
+    // JSON. Caching on.
     $response = $controller->getComplete();
     $headers = $response->headers;
 
@@ -92,7 +92,7 @@ class OpenApiControllerTest extends TestCase {
     $this->assertEquals('Cookie', $headers->get('vary'));
     $this->assertNotEmpty($headers->get('last-modified'));
 
-    // YAML. Cache on
+    // YAML. Caching on.
     $response = $controller->getComplete('yaml');
     $headers = $response->headers;
 
@@ -108,7 +108,7 @@ class OpenApiControllerTest extends TestCase {
     $generator = new DkanApiDocsGenerator($container->getMock()->get('plugin.manager.dkan_api_docs'));
     $controller = new OpenApiController($container->getMock()->get('request_stack'), $generator);
 
-    // JSON. No cache.
+    // JSON. No caching.
     $response = $controller->getComplete();
     $headers = $response->headers;
 
@@ -117,7 +117,7 @@ class OpenApiControllerTest extends TestCase {
     $this->assertEmpty($headers->get('vary'));
     $this->assertEmpty($headers->get('last-modified'));
 
-    // YAML. No cache.
+    // YAML. No caching.
     $response = $controller->getComplete('yaml');
     $headers = $response->headers;
 

--- a/modules/common/tests/src/Controller/OpenApiControllerTest.php
+++ b/modules/common/tests/src/Controller/OpenApiControllerTest.php
@@ -6,6 +6,8 @@ use Drupal\common\Controller\OpenApiController;
 use Drupal\common\Plugin\DkanApiDocsBase;
 use Drupal\common\DkanApiDocsGenerator;
 use Drupal\common\Plugin\DkanApiDocsPluginManager;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\DependencyInjection\Container;
 use Drupal\Core\Extension\ModuleHandler;
 use Drupal\Core\Serialization\Yaml;
@@ -65,13 +67,85 @@ class OpenApiControllerTest extends TestCase {
   }
 
   /**
-   * Generate mock container.
+   * Test cache headers.
+   */
+  public function testGetCompleteCacheHeaders() {
+    $spec = Yaml::decode(file_get_contents(__DIR__ . '/../../docs/openapi_spec.yml'));
+    $request = new Request();
+
+    // Create a container with caching turned on.
+    $container = $this->getContainerMock($spec, $request)
+      ->add(Container::class, 'has', TRUE)
+      ->add(ConfigFactoryInterface::class, 'get', ImmutableConfig::class)
+      ->add(ImmutableConfig::class, 'get', 600);
+    \Drupal::setContainer($container->getMock());
+
+    $generator = new DkanApiDocsGenerator($container->getMock()->get('plugin.manager.dkan_api_docs'));
+    $controller = new OpenApiController($container->getMock()->get('request_stack'), $generator);
+
+    // JSON. Cache on
+    $response = $controller->getComplete();
+    $headers = $response->headers;
+
+    $this->assertEquals('application/json', $headers->get('content-type'));
+    $this->assertEquals('max-age=600, public', $headers->get('cache-control'));
+    $this->assertEquals('Cookie', $headers->get('vary'));
+    $this->assertNotEmpty($headers->get('last-modified'));
+
+    // YAML. Cache on
+    $response = $controller->getComplete('yaml');
+    $headers = $response->headers;
+
+    $this->assertEquals('application/vnd.oai.openapi', $headers->get('content-type'));
+    $this->assertEquals('max-age=600, public', $headers->get('cache-control'));
+    $this->assertEquals('Cookie', $headers->get('vary'));
+    $this->assertNotEmpty($headers->get('last-modified'));
+
+    // Turn caching off.
+    $container->add(ImmutableConfig::class, 'get', 0);
+    \Drupal::setContainer($container->getMock());
+
+    $generator = new DkanApiDocsGenerator($container->getMock()->get('plugin.manager.dkan_api_docs'));
+    $controller = new OpenApiController($container->getMock()->get('request_stack'), $generator);
+
+    // JSON. No cache.
+    $response = $controller->getComplete();
+    $headers = $response->headers;
+
+    $this->assertEquals('application/json', $headers->get('content-type'));
+    $this->assertEquals('no-cache, private', $headers->get('cache-control'));
+    $this->assertEmpty($headers->get('vary'));
+    $this->assertEmpty($headers->get('last-modified'));
+
+    // YAML. No cache.
+    $response = $controller->getComplete('yaml');
+    $headers = $response->headers;
+
+    $this->assertEquals('application/vnd.oai.openapi', $headers->get('content-type'));
+    $this->assertEquals('no-cache, private', $headers->get('cache-control'));
+    $this->assertEmpty($headers->get('vary'));
+    $this->assertEmpty($headers->get('last-modified'));
+  }
+
+  /**
+   * Generate mock controller.
    */
   private function getControllerMock($spec, Request $request) {
+    $container = $this->getContainerMock($spec, $request)->getMock();
+
+    $generator = new DkanApiDocsGenerator($container->get('plugin.manager.dkan_api_docs'));
+    return new OpenApiController($container->get('request_stack'), $generator);
+  }
+
+  /**
+   * Generate mock container.
+   */
+  private function getContainerMock($spec, Request $request) {
     $options = (new Options())
       ->add('module_handler', ModuleHandler::class)
       ->add('request_stack', RequestStack::class)
       ->add('plugin.manager.dkan_api_docs', DkanApiDocsPluginManager::class)
+      ->add('config.factory', ConfigFactoryInterface::class)
       ->index(0);
 
     $pluginDefinition = [
@@ -85,15 +159,11 @@ class OpenApiControllerTest extends TestCase {
       ->add(DkanApiDocsBase::class, 'spec', $spec)
       ->getMock();
 
-    $container = (new Chain($this))
+    return (new Chain($this))
       ->add(Container::class, 'get', $options)
       ->add(DkanApiDocsPluginManager::class, 'getDefinitions', [$pluginDefinition])
       ->add(DkanApiDocsPluginManager::class, 'createInstance', $pluginMock)
-      ->add(RequestStack::class, 'getCurrentRequest', $request)
-      ->getMock();
-
-    $generator = new DkanApiDocsGenerator($container->get('plugin.manager.dkan_api_docs'));
-    return new OpenApiController($container->get('request_stack'), $generator);
+      ->add(RequestStack::class, 'getCurrentRequest', $request);
   }
 
 }

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\datastore\Controller;
 
-use Drupal\common\CachableResponseTrait;
+use Drupal\common\CacheableResponseTrait;
 use Drupal\common\DatasetInfo;
 use Drupal\datastore\Service\DatastoreQuery;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -22,7 +22,7 @@ use Drupal\datastore\Service;
  */
 class QueryController implements ContainerInjectionInterface {
   use JsonResponseTrait;
-  use CachableResponseTrait;
+  use CacheableResponseTrait;
 
   /**
    * Datastore Service.

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\datastore\Controller;
 
+use Drupal\common\CachableResponseTrait;
 use Drupal\common\DatasetInfo;
 use Drupal\datastore\Service\DatastoreQuery;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -21,6 +22,7 @@ use Drupal\datastore\Service;
  */
 class QueryController implements ContainerInjectionInterface {
   use JsonResponseTrait;
+  use CachableResponseTrait;
 
   /**
    * Datastore Service.
@@ -104,7 +106,8 @@ class QueryController implements ContainerInjectionInterface {
   public function formatResponse(DatastoreQuery $datastoreQuery, RootedJsonData $result) {
     switch ($datastoreQuery->{"$.format"}) {
       case 'csv':
-        return new CsvResponse($result->{"$.results"}, 'data', ',');
+        $response = new CsvResponse($result->{"$.results"}, 'data', ',');
+        return $this->addCacheHeaders($response);
 
       case 'json':
       default:

--- a/modules/datastore/tests/src/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Controller/QueryControllerTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Drupal\common\DatasetInfo;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use MockChain\Options;
 use Drupal\datastore\Service;
 use MockChain\Sequence;
@@ -33,7 +35,7 @@ class QueryControllerTest extends TestCase {
     ]);
 
     $container = $this->getQueryContainer($data);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     $result = $webServiceApi->query();
 
     $this->assertTrue($result instanceof JsonResponse);
@@ -46,7 +48,7 @@ class QueryControllerTest extends TestCase {
     ]);
 
     $container = $this->getQueryContainer($data);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     $result = $webServiceApi->query();
 
     $this->assertTrue($result instanceof JsonResponse);
@@ -58,7 +60,7 @@ class QueryControllerTest extends TestCase {
     $data = "{[";
 
     $container = $this->getQueryContainer($data);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     $result = $webServiceApi->queryResource("2");
 
     $this->assertTrue($result instanceof JsonResponse);
@@ -70,7 +72,7 @@ class QueryControllerTest extends TestCase {
       "conditions" => "nope",
     ]);
     $container = $this->getQueryContainer($data);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     $result = $webServiceApi->queryResource("2");
 
     $this->assertTrue($result instanceof JsonResponse);
@@ -85,7 +87,7 @@ class QueryControllerTest extends TestCase {
       ],
     ]);
     $container = $this->getQueryContainer($data);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     $result = $webServiceApi->queryResource("2");
 
     $this->assertTrue($result instanceof JsonResponse);
@@ -101,7 +103,7 @@ class QueryControllerTest extends TestCase {
     ]);
 
     $container = $this->getQueryContainer($data);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     $result = $webServiceApi->queryResource("2");
 
     $this->assertTrue($result instanceof JsonResponse);
@@ -123,7 +125,7 @@ class QueryControllerTest extends TestCase {
     ]);
 
     $container = $this->getQueryContainer($data);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     $result = $webServiceApi->query();
 
     $this->assertTrue($result instanceof CsvResponse);
@@ -145,7 +147,7 @@ class QueryControllerTest extends TestCase {
     ]);
 
     $container = $this->getQueryContainer($data);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     $result = $webServiceApi->queryResource("2");
 
     $this->assertTrue($result instanceof CsvResponse);
@@ -167,7 +169,7 @@ class QueryControllerTest extends TestCase {
     ]);
     // Need 2 json responses which get combined on output.
     $container = $this->getQueryContainer($data, 'POST', TRUE);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     ob_start(['self', 'getBuffer']);
     $result = $webServiceApi->query(TRUE);
     $result->sendContent();
@@ -194,7 +196,7 @@ class QueryControllerTest extends TestCase {
     ]);
     // Need 2 json responses which get combined on output.
     $container = $this->getQueryContainer($data, 'POST', TRUE);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     $result = $webServiceApi->query(TRUE);
     $this->assertEquals(400, $result->getStatusCode());
   }
@@ -208,7 +210,7 @@ class QueryControllerTest extends TestCase {
     ]);
     // Need 2 json responses which get combined on output.
     $container = $this->getQueryContainer($data, 'POST', TRUE);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     ob_start(['self', 'getBuffer']);
     $result = $webServiceApi->queryResource("2", TRUE);
     $result->sendContent();
@@ -232,7 +234,7 @@ class QueryControllerTest extends TestCase {
     $info['latest_revision']['distributions'][0]['distribution_uuid'] = '123';
 
     $container = $this->getQueryContainer($data, 'POST', TRUE, $info);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     ob_start(['self', 'getBuffer']);
     $result = $webServiceApi->queryDatasetResource("2", "0", TRUE);
     $result->sendContent();
@@ -247,7 +249,7 @@ class QueryControllerTest extends TestCase {
 
   public function testQuerySchema() {
     $container = $this->getQueryContainer();
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     $result = $webServiceApi->querySchema();
 
     $this->assertTrue($result instanceof JsonResponse);
@@ -265,7 +267,7 @@ class QueryControllerTest extends TestCase {
     $info = ['notice' => 'Not found'];
 
     $container = $this->getQueryContainer($data, "GET", FALSE, $info);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     $result = $webServiceApi->queryDatasetResource("2", "0");
 
     $this->assertTrue($result instanceof JsonResponse);
@@ -282,7 +284,7 @@ class QueryControllerTest extends TestCase {
     $info['latest_revision']['distributions'][0]['distribution_uuid'] = '123';
 
     $container = $this->getQueryContainer($data, "GET", FALSE, $info);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     $result = $webServiceApi->queryDatasetResource("2", "1");
 
     $this->assertTrue($result instanceof JsonResponse);
@@ -299,11 +301,57 @@ class QueryControllerTest extends TestCase {
     $info['latest_revision']['distributions'][0]['distribution_uuid'] = '123';
 
     $container = $this->getQueryContainer($data, "GET", FALSE, $info);
-    $webServiceApi = QueryController::create($container);
+    $webServiceApi = QueryController::create($container->getMock());
     $result = $webServiceApi->queryDatasetResource("2", "0");
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(200, $result->getStatusCode());
+  }
+
+  /**
+   *
+   */
+  public function testQueryCsvCacheHeaders() {
+    $data = json_encode([
+      "resources" => [
+        [
+          "id" => "2",
+          "alias" => "t",
+        ],
+      ],
+      "format" => "csv",
+    ]);
+
+    // Create a container with caching turned on.
+    $container = $this->getQueryContainer($data)
+      ->add(Container::class, 'has', TRUE)
+      ->add(ConfigFactoryInterface::class, 'get', ImmutableConfig::class)
+      ->add(ImmutableConfig::class, 'get', 600);
+    \Drupal::setContainer($container->getMock());
+
+    // CSV. Caching on.
+    $webServiceApi = QueryController::create($container->getMock());
+    $response = $webServiceApi->query();
+    $headers = $response->headers;
+
+    $this->assertEquals('text/csv', $headers->get('content-type'));
+    $this->assertEquals('max-age=600, public', $headers->get('cache-control'));
+    $this->assertEquals('Cookie', $headers->get('vary'));
+    $this->assertNotEmpty($headers->get('last-modified'));
+
+    // Turn caching off.
+    $container->add(ImmutableConfig::class, 'get', 0);
+    \Drupal::setContainer($container->getMock());
+
+    // CSV. No caching.
+    $webServiceApi = QueryController::create($container->getMock());
+    $response = $webServiceApi->query();
+    $headers = $response->headers;
+
+    $this->assertEquals('text/csv', $headers->get('content-type'));
+    $this->assertEquals('no-cache, private', $headers->get('cache-control'));
+    $this->assertEmpty($headers->get('vary'));
+    $this->assertEmpty($headers->get('last-modified'));
   }
 
   private function getQueryContainer($data = '', string $method = "POST", bool $stream = FALSE, array $info = []) {
@@ -319,6 +367,7 @@ class QueryControllerTest extends TestCase {
       ->add("dkan.datastore.service", Service::class)
       ->add("request_stack", RequestStack::class)
       ->add("dkan.common.dataset_info", DatasetInfo::class)
+      ->add('config.factory', ConfigFactoryInterface::class)
       ->index(0);
 
     $chain = (new Chain($this))
@@ -334,9 +383,7 @@ class QueryControllerTest extends TestCase {
       $chain->add(Service::class, 'runQuery', $queryResult);
     }
 
-    $container = $chain->getMock();
-    \Drupal::setContainer($container);
-    return $container;
+    return $chain;
   }
 
   private function addMultipleResponses() {

--- a/modules/frontend/src/Controller/Page.php
+++ b/modules/frontend/src/Controller/Page.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\frontend\Controller;
 
+use Drupal\common\CachableResponseTrait;
 use Drupal\frontend\Page as PageBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -11,6 +12,7 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
  * An ample controller.
  */
 class Page implements ContainerInjectionInterface {
+  use CachableResponseTrait;
 
   private $pageBuilder;
 
@@ -38,7 +40,8 @@ class Page implements ContainerInjectionInterface {
     if (empty($pageContent)) {
       $pageContent = $this->pageBuilder->build("404");
     }
-    return Response::create($pageContent);
+    $response = Response::create($pageContent);
+    return $this->addCacheHeaders($response);
   }
 
 }

--- a/modules/frontend/src/Controller/Page.php
+++ b/modules/frontend/src/Controller/Page.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\frontend\Controller;
 
-use Drupal\common\CachableResponseTrait;
+use Drupal\common\CacheableResponseTrait;
 use Drupal\frontend\Page as PageBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -12,7 +12,7 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
  * An ample controller.
  */
 class Page implements ContainerInjectionInterface {
-  use CachableResponseTrait;
+  use CacheableResponseTrait;
 
   private $pageBuilder;
 

--- a/modules/frontend/tests/src/Unit/Controller/PageTest.php
+++ b/modules/frontend/tests/src/Unit/Controller/PageTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use \Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\frontend\Controller\Page as PageController;
 use Drupal\frontend\Page;
 use PHPUnit\Framework\TestCase;
@@ -11,22 +13,34 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ControllerPageTest extends TestCase {
 
   /**
+   * Cache max age config value.
+   *
+   * @var int
+   */
+  private $cacheMaxAge = 0;
+
+  /**
    * Getter.
    */
   public function getContainer() {
 
     $container = $this->getMockBuilder(ContainerInterface::class)
-      ->setMethods(['get'])
+      ->setMethods(['get', 'has'])
       ->disableOriginalConstructor()
       ->getMockForAbstractClass();
 
     $container->method('get')
       ->with(
         $this->logicalOr(
-          $this->equalTo('frontend.page')
+          $this->equalTo('frontend.page'),
+          $this->equalTo('config.factory')
         )
       )
       ->will($this->returnCallback([$this, 'containerGet']));
+
+    $container->method('has')
+      ->with('config.factory')
+      ->willReturn(TRUE);
 
     return $container;
   }
@@ -45,6 +59,21 @@ class ControllerPageTest extends TestCase {
         return $pageBuilder;
 
       break;
+      case 'config.factory':
+        $immutableConfig = $this->getMockBuilder(ImmutableConfig::class)
+          ->disableOriginalConstructor()
+          ->setMethods(["get"])
+          ->getMock();
+        $immutableConfig->method('get')->willReturn($this->cacheMaxAge);
+
+        $configFactory = $this->getMockBuilder(ConfigFactory::class)
+          ->disableOriginalConstructor()
+          ->setMethods(["get"])
+          ->getMock();
+        $configFactory->method('get')->willReturn($immutableConfig);
+        return $configFactory;
+
+        break;
     }
   }
 
@@ -56,6 +85,34 @@ class ControllerPageTest extends TestCase {
     /** @var \Symfony\Component\HttpFoundation\Response $response */
     $response = $controller->page('home');
     $this->assertEquals("<h1>Hello World!!!</h1>\n", $response->getContent());
+  }
+
+  /**
+   * Test response cache headers.
+   */
+  public function testCacheHeaders() {
+    $container = $this->getContainer();
+    \Drupal::setContainer($container);
+
+    // Create controller with caching turned off.
+    $controller = PageController::create($container);
+    $response = $controller->page('home');
+    $headers = $response->headers;
+
+    $this->assertEquals('no-cache, private', $headers->get('cache-control'));
+    $this->assertEmpty($headers->get('vary'));
+    $this->assertEmpty($headers->get('last-modified'));
+
+    // Turn caching on.
+    $this->cacheMaxAge = 600;
+
+    $controller = PageController::create($container);
+    $response = $controller->page('home');
+    $headers = $response->headers;
+
+    $this->assertEquals('max-age=600, public', $headers->get('cache-control'));
+    $this->assertEquals('Cookie', $headers->get('vary'));
+    $this->assertNotEmpty($headers->get('last-modified'));
   }
 
 }


### PR DESCRIPTION
fixes [GetDKAN/dkan/issues/3558]

## Notes
- no test coverage
- cache headers are added in the trait which is quick but not the best approach

## QA Steps
Navigate to the following pages and make sure caching headers are there:
- [x] any HTML page
- [x] any API JSON entrypoint
- [x] any API CSV entrypoint
- [x] any API YAML entrypoint