### PR TITLE
Better distribution replacing & orphaning behavior

### DIFF
--- a/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
+++ b/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
@@ -101,7 +101,7 @@ class MetastoreSubscriber implements EventSubscriberInterface {
    *
    * @param string $dist_id
    *   The uuid of the distribution where this resource is know to be in use.
-   * @param string $resource
+   * @param string $file_path
    *   The file path of the resource being checked.
    *
    * @return bool

--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -8,6 +8,7 @@ use Drupal\common\LoggerTrait;
 use Drupal\common\Resource;
 use Drupal\common\UrlHostTokenResolver;
 use Drupal\metastore\ResourceMapper;
+use Drupal\metastore\Service;
 
 /**
  * Metastore referencer service.
@@ -287,7 +288,7 @@ class Referencer {
     $storage = $this->storageFactory->getInstance($property_id);
     $nodes = $storage->getEntityStorage()->loadByProperties([
       'field_data_type' => $property_id,
-      'title' => md5(json_encode($data)),
+      'title' => Service::metadataHash($data),
     ]);
 
     if ($node = reset($nodes)) {

--- a/modules/metastore/src/ResourceMapper.php
+++ b/modules/metastore/src/ResourceMapper.php
@@ -200,6 +200,8 @@ class ResourceMapper {
    * @throws \Exception
    *   An exception is thrown if the file exists with json info about the
    *   existing resource.
+   *
+   * @todo Refactor this so it's not an exception.
    */
   public function filePathExists($filePath) {
     $query = new Query();

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -466,4 +466,34 @@ class Service implements ContainerInjectionInterface {
     return $object;
   }
 
+  /**
+   * Get the md5 hash for a metadata item
+   *
+   * @param \RootedData\RootedJsonData|object|string $data
+   *   Metadata. Can be a RootedJsonData object, a stdObject or JSON string.
+   *
+   * @return string
+   *   An md5 hash of the normalized metadata.
+   *
+   * @todo This should probably be somewhere else.
+   */
+  public static function metadataHash($data) {
+    if ($data instanceof RootedJsonData) {
+      $normalizedData = $data;
+      self::removeReferences($normalizedData);
+    }
+    elseif (is_object($data)) {
+      $normalizedData = new RootedJsonData(json_encode($data));
+      self::removeReferences($normalizedData);
+    }
+    elseif (is_string($data)) {
+      $normalizedData = $data;
+    }
+    else {
+      throw new InvalidArgumentException("Invalid metadata argument.");
+    }
+
+    return md5((string) $normalizedData);
+  }
+
 }

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -447,7 +447,17 @@ class Service implements ContainerInjectionInterface {
   }
 
   /**
-   * Private.
+   * Remove references from metadata JSON.
+   *
+   * @param RootedJsonData $object
+   *   Metadata JSON object.
+   * @param string $prefix
+   *   Property prefix.
+   *
+   * @return \RootedData\RootedJsonData
+   *   The metadata without any reference artifacts.
+   *
+   * @todo Probably remove the prefix param and just always use "%Ref".
    */
   public static function removeReferences(RootedJsonData $object, $prefix = "%"): RootedJsonData {
     $array = $object->get('$');
@@ -490,7 +500,7 @@ class Service implements ContainerInjectionInterface {
       $normalizedData = $data;
     }
     else {
-      throw new InvalidArgumentException("Invalid metadata argument.");
+      throw new \InvalidArgumentException("Invalid metadata argument.");
     }
 
     return md5((string) $normalizedData);

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -449,7 +449,7 @@ class Service implements ContainerInjectionInterface {
   /**
    * Remove references from metadata JSON.
    *
-   * @param RootedJsonData $object
+   * @param \RootedData\RootedJsonData $object
    *   Metadata JSON object.
    * @param string $prefix
    *   Property prefix.
@@ -477,7 +477,7 @@ class Service implements ContainerInjectionInterface {
   }
 
   /**
-   * Get the md5 hash for a metadata item
+   * Get the md5 hash for a metadata item.
    *
    * @param \RootedData\RootedJsonData|object|string $data
    *   Metadata. Can be a RootedJsonData object, a stdObject or JSON string.

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -5,6 +5,7 @@ namespace Drupal\metastore\Storage;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\metastore\Exception\MissingObjectException;
+use Drupal\metastore\Service;
 
 /**
  * Data.
@@ -311,7 +312,7 @@ abstract class Data implements MetastoreStorageInterface {
       $title = isset($data->title) ? $data->title : $data->name;
     }
     else {
-      $title = md5(json_encode($data->data));
+      $title = Service::metadataHash($data->data);
     }
     $entity = $this->entityStorage
       ->create(

--- a/modules/metastore/tests/src/Unit/MetastoreSubscriberTest.php
+++ b/modules/metastore/tests/src/Unit/MetastoreSubscriberTest.php
@@ -56,6 +56,7 @@ class MetastoreSubscriberTest extends TestCase {
       ->add(Service::class, 'get', $dist)
       ->add(ResourceMapper::class, 'get', $resource)
       ->add(ResourceMapper::class, 'remove')
+      ->add(Resource::class, 'getFilePath', 'http://ho-st/thing.csv')
       ->add(LoggerChannelFactory::class, 'get', LoggerChannelInterface::class)
       ->add(LoggerChannelInterface::class, 'error', NULL, 'errors');
 

--- a/modules/metastore/tests/src/Unit/MetastoreSubscriberTest.php
+++ b/modules/metastore/tests/src/Unit/MetastoreSubscriberTest.php
@@ -2,24 +2,37 @@
 
 namespace Drupal\Tests\metastore\Unit\EventSubscriber;
 
+use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\Core\Logger\LoggerChannelInterface;
+
 use Drupal\common\Resource;
 use Drupal\common\Events\Event;
 use Drupal\common\Storage\JobStore;
-use MockChain\Chain;
-use MockChain\Options;
-use PHPUnit\Framework\TestCase;
-use Drupal\Core\Logger\LoggerChannelFactory;
-use Drupal\Core\Logger\LoggerChannelInterface;
-use Symfony\Component\DependencyInjection\Container;
 use Drupal\metastore\EventSubscriber\MetastoreSubscriber;
 use Drupal\metastore\Service;
 use Drupal\metastore\ResourceMapper;
 use Drupal\Tests\metastore\Unit\ServiceTest;
 
+use MockChain\Chain;
+use MockChain\Options;
+use PHPUnit\Framework\TestCase;
+use RootedData\RootedJsonData;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\RequestStack;
+
 /**
+ * Unit tests for the `MetastoreSubscriber` class.
  *
+ * @see \Drupal\metastore\EventSubscriber\MetastoreSubscriber
  */
 class MetastoreSubscriberTest extends TestCase {
+
+  /**
+   * Host protocol and domain for testing file path and download URL.
+   *
+   * @var string
+   */
+  const HOST = 'http://h-o.st';
 
   /**
    * The ValidMetadataFactory class used for testing.
@@ -28,73 +41,124 @@ class MetastoreSubscriberTest extends TestCase {
    */
   protected $validMetadataFactory;
 
+  /**
+   * @inheritDoc
+   */
   protected function setUp(): void {
     parent::setUp();
+    $this->initializeContainerWithRequestStack();
     $this->validMetadataFactory = ServiceTest::getValidMetadataFactory($this);
   }
 
   /**
-   * Test clean up.
+   * Initialize `\Drupal::$container` with a custom 'request_stack' service.
    */
-  public function testResourceMapperCleanUp() {
-
-    $url = 'http://hello.world/file.csv';
-    $resource = new Resource($url, 'text/csv');
-    $dist = '{"data":{"%Ref:downloadURL":[{"data":{"identifier":"qwerty","version":"uiop","perspective":"source"}}]}}';
-    $dist = $this->validMetadataFactory->get($dist, 'distribution');
-    $event = new Event($resource);
-
+  protected function initializeContainerWithRequestStack(): void {
     $options = (new Options())
-      ->add('logger.factory', LoggerChannelFactory::class)
-      ->add('dkan.metastore.service', Service::class)
-      ->add('dkan.metastore.resource_mapper', ResourceMapper::class)
-      ->add("database", Connection::class)
+      ->add('request_stack', RequestStack::class)
       ->index(0);
-
-    $chain = (new Chain($this))
+    $container = (new Chain($this))
       ->add(Container::class, 'get', $options)
-      ->add(Service::class, 'get', $dist)
-      ->add(ResourceMapper::class, 'get', $resource)
-      ->add(ResourceMapper::class, 'remove')
-      ->add(Resource::class, 'getFilePath', 'http://ho-st/thing.csv')
-      ->add(LoggerChannelFactory::class, 'get', LoggerChannelInterface::class)
-      ->add(LoggerChannelInterface::class, 'error', NULL, 'errors');
-
-    $subscriber = MetastoreSubscriber::create($chain->getMock());
-    $test = $subscriber->cleanResourceMapperTable($event);
-    $this->assertEmpty($chain->getStoredInput('errors'));
+      ->add(RequestStack::class, 'getCurrentRequest', new class { public function getHost() { return MetastoreSubscriberTest::HOST; } })
+      ->getMock();
+    \Drupal::setContainer($container);
   }
 
   /**
-   * Test exception.
+   * Create a JSON Metadata distribution with the given file path.
+   *
+   * @param string $file_path
+   *   Optional resource file path and download URL.
    */
-  public function testResourceMapperCleanUpException() {
+  protected function createDistribution(string $file_path = ''): RootedJsonData {
+    $file_path = $file_path ?: (self::HOST . '/' . uniqid() . '.csv');
+    return $this->validMetadataFactory->get(json_encode([
+      'identifier' => uniqid(),
+      'data' => [
+        '@type' => 'dcat:Distribution',
+        'title' => 'Test Distribution',
+        'format' => 'csv',
+        'downloadURL' => $file_path,
+        '%Ref:downloadURL' => [
+          [
+            'data' => [
+              'identifier' => uniqid(),
+              'filePath' => $file_path,
+              'mimeType' => 'text/csv',
+              'perspective' => 'source',
+              'version' => '1',
+            ],
+          ],
+        ],
+      ],
+    ]), 'distribution');
+  }
 
-    $url = 'http://hello.world/file.csv';
-    $resource = new Resource($url, 'text/csv');
-    $dist = '{"data":{"%Ref:downloadURL":[{"data":{"identifier":"qwerty","version":"uiop","perspective":"source"}}]}}';
-    $dist = $this->validMetadataFactory->get($dist, 'distribution');
-    $event = new Event($resource);
+  /**
+   * Tests that if a resource is not in use elsewhere, it is removed.
+   */
+  public function testCleanupWithResourceNotInUseElsewhere(): void {
+    $resource_path = self::HOST . '/single.csv';
+    // Create a test resource.
+    $resource = new Resource($resource_path, 'text/csv');
+    // Create a test distribution.
+    $distribution = $this->createDistribution($resource_path);
 
     $options = (new Options())
       ->add('logger.factory', LoggerChannelFactory::class)
       ->add('dkan.metastore.service', Service::class)
       ->add('dkan.metastore.resource_mapper', ResourceMapper::class)
-      ->add("database", Connection::class)
+      ->add('database', Connection::class)
+      ->index(0);
+
+    $removal_message = 'Removed Successfully!';
+
+    $chain = (new Chain($this))
+      ->add(Container::class, 'get', $options)
+      ->add(Service::class, 'get', $distribution)
+      ->add(Service::class, 'getAll', [$distribution])
+      ->add(ResourceMapper::class, 'get', $resource)
+      ->add(ResourceMapper::class, 'remove', new \Exception($removal_message))
+      ->add(LoggerChannelFactory::class, 'get', LoggerChannelInterface::class)
+      ->add(LoggerChannelInterface::class, 'error', NULL, 'errors');
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage($removal_message);
+
+    $subscriber = MetastoreSubscriber::create($chain->getMock());
+    $subscriber->cleanResourceMapperTable(new Event($distribution->{'$.identifier'}));
+  }
+
+  /**
+   * Tests that if a resource is in use elsewhere, it is not removed.
+   *
+   * @doesNotPerformAssertions
+   */
+  public function testCleanupWithResourceInUseElsewhere(): void {
+    $resource_path = self::HOST . '/single.csv';
+    // Create a test resource.
+    $resource = new Resource($resource_path, 'text/csv');
+    // Create a test distribution.
+    $distribution_1 = $this->createDistribution($resource_path);
+    $distribution_2 = $this->createDistribution($resource_path);
+
+    $options = (new Options())
+      ->add('logger.factory', LoggerChannelFactory::class)
+      ->add('dkan.metastore.service', Service::class)
+      ->add('dkan.metastore.resource_mapper', ResourceMapper::class)
+      ->add('database', Connection::class)
       ->index(0);
 
     $chain = (new Chain($this))
       ->add(Container::class, 'get', $options)
-      ->add(Service::class, 'get', $dist)
-      ->add(ResourceMapper::class, 'get', NULL)
-      ->add(ResourceMapper::class, 'remove')
+      ->add(Service::class, 'get', $distribution_1)
+      ->add(Service::class, 'getAll', [$distribution_1, $distribution_2])
+      ->add(ResourceMapper::class, 'get', $resource)
+      ->add(ResourceMapper::class, 'remove', new \LogicException('Erroneous attempt to remove resource which is in use elsewhere'))
       ->add(LoggerChannelFactory::class, 'get', LoggerChannelInterface::class)
       ->add(LoggerChannelInterface::class, 'error', NULL, 'errors');
 
     $subscriber = MetastoreSubscriber::create($chain->getMock());
-    $test = $subscriber->cleanResourceMapperTable($event);
-    $this->assertContains('Failed to remove resource', $chain->getStoredInput('errors')[0]);
-
+    $subscriber->cleanResourceMapperTable(new Event($distribution_1->{'$.identifier'}));
   }
-
 }


### PR DESCRIPTION
Fixes #3595

This PR fixes serious issues with distribution and resource handling. It should:

1. Stop replacing distributions every time a dataset is changed, regardless of whether the distro itself has changed.
2. Stop removing resources (from the dkan_metastore_resource_mapper table and the datastore) every time a distribution is orphaned, without checking to see if the resource is still in use by another distribution.

## QA Steps

Perform the QA steps from #3595 and ensure that the bug is no longer appearing.

In addition:

1. After performing the #3595 reproduction steps, you should not see any duplicate distributions in the admin page, as we have not changed the distribution yet.
2. If we do change the distribution, it should replace the old distro with a new one, unpublish the old one, but leave the resource in place. Try:
```http
PATCH http://test.localtest.me/api/1/metastore/schemas/dataset/items/cedcd327-4e5d-43f9-8eb1-c11850fa7c55
Authorization: Basic admin:mypassword

{
  "modified": "2016-06-23",
  "distribution": [
    {
      "@type": "dcat:Distribution",
      "downloadURL": "http:\/\/test.localtest.me\/sites\/default\/files\/distribution\/cedcd327-4e5d-43f9-8eb1-c11850fa7c55\/Bike_Lane.csv",
      "mediaType": "text\/csv",
      "format": "csv",
      "title": "Florida Bike Lanes 2"
    }
  ]
}
```
(make sure the download URL is identical to the value you get when you retrieve the JSON from the metastore.)

3. Now run `drush cron`. There should be a new distribution in the admin page with a new title, the old distribution should be unpublished, but the resource should still be present. Make sure the datastore endpoint still works, also try running against the db: `SELECT * FROM dkan_metastore_resource_mapper WHERE filepath LIKE '%Lane.csv';`

4. Make sure orphaning still does work as expected. From the admin interface or the API, delete the parent dataset Florida Bike Lanes. Run cron. Make sure that all the distributions for that dataset are now unpublished, and that the db query from earlier now returns no results.

5. Do some more patches against other datasets and make sure no other strange behavior is observed.

## Notes

The reason distributions were being duplicated was the presence of reference artifacts in the JSON that was being hashed. This PR removes the references before hashing, but we should be more careful in general about knowing whether we're handling data with reference artifacts (`%Ref:` properties) or not.