### PR TITLE
Recover from incomplete example identifiers array in docs

### DIFF
--- a/modules/datastore/src/Plugin/DkanApiDocs/DatastoreApiDocs.php
+++ b/modules/datastore/src/Plugin/DkanApiDocs/DatastoreApiDocs.php
@@ -300,15 +300,15 @@ class DatastoreApiDocs extends DkanApiDocsBase {
       $i++;
       $datastore = (bool) ($identifiers = $this->getDatastoreIds($item));
     }
-    if (empty($identifiers)) {
-      $identifiers = [
+    return array_merge(
+      [
         'resource' => '00000000000000000000000000000000__0000000000__source',
         'distribution' => "00000000-0000-0000-0000-000000000000",
         'dataset' => "00000000-0000-0000-0000-000000000000",
         'datasetDistributionIndex' => 0,
-      ];
-    }
-    return $identifiers;
+      ],
+      $identifiers
+    );
   }
 
   /**

--- a/modules/datastore/src/Plugin/DkanApiDocs/DatastoreApiDocs.php
+++ b/modules/datastore/src/Plugin/DkanApiDocs/DatastoreApiDocs.php
@@ -307,7 +307,7 @@ class DatastoreApiDocs extends DkanApiDocsBase {
         'dataset' => "00000000-0000-0000-0000-000000000000",
         'datasetDistributionIndex' => 0,
       ],
-      $identifiers
+      $identifiers ?: []
     );
   }
 


### PR DESCRIPTION
Have seen several circumstances where docs tries to get example IDs for the datastore spec, fails to get a resource ID, and throws an error. This will more safely return fake IDs when a real one has not been found.