### PR TITLE
Properly escape headers in MySQL fast import

### DIFF
--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -44,7 +44,7 @@ class MysqlImport extends Importer {
     $storage = $this->dataStorage;
     $storage->count();
 
-    $sqlStatementLines = $this->getSqlStatement($filename, $storage, $header);
+    $sqlStatementLines = $this->getSqlStatement($filename, $storage, $headers);
 
     $sqlStatement = implode(' ', $sqlStatementLines);
 
@@ -73,7 +73,7 @@ class MysqlImport extends Importer {
   /**
    * Properly escape and format the supplied list of column names.
    *
-   * @param string[] $columnNames
+   * @param string[] $columns
    *   List of column names.
    *
    * @return array

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -69,7 +69,8 @@ class MysqlImport extends Importer {
     'undo', 'union', 'unique', 'unlock', 'unsigned', 'update', 'usage', 'use',
     'using', 'utc_date', 'utc_time', 'utc_timestamp', 'values', 'varbinary',
     'varchar', 'varcharacter', 'varying', 'virtual', 'when', 'where', 'while',
-    'window', 'with', 'write', 'xor', 'year_month', 'zerofill'];
+    'window', 'with', 'write', 'xor', 'year_month', 'zerofill',
+  ];
 
   /**
    * Override.

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -83,11 +83,14 @@ class MysqlImport extends Importer {
     return array_replace([], ...array_map(function ($column) {
       // Sanitize the supplied table header to generate a unique column name.
       $header = $this->sanitizeHeader($column);
-      // Prepend "d_" to the table column name to prevent numeric column name
-      // parsing issues.
-      //
-      // @see https://github.com/GetDKAN/dkan/issues/3606
-      $header = 'd_' . $header;
+
+      if (is_numeric($header)) {
+        // Prepend "_" to fully numeric table column name to prevent column name
+        // parsing issues - can be dropped after move to Drupal 9.
+        // @see https://github.com/GetDKAN/dkan/issues/3606
+        $header = '_' . $header;
+      }
+
       // Truncate the generated table column name, if necessary, to fit the max
       // column length.
       $header = $this->truncateHeader($header);

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -78,7 +78,10 @@ class MysqlImport extends Importer {
         $new = $strings[0] . "_{$token}";
       }
 
-      $row[] = $new;
+      // Enclose all headers in backticks to allow non-standard headers.
+      //
+      // @see https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
+      $row[] = '`' . $new . '`';
     }
     return $row;
   }

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -21,6 +21,57 @@ class MysqlImport extends Importer {
   protected const MAX_COLUMN_LENGTH = 64;
 
   /**
+   * List of reserved words in MySQL 5.6-8 and MariaDB.
+   *
+   * @var array
+   */
+  protected const RESERVED_WORDS = ['accessible', 'add', 'all', 'alter', 'analyze',
+    'and', 'as', 'asc', 'asensitive', 'before', 'between', 'bigint', 'binary',
+    'blob', 'both', 'by', 'call', 'cascade', 'case', 'change', 'char',
+    'character', 'check', 'collate', 'column', 'condition', 'constraint',
+    'continue', 'convert', 'create', 'cross', 'cube', 'cume_dist',
+    'current_date', 'current_role', 'current_time', 'current_timestamp',
+    'current_user', 'cursor', 'database', 'databases', 'day_hour',
+    'day_microsecond', 'day_minute', 'day_second', 'dec', 'decimal', 'declare',
+    'default', 'delayed', 'delete', 'dense_rank', 'desc', 'describe',
+    'deterministic', 'distinct', 'distinctrow', 'div', 'do_domain_ids',
+    'double', 'drop', 'dual', 'each', 'else', 'elseif', 'empty', 'enclosed',
+    'escaped', 'except', 'exists', 'exit', 'explain', 'false', 'fetch',
+    'first_value', 'float', 'float4', 'float8', 'for', 'force', 'foreign',
+    'from', 'fulltext', 'function', 'general', 'generated', 'get', 'grant',
+    'group', 'grouping', 'groups', 'having', 'high_priority', 'hour_microsecond',
+    'hour_minute', 'hour_second', 'if', 'ignore', 'ignore_domain_ids',
+    'ignore_server_ids', 'in', 'index', 'infile', 'inner', 'inout',
+    'insensitive', 'insert', 'int', 'int1', 'int2', 'int3', 'int4', 'int8',
+    'integer', 'intersect', 'interval', 'into', 'io_after_gtids',
+    'io_before_gtids', 'is', 'iterate', 'join', 'json_table', 'key', 'keys',
+    'kill', 'lag', 'last_value', 'lateral', 'lead', 'leading', 'leave', 'left',
+    'like', 'limit', 'linear', 'lines', 'load', 'localtime', 'localtimestamp',
+    'lock', 'long', 'longblob', 'longtext', 'loop', 'low_priority',
+    'master_bind', 'master_heartbeat_period', 'master_ssl_verify_server_cert',
+    'match', 'maxvalue', 'mediumblob', 'mediumint', 'mediumtext', 'middleint',
+    'minute_microsecond', 'minute_second', 'mod', 'modifies', 'natural', 'not',
+    'no_write_to_binlog', 'nth_value', 'ntile', 'null', 'numeric', 'of',
+    'offset', 'on', 'optimize', 'optimizer_costs', 'option', 'optionally',
+    'or', 'order', 'out', 'outer', 'outfile', 'over', 'page_checksum',
+    'parse_vcol_expr', 'partition', 'percent_rank', 'position', 'precision',
+    'primary', 'procedure', 'purge', 'range', 'rank', 'read', 'reads',
+    'read_write', 'real', 'recursive', 'references', 'ref_system_id', 'regexp',
+    'release', 'rename', 'repeat', 'replace', 'require', 'resignal',
+    'restrict', 'return', 'returning', 'revoke', 'right', 'rlike', 'row',
+    'row_number', 'rows', 'schema', 'schemas', 'second_microsecond', 'select',
+    'sensitive', 'separator', 'set', 'show', 'signal', 'slow', 'smallint',
+    'spatial', 'specific', 'sql', 'sql_big_result', 'sql_calc_found_rows',
+    'sqlexception', 'sql_small_result', 'sqlstate', 'sqlwarning', 'ssl',
+    'starting', 'stats_auto_recalc', 'stats_persistent', 'stats_sample_pages',
+    'stored', 'straight_join', 'system', 'table', 'terminated', 'then',
+    'tinyblob', 'tinyint', 'tinytext', 'to', 'trailing', 'trigger', 'true',
+    'undo', 'union', 'unique', 'unlock', 'unsigned', 'update', 'usage', 'use',
+    'using', 'utc_date', 'utc_time', 'utc_timestamp', 'values', 'varbinary',
+    'varchar', 'varcharacter', 'varying', 'virtual', 'when', 'where', 'while',
+    'window', 'with', 'write', 'xor', 'year_month', 'zerofill'];
+
+  /**
    * Override.
    *
    * {@inheritdoc}
@@ -84,9 +135,9 @@ class MysqlImport extends Importer {
       // Sanitize the supplied table header to generate a unique column name.
       $header = $this->sanitizeHeader($column);
 
-      if (is_numeric($header)) {
-        // Prepend "_" to fully numeric table column name to prevent column name
-        // parsing issues - can be dropped after move to Drupal 9.
+      if (is_numeric($header) || in_array($header, self::RESERVED_WORDS)) {
+        // Prepend "_" to column name that are not allowed in MySQL
+        // This can be dropped after move to Drupal 9.
         // @see https://github.com/GetDKAN/dkan/issues/3606
         $header = '_' . $header;
       }

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -80,7 +80,7 @@ class MysqlImport extends Importer {
    *   List of sanitized table headers keyed by original column names.
    */
   private function generateTableHeaders(array $columns): array {
-    return array_merge([], ...array_map(function ($column) {
+    return array_replace([], ...array_map(function ($column) {
       // Sanitize the supplied table header to generate a unique column name.
       $header = $this->sanitizeHeader($column);
       // Prepend "d_" to the table column name to prevent numeric column name


### PR DESCRIPTION
fixes #3606

This PR adds a one-character prefix (`_`) to incoming column names that are not compatible with mysql. These include:

- Numeric column names
- Column names matching any [MySQL reserved words](https://dev.mysql.com/doc/refman/5.7/en/keywords.html).

This is essentially a stopgap, as [Drupal 9 takes care of this for us](https://www.drupal.org/project/drupal/issues/2986452). Once we drop support for Drupal 8 (don't worry no plans for this yet) we can revert this.  

## QA Steps

- [x] Ensure you're on the latest version of `GetDKAN/datastore`.
  - [x] Create a dataset with a resource file which has column names starting with integers.
  - [x] Ensure you're able to import the newly created dataset.
  - [x] Ensure all of the columns in the newly created dataset have a `d_` prefix and have been properly escaped.
- [x] Switch to the `34-allow-column-names-for-table-fields` branch on `GetDKAN/datastore`.
  - [x] Create a dataset with a resource file which has column names starting with integers.
  - [x] Ensure you're able to import the newly created dataset.
  - [ ] Ensure all of the columns in the newly created dataset have their original table names.

## Known issues

Test coverage for the mysql importer is still incomplete. This module will remain marked as "experimental".