### PR TITLE
Reference lookup service

### DIFF
--- a/modules/metastore/docs/legacy_metadata.json
+++ b/modules/metastore/docs/legacy_metadata.json
@@ -1,0 +1,24 @@
+{
+    "type": "object",
+    "required": [
+        "identifier",
+        "data"
+    ],
+    "properties": {
+        "identifier": {
+            "title": "Identifier",
+            "type": "string"
+        },
+        "data": {
+            "anyOf": [
+                {
+                    "type": "object"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        }
+    },
+    "additionalProperties": false
+}

--- a/modules/metastore/metastore.module
+++ b/modules/metastore/metastore.module
@@ -157,3 +157,10 @@ function metastore_entity_view_alter(array &$build, EntityInterface $entity, Ent
     $build[$fieldName][0]['#context']['value'] = (string) $object;
   }
 }
+
+/**
+ * Get the name of the current module.
+ */
+function get_module_name(): string {
+  return basename(__FILE__, '.module');
+}

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -90,3 +90,9 @@ services:
     arguments:
       - '@dkan.common.docs_generator'
       - '@dkan.metastore.service'
+
+  dkan.metastore.reference_lookup:
+    class: \Drupal\metastore\Reference\ReferenceLookup
+    arguments:
+      - '@dkan.metastore.storage'
+      - '@dkan.metastore.metastore_item_factory'

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -96,3 +96,4 @@ services:
     arguments:
       - '@dkan.metastore.storage'
       - '@dkan.metastore.metastore_item_factory'
+      - '@module_handler'

--- a/modules/metastore/src/Factory/MetastoreEntityItemFactoryInterface.php
+++ b/modules/metastore/src/Factory/MetastoreEntityItemFactoryInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\metastore\Factory;
+
+/**
+ * Interface MetastoreItemFactoryInterface.
+ *
+ * Used for service dkan.metastore.metastore_item_factory. Override the service
+ * to use different logic for producing a MetastoreItemInterface object from
+ * just an indentifier.
+ */
+interface MetastoreEntityItemFactoryInterface extends MetastoreItemFactoryInterface {
+
+  /**
+   * Get the entity type used for this item factory.
+   *
+   * @return string
+   *   The entity type ID, e.g. 'node'.
+   */
+  public static function getEntityType();
+
+  /**
+   * Get the bundles, if any, used by this factory for storing item entities.
+   *
+   * @return array
+   *   Array of bundle IDs.
+   */
+  public static function getBundles();
+
+  /**
+   * Get the name of the entity field or property used to store metadata.
+   *
+   * @return string
+   *   Field API name.
+   */
+  public static function getMetadataField();
+}

--- a/modules/metastore/src/Factory/MetastoreEntityItemFactoryInterface.php
+++ b/modules/metastore/src/Factory/MetastoreEntityItemFactoryInterface.php
@@ -34,4 +34,5 @@ interface MetastoreEntityItemFactoryInterface extends MetastoreItemFactoryInterf
    *   Field API name.
    */
   public static function getMetadataField();
+
 }

--- a/modules/metastore/src/NodeWrapper/NodeDataFactory.php
+++ b/modules/metastore/src/NodeWrapper/NodeDataFactory.php
@@ -3,14 +3,14 @@
 namespace Drupal\metastore\NodeWrapper;
 
 use Drupal\Core\Entity\EntityRepository;
-use Drupal\metastore\Factory\MetastoreItemFactoryInterface;
+use Drupal\metastore\Factory\MetastoreEntityItemFactoryInterface;
 
 /**
  * Class NodeDataFactory.
  *
  * Build a MetastoreItemInterface object from a simple node.
  */
-class NodeDataFactory implements MetastoreItemFactoryInterface {
+class NodeDataFactory implements MetastoreEntityItemFactoryInterface {
 
   /**
    * EntityRepository object.

--- a/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php
+++ b/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php
@@ -10,7 +10,7 @@ use Drupal\Core\Queue\QueueWorkerBase;
 use Drupal\node\NodeStorageInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\common\EventDispatcherTrait;
-use Drupal\metastore\Reference\ReferenceLookup;
+use Drupal\metastore\ReferenceLookupInterface;
 
 /**
  * Verifies if a dataset property reference is orphaned, then deletes it.
@@ -47,7 +47,7 @@ class OrphanReferenceProcessor extends QueueWorkerBase implements ContainerFacto
    *   The plugin implementation definition.
    * @param \Drupal\node\NodeStorageInterface $nodeStorage
    *   Node storage service.
-   * @param \Drupal\metastore\Reference\ReferenceLookup $referenceLookup
+   * @param \Drupal\metastore\ReferenceLookupInterface $referenceLookup
    *   The referencer lookup service.
    */
   public function __construct(
@@ -55,7 +55,7 @@ class OrphanReferenceProcessor extends QueueWorkerBase implements ContainerFacto
     $plugin_id,
     $plugin_definition,
     NodeStorageInterface $nodeStorage,
-    ReferenceLookup $referenceLookup) {
+    ReferenceLookupInterface $referenceLookup) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->referenceLookup = $referenceLookup;
     $this->nodeStorage = $nodeStorage;

--- a/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php
+++ b/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php
@@ -7,10 +7,10 @@ namespace Drupal\metastore\Plugin\QueueWorker;
 use Drupal\common\LoggerTrait;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
-use Drupal\metastore\NodeWrapper\Data;
 use Drupal\node\NodeStorageInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\common\EventDispatcherTrait;
+use Drupal\metastore\Reference\ReferenceLookup;
 
 /**
  * Verifies if a dataset property reference is orphaned, then deletes it.
@@ -47,9 +47,17 @@ class OrphanReferenceProcessor extends QueueWorkerBase implements ContainerFacto
    *   The plugin implementation definition.
    * @param \Drupal\node\NodeStorageInterface $nodeStorage
    *   Node storage service.
+   * @param \Drupal\metastore\Reference\ReferenceLookup $referenceLookup
+   *   The referencer lookup service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, NodeStorageInterface $nodeStorage) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    NodeStorageInterface $nodeStorage,
+    ReferenceLookup $referenceLookup) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->referenceLookup = $referenceLookup;
     $this->nodeStorage = $nodeStorage;
   }
 
@@ -63,41 +71,25 @@ class OrphanReferenceProcessor extends QueueWorkerBase implements ContainerFacto
           $configuration,
           $plugin_id,
           $plugin_definition,
-          $container->get('dkan.common.node_storage')
+          $container->get('dkan.common.node_storage'),
+          $container->get('dkan.metastore.reference_lookup')
       );
     $me->setLoggerFactory($container->get('logger.factory'));
     return $me;
   }
 
   /**
-   * Inherited.
-   *
    * {@inheritdoc}
+   *
+   * @todo make the SchemaID for this dynamic
    */
   public function processItem($data) {
     $metadataProperty = $data[0];
     $identifier = $data[1];
+    $referencers = $this->referenceLookup->getReferencers('dataset', $identifier, $metadataProperty);
 
-    // @todo Search for uuid directly within the loadByProperties array.
-    // Search datasets using this uuid for this property id.
-    $properties = [
-      'type' => 'data',
-      'field_data_type' => 'dataset',
-    ];
-
-    $datasetNodes = $this->nodeStorage->loadByProperties($properties);
-
-    foreach ($datasetNodes as $node) {
-      $data = new Data($node);
-      $raw = $data->getRawMetadata();
-      $value = $raw->{$metadataProperty};
-      // Check if uuid is found either directly or in an array.
-      $uuid_is_value = $identifier == $value;
-      $uuid_found_in_array = is_array($value) && in_array($identifier, $value);
-      if ($uuid_is_value || $uuid_found_in_array) {
-        // Uuid found in use, abort.
-        return;
-      }
+    if (!empty($referencers)) {
+      return;
     }
 
     // Value reference uuid not found in any dataset, therefore safe to delete.

--- a/modules/metastore/src/Reference/ReferenceLookup.php
+++ b/modules/metastore/src/Reference/ReferenceLookup.php
@@ -2,61 +2,113 @@
 
 namespace Drupal\metastore\Reference;
 
-use Contracts\FactoryInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
 use Drupal\common\LoggerTrait;
 use Drupal\metastore\Factory\MetastoreItemFactoryInterface;
+use Drupal\metastore\ReferenceLookupInterface;
+
+use Contracts\FactoryInterface;
+use RootedData\RootedJsonData;
 
 /**
- * Service to find metastore items referencing an identifier.
+ * {@inheritDoc}
  */
-class ReferenceLookup {
+class ReferenceLookup implements ReferenceLookupInterface {
   use HelperTrait;
   use LoggerTrait;
 
   /**
-   * Constructor.
+   * Metastore Storage service.
+   *
+   * @var \Contracts\FactoryInterface
    */
-  public function __construct(FactoryInterface $metastoreStorage, MetastoreItemFactoryInterface $metastoreItemFactory) {
+  protected $metastoreStorage;
+
+  /**
+   * Metastore Item Factory service.
+   *
+   * @var \Drupal\metastore\Factory\MetastoreItemFactoryInterface
+   */
+  protected $metastoreItemFactory;
+
+  /**
+   * Module Handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Construct a ReferenceLookup object.
+   *
+   * @param \Contracts\FactoryInterface $metastoreStorage
+   *   Metastore Storage service.
+   * @param \Drupal\metastore\Factory\MetastoreItemFactoryInterface $metastoreItemFactory
+   *   Metastore Item Factory service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
+   *   Module Handler service.
+   */
+  public function __construct(FactoryInterface $metastoreStorage, MetastoreItemFactoryInterface $metastoreItemFactory, ModuleHandlerInterface $moduleHandler) {
     $this->metastoreStorage = $metastoreStorage;
     $this->metastoreItemFactory = $metastoreItemFactory;
+    $this->moduleHandler = $moduleHandler;
   }
 
   /**
-   * Get UUIDs of all metastore items referencing an ID through a property.
-   *
-   * @param string $schemaId
-   *   The type of metadata to look for references within.
-   * @param string $referenceId
-   *   The UUID of the reference we're looking for.
-   * @param string $propertyId
-   *   The metadata property we hope to find it in.
-   *
-   * @return array
-   *   Array of metastore UUIDs for matching items.
+   * {@inheritDoc}
    *
    * @todo Refactor when this storage vs item factory mess is resolved.
    */
   public function getReferencers(string $schemaId, string $referenceId, string $propertyId) {
-
     // This will give us a smaller subset of metastore items to parse through.
     $metastoreItems = $this->metastoreStorage->getInstance($schemaId)->retrieveContains($referenceId);
 
     $referencers = [];
-
     foreach ($metastoreItems as $item) {
-      $metadata = json_decode($item);
-      $item = $this->metastoreItemFactory->getInstance($metadata->identifier);
-      $raw = $item->getRawMetadata();
-      $value = $raw->{$propertyId};
+      [$identifier, $metadata] = $this->decodeJsonMetadata($item);
+      $propertyValue = $metadata->{$propertyId};
       // Check if uuid is found either directly or in an array.
-      $idIsValue = $referenceId == $value;
-      $idInArray = is_array($value) && in_array($referenceId, $value);
+      $idIsValue = $referenceId == $propertyValue;
+      $idInArray = is_array($propertyValue) && in_array($referenceId, $value);
       if ($idIsValue || $idInArray) {
-        $referencers[] = $metadata->identifier;
+        $referencers[] = $identifier;
       }
     }
 
     return $referencers;
+  }
+
+  /**
+   * Decode the supplied JSON metadata.
+   *
+   * @param string $json
+   *   JSON metadata string.
+   *
+   * @return array
+   *   JSON metadata identifier and object.
+   */
+  protected function decodeJsonMetadata(string $json): array {
+    // Decode the supplied JSON metadata string.
+    $metadata = json_decode($json);
+    // Determine the path to the legacy metadata schema file.
+    $module_path = $this->moduleHandler->getModule(get_module_name())->getPath();
+    $legacy_schema_path = $module_path . '/docs/legacy_metadata.json';
+    // Fetch the legacy metadata schema.
+    $legacy_schema = file_get_contents($legacy_schema_path);
+    // Record metadata identifier.
+    $identifier = $metadata->identifier;
+    // Get raw metadata using identifier.
+    $metadata = $this->metastoreItemFactory->getInstance($identifier)->getRawMetadata();
+    // Validate JSON against legacy schema.
+    $validation_result = RootedJsonData::validate(json_encode($metadata), $legacy_schema);
+    // If the JSON metadata matches the legacy schema, extract the content of
+    // the "data" property.
+    if ($validation_result->isValid()) {
+      $metadata = $metadata->data;
+    }
+
+    return [$identifier, $metadata];
   }
 
 }

--- a/modules/metastore/src/Reference/ReferenceLookup.php
+++ b/modules/metastore/src/Reference/ReferenceLookup.php
@@ -70,7 +70,7 @@ class ReferenceLookup implements ReferenceLookupInterface {
       $propertyValue = $metadata->{$propertyId};
       // Check if uuid is found either directly or in an array.
       $idIsValue = $referenceId == $propertyValue;
-      $idInArray = is_array($propertyValue) && in_array($referenceId, $value);
+      $idInArray = is_array($propertyValue) && in_array($referenceId, $propertyValue);
       if ($idIsValue || $idInArray) {
         $referencers[] = $identifier;
       }

--- a/modules/metastore/src/Reference/ReferenceLookup.php
+++ b/modules/metastore/src/Reference/ReferenceLookup.php
@@ -12,7 +12,7 @@ use Contracts\FactoryInterface;
 use RootedData\RootedJsonData;
 
 /**
- * {@inheritDoc}
+ * {@inheritdoc}
  */
 class ReferenceLookup implements ReferenceLookupInterface {
   use HelperTrait;
@@ -56,7 +56,7 @@ class ReferenceLookup implements ReferenceLookupInterface {
   }
 
   /**
-   * {@inheritDoc}
+   * {@inheritdoc}
    *
    * @todo Refactor when this storage vs item factory mess is resolved.
    */

--- a/modules/metastore/src/Reference/ReferenceLookup.php
+++ b/modules/metastore/src/Reference/ReferenceLookup.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\metastore\Reference;
+
+use Contracts\FactoryInterface;
+use Drupal\common\LoggerTrait;
+use Drupal\metastore\Factory\MetastoreItemFactoryInterface;
+
+/**
+ * Service to find metastore items referencing an identifier.
+ */
+class ReferenceLookup {
+  use HelperTrait;
+  use LoggerTrait;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(FactoryInterface $metastoreStorage, MetastoreItemFactoryInterface $metastoreItemFactory) {
+    $this->metastoreStorage = $metastoreStorage;
+    $this->metastoreItemFactory = $metastoreItemFactory;
+  }
+
+  /**
+   * Get UUIDs of all metastore items referencing an ID through a property.
+   *
+   * @param string $schemaId
+   *   The type of metadata to look for references within.
+   * @param string $referenceId
+   *   The UUID of the reference we're looking for.
+   * @param string $propertyId
+   *   The metadata property we hope to find it in.
+   *
+   * @return array
+   *   Array of metastore UUIDs for matching items.
+   *
+   * @todo Refactor when this storage vs item factory mess is resolved.
+   */
+  public function getReferencers(string $schemaId, string $referenceId, string $propertyId) {
+
+    // This will give us a smaller subset of metastore items to parse through.
+    $metastoreItems = $this->metastoreStorage->getInstance($schemaId)->retrieveContains($referenceId);
+
+    $referencers = [];
+
+    foreach ($metastoreItems as $item) {
+      $metadata = json_decode($item);
+      $item = $this->metastoreItemFactory->getInstance($metadata->identifier);
+      $raw = $item->getRawMetadata();
+      $value = $raw->{$propertyId};
+      // Check if uuid is found either directly or in an array.
+      $idIsValue = $referenceId == $value;
+      $idInArray = is_array($value) && in_array($referenceId, $value);
+      if ($idIsValue || $idInArray) {
+        $referencers[] = $metadata->identifier;
+      }
+    }
+
+    return $referencers;
+  }
+
+}

--- a/modules/metastore/src/ReferenceLookupInterface.php
+++ b/modules/metastore/src/ReferenceLookupInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\metastore;
+
+/**
+ * Service to find metastore items referencing an identifier.
+ */
+interface ReferenceLookupInterface {
+
+  /**
+   * Get UUIDs of all metastore items referencing an ID through a property.
+   *
+   * @param string $schemaId
+   *   The type of metadata to look for references within.
+   * @param string $referenceId
+   *   The UUID of the reference we're looking for.
+   * @param string $propertyId
+   *   The metadata property we hope to find it in.
+   *
+   * @return array
+   *   Array of metastore UUIDs for matching items.
+   */
+  public function getReferencers(string $schemaId, string $referenceId, string $propertyId);
+
+}

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -24,7 +24,7 @@ abstract class Data implements MetastoreStorageInterface {
    *
    * @var string
    */
-  private $schemaId;
+  protected $schemaId;
 
   /**
    * Entity storage service.

--- a/modules/metastore/src/Storage/MetastoreStorageInterface.php
+++ b/modules/metastore/src/Storage/MetastoreStorageInterface.php
@@ -34,12 +34,30 @@ interface MetastoreStorageInterface extends StorerInterface, BulkRetrieverInterf
    *
    * @param int $start
    *   Offset.
-   * @param int $length 
+   * @param int $length
    *   Number to retrieve.
+   *
    * @return array
    *   An array of metadata objects.
    */
   public function retrieveRange(int $start, int $length): array;
+
+  /**
+   * Retrieve all metadata items that contain a particular exact string.
+   *
+   * This will be used to query raw, referenced metadata in the storage system.
+   * Use the metastore search service for more precise/cofigurable searching
+   * and searching dereferenced, user-facing metadata.
+   *
+   * @param string $string
+   *   The string to match within raw metastore item JSON.
+   * @param bool $caseSensitive
+   *   Whether to search metadata in a case-sensitive manner.
+   *
+   * @return array
+   *   An array of metadata objects.
+   */
+  public function retrieveContains(string $string, bool $caseSensitive): array;
 
   /**
    * Retrieve the json metadata from an entity only if it is published.

--- a/modules/metastore/src/Storage/NodeData.php
+++ b/modules/metastore/src/Storage/NodeData.php
@@ -23,6 +23,28 @@ class NodeData extends Data implements MetastoreEntityStorageInterface {
   /**
    * {@inheritdoc}
    */
+  public function retrieveContains(string $string, bool $caseSensitive = TRUE): array {
+
+    $entity_ids = $this->entityStorage->getQuery()
+      ->condition($this->bundleKey, $this->bundle)
+      ->condition('field_data_type', $this->schemaId)
+      ->condition($this->getMetadataField(), $string, 'CONTAINS')
+      ->addTag('case_sensitive')
+      ->execute();
+
+    $all = [];
+    foreach ($entity_ids as $nid) {
+      $entity = $this->entityStorage->load($nid);
+      if ($entity->get('moderation_state')->getString() === 'published') {
+        $all[] = $entity->get('field_json_metadata')->getString();
+      }
+    }
+    return $all;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public static function getEntityType() {
     return 'node';
   }

--- a/modules/metastore/tests/src/Functional/OrphanCheckerTest.php
+++ b/modules/metastore/tests/src/Functional/OrphanCheckerTest.php
@@ -42,6 +42,8 @@ class OrphanCheckerTest extends ExistingSiteBase {
     $service = \Drupal::service('dkan.metastore.service');
     $dataset = $this->validMetadataFactory->get($this->getDataset(123, 'Test #1', ['district_centerpoints_small.csv']), 'dataset');
     $service->post('dataset', $dataset);
+    $dataset2 = $this->validMetadataFactory->get($this->getDataset(456, 'Test #2', ['district_centerpoints_small.csv']), 'dataset');
+    $service->post('dataset', $dataset2);
     $this->runQueues(['datastore_import']);
     $service->delete('dataset', 123);
     $success = $this->runQueues(['orphan_reference_processor']);


### PR DESCRIPTION
This starts to provide some revers-lookup functionality that can be used in other serivces. For now, it will replace the more expensive orphan reference processor code that was loading _every_ dataset and then parsing for the property. Particularly when using real UUIDs or other complex identifiers in our metadata, this should filter out most of the metastore items in the initial query.