### PR TITLE
Prevent datastore_import queue worker from being run by cron

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "ilbee/csv-response": "^1.0",
         "oomphinc/composer-installers-extender": "^2.0",
         "stolt/json-merge-patch": "^1.0",
-        "drupal/openapi_ui": "^1.0@RC"
+        "drupal/openapi_ui": "^1.0@RC",
+        "drush/drush": "^10.1"
     },
     "require-dev": {
         "getdkan/mock-chain": "^1.3.0",

--- a/modules/datastore/src/Plugin/QueueWorker/Import.php
+++ b/modules/datastore/src/Plugin/QueueWorker/Import.php
@@ -19,8 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @QueueWorker(
  *   id = "datastore_import",
- *   title = @Translation("Queue to process datastore import"),
- *   cron = {"time" = 60}
+ *   title = @Translation("Queue to process datastore import")
  * )
  */
 class Import extends QueueWorkerBase implements ContainerFactoryPluginInterface {


### PR DESCRIPTION
Since the Drupal Core cron service doesn't seem to handle jobs in the `datastore_import` queue properly, it should be removed in favor of using the `drush queue:run` command supplied by Drush.

A potential remedy may be supplied by [Drupal Core issue #2893933](https://www.drupal.org/project/drupal/issues/2893933), however it has yet to be merged.

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Create a new dataset with a large resource file (>= 100 MB).
- [ ] Run cron using Drush (`drush cron`).
- [ ] Run another instance of cron using Drush (`drush cron`).
- [ ] Wait until both cron jobs have completed.
- [ ] Ensure no duplicate rows were imported into the datastore for the created dataset.