### PR TITLE
Prevent fatal error when processing dataset resources.

### DIFF
--- a/modules/datastore/src/Service/ResourcePurger.php
+++ b/modules/datastore/src/Service/ResourcePurger.php
@@ -180,6 +180,9 @@ class ResourcePurger implements ContainerInjectionInterface {
    *   The dataset identifier.
    * @param bool $prior
    *   Whether to include all prior revisions.
+   *
+   * @throws \UnexpectedValueException
+   *   When a missing resource ID or version is encountered.
    */
   private function purge(int $vid, string $uuid, bool $prior) {
     $node = $this->storage->getEntityStorage()->loadRevision($vid);
@@ -189,10 +192,19 @@ class ResourcePurger implements ContainerInjectionInterface {
     $keep = $this->getResourcesToKeep($uuid);
     $purge = $this->getResourcesToPurge($vid, $node, $prior);
 
+    $missing_resource_count = 0;
     foreach (array_diff($purge, $keep) as $idAndVersion) {
       // $idAndVersion is a json encoded array with resource's id and version.
       list($id, $version) = json_decode($idAndVersion);
-      $this->delete($id, $version);
+      if (isset($id, $version)) {
+        $this->delete($id, $version);
+      }
+      else {
+        $missing_resource_count++;
+      }
+    }
+    if ($missing_resource_count > 0) {
+      throw new \UnexpectedValueException("Missing required ID or version for {$missing_resource_count} resources.");
     }
   }
 

--- a/modules/datastore/src/Service/ResourcePurger.php
+++ b/modules/datastore/src/Service/ResourcePurger.php
@@ -301,10 +301,11 @@ class ResourcePurger implements ContainerInjectionInterface {
     $distributions = $metadata->{'%Ref:distribution'};
 
     foreach ($distributions as $distribution) {
-      foreach ($distribution->data->{'%Ref:downloadURL'} ?? [] as $resource) {
-        if (isset($resource->data->identifier, $resource->data->version)) {
-          $resources[] = json_encode([$resource->data->identifier, $resource->data->version]);
-        }
+      // Retrieve and validate the resource for this distribution before adding
+      // it to the resources list.
+      $resource = array_shift($distribution->data->{'%Ref:downloadURL'});
+      if (isset($resource->data->identifier, $resource->data->version)) {
+        $resources[] = json_encode([$resource->data->identifier, $resource->data->version]);
       }
     }
 

--- a/modules/datastore/src/Service/ResourcePurger.php
+++ b/modules/datastore/src/Service/ResourcePurger.php
@@ -303,7 +303,7 @@ class ResourcePurger implements ContainerInjectionInterface {
     foreach ($distributions as $distribution) {
       // Retrieve and validate the resource for this distribution before adding
       // it to the resources list.
-      $resource = array_shift($distribution->data->{'%Ref:downloadURL'});
+      $resource = $distribution->data->{'%Ref:downloadURL'}[0] ?? NULL;
       if (isset($resource->data->identifier, $resource->data->version)) {
         $resources[] = json_encode([$resource->data->identifier, $resource->data->version]);
       }

--- a/modules/datastore/src/Service/ResourcePurger.php
+++ b/modules/datastore/src/Service/ResourcePurger.php
@@ -180,9 +180,6 @@ class ResourcePurger implements ContainerInjectionInterface {
    *   The dataset identifier.
    * @param bool $prior
    *   Whether to include all prior revisions.
-   *
-   * @throws \UnexpectedValueException
-   *   When a missing resource ID or version is encountered.
    */
   private function purge(int $vid, string $uuid, bool $prior) {
     $node = $this->storage->getEntityStorage()->loadRevision($vid);
@@ -192,19 +189,10 @@ class ResourcePurger implements ContainerInjectionInterface {
     $keep = $this->getResourcesToKeep($uuid);
     $purge = $this->getResourcesToPurge($vid, $node, $prior);
 
-    $missing_resource_count = 0;
     foreach (array_diff($purge, $keep) as $idAndVersion) {
       // $idAndVersion is a json encoded array with resource's id and version.
       list($id, $version) = json_decode($idAndVersion);
-      if (isset($id, $version)) {
-        $this->delete($id, $version);
-      }
-      else {
-        $missing_resource_count++;
-      }
-    }
-    if ($missing_resource_count > 0) {
-      throw new \UnexpectedValueException("Missing required ID or version for {$missing_resource_count} resources.");
+      $this->delete($id, $version);
     }
   }
 

--- a/modules/datastore/src/Service/ResourcePurger.php
+++ b/modules/datastore/src/Service/ResourcePurger.php
@@ -301,8 +301,11 @@ class ResourcePurger implements ContainerInjectionInterface {
     $distributions = $metadata->{'%Ref:distribution'};
 
     foreach ($distributions as $distribution) {
-      $resource = $distribution->data->{'%Ref:downloadURL'}[0]->data;
-      $resources[] = json_encode([$resource->identifier, $resource->version]);
+      foreach ($distribution->data->{'%Ref:downloadURL'} ?? [] as $resource) {
+        if (isset($resource->data->identifier, $resource->data->version)) {
+          $resources[] = json_encode([$resource->data->identifier, $resource->data->version]);
+        }
+      }
     }
 
     return $resources;

--- a/modules/metastore/tests/src/Unit/MetastoreSubscriberTest.php
+++ b/modules/metastore/tests/src/Unit/MetastoreSubscriberTest.php
@@ -85,14 +85,14 @@ class MetastoreSubscriberTest extends TestCase {
     $chain = (new Chain($this))
       ->add(Container::class, 'get', $options)
       ->add(Service::class, 'get', $dist)
-      ->add(ResourceMapper::class, 'get', $resource)
-      ->add(ResourceMapper::class, 'remove', new \Exception('error'))
+      ->add(ResourceMapper::class, 'get', NULL)
+      ->add(ResourceMapper::class, 'remove')
       ->add(LoggerChannelFactory::class, 'get', LoggerChannelInterface::class)
       ->add(LoggerChannelInterface::class, 'error', NULL, 'errors');
 
     $subscriber = MetastoreSubscriber::create($chain->getMock());
     $test = $subscriber->cleanResourceMapperTable($event);
-    $this->assertContains('Failed to remove', $chain->getStoredInput('errors')[0]);
+    $this->assertContains('Failed to remove resource', $chain->getStoredInput('errors')[0]);
 
   }
 


### PR DESCRIPTION
fixes #3572 

## QA Steps

1. Navigate to the Dataset Creation page (`/node/add/data`).
2. Fill out all of the required fields.
3. Fill out the distribution title field and the distribution format field, but not the Download URL field.
4. Save the dataset.
5. Edit the newly created dataset.
6. Provide a resource for the Download URL field.
7. Save the dataset.
8. Run the `resource_purger` queue.
9. Ensure you do not encounter either of the following errors:
```
TypeError: Argument 1 passed to Drupal\datastore\Service\ResourcePurger::delete() must be of the type string, null given, called in /var/www/docroot/modules/contrib/dkan/modules/datastore/src/Service/ResourcePurger.php on line 195 in Drupal\datastore\Service\ResourcePurger->delete() (line 319 of /var/www/docroot/modules/contrib/dkan/modules/datastore/src/Service/ResourcePurger.php) #0 /var/www/docroot/modules/contrib/dkan/modules/datastore/src/Service/ResourcePurger.php(195): Drupal\datastore\Service\ResourcePurger->delete(NULL, NULL)
#1 /var/www/docroot/modules/contrib/dkan/modules/datastore/src/Service/ResourcePurger.php(167): Drupal\datastore\Service\ResourcePurger->purge(60, '5afbe096-37d6-4...', false)
#2 /var/www/docroot/modules/contrib/dkan/modules/datastore/src/Service/ResourcePurger.php(150): Drupal\datastore\Service\ResourcePurger->purgeHelper(60, '5afbe096-37d6-4...', false)
#3 /var/www/docroot/modules/contrib/dkan/modules/datastore/src/Plugin/QueueWorker/ResourcePurgerWorker.php(52): Drupal\datastore\Service\ResourcePurger->purgeMultiple(Array, false)
#4 /var/www/vendor/drush/drush/src/Drupal/Commands/core/QueueCommands.php(77): Drupal\datastore\Plugin\QueueWorker\ResourcePurgerWorker->processItem(Array)
#5 [internal function]: Drush\Drupal\Commands\core\QueueCommands->run('resource_purger', Array)
#6 /var/www/vendor/consolidation/annotated-command/src/CommandProcessor.php(257): call_user_func_array(Array, Array)
#7 /var/www/vendor/consolidation/annotated-command/src/CommandProcessor.php(212): Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback(Array, Object(Consolidation\AnnotatedCommand\CommandData))
#8 /var/www/vendor/consolidation/annotated-command/src/CommandProcessor.php(176): Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter(Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#9 /var/www/vendor/consolidation/annotated-command/src/AnnotatedCommand.php(302): Consolidation\AnnotatedCommand\CommandProcessor->process(Object(Symfony\Component\Console\Output\ConsoleOutput), Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#10 /var/www/vendor/symfony/console/Command/Command.php(255): Consolidation\AnnotatedCommand\AnnotatedCommand->execute(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 /var/www/vendor/symfony/console/Application.php(1005): Symfony\Component\Console\Command\Command->run(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /var/www/vendor/symfony/console/Application.php(255): Symfony\Component\Console\Application->doRunCommand(Object(Consolidation\AnnotatedCommand\AnnotatedCommand), Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 /var/www/vendor/symfony/console/Application.php(148): Symfony\Component\Console\Application->doRun(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 /var/www/vendor/drush/drush/src/Runtime/Runtime.php(118): Symfony\Component\Console\Application->run(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 /var/www/vendor/drush/drush/src/Runtime/Runtime.php(48): Drush\Runtime\Runtime->doRun(Array, Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 /var/www/vendor/drush/drush/drush.php(72): Drush\Runtime\Runtime->run(Array)
#17 /var/www/vendor/drush/drush/drush(4): require('/var/www/vendor...')
#18 {main}.
```
```
TypeError: Argument 1 passed to Drupal\metastore\ResourceMapper::get() must be of the type string, null given, called in /var/www/docroot/modules/contrib/dkan/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php on line 81 in /var/www/docroot/modules/contrib/dkan/modules/metastore/src/ResourceMapper.php on line 112 #0 /var/www/docroot/modules/contrib/dkan/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php(81): Drupal\metastore\ResourceMapper->get(NULL, NULL, NULL)
#1 [internal function]: Drupal\metastore\EventSubscriber\MetastoreSubscriber->cleanResourceMapperTable(Object(Drupal\common\Events\Event), 'metastore_orpha...', Object(Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher))
#2 /var/www/docroot/core/lib/Drupal/Component/EventDispatcher/ContainerAwareEventDispatcher.php(111): call_user_func(Array, Object(Drupal\common\Events\Event), 'metastore_orpha...', Object(Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher))
#3 /var/www/docroot/modules/contrib/dkan/modules/common/src/EventDispatcherTrait.php(36): Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch('metastore_orpha...', Object(Drupal\common\Events\Event))
#4 /var/www/docroot/modules/contrib/dkan/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php(126): Drupal\metastore\Plugin\QueueWorker\OrphanReferenceProcessor->dispatchEvent('metastore_orpha...', '882887c5-aee8-5...')
#5 /var/www/docroot/modules/contrib/dkan/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php(104): Drupal\metastore\Plugin\QueueWorker\OrphanReferenceProcessor->unpublishReference('distribution', '882887c5-aee8-5...')
#6 /var/www/docroot/core/lib/Drupal/Core/Cron.php(180): Drupal\metastore\Plugin\QueueWorker\OrphanReferenceProcessor->processItem(Object(Drupal\metastore\NodeWrapper\Data))
#7 /var/www/docroot/core/lib/Drupal/Core/Cron.php(145): Drupal\Core\Cron->processQueues()
#8 /var/www/docroot/core/lib/Drupal/Core/ProxyClass/Cron.php(75): Drupal\Core\Cron->run()
#9 /var/www/vendor/drush/drush/src/Drupal/Commands/core/DrupalCommands.php(76): Drupal\Core\ProxyClass\Cron->run()
#10 [internal function]: Drush\Drupal\Commands\core\DrupalCommands->cron(Array)
#11 /var/www/vendor/consolidation/annotated-command/src/CommandProcessor.php(257): call_user_func_array(Array, Array)
#12 /var/www/vendor/consolidation/annotated-command/src/CommandProcessor.php(212): Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback(Array, Object(Consolidation\AnnotatedCommand\CommandData))
#13 /var/www/vendor/consolidation/annotated-command/src/CommandProcessor.php(176): Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter(Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#14 /var/www/vendor/consolidation/annotated-command/src/AnnotatedCommand.php(302): Consolidation\AnnotatedCommand\CommandProcessor->process(Object(Symfony\Component\Console\Output\ConsoleOutput), Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#15 /var/www/vendor/symfony/console/Command/Command.php(255): Consolidation\AnnotatedCommand\AnnotatedCommand->execute(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 /var/www/vendor/symfony/console/Application.php(1005): Symfony\Component\Console\Command\Command->run(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#17 /var/www/vendor/symfony/console/Application.php(255): Symfony\Component\Console\Application->doRunCommand(Object(Consolidation\AnnotatedCommand\AnnotatedCommand), Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#18 /var/www/vendor/symfony/console/Application.php(148): Symfony\Component\Console\Application->doRun(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#19 /var/www/vendor/drush/drush/src/Runtime/Runtime.php(118): Symfony\Component\Console\Application->run(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#20 /var/www/vendor/drush/drush/src/Runtime/Runtime.php(48): Drush\Runtime\Runtime->doRun(Array, Object(Symfony\Component\Console\Output\ConsoleOutput))
#21 /var/www/vendor/drush/drush/drush.php(72): Drush\Runtime\Runtime->run(Array)
#22 /var/www/vendor/drush/drush/drush(4): require('/var/www/vendor...')
#23 {main}
TypeError: Argument 1 passed to Drupal\metastore\ResourceMapper::get() must be of the type string, null given, called in /var/www/docroot/modules/contrib/dkan/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php on line 81 in Drupal\metastore\ResourceMapper->get() (line 112 of /var/www/docroot/modules/contrib/dkan/modules/metastore/src/ResourceMapper.php).
```