### PR TITLE
Add 3 hour lease time to `datastore_import` queue

### DIFF
--- a/modules/datastore/src/Plugin/QueueWorker/Import.php
+++ b/modules/datastore/src/Plugin/QueueWorker/Import.php
@@ -21,7 +21,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @QueueWorker(
  *   id = "datastore_import",
  *   title = @Translation("Queue to process datastore import"),
- *   cron = {"time" = 60}
+ *   cron = {
+ *     "time" = 60,
+ *     "lease_time" = 10800
+ *   }
  * )
  */
 class Import extends QueueWorkerBase implements ContainerFactoryPluginInterface {

--- a/modules/datastore/src/Plugin/QueueWorker/Import.php
+++ b/modules/datastore/src/Plugin/QueueWorker/Import.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "datastore_import",
  *   title = @Translation("Queue to process datastore import"),
  *   cron = {
- *     "time" = 60,
+ *     "time" = 180,
  *     "lease_time" = 10800
  *   }
  * )


### PR DESCRIPTION
fixes #3639

This is a follow up to https://github.com/GetDKAN/recommended-project/pull/5, since the patch had to be applied before a lease time could be provided to the queue processor.

## QA Steps

- [x] Create a vanilla DKAN project.
- [x] Create a new dataset with a large remote resource file (here's a good one: https://download.cms.gov/openpayments/PGYR19_P063021/OP_DTL_GNRL_PGYR2019_P06302021.csv).
- [x] Run cron using Drush (`dktl drush cron`).
- [x] Login into the MySQL CLI using drush (`dktl drush sqlc`).
- [x] Ensure the datastore import queue job which is being run has an expire timestamp of 3 hours after when `dktl drush cron` was called.
