### PR TITLE
Moving the harvest unit test to the correct location.

### DIFF
--- a/modules/harvest/tests/src/Unit/DashboardControllerTest.php
+++ b/modules/harvest/tests/src/Unit/DashboardControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\harvest;
+namespace Drupal\Tests\harvest\Unit;
 
 use Drupal\Core\DependencyInjection\Container;
 use Drupal\common\DatasetInfo;

--- a/modules/harvest/tests/src/Unit/Load/DatasetTest.php
+++ b/modules/harvest/tests/src/Unit/Load/DatasetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\harvest\Load;
+namespace Drupal\Tests\harvest\Unit\Load;
 
 use Contracts\Mock\Storage\Memory;
 use Drupal\Core\DependencyInjection\Container;

--- a/modules/harvest/tests/src/Unit/ServiceTest.php
+++ b/modules/harvest/tests/src/Unit/ServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\harvest;
+namespace Drupal\Tests\harvest\Unit;
 
 use Contracts\FactoryInterface;
 use Contracts\Mock\Storage\Memory;
@@ -53,7 +53,7 @@ class ServiceTest extends TestCase {
       'identifier' => 'test_plan',
       'extract' => (object) [
         "type" => DataJson::class,
-        "uri" => "file://" . __DIR__ . '/../files/data.json',
+        "uri" => "file://" . __DIR__ . '/../../files/data.json',
       ],
       'transforms' => [],
       'load' => (object) [
@@ -90,7 +90,7 @@ class ServiceTest extends TestCase {
 
     // Run harvest with changes.
     $plan2 = clone $plan;
-    $plan2->extract->uri = "file://" . __DIR__ . '/../files/data2.json';
+    $plan2->extract->uri = "file://" . __DIR__ . '/../../files/data2.json';
     $service->registerHarvest($plan2);
     $result = $service->runHarvest('test_plan');
 

--- a/modules/harvest/tests/src/Unit/Storage/DatabaseTableFactoryTest.php
+++ b/modules/harvest/tests/src/Unit/Storage/DatabaseTableFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\harvest\Storage;
+namespace Drupal\Tests\harvest\Unit\Storage;
 
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Schema;

--- a/modules/harvest/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/harvest/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\harvest\Storage;
+namespace Drupal\Tests\harvest\Unit\Storage;
 
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Schema;

--- a/modules/harvest/tests/src/Unit/WebServiceApiTest.php
+++ b/modules/harvest/tests/src/Unit/WebServiceApiTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\harvest;
+namespace Drupal\Tests\harvest\Unit;
 
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\metastore\Service as Metastore;


### PR DESCRIPTION
We want to follow Drupal's test organization practices by having our unit tests in `tests/src/Unit`
