### PR TITLE
Upgrade to latest dkan-tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
         type: boolean
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "4.2.3"
+      DKTL_VERSION: "4.2.4"
     steps:
       - checkout:
           path: dkan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,14 +102,7 @@ jobs:
           command: |
             dktl xdebug:start
             sed -i "/=debug/s/=.*/=coverage/" src/docker/etc/php/xdebug.ini
-            cat src/docker/etc/php/xdebug.ini
             dktl dkan:test-phpunit-coverage $CC_TEST_REPORTER_ID
-      # - run:
-      #     name: Run DKAN dredd tests
-      #     command: |
-      #       dktl install:sample
-      #       dktl dc exec web chmod -R 777 /var/www/docroot/sites/default/files/dkan-tmp
-      #       dktl dkan:test-dredd
   cypress_backend:
     machine:
       image: circleci/classic:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - checkout:
           path: dkan
       - run:
-          name: Setup composer config
+          name: Set up composer config
           command: |
             mkdir ~/.composer
             bash -c 'echo "{\"github-oauth\": {\"github.com\": \"$GITHUB_TOKEN\"}}"' > ~/.composer/auth.json
@@ -97,12 +97,21 @@ jobs:
       - dktl
       - prepare_site:
           upgrade: << parameters.upgrade >>
-      - run:
-          name: Run phpUnit tests
-          command: |
-            dktl xdebug:start
-            sed -i "/=debug/s/=.*/=coverage/" src/docker/etc/php/xdebug.ini
-            dktl dkan:test-phpunit-coverage $CC_TEST_REPORTER_ID
+      - when:
+          condition: << parameters.upgrade >>
+          steps:
+            - run:
+                name: Run phpUnit tests
+                command: dktl dkan:test-phpunit --testsuite="DKAN Test Suite"
+      - unless:
+          condition: << parameters.upgrade >>
+          steps:
+            - run:
+                name: Run phpUnit tests
+                command: |
+                  dktl xdebug:start
+                  sed -i "/=debug/s/=.*/=coverage/" src/docker/etc/php/xdebug.ini
+                  dktl dkan:test-phpunit-coverage $CC_TEST_REPORTER_ID
   cypress_backend:
     machine:
       image: circleci/classic:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
         type: boolean
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "4.2.2"
+      DKTL_VERSION: "4.2.3"
     steps:
       - checkout:
           path: dkan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
         type: boolean
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "4.2.3"
+      DKTL_VERSION: "master"
     steps:
       - checkout:
           path: dkan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
         type: boolean
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "master"
+      DKTL_VERSION: "4.2.3"
     steps:
       - checkout:
           path: dkan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
           name: Run phpUnit tests
           command: |
             dktl xdebug:start
-            echo 'xdebug.mode=coverage' >> src/docker/etc/php/xdebug.ini
+            sed -i "/=debug/s/=.*/=coverage/" src/docker/etc/php/xdebug.ini
             cat src/docker/etc/php/xdebug.ini
             dktl dkan:test-phpunit-coverage $CC_TEST_REPORTER_ID
       # - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,8 @@ jobs:
           name: Run phpUnit tests
           command: |
             dktl xdebug:start
-            echo "xdebug.mode=coverage" >> src/docker/etc/php/xdebug.ini
+            echo 'xdebug.mode=coverage' >> src/docker/etc/php/xdebug.ini
+            cat src/docker/etc/php/xdebug.ini
             dktl dkan:test-phpunit-coverage $CC_TEST_REPORTER_ID
       # - run:
       #     name: Run DKAN dredd tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ jobs:
           name: Run phpUnit tests
           command: |
             dktl xdebug:start
+            echo "xdebug.mode=coverage" >> src/docker/etc/php/xdebug.ini
             dktl dkan:test-phpunit-coverage $CC_TEST_REPORTER_ID
       # - run:
       #     name: Run DKAN dredd tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,14 @@ commands:
                   dktl exec:composer -- update --no-interaction --ansi
                   dktl drush cache:rebuild
                   dktl drush updatedb -y
+      - unless:
+          condition: << parameters.upgrade >>
+          steps:
+            - run:
+                name: Just in case, run a composer update
+                command: |
+                  dktl exec:composer -- update --no-interaction --ansi
+
 
 jobs:
   build:
@@ -130,7 +138,8 @@ jobs:
           upgrade: << parameters.upgrade >>
       - run:
           name: Run DKAN cypress tests
-          command: dktl dkan:test-cypress --headless --browser=chromium
+          command: |
+            dktl dkan:test-cypress --headless --browser=chromium
       - store_artifacts:
           path: docroot/modules/contrib/dkan/cypress/screenshots
       - store_artifacts:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
             when { changeRequest(); }
                 steps {
                     dir ("dkan-tools") {
-                        git url: DKTL_REPO, branch: "master"
+                        git url: DKTL_REPO, branch: "dkan-qa-builder-no-proxy"
                     }
                 }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
             when { changeRequest(); }
                 steps {
                     dir ("dkan-tools") {
-                        git url: DKTL_REPO, branch: "dkan-qa-builder-no-proxy"
+                        git url: DKTL_REPO, branch: "master"
                     }
                 }
         }

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\datastore\Unit\Controller;
 
 use Drupal\common\DatasetInfo;
+use Drupal\Core\Cache\Context\CacheContextsManager;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
 use MockChain\Options;
@@ -18,6 +19,7 @@ use Drupal\metastore\NodeWrapper\NodeDataFactory;
 use Drupal\metastore\Storage\DataFactory;
 use Ilbee\CSVResponse\CSVResponse as CsvResponse;
 use RootedData\RootedJsonData;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -28,6 +30,18 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class QueryControllerTest extends TestCase {
 
   private $buffer;
+
+  protected function setUp() {
+    parent::setUp();
+    // Set cache services
+    $options = (new Options)
+      ->add('cache_contexts_manager', CacheContextsManager::class)
+      ->index(0);
+    $chain = (new Chain($this))
+      ->add(ContainerInterface::class, 'get', $options)
+      ->add(CacheContextsManager::class, 'assertValidTokens', TRUE);
+    \Drupal::setContainer($chain->getMock());
+  }
 
   public function testQueryJson() {
     $data = json_encode([

--- a/modules/datastore/tests/src/Unit/SqlEndpoint/WebServiceApiTest.php
+++ b/modules/datastore/tests/src/Unit/SqlEndpoint/WebServiceApiTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\datastore\Unit\SqlEndpoint;
 
 use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
+use Drupal\Core\Cache\Context\CacheContextsManager;
 use Drupal\Core\Config\Config;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Database\Connection;
@@ -16,6 +17,7 @@ use Drupal\metastore\MetastoreApiResponse;
 use Drupal\metastore\NodeWrapper\Data;
 use Drupal\metastore\NodeWrapper\NodeDataFactory;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -27,12 +29,25 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class WebServiceApiTest extends TestCase {
   use TestHelperTrait;
 
+  protected function setUp() {
+    parent::setUp();
+    // Set cache services
+    $options = (new Options)
+      ->add('cache_contexts_manager', CacheContextsManager::class)
+      ->add('event_dispatcher', ContainerAwareEventDispatcher::class)
+      ->index(0);
+    $chain = (new Chain($this))
+      ->add(ContainerInterface::class, 'get', $options)
+      ->add(CacheContextsManager::class, 'assertValidTokens', TRUE);
+    \Drupal::setContainer($chain->getMock());
+  }
+
   /**
    *
    */
   public function testGet() {
     $container = $this->getCommonMockChain()->getMock();
-    \Drupal::setContainer($container);
+    // \Drupal::setContainer($container);
     $controller = WebServiceApi::create($container);
     $response = $controller->runQueryGet();
     $this->assertEquals("[{\"column_1\":\"hello\",\"column_2\":\"goodbye\"}]", $response->getContent());
@@ -55,7 +70,7 @@ class WebServiceApiTest extends TestCase {
    */
   public function testPost() {
     $container = $this->getCommonMockChain()->getMock();
-    \Drupal::setContainer($container);
+    // \Drupal::setContainer($container);
     $controller = WebServiceApi::create($container);
     $response = $controller->runQueryPost();
     $this->assertEquals("[{\"column_1\":\"hello\",\"column_2\":\"goodbye\"}]", $response->getContent());
@@ -85,6 +100,7 @@ class WebServiceApiTest extends TestCase {
       ->add("database", Connection::class)
       ->add('request_stack', RequestStack::class)
       ->add('event_dispatcher', ContainerAwareEventDispatcher::class)
+      ->add('cache_contexts_manager', CacheContextsManager::class)
       ->index(0);
 
     $body = json_encode(["query" => $query]);
@@ -102,6 +118,7 @@ class WebServiceApiTest extends TestCase {
       ->add(Service::class, 'getTableNameFromSelect', '465s')
       ->add(MetastoreApiResponse::class, 'getMetastoreItemFactory', NodeDataFactory::class)
       ->add(MetastoreApiResponse::class, 'addReferenceDependencies', NULL)
+      ->add(CacheContextsManager::class, 'assertValidTokens', TRUE)
       ->add(NodeDataFactory::class, 'getInstance', Data::class)
       ->add(Data::class, 'getCacheContexts', ['url'])
       ->add(Data::class, 'getCacheTags', ['node:1'])

--- a/modules/metastore/tests/src/Unit/MetastoreApiResponseTest.php
+++ b/modules/metastore/tests/src/Unit/MetastoreApiResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\metastore\Unit;
 
+use Drupal\Core\Cache\Context\CacheContextsManager;
 use Drupal\metastore\MetastoreApiResponse;
 use Drupal\metastore\NodeWrapper\Data as NodeWrapperData;
 use Drupal\metastore\NodeWrapper\NodeDataFactory;
@@ -59,8 +60,10 @@ class MetastoreApiResponseTest extends TestCase {
    * Private.
    */
   private function getContainer() {
+
     $options = (new Options)
       ->add('dkan.metastore.metastore_item_factory', NodeDataFactory::class)
+      ->add('cache_contexts_manager', CacheContextsManager::class)
       ->index(0);
 
     $dataset = $this->getDataset();
@@ -78,6 +81,7 @@ class MetastoreApiResponseTest extends TestCase {
     $mockChain = (new Chain($this))
       ->add(ContainerInterface::class, 'get', $options)
       ->add(Service::class, 'getSchemas', ['dataset'])
+      ->add(CacheContextsManager::class, 'assertValidTokens', TRUE)
       ->add(Service::class, 'getSchema', (object) ["id" => "http://schema"])
       ->add(NodeDataFactory::class, 'getInstance', NodeWrapperData::class)
       ->add(NodeWrapperData::class, 'getMetadata', $getMetadataResults)


### PR DESCRIPTION
See GetDKAN/dkan-cli#9

* Brings the CLI tooling to php 7.4, and
* Fixes the certificate issue that has been causing all builds to fail
* Adds a `composer update` command in circleCI to avoid recurring build problems with [select2](https://www.drupal.org/project/select2)
* Fixes the xdebug commands in CircleCI for v3 and to avoid double coverage reporting
* Fixes some tests that broke after PHP upgrade (not clear why they worked before!)