### PR TITLE
Fix remaining usage of \Drupal\metastore\WebServiceApi

### DIFF
--- a/modules/common/modules/dkan_alt_api/dkan_alt_api.routing.yml
+++ b/modules/common/modules/dkan_alt_api/dkan_alt_api.routing.yml
@@ -2,7 +2,7 @@ dkan_alt_api.1.metastore.schemas.id.items:
   path: '/alt/api/1/metastore/schemas/{schema_id}/items'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\metastore\WebServiceApi::getAll'}
+    { _controller: '\Drupal\metastore\Controller\MetastoreController::getAll'}
   requirements:
     _permission: 'get data through the alternate metastore api'
   options:
@@ -12,7 +12,7 @@ dkan_alt_api.1.metastore.schemas.id.items.id:
   path: '/alt/api/1/metastore/schemas/{schema_id}/items/{identifier}'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\metastore\WebServiceApi::get'}
+    { _controller: '\Drupal\metastore\Controller\MetastoreController::get'}
   requirements:
     _permission: 'get data through the alternate metastore api'
   options:


### PR DESCRIPTION
fixes https://github.com/GetDKAN/dkan/issues/3678

## QA Steps

1. `drush en dkan_alt_api -y; drush cr` should not throw an error about `\Drupal\metastore\WebServiceApi` not existing.