### PR TITLE
Translatable form and schemas.

### DIFF
--- a/modules/json_form_widget/json_form_widget.services.yml
+++ b/modules/json_form_widget/json_form_widget.services.yml
@@ -1,7 +1,7 @@
 services:
   json_form.builder:
     class: \Drupal\json_form_widget\FormBuilder
-    arguments: ['@dkan.metastore.schema_retriever','@json_form.router', '@json_form.schema_ui_handler', '@logger.factory']
+    arguments: ['@dkan.metastore.schema_retriever','@json_form.router', '@json_form.schema_ui_handler', '@logger.factory', '@language_manager']
   json_form.router:
     class: \Drupal\json_form_widget\FieldTypeRouter
     arguments: ['@json_form.string_helper','@json_form.object_helper', '@json_form.array_helper']

--- a/modules/json_form_widget/src/FormBuilder.php
+++ b/modules/json_form_widget/src/FormBuilder.php
@@ -3,6 +3,7 @@
 namespace Drupal\json_form_widget;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Language\LanguageManager;
 use Drupal\metastore\SchemaRetriever;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Logger\LoggerChannelFactory;
@@ -48,6 +49,13 @@ class FormBuilder implements ContainerInjectionInterface {
   protected $loggerFactory;
 
   /**
+   * Language manager service.
+   *
+   * @var \Drupal\Core\Language\LanguageManager
+   */
+  protected $languageManager;
+
+  /**
    * Inherited.
    *
    * @{inheritdocs}
@@ -57,18 +65,20 @@ class FormBuilder implements ContainerInjectionInterface {
       $container->get('dkan.metastore.schema_retriever'),
       $container->get('json_form.router'),
       $container->get('json_form.schema_ui_handler'),
-      $container->get('logger.factory')
+      $container->get('logger.factory'),
+      $container->get('language_manager')
     );
   }
 
   /**
    * Constructor.
    */
-  public function __construct(SchemaRetriever $schema_retriever, FieldTypeRouter $router, SchemaUiHandler $schema_ui_handler, LoggerChannelFactory $logger_factory) {
+  public function __construct(SchemaRetriever $schema_retriever, FieldTypeRouter $router, SchemaUiHandler $schema_ui_handler, LoggerChannelFactory $logger_factory, LanguageManager $language_manager) {
     $this->schemaRetriever = $schema_retriever;
     $this->router = $router;
     $this->schemaUiHandler = $schema_ui_handler;
     $this->loggerFactory = $logger_factory;
+    $this->languageManager = $language_manager;
   }
 
   /**
@@ -81,9 +91,11 @@ class FormBuilder implements ContainerInjectionInterface {
       if (!empty($type) && $type !== $schema_name) {
         $schema_name = $type;
       }
-      $schema = $this->schemaRetriever->retrieve($schema_name);
+
+      $language = $this->languageManager->getCurrentLanguage()->getId();
+      $schema = $this->schemaRetriever->retrieve($schema_name, $language);
       $this->schema = json_decode($schema);
-      $this->schemaUiHandler->setSchemaUi($schema_name);
+      $this->schemaUiHandler->setSchemaUi($schema_name, $language);
       $this->router->setSchema($this->schema);
     }
     catch (\Exception $exception) {

--- a/modules/json_form_widget/src/SchemaUiHandler.php
+++ b/modules/json_form_widget/src/SchemaUiHandler.php
@@ -76,9 +76,9 @@ class SchemaUiHandler implements ContainerInjectionInterface {
    * @param mixed $schema_name
    *   The schema name.
    */
-  public function setSchemaUi($schema_name) {
+  public function setSchemaUi($schema_name, $language = '') {
     try {
-      $schema_ui = $this->schemaRetriever->retrieve($schema_name . '.ui');
+      $schema_ui = $this->schemaRetriever->retrieve($schema_name . '.ui', $language);
       $this->schemaUi = json_decode($schema_ui);
     }
     catch (\Exception $exception) {

--- a/modules/metastore/src/SchemaRetriever.php
+++ b/modules/metastore/src/SchemaRetriever.php
@@ -67,9 +67,13 @@ class SchemaRetriever implements RetrieverInterface, ContainerInjectionInterface
   /**
    * Public.
    */
-  public function retrieve(string $id): ?string {
-
+  public function retrieve(string $id, string $langcode = ''): ?string {
     $filename = $this->getSchemaDirectory() . "/collections/{$id}.json";
+
+    if ($langcode !== '') {
+      $file = $this->getSchemaDirectory() . "/collections/{$id}.{$langcode}.json";
+      $filename = is_readable($file) ? $file : $filename;
+    }
 
     if (in_array($id, $this->getAllIds())
           && is_readable($filename)


### PR DESCRIPTION
Adding support for displaying form in different languages using a particular schema for said language, as part of this I:
- added support in the SchemaRetriever so we can get the schema for a particular language
- updated FormBuilder so that it gets the current language and retrieves the schema for it, if no schema is found, the default is used.

## QA Steps

- [ ] Go to /node/add/data the form should work as usual.
- [ ] Create a new schema for another language in schema/collections, for example dataset.es.json
- [ ] Enable language modules in your Drupal site and add one extra language, for example spanish
- [ ] Go to /en/node/add/data the form should look as usual
- [ ] Go to /es/node/add/data the form should be displaying the data as specified in the dataset.es.json file.
