### PR TITLE
Describe columns better in datastore API

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
             when { changeRequest(); }
                 steps {
                     dir ("dkan-tools") {
-                        git url: DKTL_REPO, branch: "master"
+                        git url: DKTL_REPO, branch: "dkan-qa-builder-no-proxy"
                     }
                 }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
             when { changeRequest(); }
                 steps {
                     dir ("dkan-tools") {
-                        git url: DKTL_REPO, branch: "dkan-qa-builder-no-proxy"
+                        git url: DKTL_REPO, branch: "master"
                     }
                 }
         }

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -8,7 +8,7 @@ use Drupal\Core\Database\DatabaseExceptionWrapper;
 use Drupal\common\EventDispatcherTrait;
 
 /**
- * AbstractDatabaseTable class.
+ * Base class for database storage methods.
  */
 abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   use SqlStorageTrait;
@@ -59,19 +59,15 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   }
 
   /**
-   * Inherited.
-   *
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function retrieve(string $id) {
     $this->setTable();
 
-    /* @var \Drupal\Core\Database\Query\Select $select */
     $select = $this->connection->select($this->getTableName(), 't')
       ->fields('t', array_keys($this->getSchema()['fields']))
       ->condition($this->primaryKey(), $id);
 
-    /* @var \Drupal\Core\Database\StatementInterface $statement */
     $statement = $select->execute();
 
     // The docs do not mention it, but fetch can return false.
@@ -81,9 +77,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   }
 
   /**
-   * Inherited.
-   *
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function retrieveAll(): array {
     $this->setTable();
@@ -273,7 +267,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   /**
    * Check for existence of a table name.
    */
-  private function tableExist($table_name) {
+  protected function tableExist($table_name) {
     $exists = $this->connection->schema()->tableExists($table_name);
     return $exists;
   }

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -42,7 +42,9 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   /**
    * Get the primary key used in the table.
    */
-  abstract protected function primaryKey();
+  public function primaryKey() {
+    return 'id';
+  }
 
   /**
    * Constructor.

--- a/modules/common/src/Storage/DatabaseTableInterface.php
+++ b/modules/common/src/Storage/DatabaseTableInterface.php
@@ -22,4 +22,12 @@ interface DatabaseTableInterface extends StorageInterface, StorerInterface, Retr
    */
   public function query(Query $query);
 
+  /**
+   * Return the primary key for the table.
+   *
+   * @return string
+   *   Primary key name.
+   */
+  public function primaryKey();
+
 }

--- a/modules/common/src/Storage/JobStore.php
+++ b/modules/common/src/Storage/JobStore.php
@@ -88,7 +88,7 @@ class JobStore extends AbstractDatabaseTable {
    *
    * @inheritdoc
    */
-  protected function primaryKey() {
+  public function primaryKey() {
     return 'ref_uuid';
   }
 

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -387,7 +387,7 @@ class QueryController implements ContainerInjectionInterface {
   }
 
   /**
-   * Get the rows limit for datastore queries.t
+   * Get the rows limit for datastore queries.
    *
    * @return int
    *   API rows limit.

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -12,6 +12,7 @@ use Drupal\common\JsonResponseTrait;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use RootedData\RootedJsonData;
 use Drupal\common\Util\RequestParamNormalizer;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Ilbee\CSVResponse\CSVResponse as CsvResponse;
 use Drupal\datastore\Service;
 use Drupal\metastore\MetastoreApiResponse;
@@ -49,7 +50,7 @@ class QueryController implements ContainerInjectionInterface {
   /**
    * ConfigFactory object.
    *
-   * @var Drupal\Core\Config\ConfigFactory
+   * @var Drupal\Core\Config\ConfigFactoryInterface
    */
   private $configFactory;
 
@@ -68,7 +69,7 @@ class QueryController implements ContainerInjectionInterface {
     RequestStack $requestStack,
     DatasetInfo $datasetInfo,
     MetastoreApiResponse $metastoreApiResponse,
-    ConfigFactory $configFactory
+    ConfigFactoryInterface $configFactory
   ) {
     $this->datastoreService = $datastoreService;
     $this->requestStack = $requestStack;

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\datastore\Controller;
 
-use Drupal\Core\Config\ConfigFactory;
 use Drupal\common\DatasetInfo;
 use Drupal\datastore\Service\DatastoreQuery;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -388,7 +387,7 @@ class QueryController implements ContainerInjectionInterface {
   }
 
   /**
-   * Get the rows limit for datastore queries.
+   * Get the rows limit for datastore queries.t
    *
    * @return int
    *   API rows limit.

--- a/modules/datastore/src/Service.php
+++ b/modules/datastore/src/Service.php
@@ -3,7 +3,6 @@
 namespace Drupal\datastore;
 
 use Drupal\common\Resource;
-use Drupal\common\Storage\DatabaseTableInterface;
 use Drupal\common\Storage\JobStoreFactory;
 use Drupal\datastore\Service\DatastoreQuery;
 use Procrastinator\Result;
@@ -352,10 +351,12 @@ class Service implements ContainerInjectionInterface {
   }
 
   /**
-   * Filters schema fields.
+   * Remove the primary key from the schema field list.
    *
    * @param array $schema
-   *   Schema.
+   *   Schema array, should contain a key "fields".
+   * @param string $primaryKey
+   *   The name of the primary key field to filter out.
    *
    * @return array
    *   Filtered schema fields.

--- a/modules/datastore/src/Service.php
+++ b/modules/datastore/src/Service.php
@@ -336,7 +336,7 @@ class Service implements ContainerInjectionInterface {
 
     if (empty($datastoreQuery->{"$.rowIds"}) && empty($datastoreQuery->{"$.properties"})) {
       $storage = $storageMap[$primaryAlias];
-      $schema = $this->filterSchemaFields($$storage->getSchema(), $storage->primaryKey());
+      $schema = $this->filterSchemaFields($storage->getSchema(), $storage->primaryKey());
       $datastoreQuery->{"$.properties"} = array_keys($schema['fields']);
     }
 

--- a/modules/datastore/src/Service/DatastoreQuery.php
+++ b/modules/datastore/src/Service/DatastoreQuery.php
@@ -17,7 +17,7 @@ class DatastoreQuery extends RootedJsonData {
    * @param int $rows_limit
    *   Maxmimum rows of data to return.
    */
-  public function __construct(string $json, int $rows_limit) {
+  public function __construct(string $json, int $rows_limit = 500) {
     $schema = file_get_contents(__DIR__ . "/../../docs/query.json");
     $q = json_decode($schema);
     $q->properties->limit->maximum = $rows_limit;

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -181,9 +181,8 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    *
    * @param string $type
    *   Type returned from the describe query.
-   *
    * @param string|null $extra
-   *   MySQL "Extra" property for column
+   *   MySQL "Extra" property for column.
    *
    * @return string
    *   Fritionless Table Schema compatible type.

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -111,7 +111,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
   /**
    * Protected.
    */
-  protected function primaryKey() {
+  public function primaryKey() {
     return "record_number";
   }
 
@@ -139,21 +139,39 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function setSchema($schema) {
+    $fields = $schema['fields'];
+    $new_field = [
+      $this->primaryKey() =>
+      [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+    ];
+    $fields = array_merge($new_field, $fields);
+
+    $schema['fields'] = $fields;
+    $schema['primary key'] = [$this->primaryKey()];
+    parent::setSchema($schema);
+  }
+
+  /**
    * Get table schema.
    *
-   * @todo Note that this will brake on PostgresSQL
+   * @todo Note that this will breakZ on PostgresSQL
    */
   private function buildTableSchema($tableName, $fieldsInfo) {
-    $schema = ['primary key' => NULL, 'fields' => []];
     $canGetComment = method_exists($this->connection->schema(), 'getComment');
     foreach ($fieldsInfo as $info) {
       $name = $info->Field;
-      $schema['fields'][$name] = $this->translateType($info->Type);
+      $schema['fields'][$name] = $this->translateType($info->Type, $info->Extra);
       $schema['fields'][$name] += [
         'description' => $canGetComment ? $this->connection->schema()->getComment($tableName, $name) : '',
       ];
       $schema['fields'][$name] = array_filter($schema['fields'][$name]);
-      $schema['primary key'] = (isset($info->Key) && $info->Key == 'PRI') ? $name : $schema['primary key'];
     }
     return $schema;
   }
@@ -164,29 +182,36 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    * @param string $type
    *   Type returned from the describe query.
    *
+   * @param string|null $extra
+   *   MySQL "Extra" property for column
+   *
    * @return string
    *   Fritionless Table Schema compatible type.
    *
    * @see https://specs.frictionlessdata.io/table-schema
    */
-  private function translateType(string $type) {
+  private function translateType(string $type, $extra = NULL) {
     // Clean up things like "int(10) unsigned".
     $db_type = strtok($type, '(');
     $driver = $this->connection->driver();
 
     preg_match('#\((.*?)\)#', $type, $match);
-    $length = $match[1] ?? NULL;
+    $length = (int) $match[1] ?? NULL;
 
     $map = array_flip(array_map('strtolower', $this->connection->schema()->getFieldTypeMap()));
 
-    $fullType = $map[$db_type] ?? 'varchar';
-    $type = (explode(':', $fullType))[0];
-    $size = (explode(':', $fullType))[1] ?? NULL;
+    $fullType = explode(':', ($map[$db_type] ?? 'varchar'));
+    // Set type to serial if auto-increment, else use mapped type.
+    $type = ($fullType[0] == 'int' && $extra == 'auto_increment') ? 'serial' : $fullType[0];
+    $unsigned = ($type == 'serial') ? TRUE : NULL;
+    // Ignore size if "normal" or unset.
+    $size = (isset($fullType[1]) && $fullType[1] != 'normal') ? $fullType[1] : NULL;
 
     return [
       'type' => $type,
       'length' => $length,
       'size' => $size,
+      'unsigned' => $unsigned,
       "{$driver}_type" => $db_type,
     ];
   }

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -427,7 +427,10 @@ class QueryControllerTest extends TestCase {
       ->add(NodeDataFactory::class, 'getInstance', Data::class)
       ->add(Data::class, 'getCacheContexts', ['url'])
       ->add(Data::class, 'getCacheTags', ['node:1'])
-      ->add(Data::class, 'getCacheMaxAge', 0);
+      ->add(Data::class, 'getCacheMaxAge', 0)
+      ->add(ConfigFactoryInterface::class, 'get', ImmutableConfig::class)
+      ->add(ImmutableConfig::class, 'get', 500);
+
     if ($stream) {
       $chain->add(Service::class, "runQuery", $this->addMultipleResponses());
     }

--- a/modules/datastore/tests/src/Unit/Service/DatastoreQueryTest.php
+++ b/modules/datastore/tests/src/Unit/Service/DatastoreQueryTest.php
@@ -197,7 +197,8 @@ class DatastoreQueryTest extends TestCase {
       ->add(ServiceImport::class, "getStorage", DatabaseTable::class)
       ->add(DatabaseTable::class, "query", $queryResult, 'DatabaseTableQuery')
       ->add(DatabaseTable::class, "getSchema", ["fields" => ["a" => "a", "b" => "b"]])
-      ->add(DatabaseTable::class, "getTableName", "table2");
+      ->add(DatabaseTable::class, "getTableName", "table2")
+      ->add(DatabaseTable::class, "primaryKey", "record_number");
 
   }
 

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -49,14 +49,19 @@ class DatabaseTableTest extends TestCase {
           "type" => "serial",
           "unsigned" => TRUE,
           "not null" => TRUE,
+          'length' => 10,
+          'mysql_type' => 'int',
         ],
         "first_name" => [
-          "type" => "text",
+          "type" => "varchar",
           "description" => "First Name",
+          'length' => 10,
+          'mysql_type' => 'varchar'
         ],
         "last_name" => [
           "type" => "text",
           "description" => "lAST nAME",
+          "mysql_type" => "text",
         ],
       ],
     ];
@@ -70,8 +75,8 @@ class DatabaseTableTest extends TestCase {
   public function testRetrieveAll() {
 
     $fieldInfo = [
-      (object) ['Field' => "first_name"],
-      (object) ['Field' => "last_name"],
+      (object) ['Field' => "first_name", 'Type' => "varchar(10)"],
+      (object) ['Field' => "last_name", 'Type' => 'text']
     ];
 
     $sequence = (new Sequence())
@@ -365,8 +370,20 @@ class DatabaseTableTest extends TestCase {
    */
   private function getConnectionChain() {
     $fieldInfo = [
-      (object) ['Field' => "first_name"],
-      (object) ['Field' => "last_name"],
+      (object) [
+        'Field' => "record_number", 
+        'Type' => "int(10)",
+        'Extra' => "auto_increment",
+      ],
+      (object) [
+        'Field' => "first_name", 
+        'Type' => "varchar(10)"
+      ],
+      (object) [
+        'Field' => 
+        "last_name", 
+        'Type' => 'text'
+      ]
     ];
 
     $chain = (new Chain($this))
@@ -376,7 +393,7 @@ class DatabaseTableTest extends TestCase {
       ->add(Statement::class, 'fetchAll', $fieldInfo)
       ->add(Schema::class, "tableExists", TRUE)
       ->add(Schema::class, 'getComment',
-        (new Sequence())->add('First Name')->add('lAST nAME')
+        (new Sequence())->add(NULL)->add('First Name')->add('lAST nAME')
       )
       ->add(Schema::class, 'dropTable', NULL);
 

--- a/modules/harvest/src/Storage/DatabaseTable.php
+++ b/modules/harvest/src/Storage/DatabaseTable.php
@@ -58,7 +58,7 @@ class DatabaseTable extends AbstractDatabaseTable {
    *
    * @inheritdoc
    */
-  protected function primaryKey() {
+  public function primaryKey() {
     return "id";
   }
 

--- a/modules/metastore/src/Storage/ResourceMapperDatabaseTable.php
+++ b/modules/metastore/src/Storage/ResourceMapperDatabaseTable.php
@@ -109,7 +109,7 @@ class ResourceMapperDatabaseTable extends AbstractDatabaseTable {
   /**
    * Protected.
    */
-  protected function primaryKey() {
+  public function primaryKey() {
     return "id";
   }
 

--- a/modules/metastore/tests/src/Unit/DatabaseTableMock.php
+++ b/modules/metastore/tests/src/Unit/DatabaseTableMock.php
@@ -12,6 +12,10 @@ class DatabaseTableMock implements DatabaseTableInterface {
   private $id = 0;
   private $store = [];
 
+  public function primaryKey() {
+    return 'id';
+  }
+
   /**
    *
    */


### PR DESCRIPTION
We are currently manually setting every column to "text" in the schema object returned in datastore query API responses. As we are starting to see datastore table columns cast to other data types, we need to make this more precise. This PR follows the existing pattern of using the [Drupal Schema API](https://www.drupal.org/docs/7/api/schema-api/schema-reference) to describe a database table. In our next major release, it would be good to swap this for a more universal standard -- namely, the [Frictionless Table Schema](https://specs.frictionlessdata.io/table-schema/)

This PR also fixes test failures and a backwards-compatibility-breaking change introduced in #3689.

## QA Steps

1. [Fetch the schema for the "gold prices" datastore](https://dkan-qa-3686.ci.civicactions.net/api/1/datastore/query/5dc1cfcf-8028-476c-a020-f58ec6dd621c/0?rowIds=true). The schema object should look like this (with a different UUID, most likely):

```json
  "schema": {
    "0098fcb2-241b-5a3a-a6d8-cf253a5be267": {
      "fields": {
        "record_number": {
          "type": "serial",
          "length": 10,
          "unsigned": true,
          "not null": true,
          "mysql_type": "int"
        },
        "date": {
          "type": "text",
          "mysql_type": "text"
        },
        "price": {
          "type": "text",
          "mysql_type": "text"
        }
      },
      "primary key": [
        "record_number"
      ]
    }
  }
```
Confirm that the record_number field is shown as a serial/integer field.

2. If you have a local build and are able, modify the datastore table and re-cast the date field as a date.

```sql
ALTER TABLE datastore_08a93cd247d4da196b2f2cfe9ac43001 MODIFY `date` DATE;
```
(Your table name will be different.)

The schema should now look like:

```json
  "schema": {
    "0098fcb2-241b-5a3a-a6d8-cf253a5be267": {
      "fields": {
        "record_number": {
          "type": "serial",
          "length": 10,
          "unsigned": true,
          "not null": true,
          "mysql_type": "int"
        },
        "date": {
          "type": "varchar",
          "mysql_type": "date"
        },
        "price": {
          "type": "text",
          "mysql_type": "text"
        }
      },
      "primary key": [
        "record_number"
      ]
    }
  }
```
