### PR TITLE
Fix errors when uploading file to "upload or link" widget.

### DIFF
--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -231,7 +231,7 @@ class UploadOrLink extends ManagedFile {
    */
   public static function validateManagedFile(&$element, FormStateInterface $form_state, &$complete_form) {
     $uri = static::getDefaultUri($element, $form_state);
-    if ($element['#value']['file_url_type'] == static::TYPE_UPLOAD || !empty($element['#value']['fids'])) {
+    if (($element['#value']['file_url_type'] ?? NULL) === static::TYPE_UPLOAD || !empty($element['#value']['fids'])) {
       parent::validateManagedFile($element, $form_state, $complete_form);
       if ($element_parents = $form_state->get('upload_or_link_element')) {
         $element_parents[] = $element['#parents'];

--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -290,7 +290,7 @@ class UploadOrLink extends ManagedFile {
    * Helper function to get the URL of a local file.
    */
   protected static function getLocalFileUrl($element) {
-    $fids = $element['fids']['#value'];
+    $fids = $element['#value']['fids'];
     foreach ($fids as $fid) {
       if ($file = File::load($fid)) {
         $uri = $file->getFileUri();


### PR DESCRIPTION
fixes #3568 

## QA Steps

- [ ] 1. Navigate to the DKAN dataset creation page (`/node/add/data`). Under Distribution > Download URL:
  - [ ] a. Select Upload File.
  - [ ] b. Upload a dataset distribution file.
- [ ] 2. Navigate to the watchdog error log page (`/admin/reports/dblog`).
  - [ ] a. Ensure there are no watchdog errors with the message `Notice: Undefined index: fids in Drupal\json_form_widget\Element\UploadOrLink::getLocalFileUrl() (line 294 of /var/www/docroot/modules/contrib/dkan/modules/json_form_widget/src/Element/UploadOrLink.php)`.
  - [ ] b. Ensure there are no watchdog errors with the message `Notice: Undefined index: file_url_type in Drupal\json_form_widget\Element\UploadOrLink::validateManagedFile() (line 235 of /var/www/docroot/modules/contrib/dkan/modules/json_form_widget/src/Element/UploadOrLink.php)`.

