### PR TITLE
Set CSV header row from properties specified in the query

### DIFF
--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -214,10 +214,17 @@ class QueryController implements ContainerInjectionInterface {
   }
 
   /**
-   * Add the header row.
+   * Add the header row, from specified properties, if any, or the schema.
    */
   private function addHeaderRow(array &$data) {
-    $header_row = array_keys(reset($data['schema'])['fields']);
+
+    if (!empty($data['query']['properties'])) {
+      $header_row = $data['query']['properties'];
+    }
+    else {
+      $header_row = array_keys(reset($data['schema'])['fields']);
+    }
+
     if (is_array($header_row)) {
       array_unshift($data['results'], $header_row);
     }

--- a/modules/datastore/tests/data/response_with_specific_header.json
+++ b/modules/datastore/tests/data/response_with_specific_header.json
@@ -1,0 +1,40 @@
+{
+  "results": [
+    {
+      "record_number": "1",
+      "data": "data"
+    }
+  ],
+  "count": "1",
+  "schema": {
+    "2": {
+      "fields": {
+        "record_number": {
+          "type": "text",
+          "description": ""
+        },
+        "data": {
+          "type": "text",
+          "description": ""
+        }
+      },
+      "primary key": [
+        "record_number"
+      ]
+    }
+  },
+  "query": {
+    "resources": [
+      {
+        "alias": "t",
+        "id": "2"
+      }
+    ],
+    "properties": ["record_number", "data"],
+    "offset": 0,
+    "count": true,
+    "results": true,
+    "schema": true,
+    "keys": true
+  }
+}


### PR DESCRIPTION
fixes #3570

## QA Steps

1. Spin up a DKAN site with its demo data
2. Get the distribution's UUID of the Florida Bike Lanes dataset using `/api/1/metastore/schemas/dataset/items/cedcd327-4e5d-43f9-8eb1-c11850fa7c55?show_reference_ids`
3. POST on `/api/1/datastore/query/download` with the following payload `{"format": "csv","properties":["road_side","descr","shape_leng"],"resources":[{"id":"UUID","alias":"t"}]}`, replacing UUID with the above identifier
1. Expected CSV contains:
```
road_side,descr,shape_leng
R,DESIGNATED,463.2487
R,DESIGNATED,8267.4337
R,DESIGNATED,5430.1665
R,DESIGNATED,1825.1312
L,DESIGNATED,101.6744
R,DESIGNATED,185.7312
R,DESIGNATED,653.9896
L,DESIGNATED,80.7363
R,DESIGNATED,4964.3072
...
```