### PR TITLE
Correct for for getStatus on null in datastore import

### DIFF
--- a/modules/datastore/src/Plugin/QueueWorker/Import.php
+++ b/modules/datastore/src/Plugin/QueueWorker/Import.php
@@ -96,7 +96,7 @@ class Import extends QueueWorkerBase implements ContainerFactoryPluginInterface 
 
       $queued = FALSE;
       foreach ($results as $result) {
-        $queued = $result ? $this->processResult($result, $data, $queued) : FALSE;
+        $queued = isset($result) ? $this->processResult($result, $data, $queued) : FALSE;
       }
     }
     catch (\Exception $e) {

--- a/modules/datastore/src/Plugin/QueueWorker/Import.php
+++ b/modules/datastore/src/Plugin/QueueWorker/Import.php
@@ -96,7 +96,7 @@ class Import extends QueueWorkerBase implements ContainerFactoryPluginInterface 
 
       $queued = FALSE;
       foreach ($results as $result) {
-        if (isset($result)){
+        if (isset($result)) {
           $queued = $this->processResult($result, $data, $queued);
         }
       }

--- a/modules/datastore/src/Plugin/QueueWorker/Import.php
+++ b/modules/datastore/src/Plugin/QueueWorker/Import.php
@@ -96,7 +96,9 @@ class Import extends QueueWorkerBase implements ContainerFactoryPluginInterface 
 
       $queued = FALSE;
       foreach ($results as $result) {
-        $queued = $this->processResult($result, $data, $queued);
+        if (isset($result)){
+          $queued = $this->processResult($result, $data, $queued);
+        }
       }
     }
     catch (\Exception $e) {

--- a/modules/datastore/src/Plugin/QueueWorker/Import.php
+++ b/modules/datastore/src/Plugin/QueueWorker/Import.php
@@ -96,9 +96,7 @@ class Import extends QueueWorkerBase implements ContainerFactoryPluginInterface 
 
       $queued = FALSE;
       foreach ($results as $result) {
-        if (isset($result)) {
-          $queued = $this->processResult($result, $data, $queued);
-        }
+        $queued = $result ? $this->processResult($result, $data, $queued) : FALSE;
       }
     }
     catch (\Exception $e) {

--- a/modules/datastore/src/Service.php
+++ b/modules/datastore/src/Service.php
@@ -147,7 +147,7 @@ class Service implements ContainerInjectionInterface {
       $label => $this->resourceLocalizer->localize($identifier, $version),
     ];
 
-    if ($result[$label]->getStatus() == Result::DONE) {
+    if (isset($result[$label]) && $result[$label]->getStatus() == Result::DONE) {
       $resource = $this->resourceLocalizer->get($identifier, $version);
     }
 


### PR DESCRIPTION
Missing resources cause errors when running queue jobs

```
[error]  Error: Call to a member function getStatus() on null in Drupal\datastore\Service->getResource() (line 150 of /var/www/dkan/modules/datastore/src/Service.php) #0 /var/www/dkan/modules/datastore/src/Service.php(104): Drupal\datastore\Service->getResource('62ee0ef104078be...', 1628895867)
```
and 
```
TypeError: Argument 1 passed to Drupal\datastore\Plugin\QueueWorker\Import::processResult() must be an instance of Procrastinator\Result, null given, called in /var/www/dkan/modules/datastore/src/Plugin/QueueWorker/Import.php on line 99 in /var/www/dkan/modules/datastore/src/Plugin/QueueWorker/Import.php on line 111 #0 /var/www/dkan/modules/datastore/src/Plugin/QueueWorker/Import.php(99): Drupal\datastore\Plugin\QueueWorker\Import->processResult(NULL, Array, false)
```
and

```
Error: Call to a member function getUniqueIdentifier() on null in Drupal\datastore\Drush->jobstorePrune() (line 21 of /mnt/www/html/datahealthcare/docroot/modules/contrib/dkan/modules/datastore/src/TableTrait.php) #0 /mnt/www/html/datahealthcare/docroot/modules/contrib/dkan/modules/datastore/src/Drush.php(172): Drupal\datastore\Drush->jobstorePrune('c93e6d572c775ea...')

```