### PR TITLE
Catalog endpoint (data.json) empty datasets fix

### DIFF
--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -404,7 +404,7 @@ class Service implements ContainerInjectionInterface {
    */
   public function getCatalog() {
     $catalog = $this->getSchema('catalog');
-    $catalog->dataset = array_map(function ($object) use ($keepRefs) {
+    $catalog->dataset = array_map(function ($object) {
       $modified_object = $this->removeReferences($object);
       return (object) $modified_object->get('$');
     }, $this->getAll('dataset'));

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -404,7 +404,10 @@ class Service implements ContainerInjectionInterface {
    */
   public function getCatalog() {
     $catalog = $this->getSchema('catalog');
-    $catalog->dataset = $this->getAll('dataset');
+    $catalog->dataset = array_map(function ($object) use ($keepRefs) {
+      $modified_object = $this->removeReferences($object);
+      return (object) $modified_object->get('$');
+    }, $this->getAll('dataset'));
 
     return $catalog;
   }

--- a/modules/metastore/tests/src/Unit/ServiceTest.php
+++ b/modules/metastore/tests/src/Unit/ServiceTest.php
@@ -351,8 +351,8 @@ EOF;
 
     $service = Service::create($container->getMock());
     $catalog->dataset = [
-      $dataset,
-      $dataset,
+      (object) $dataset->{'$'},
+      (object) $dataset->{'$'},
     ];
     $this->assertEquals($catalog, $service->getCatalog());
   }

--- a/modules/sample_content/sample_content.json
+++ b/modules/sample_content/sample_content.json
@@ -64,6 +64,7 @@
         {
           "@type":"dcat:Distribution",
           "downloadURL":"file:\/\//var/www/docroot/modules/contrib/dkan/modules/sample_content/files\/IMD-MAPS.zip",
+          "mediaType":"application\/zip",
           "format":"zip",
           "title":"Map files"
         }
@@ -78,7 +79,7 @@
         "name": "State Economic Council"
       },
       "spatial":"Pittsburgh, PA",
-      "temporal": "2016",
+      "temporal": "2016/P1Y",
       "theme":["Finance and Budgeting"],
       "title":"Market Value Analysis - Urban Redevelopment Authority"
     },

--- a/modules/sample_content/sample_content.template.json
+++ b/modules/sample_content/sample_content.template.json
@@ -64,6 +64,7 @@
         {
           "@type":"dcat:Distribution",
           "downloadURL":"file:\/\/<!*path*!>\/IMD-MAPS.zip",
+          "mediaType":"application\/zip",
           "format":"zip",
           "title":"Map files"
         }
@@ -78,7 +79,7 @@
         "name": "State Economic Council"
       },
       "spatial":"Pittsburgh, PA",
-      "temporal": "2016",
+      "temporal": "2016/P1Y",
       "theme":["Finance and Budgeting"],
       "title":"Market Value Analysis - Urban Redevelopment Authority"
     },


### PR DESCRIPTION
A small logic bug was returning an array of empty dataset objects at /data.json. This should correct that, and also fixes a couple validation errors in the sample content.

## QA steps
- Visit https://dkan-qa-3675.ci.civicactions.net/data.json
- Full dataset objects should display (see https://demo.getdkan.org/data.json for example of the bug)
- Copy the raw JSON from /data.json and paste into https://labs.data.gov/dashboard/validate as Non-federal 1.1
- Confirm it passes validation with no errors.