### PR TITLE
Save new distribution version when MIME type changes

### DIFF
--- a/modules/common/src/Resource.php
+++ b/modules/common/src/Resource.php
@@ -94,6 +94,13 @@ class Resource implements \JsonSerializable {
   }
 
   /**
+   * Change MIME type.
+   */
+  public function changeMimeType($newMimeType) {
+    $this->mimeType = $newMimeType;
+  }
+
+  /**
    * Private.
    */
   private function createCommon($property, $value) {

--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -204,7 +204,7 @@ class Referencer {
       if (isset($info[0]->identifier)) {
         /** @var \Drupal\common\Resource $stored */
         $stored = $this->getFileMapper()->get($info[0]->identifier, Resource::DEFAULT_SOURCE_PERSPECTIVE);
-        $downloadUrl = $this->handleExistingResource($info, $stored);
+        $downloadUrl = $this->handleExistingResource($info, $stored, $mimeType);
       }
     }
 
@@ -214,9 +214,13 @@ class Referencer {
   /**
    * Private.
    */
-  private function handleExistingResource($info, $stored) {
-    if ($info[0]->perspective == Resource::DEFAULT_SOURCE_PERSPECTIVE && resource_mapper_new_revision() == 1) {
+  private function handleExistingResource($info, $stored, $mimeType) {
+    if ($info[0]->perspective == Resource::DEFAULT_SOURCE_PERSPECTIVE &&
+      (resource_mapper_new_revision() == 1 || $stored->mimetype != $mimeType)) {
       $new = $stored->createNewVersion();
+      // Update the MIME type, since this may be updated by the user.
+      $new->changeMimeType($mimeType);
+
       $this->getFileMapper()->registerNewVersion($new);
       $downloadUrl = $new->getUniqueIdentifier();
     }

--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -216,7 +216,7 @@ class Referencer {
    */
   private function handleExistingResource($info, $stored, $mimeType) {
     if ($info[0]->perspective == Resource::DEFAULT_SOURCE_PERSPECTIVE &&
-      (resource_mapper_new_revision() == 1 || $stored->mimetype != $mimeType)) {
+      (resource_mapper_new_revision() == 1 || $stored->getMimeType() != $mimeType)) {
       $new = $stored->createNewVersion();
       // Update the MIME type, since this may be updated by the user.
       $new->changeMimeType($mimeType);

--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -216,7 +216,7 @@ class Referencer {
    */
   private function handleExistingResource($info, $stored, $mimeType) {
     if ($info[0]->perspective == Resource::DEFAULT_SOURCE_PERSPECTIVE &&
-      (resource_mapper_new_revision() == 1 || $stored->getMimeType() != $mimeType)) {
+      (ResourceMapper::newRevision() == 1 || $stored->getMimeType() != $mimeType)) {
       $new = $stored->createNewVersion();
       // Update the MIME type, since this may be updated by the user.
       $new->changeMimeType($mimeType);

--- a/modules/metastore/src/ResourceMapper.php
+++ b/modules/metastore/src/ResourceMapper.php
@@ -47,16 +47,6 @@ class ResourceMapper {
    * @return string
    *   A resource perspective.
    */
-  public static function display() {
-    return drupal_static('metastore_resource_mapper_display', Resource::DEFAULT_SOURCE_PERSPECTIVE);
-  }
-
-  /**
-   * Helper method to retrieve the static value for a resource's display.
-   *
-   * @return string
-   *   A resource perspective.
-   */
   public static function newRevision() {
     return drupal_static('metastore_resource_mapper_new_revision', 0);
   }

--- a/modules/metastore/src/ResourceMapper.php
+++ b/modules/metastore/src/ResourceMapper.php
@@ -241,6 +241,12 @@ class ResourceMapper {
     return isset($item);
   }
 
+  /**
+   * Get the storage class.
+   *
+   * @return \Drupal\common\Storage\DatabaseTableInterface
+   *   A DB storage service.
+   */
   public function getStore() {
     return $this->store;
   }

--- a/modules/metastore/src/ResourceMapper.php
+++ b/modules/metastore/src/ResourceMapper.php
@@ -42,6 +42,26 @@ class ResourceMapper {
   }
 
   /**
+   * Helper method to retrieve the static value for a resource's display.
+   *
+   * @return string
+   *   A resource perspective.
+   */
+  public static function display() {
+    return drupal_static('metastore_resource_mapper_display', Resource::DEFAULT_SOURCE_PERSPECTIVE);
+  }
+
+  /**
+   * Helper method to retrieve the static value for a resource's display.
+   *
+   * @return string
+   *   A resource perspective.
+   */
+  public static function newRevision() {
+    return drupal_static('metastore_resource_mapper_new_revision', 0);
+  }
+
+  /**
    * Register a new url for mapping.
    *
    * @todo the Resource class currently lives in datastore, we should move it
@@ -81,14 +101,14 @@ class ResourceMapper {
    */
   public function registerNewVersion(Resource $resource) {
     $this->validateNewVersion($resource);
-    $this->store->store(json_encode($resource));
+    $this->getStore()->store(json_encode($resource));
     $this->dispatchEvent(self::EVENT_REGISTRATION, $resource);
   }
 
   /**
    * Private.
    */
-  private function validateNewVersion(Resource $resource) {
+  protected function validateNewVersion(Resource $resource) {
     if ($resource->getPerspective() !== Resource::DEFAULT_SOURCE_PERSPECTIVE) {
       throw new \Exception("Only versions of source resources are allowed.");
     }
@@ -206,7 +226,7 @@ class ResourceMapper {
   public function filePathExists($filePath) {
     $query = new Query();
     $query->conditionByIsEqualTo('filePath', $filePath);
-    $results = $this->store->query($query);
+    $results = $this->getStore()->query($query);
     if (!empty($results)) {
       throw new AlreadyRegistered(json_encode($results));
     }
@@ -219,6 +239,10 @@ class ResourceMapper {
   private function exists($identifier, $perspective, $version = NULL) : bool {
     $item = $this->get($identifier, $perspective, $version);
     return isset($item);
+  }
+
+  public function getStore() {
+    return $this->store;
   }
 
 }


### PR DESCRIPTION
Updating the distribution saving logic to handle the case of a distribution MIME type being updated.

fixes #3603 

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Switch to the 2.x branch
- [ ] Create a dataset using the remote URL https://download.medicaid.gov/data/newNADACPrice.csv
- [ ] Check the distribution mime type is `application/octet-stream`
- [ ] Run the import queue - no import should run
- [ ] Switch to this branch AND cherry pick the commit from #3613
- [ ] Create a new dataset using the remote URL https://download.medicaid.gov/data/newNADACPrice.csv
- [ ] Check the distribution mime type is now `text/csv`
- [ ] Run the import queue - the import should run and data should be available in preview
