### PR TITLE
Update default search config to include modified date

### DIFF
--- a/modules/metastore/modules/metastore_search/config/install/search_api.index.dkan.yml
+++ b/modules/metastore/modules/metastore_search/config/install/search_api.index.dkan.yml
@@ -1,3 +1,4 @@
+uuid: 55ab101c-3fc3-450b-b055-f3a8dc208437
 langcode: en
 status: true
 dependencies:
@@ -6,6 +7,8 @@ dependencies:
   module:
     - search_api
     - metastore_search
+_core:
+  default_config_hash: RUXS1l48SEXxagXAmVGSKfKQwV2h9u0DVJW_3WHlaaM
 id: dkan
 name: DKAN
 description: ''
@@ -21,6 +24,11 @@ field_settings:
     datasource_id: dkan_dataset
     property_path: keyword
     type: string
+  modified:
+    label: modified
+    datasource_id: dkan_dataset
+    property_path: modified
+    type: date
   publisher__name:
     label: publisher__name
     datasource_id: dkan_dataset
@@ -47,9 +55,9 @@ processor_settings:
       - description
       - keyword
       - publisher__name
+      - publisher__name
       - theme
       - title
-      - publisher__name
     weights:
       preprocess_index: -20
       preprocess_query: -20

--- a/modules/metastore/modules/metastore_search/config/install/search_api.index.dkan.yml
+++ b/modules/metastore/modules/metastore_search/config/install/search_api.index.dkan.yml
@@ -1,4 +1,3 @@
-uuid: 55ab101c-3fc3-450b-b055-f3a8dc208437
 langcode: en
 status: true
 dependencies:
@@ -7,8 +6,6 @@ dependencies:
   module:
     - search_api
     - metastore_search
-_core:
-  default_config_hash: RUXS1l48SEXxagXAmVGSKfKQwV2h9u0DVJW_3WHlaaM
 id: dkan
 name: DKAN
 description: ''

--- a/modules/metastore/modules/metastore_search/config/install/search_api.index.dkan.yml
+++ b/modules/metastore/modules/metastore_search/config/install/search_api.index.dkan.yml
@@ -25,7 +25,7 @@ field_settings:
     label: modified
     datasource_id: dkan_dataset
     property_path: modified
-    type: date
+    type: string
   publisher__name:
     label: publisher__name
     datasource_id: dkan_dataset

--- a/modules/metastore/modules/metastore_search/config/install/search_api.index.dkan.yml
+++ b/modules/metastore/modules/metastore_search/config/install/search_api.index.dkan.yml
@@ -52,7 +52,6 @@ processor_settings:
       - description
       - keyword
       - publisher__name
-      - publisher__name
       - theme
       - title
     weights:


### PR DESCRIPTION
## QA Steps
https://dkan-qa-3677.ci.civicactions.net/
- Go to the Datasets page
- Change the sort order to alphabetical, then back to "date"
- Confirm that the oldest dataset is displayed first (probably "Afghanistan Election Districts")

## Known issues

For this to work as expected out of the box we need to modify the front-end to:
1. Apply the date sort on initial page load, instead of needing the form element to be updated
2. Apply the descending order when using date, since that is most likely how people want it ordered (while still applying ascending order on alphabetical)