### PR TITLE
Report QA site build status to GitHub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+import groovy.json.JsonOutput
+
 pipeline {
     agent any
     environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,8 +67,6 @@ pipeline {
                         export DKTL_DIRECTORY="$WORKSPACE/dkan-tools"
                         echo $DKTL_DIRECTORY
                         dktl init --dkan-local
-                        dktl demo
-                        dktl drush user:password admin mayisnice
                         sudo chown -R 1000:docker $WORKSPACE/dkan-tools/vendor
                     '''
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,14 +103,14 @@ pipeline {
 void setBuildStatus(String message, String target_url, String state) {
     withCredentials([string(credentialsId: 'dkanuploadassets',
 			  variable: 'GITHUB_API_TOKEN')]) {
-	def url = "https://api.github.com/repos/getdkan/dkan/statuses/$GIT_COMMIT?access_token=${GITHUB_API_TOKEN}"
-	def data = [
-	    target_url: target_url,
-	    state: state,
-	    description: message,
-	    context: "continuous-integration/jenkins/qa-site"
-	]
-	def payload = JsonOutput.toJson(data)
-	sh "curl -X POST -H 'Content-Type: application/json' -d '${payload}' ${url}"
+        def url = "https://api.github.com/repos/getdkan/dkan/statuses/$GIT_COMMIT?access_token=${GITHUB_API_TOKEN}"
+        def data = [
+            target_url: target_url,
+            state: state,
+            description: message,
+            context: "continuous-integration/jenkins/qa-site"
+        ]
+        def payload = JsonOutput.toJson(data)
+        sh "curl -X POST -H 'Content-Type: application/json' -d '${payload}' ${url}"
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ void setBuildStatus(String message, String target_url, String state) {
 	    target_url: target_url,
 	    state: state,
 	    description: message,
-	    context: "continuous-integration/jenkins/build-status"
+	    context: "continuous-integration/jenkins/qa-site"
 	]
 	def payload = JsonOutput.toJson(data)
 	sh "curl -X POST -H 'Content-Type: application/json' -d '${payload}' ${url}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,19 +72,6 @@ pipeline {
                 }
             }
         }
-        stage('Check QA Site') {
-            when { changeRequest(); }
-            steps {
-                script {
-                    sh '''
-                    QA_SITE_WEB_ID=`docker ps|grep qa_$CHANGE_ID|grep web|awk '{ print $1 }'`
-                    QA_SITE_PORT=`docker container port $QA_SITE_WEB_ID|grep 80|awk '{ print $3 }'|awk 'BEGIN { FS = ":" };{ print $2 }'`
-                    echo QA site ready at http://$DKTL_SLUG.$WEB_DOMAIN
-                    curl -I "http://$DKTL_SLUG.$WEB_DOMAIN"
-                    '''
-                }
-            }
-        }
     }
     post {
         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,13 +76,13 @@ pipeline {
             when { changeRequest(); }
             steps {
                 script {
+                    def target_url = "http://$DKTL_SLUG.$WEB_DOMAIN"
                     sh '''
                     QA_SITE_WEB_ID=`docker ps|grep qa_$CHANGE_ID|grep web|awk '{ print $1 }'`
                     QA_SITE_PORT=`docker container port $QA_SITE_WEB_ID|grep 80|awk '{ print $3 }'|awk 'BEGIN { FS = ":" };{ print $2 }'`
                     echo QA site ready at ${target_url}
                     curl -I ${target_url}
                     '''
-                    def target_url = "http://$DKTL_SLUG.$WEB_DOMAIN"
                     setBuildStatus("QA site ready at ${target_url}", target_url, "success");
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,12 +77,6 @@ pipeline {
             steps {
                 script {
                     def target_url = "http://$DKTL_SLUG.$WEB_DOMAIN"
-                    sh '''
-                    QA_SITE_WEB_ID=`docker ps|grep qa_$CHANGE_ID|grep web|awk '{ print $1 }'`
-                    QA_SITE_PORT=`docker container port $QA_SITE_WEB_ID|grep 80|awk '{ print $3 }'|awk 'BEGIN { FS = ":" };{ print $2 }'`
-                    echo QA site ready at ${target_url}
-                    curl -I ${target_url}
-                    '''
                     setBuildStatus("QA site ready at ${target_url}", target_url, "success");
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {
 void setBuildStatus(String message, String target_url, String state) {
     withCredentials([string(credentialsId: 'dkanuploadassets',
 			  variable: 'GITHUB_API_TOKEN')]) {
-	def url = "https://api.github.com/repos/getdkan/dkan-code/statuses/$GIT_COMMIT?access_token=${GITHUB_API_TOKEN}"
+	def url = "https://api.github.com/repos/getdkan/dkan/statuses/$GIT_COMMIT?access_token=${GITHUB_API_TOKEN}"
 	def data = [
 	    target_url: target_url,
 	    state: state,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,8 @@ pipeline {
                         export DKTL_DIRECTORY="$WORKSPACE/dkan-tools"
                         echo $DKTL_DIRECTORY
                         dktl init --dkan-local
+                        dktl demo
+                        dktl drush user:password admin mayisnice
                         sudo chown -R 1000:docker $WORKSPACE/dkan-tools/vendor
                     '''
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,6 @@ pipeline {
         stage('Check QA Site') {
             when { changeRequest(); }
             steps {
-                def target_url = "http://$DKTL_SLUG.$WEB_DOMAIN"
                 script {
                     sh '''
                     QA_SITE_WEB_ID=`docker ps|grep qa_$CHANGE_ID|grep web|awk '{ print $1 }'`
@@ -83,8 +82,9 @@ pipeline {
                     echo QA site ready at ${target_url}
                     curl -I ${target_url}
                     '''
+                    def target_url = "http://$DKTL_SLUG.$WEB_DOMAIN"
+                    setBuildStatus("QA site ready at ${target_url}", target_url, "success");
                 }
-                setBuildStatus("QA site ready at ${target_url}", target_url, "success");
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,7 @@ pipeline {
  * @param state State to report to Github (e.g. "success")
  */
 void setBuildStatus(String message, String target_url, String state) {
-    withCredentials([string(credentialsId: 'nucivicmachine',
+    withCredentials([string(credentialsId: 'dkanuploadassets',
 			  variable: 'GITHUB_API_TOKEN')]) {
 	def url = "https://api.github.com/repos/getdkan/dkan-code/statuses/$GIT_COMMIT?access_token=${GITHUB_API_TOKEN}"
 	def data = [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,7 @@ pipeline {
                         dktl demo
                         dktl drush user:password admin mayisnice
                         sudo chown -R 1000:docker $WORKSPACE/dkan-tools/vendor
+                        curl -fI `dktl url`
                     '''
                 }
             }


### PR DESCRIPTION
Report a second status to github from Jenkins with a direct link to the QA site. Also removes the "Check QA site" stage which seems to be unnecessary. 

Shoutout to @woodt for the new function added to the Jenkinsfile.

## QA Steps

Click "details" link in the new continuous-integration/jenkins/qa-site status in this PR and confirm it links directly to a site.