### PR TITLE
Fix how the Drupal cron service processes `datastore_import` jobs.

### DIFF
--- a/modules/better_cron/better_cron.info.yml
+++ b/modules/better_cron/better_cron.info.yml
@@ -1,0 +1,6 @@
+name: Better Cron
+description: A Drupal Cron service implementation with support for separate queue time-limits and item lease times.
+type: module
+core: 8.x
+core_version_requirement: ^8 || ^9
+package: DKAN

--- a/modules/better_cron/better_cron.services.yml
+++ b/modules/better_cron/better_cron.services.yml
@@ -1,0 +1,14 @@
+services:
+  cron:
+    class: Drupal\better_cron\BetterCron
+    arguments: [
+      '@module_handler',
+      '@lock',
+      '@queue',
+      '@state',
+      '@account_switcher',
+      '@logger.channel.cron',
+      '@plugin.manager.queue_worker',
+      '@datetime.time'
+    ]
+    lazy: true

--- a/modules/better_cron/src/BetterCron.php
+++ b/modules/better_cron/src/BetterCron.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\better_cron;
+
+use Drupal\Core\Cron;
+use Drupal\Core\CronInterface;
+use Drupal\Core\Queue\DelayableQueueInterface;
+use Drupal\Core\Queue\DelayedRequeueException;
+use Drupal\Core\Queue\RequeueException;
+use Drupal\Core\Queue\SuspendQueueException;
+
+/**
+ * Cron service which allows for a separate queue time-limit and lease time.
+ */
+class BetterCron extends Cron implements CronInterface {
+
+  /**
+   * Default time-limit for a queue.
+   *
+   * @var string
+   */
+  protected const DEFAULT_QUEUE_CRON_TIME = 15;
+
+  /**
+   * Default lease time for a queue item.
+   *
+   * @var string
+   */
+  protected const DEFAULT_QUEUE_CRON_LEASE_TIME = 30;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function processQueues(): void {
+    // Grab the defined cron queues.
+    foreach ($this->queueManager->getDefinitions() as $queue_name => $info) {
+      // Ensure the queue is annotated such as to be processed by cron.
+      if (isset($info['cron'])) {
+        // Make sure every queue exists. There is no harm in trying to recreate
+        // an existing queue.
+        $this->queueFactory->get($queue_name)->createQueue();
+
+        // Fetch queue and queue worker for processing this queue instance.
+        $queue = $this->queueFactory->get($queue_name);
+        $queue_worker = $this->queueManager->createInstance($queue_name);
+
+        // Calculate the end time based on the time-limit for this queue.
+        $time_limit = $this->time->getCurrentTime() + ($info['cron']['time'] ?? static::DEFAULT_QUEUE_CRON_TIME);
+        // Fetch the maximum lease time for items in this queue.
+        $lease_time = $info['cron']['lease_time'] ?? static::DEFAULT_QUEUE_CRON_LEASE_TIME;
+
+        // While the time limit has not been reached for this queue, and there
+        // are still remaining queue items to be processed...
+        while ($this->time->getCurrentTime() < $time_limit && ($item = $queue->claimItem($lease_time))) {
+          try {
+            $queue_worker->processItem($item->data);
+            $queue->deleteItem($item);
+          }
+          catch (DelayedRequeueException $e) {
+            // The worker requested the task not be immediately re-queued.
+            // - If the queue doesn't support ::delayItem(), we should leave the
+            // item's current expiry time alone.
+            // - If the queue does support ::delayItem(), we should allow the
+            // queue to update the item's expiry using the requested delay.
+            if ($queue instanceof DelayableQueueInterface) {
+              // This queue can handle a custom delay; use the duration provided
+              // by the exception.
+              $queue->delayItem($item, $e->getDelay());
+            }
+          }
+          catch (RequeueException $e) {
+            // The worker requested the task be immediately requeued.
+            $queue->releaseItem($item);
+          }
+          catch (SuspendQueueException $e) {
+            // If the worker indicates there is a problem with the whole queue,
+            // release the item and skip to the next queue.
+            $queue->releaseItem($item);
+
+            watchdog_exception('cron', $e);
+
+            // Skip to the next queue.
+            continue 2;
+          }
+          catch (\Exception $e) {
+            // In case of any other kind of exception, log it and leave the item
+            // in the queue to be processed again later.
+            watchdog_exception('cron', $e);
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/better_cron/src/BetterCron.php
+++ b/modules/better_cron/src/BetterCron.php
@@ -8,6 +8,7 @@ use Drupal\Core\Queue\DelayableQueueInterface;
 use Drupal\Core\Queue\DelayedRequeueException;
 use Drupal\Core\Queue\RequeueException;
 use Drupal\Core\Queue\SuspendQueueException;
+use Drupal\Core\Utility\Error;
 
 /**
  * Cron service which allows for a separate queue time-limit and lease time.
@@ -77,7 +78,7 @@ class BetterCron extends Cron implements CronInterface {
             // release the item and skip to the next queue.
             $queue->releaseItem($item);
 
-            watchdog_exception('cron', $e);
+            $this->logger->error('%type: @message in %function (line %line of %file).', Error::decodeException($e));
 
             // Skip to the next queue.
             continue 2;
@@ -85,10 +86,11 @@ class BetterCron extends Cron implements CronInterface {
           catch (\Exception $e) {
             // In case of any other kind of exception, log it and leave the item
             // in the queue to be processed again later.
-            watchdog_exception('cron', $e);
+            $this->logger->error('%type: @message in %function (line %line of %file).', Error::decodeException($e));
           }
         }
       }
     }
   }
+
 }

--- a/modules/better_cron/src/ProxyClass/BetterCron.php
+++ b/modules/better_cron/src/ProxyClass/BetterCron.php
@@ -1,0 +1,80 @@
+<?php
+// @codingStandardsIgnoreFile
+
+/**
+ * This file was generated via php core/scripts/generate-proxy-class.php 'Drupal\better_cron\BetterCron' "modules/contrib/dkan/modules/better_cron/src".
+ */
+
+namespace Drupal\better_cron\ProxyClass {
+
+    /**
+     * Provides a proxy class for \Drupal\better_cron\BetterCron.
+     *
+     * @see \Drupal\Component\ProxyBuilder
+     */
+    class BetterCron implements \Drupal\Core\CronInterface
+    {
+
+        use \Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
+        /**
+         * The id of the original proxied service.
+         *
+         * @var string
+         */
+        protected $drupalProxyOriginalServiceId;
+
+        /**
+         * The real proxied service, after it was lazy loaded.
+         *
+         * @var \Drupal\better_cron\BetterCron
+         */
+        protected $service;
+
+        /**
+         * The service container.
+         *
+         * @var \Symfony\Component\DependencyInjection\ContainerInterface
+         */
+        protected $container;
+
+        /**
+         * Constructs a ProxyClass Drupal proxy object.
+         *
+         * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+         *   The container.
+         * @param string $drupal_proxy_original_service_id
+         *   The service ID of the original service.
+         */
+        public function __construct(\Symfony\Component\DependencyInjection\ContainerInterface $container, $drupal_proxy_original_service_id)
+        {
+            $this->container = $container;
+            $this->drupalProxyOriginalServiceId = $drupal_proxy_original_service_id;
+        }
+
+        /**
+         * Lazy loads the real service from the container.
+         *
+         * @return object
+         *   Returns the constructed real service.
+         */
+        protected function lazyLoadItself()
+        {
+            if (!isset($this->service)) {
+                $this->service = $this->container->get($this->drupalProxyOriginalServiceId);
+            }
+
+            return $this->service;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function run()
+        {
+            return $this->lazyLoadItself()->run();
+        }
+
+    }
+
+}

--- a/modules/datastore/datastore.info.yml
+++ b/modules/datastore/datastore.info.yml
@@ -4,5 +4,6 @@ type: module
 core_version_requirement: ^8 || ^9
 package: DKAN
 dependencies:
+  - better_cron
   - common
   - metastore

--- a/modules/datastore/src/Plugin/QueueWorker/Import.php
+++ b/modules/datastore/src/Plugin/QueueWorker/Import.php
@@ -20,7 +20,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @QueueWorker(
  *   id = "datastore_import",
  *   title = @Translation("Queue to process datastore import"),
- *   cron = {"time" = 60}
+ *   cron = {
+ *     "time" = 60,
+ *     "lease_time" = 3600
+ *   }
  * )
  */
 class Import extends QueueWorkerBase implements ContainerFactoryPluginInterface {


### PR DESCRIPTION
This is an alternative approach to issue #3639 (as opposed to fix outlined in PR #3640).

In this PR, a custom alternative cron service is used in place of `\Drupal\Core\Cron` which adds support for specification of a separate queue time-limit and queue item lease time.

I can think of two main benefit to this approach over #3640:
1. It maintains the single responsibility principle by allowing all queue jobs to be processed in the standard Drupal manner, rather than dividing the responsibility of processing queue jobs across more than one mechanism.
2. It does not require any additional setup on the environment level. As opposed to requiring some additional timed queue processing mechanism.

This approach may require additional maintenance if/when the Drupal Core cron queue processing mechanism is ever updated in Drupal Core, however #3640 would also require additional maintenance, albeit for a separate mechanism outside of Drupal entirely.

A side note: the `better_cron` module in this PR will no longer be necessary if/when [Drupal Core issue #2893933](https://www.drupal.org/project/drupal/issues/2893933) is merged.

## QA Steps

- [ ] Create a new dataset with a large resource file (>= 100 MB).
- [ ] Run cron using Drush (`drush cron`).
- [ ] Wait long enough for the queue time-limit to have expired, but for the item lease time to still be active for the `datastore_import` queue worker (1-2 minutes).
- [ ] Run another instance of cron using Drush (if there was only one job in the queue, the second instance should stop relatively quickly on account of not having any jobs to process).
- [ ] Wait until both cron jobs have completed.
- [ ] Ensure no duplicate rows were imported into the datastore for the created dataset.