### PR TITLE
Only generate resource file checksums for resources once

### DIFF
--- a/modules/common/src/Resource.php
+++ b/modules/common/src/Resource.php
@@ -86,10 +86,6 @@ class Resource implements \JsonSerializable {
     $new = $this->createCommon('perspective', $perspective);
     $new->changeFilePath($uri);
 
-    if ($perspective == 'local_file') {
-      $new->generateChecksum();
-    }
-
     return $new;
   }
 

--- a/modules/metastore/src/ResourceMapper.php
+++ b/modules/metastore/src/ResourceMapper.php
@@ -6,6 +6,7 @@ use Drupal\common\Resource;
 use Drupal\common\Storage\DatabaseTableInterface;
 use Drupal\common\Storage\Query;
 use Drupal\common\EventDispatcherTrait;
+use Drupal\datastore\Service\ResourceLocalizer;
 use Drupal\metastore\Exception\AlreadyRegistered;
 
 /**
@@ -74,6 +75,11 @@ class ResourceMapper {
     $perspective = $resource->getPerspective();
     if ($this->exists($identifier, Resource::DEFAULT_SOURCE_PERSPECTIVE, $version)) {
       if (!$this->exists($identifier, $perspective, $version)) {
+        // If the given resource has a local file, generate a checksum for the
+        // file before storing the resource.
+        if ($perspective == ResourceLocalizer::LOCAL_FILE_PERSPECTIVE) {
+          $resource->generateChecksum();
+        }
         $this->store->store(json_encode($resource));
         $this->dispatchEvent(self::EVENT_REGISTRATION, $resource);
       }


### PR DESCRIPTION
This PR restricts resource file checksum generation to when the local file perspective is first registered for a resource.

fixes #3669 

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Create a new resource.
- [ ] Run the `datastore_import` queue.
- [ ] Ensure a checksum has been generated for the local file perspective of the new resource in the `dkan_metastore_resource_mapper` table.
- [ ] Ensure performing requests against datastore query endpoints (`/api/1/datastore/query/...`) is not slow (or at least not being slowed down by resource checksum generation; see #3669).
