### PR TITLE
Support both versions of Symfony events

### DIFF
--- a/modules/common/src/EventDispatcherTrait.php
+++ b/modules/common/src/EventDispatcherTrait.php
@@ -5,9 +5,11 @@ namespace Drupal\common;
 use Drupal\common\Events\Event;
 
 /**
- * Trait EventDispatcherTrait.
+ * Event dispatcher trait.
  *
- * @package Drupal\common
+ * @todo Refactor as service.
+ *
+ * @codeCoverageIgnore
  */
 trait EventDispatcherTrait {
 
@@ -29,10 +31,54 @@ trait EventDispatcherTrait {
    *   If any of the subscribers registered and Exception it is thrown.
    */
   private function dispatchEvent($eventName, $data, $validator = NULL) {
-    /* @var ContainerAwareEventDispatcher $dispatcher */
+    if ($this->useLegacyDispatcher()) {
+      $this->legacyDispatchEvent($eventName, $data, $validator);
+    }    
     $dispatcher = \Drupal::service('event_dispatcher');
 
-    /* @var \Drupal\common\Events\Event $event */
+    if ($event = $dispatcher->dispatch(new Event($data, $validator), $eventName)) {
+      if ($e = $event->getException()) {
+        throw $e;
+      }
+
+      $data = $event->getData();
+    }
+
+    return $data;
+  }
+
+  /**
+   * If we're on Drupal 8.9 or 9.0, we have to use the old dispatch sig.
+   *
+   * @see https://www.drupal.org/node/3154407
+   *
+   * @return bool
+   *   True if the newer Symfony event system is available.
+   */
+  private function useLegacyDispatcher() {
+    return class_exists('\Symfony\Contracts\EventDispatcher\Event');
+  }
+
+  /**
+   * Legacy version of the dispatchEvent() method.
+   *
+   * @param mixed $eventName
+   *   The name of the event.
+   * @param mixed $data
+   *   The data that will be given to the listeners/subscribers.
+   * @param mixed $validator
+   *   A callable used to validate that the data in the event as it is modified
+   *   keeps its integrity.
+   *
+   * @return mixed
+   *   The data returned by the listeners/subscribers.
+   *
+   * @throws \Exception
+   *   If any of the subscribers registered and Exception it is thrown.
+   */
+  private function legacyDispatchEvent($eventName, $data, $validator = NULL) {
+    $dispatcher = \Drupal::service('event_dispatcher');
+
     if ($event = $dispatcher->dispatch($eventName, new Event($data, $validator))) {
       if ($e = $event->getException()) {
         throw $e;

--- a/modules/common/src/EventDispatcherTrait.php
+++ b/modules/common/src/EventDispatcherTrait.php
@@ -33,7 +33,7 @@ trait EventDispatcherTrait {
   private function dispatchEvent($eventName, $data, $validator = NULL) {
     if ($this->useLegacyDispatcher()) {
       $this->legacyDispatchEvent($eventName, $data, $validator);
-    }    
+    }
     $dispatcher = \Drupal::service('event_dispatcher');
 
     if ($event = $dispatcher->dispatch(new Event($data, $validator), $eventName)) {

--- a/modules/common/src/EventDispatcherTrait.php
+++ b/modules/common/src/EventDispatcherTrait.php
@@ -32,7 +32,8 @@ trait EventDispatcherTrait {
    */
   private function dispatchEvent($eventName, $data, $validator = NULL) {
     if ($this->useLegacyDispatcher()) {
-      $this->legacyDispatchEvent($eventName, $data, $validator);
+      $data = $this->legacyDispatchEvent($eventName, $data, $validator);
+      return $data;
     }
     $dispatcher = \Drupal::service('event_dispatcher');
 
@@ -56,7 +57,7 @@ trait EventDispatcherTrait {
    *   True if the newer Symfony event system is available.
    */
   private function useLegacyDispatcher() {
-    return class_exists('\Symfony\Contracts\EventDispatcher\Event');
+    return !class_exists('\Symfony\Contracts\EventDispatcher\Event');
   }
 
   /**


### PR DESCRIPTION
See https://www.drupal.org/node/3154407

No code coverage on trait because impossible to test both cases.

## QA Steps

This will need some local CLI-based QA. Build two different DKAN instances, one with 9.0 and one with 9.1. For each, ensure that you get no errors when you:

- [x] Run the full functional test suite
- [x] Run a test harvest, revert it, and run the queues
