### PR TITLE
Make sure getAll is giving is a plain array

### DIFF
--- a/modules/metastore/src/WebServiceApi.php
+++ b/modules/metastore/src/WebServiceApi.php
@@ -91,6 +91,7 @@ class WebServiceApi implements ContainerInjectionInterface {
       return (object) $modified_object->get('$');
     }, $this->service->getAll($schema_id));
 
+    $output = array_values($output);
     return $this->getResponse($output);
   }
 


### PR DESCRIPTION
A RootedJson validation failure can end up changing the `/api/1/metastore/schemas/dataset/items` endpoint to an object rather than an array.
