### PR TITLE
Remove vary cookie from cache headers

### DIFF
--- a/modules/common/src/CacheableResponseTrait.php
+++ b/modules/common/src/CacheableResponseTrait.php
@@ -39,7 +39,6 @@ trait CacheableResponseTrait {
         'max_age' => $this->cacheMaxAge,
         'last_modified' => new \DateTime(),
       ]);
-      $response->setVary('Cookie');
     }
     return $response;
   }

--- a/modules/common/tests/src/Controller/OpenApiControllerTest.php
+++ b/modules/common/tests/src/Controller/OpenApiControllerTest.php
@@ -89,7 +89,6 @@ class OpenApiControllerTest extends TestCase {
 
     $this->assertEquals('application/json', $headers->get('content-type'));
     $this->assertEquals('max-age=600, public', $headers->get('cache-control'));
-    $this->assertEquals('Cookie', $headers->get('vary'));
     $this->assertNotEmpty($headers->get('last-modified'));
 
     // YAML. Caching on.
@@ -98,7 +97,6 @@ class OpenApiControllerTest extends TestCase {
 
     $this->assertEquals('application/vnd.oai.openapi', $headers->get('content-type'));
     $this->assertEquals('max-age=600, public', $headers->get('cache-control'));
-    $this->assertEquals('Cookie', $headers->get('vary'));
     $this->assertNotEmpty($headers->get('last-modified'));
 
     // Turn caching off.

--- a/modules/datastore/tests/src/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Controller/QueryControllerTest.php
@@ -336,7 +336,6 @@ class QueryControllerTest extends TestCase {
 
     $this->assertEquals('text/csv', $headers->get('content-type'));
     $this->assertEquals('max-age=600, public', $headers->get('cache-control'));
-    $this->assertEquals('Cookie', $headers->get('vary'));
     $this->assertNotEmpty($headers->get('last-modified'));
 
     // Turn caching off.

--- a/modules/frontend/tests/src/Unit/Controller/PageTest.php
+++ b/modules/frontend/tests/src/Unit/Controller/PageTest.php
@@ -111,7 +111,6 @@ class ControllerPageTest extends TestCase {
     $headers = $response->headers;
 
     $this->assertEquals('max-age=600, public', $headers->get('cache-control'));
-    $this->assertEquals('Cookie', $headers->get('vary'));
     $this->assertNotEmpty($headers->get('last-modified'));
   }
 


### PR DESCRIPTION
Akamai will not cache if that is present.