### PR TITLE
Fix File URL Type widget unable to determine item type

### DIFF
--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -246,21 +246,18 @@ class UploadOrLink extends ManagedFile {
    * Helper function for getting the url type.
    */
   protected static function getUrlType($element) {
+    $type = NULL;
     if (isset($element['#value']['file_url_type'])) {
-      return $element['#value']['file_url_type'];
+      $type = $element['#value']['file_url_type'];
     }
     elseif (!empty($element['#value']['fids'])) {
-      return static::TYPE_UPLOAD;
+      $type = static::TYPE_UPLOAD;
     }
     elseif (isset($element['#uri'])) {
-      if (static::checkIfLocalFile($element['#uri'])) {
-        return static::TYPE_UPLOAD;
-      }
-      else {
-        return static::TYPE_REMOTE;
-      }
+      $type = static::checkIfLocalFile($element['#uri']) ?
+        static::TYPE_UPLOAD : static::TYPE_REMOTE;
     }
-    return NULL;
+    return $type;
   }
 
   /**

--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -229,7 +229,7 @@ class UploadOrLink extends ManagedFile {
    */
   public static function validateManagedFile(&$element, FormStateInterface $form_state, &$complete_form) {
     $uri = static::getDefaultUri($element, $form_state);
-    if (static::getUrlType($element) === static::TYPE_UPLOAD || !empty($element['#value']['fids'])) {
+    if (static::getUrlType($element) === static::TYPE_UPLOAD) {
       parent::validateManagedFile($element, $form_state, $complete_form);
       if ($element_parents = $form_state->get('upload_or_link_element')) {
         $element_parents[] = $element['#parents'];
@@ -248,6 +248,9 @@ class UploadOrLink extends ManagedFile {
   protected static function getUrlType($element) {
     if (isset($element['#value']['file_url_type'])) {
       return $element['#value']['file_url_type'];
+    }
+    elseif (!empty($element['#value']['fids'])) {
+      return static::TYPE_UPLOAD;
     }
     elseif (isset($element['#uri'])) {
       if (static::checkIfLocalFile($element['#uri'])) {

--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -182,20 +182,18 @@ class UploadOrLink extends ManagedFile {
    * Helper function to load files when local.
    */
   private static function loadLocalFilesWhenDefault($element) {
-    if (empty($element['#value']['fids']) && !empty($element['#uri'])) {
-      $file = static::checkIfLocalFile($element['#uri']);
-      if ($file && $element['#value']['file_url_type'] !== static::TYPE_REMOTE) {
-        $element['#files'][$file->id()] = $file;
-        $element['#value']['fids'] = [$file->id()];
-        $element['#value']['file_url_type'] = "upload";
-        $element['fids']['#type'] = 'hidden';
-        $element['fids']['#value'] = [$file->id()];
-        $file_link = [
-          '#theme' => 'file_link',
-          '#file' => $file,
-        ];
-        $element['file_' . $file->id()]['filename'] = $file_link + ['#weight' => -10];
-      }
+    if (empty($element['#value']['fids']) && !empty($element['#uri']) &&
+        $file = static::checkIfLocalFile($element['#uri'])) {
+      $element['#files'][$file->id()] = $file;
+      $element['#value']['fids'] = [$file->id()];
+      $element['#value']['file_url_type'] = static::TYPE_UPLOAD;
+      $element['fids']['#type'] = 'hidden';
+      $element['fids']['#value'] = [$file->id()];
+      $file_link = [
+        '#theme' => 'file_link',
+        '#file' => $file,
+      ];
+      $element['file_' . $file->id()]['filename'] = $file_link + ['#weight' => -10];
     }
     return $element;
   }
@@ -231,7 +229,7 @@ class UploadOrLink extends ManagedFile {
    */
   public static function validateManagedFile(&$element, FormStateInterface $form_state, &$complete_form) {
     $uri = static::getDefaultUri($element, $form_state);
-    if (($element['#value']['file_url_type'] ?? NULL) === static::TYPE_UPLOAD || !empty($element['#value']['fids'])) {
+    if (static::getUrlType($element) === static::TYPE_UPLOAD || !empty($element['#value']['fids'])) {
       parent::validateManagedFile($element, $form_state, $complete_form);
       if ($element_parents = $form_state->get('upload_or_link_element')) {
         $element_parents[] = $element['#parents'];
@@ -272,10 +270,7 @@ class UploadOrLink extends ManagedFile {
       return '';
     }
 
-    if ((isset($element['#value']['file_url_type'])
-      && $element['#value']['file_url_type'] == static::TYPE_UPLOAD)
-      || !empty($element['#value']['fids'])
-    ) {
+    if (static::getUrlType($element) == static::TYPE_UPLOAD) {
       return static::getLocalFileUrl($element);
     }
     elseif (!empty($element['#value']['file_url_remote'])) {


### PR DESCRIPTION
fixes #3590 

## QA Steps

### Part 1
- [x] Create a DKAN dataset with a resource.
- [x] Navigate to the edit form for the dataset.
- [x] Ensure the following error does not appear on the page or in watchdog:
```
Notice: Undefined index: file_url_type in Drupal\json_form_widget\Element\UploadOrLink::loadLocalFilesWhenDefault() (line 187 of /var/www/docroot/modules/contrib/dkan/modules/json_form_widget/src/Element/UploadOrLink.php)

#0 /var/www/docroot/core/includes/bootstrap.inc(600): _drupal_error_handler_real(8, 'Undefined index...', '/var/www/docroo...', 187, Array)
#1 /var/www/docroot/modules/contrib/dkan/modules/json_form_widget/src/Element/UploadOrLink.php(187): _drupal_error_handler(8, 'Undefined index...', '/var/www/docroo...', 187, Array)
#2 /var/www/docroot/modules/contrib/dkan/modules/json_form_widget/src/Element/UploadOrLink.php(85): Drupal\json_form_widget\Element\UploadOrLink::loadLocalFilesWhenDefault(Array)
#3 [internal function]: Drupal\json_form_widget\Element\UploadOrLink::processManagedFile(Array, Object(Drupal\Core\Form\FormState), Array)
#4 /var/www/docroot/core/lib/Drupal/Core/Form/FormBuilder.php(1008): call_user_func_array(Array, Array)
#5 /var/www/docroot/core/lib/Drupal/Core/Form/FormBuilder.php(1071): Drupal\Core\Form\FormBuilder->doBuildForm('node_data_edit_...', Array, Object(Drupal\Core\Form\FormState))
#6 /var/www/docroot/core/lib/Drupal/Core/Form/FormBuilder.php(1071): Drupal\Core\Form\FormBuilder->doBuildForm('node_data_edit_...', Array, Object(Drupal\Core\Form\FormState))
#7 /var/www/docroot/core/lib/Drupal/Core/Form/FormBuilder.php(1071): Drupal\Core\Form\FormBuilder->doBuildForm('node_data_edit_...', Array, Object(Drupal\Core\Form\FormState))
#8 /var/www/docroot/core/lib/Drupal/Core/Form/FormBuilder.php(1071): Drupal\Core\Form\FormBuilder->doBuildForm('node_data_edit_...', Array, Object(Drupal\Core\Form\FormState))
#9 /var/www/docroot/core/lib/Drupal/Core/Form/FormBuilder.php(1071): Drupal\Core\Form\FormBuilder->doBuildForm('node_data_edit_...', Array, Object(Drupal\Core\Form\FormState))
#10 /var/www/docroot/core/lib/Drupal/Core/Form/FormBuilder.php(1071): Drupal\Core\Form\FormBuilder->doBuildForm('node_data_edit_...', Array, Object(Drupal\Core\Form\FormState))
#11 /var/www/docroot/core/lib/Drupal/Core/Form/FormBuilder.php(1071): Drupal\Core\Form\FormBuilder->doBuildForm('node_data_edit_...', Array, Object(Drupal\Core\Form\FormState))
#12 /var/www/docroot/core/lib/Drupal/Core/Form/FormBuilder.php(1071): Drupal\Core\Form\FormBuilder->doBuildForm('node_data_edit_...', Array, Object(Drupal\Core\Form\FormState))
#13 /var/www/docroot/core/lib/Drupal/Core/Form/FormBuilder.php(1071): Drupal\Core\Form\FormBuilder->doBuildForm('node_data_edit_...', Array, Object(Drupal\Core\Form\FormState))
#14 /var/www/docroot/core/lib/Drupal/Core/Form/FormBuilder.php(575): Drupal\Core\Form\FormBuilder->doBuildForm('node_data_edit_...', Array, Object(Drupal\Core\Form\FormState))
#15 /var/www/docroot/core/lib/Drupal/Core/Form/FormBuilder.php(321): Drupal\Core\Form\FormBuilder->processForm('node_data_edit_...', Array, Object(Drupal\Core\Form\FormState))
#16 /var/www/docroot/core/lib/Drupal/Core/Controller/FormController.php(91): Drupal\Core\Form\FormBuilder->buildForm(Object(Drupal\node\NodeForm), Object(Drupal\Core\Form\FormState))
#17 [internal function]: Drupal\Core\Controller\FormController->getContentResult(Object(Symfony\Component\HttpFoundation\Request), Object(Drupal\Core\Routing\RouteMatch))
#18 /var/www/docroot/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array(Array, Array)
#19 /var/www/docroot/core/lib/Drupal/Core/Render/Renderer.php(573): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#20 /var/www/docroot/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(124): Drupal\Core\Render\Renderer->executeInRenderContext(Object(Drupal\Core\Render\RenderContext), Object(Closure))
#21 /var/www/docroot/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(97): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext(Array, Array)
#22 /var/www/vendor/symfony/http-kernel/HttpKernel.php(151): Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}()
#23 /var/www/vendor/symfony/http-kernel/HttpKernel.php(68): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#24 /var/www/docroot/core/lib/Drupal/Core/StackMiddleware/Session.php(57): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#25 /var/www/docroot/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(47): Drupal\Core\StackMiddleware\Session->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#26 /var/www/docroot/core/modules/page_cache/src/StackMiddleware/PageCache.php(106): Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#27 /var/www/docroot/core/modules/page_cache/src/StackMiddleware/PageCache.php(85): Drupal\page_cache\StackMiddleware\PageCache->pass(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#28 /var/www/vendor/asm89/stack-cors/src/Asm89/Stack/Cors.php(49): Drupal\page_cache\StackMiddleware\PageCache->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#29 /var/www/docroot/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(47): Asm89\Stack\Cors->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#30 /var/www/docroot/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(52): Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#31 /var/www/vendor/stack/builder/src/Stack/StackedHttpKernel.php(23): Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#32 /var/www/docroot/core/lib/Drupal/Core/DrupalKernel.php(708): Stack\StackedHttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#33 /var/www/docroot/index.php(19): Drupal\Core\DrupalKernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#34 {main}
```

### Part 2
- [x] Create a DKAN dataset with an uploaded resource.
- [x] Navigate to the edit form for the dataset and ensure the upload or link widget contains the uploaded file.
- [x] Ensure an import queue job was created for the uploaded resource.
- [x] Create a DKAN dataset with an link resource.
- [x] Ensure an import queue job was created for the linked resource.
- [x] Navigate to the edit form for the dataset and ensure the upload or link widget contains the link.
