### PR TITLE
Fix CSV header collisions by generating unique suffixes

### DIFF
--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -212,7 +212,9 @@ class MysqlImport extends Importer {
    *   List of sanitized table headers keyed by original column names.
    */
   private function generateTableHeaders(array $columns): array {
-    return array_replace([], ...array_map(function ($column) {
+    $headers = [];
+
+    foreach ($columns as $column) {
       // Sanitize the supplied table header to generate a unique column name;
       // null-coalesce potentially NULL column names to empty strings.
       $header = $this->sanitizeHeader($column ?? '');
@@ -228,8 +230,17 @@ class MysqlImport extends Importer {
       // column length.
       $header = $this->truncateHeader($header);
 
-      return [$column => $header];
-    }, $columns));
+      // Generate unique numeric suffix for the header if a header already
+      // exists with the same name.
+      for ($i = 2; isset($headers[$column]); $i++) {
+        $suffix = '_' . $i;
+        $column = substr($column, 0, self::MAX_COLUMN_LENGTH - strlen($suffix)) . $suffix;
+      }
+
+      $headers[$header] = $column;
+    }
+
+    return array_flip($headers);
   }
 
   /**

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -209,7 +209,7 @@ class MysqlImport extends Importer {
    *   List of column names.
    *
    * @return array
-   *   List of sanitized table headers keyed by original column names.
+   *   List of sanitized table headers.
    */
   private function generateTableHeaders(array $columns): array {
     $headers = [];
@@ -237,10 +237,10 @@ class MysqlImport extends Importer {
         $header = substr($header, 0, self::MAX_COLUMN_LENGTH - strlen($suffix)) . $suffix;
       }
 
-      $headers[$header] = $column;
+      $headers[$header] = $header;
     }
 
-    return array_flip($headers);
+    return $headers;
   }
 
   /**

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -232,9 +232,9 @@ class MysqlImport extends Importer {
 
       // Generate unique numeric suffix for the header if a header already
       // exists with the same name.
-      for ($i = 2; isset($headers[$column]); $i++) {
+      for ($i = 2; isset($headers[$header]); $i++) {
         $suffix = '_' . $i;
-        $column = substr($column, 0, self::MAX_COLUMN_LENGTH - strlen($suffix)) . $suffix;
+        $header = substr($header, 0, self::MAX_COLUMN_LENGTH - strlen($suffix)) . $suffix;
       }
 
       $headers[$header] = $column;


### PR DESCRIPTION
fixes [org/repo/issue#]

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Create a dataset with a CSV file with duplicate column names.
- [ ] Ensure the CSV file is imported correctly by the `datastore_import` queue.