### PR TITLE
Datastore schemas as frictionless table schema

### DIFF
--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -8,7 +8,7 @@ use Drupal\Core\Database\DatabaseExceptionWrapper;
 use Drupal\common\EventDispatcherTrait;
 
 /**
- * AbstractDatabaseTable class.
+ * Base class for database storage methods.
  */
 abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   use SqlStorageTrait;
@@ -59,19 +59,15 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   }
 
   /**
-   * Inherited.
-   *
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function retrieve(string $id) {
     $this->setTable();
 
-    /* @var \Drupal\Core\Database\Query\Select $select */
     $select = $this->connection->select($this->getTableName(), 't')
       ->fields('t', array_keys($this->getSchema()['fields']))
       ->condition($this->primaryKey(), $id);
 
-    /* @var \Drupal\Core\Database\StatementInterface $statement */
     $statement = $select->execute();
 
     // The docs do not mention it, but fetch can return false.
@@ -81,9 +77,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   }
 
   /**
-   * Inherited.
-   *
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function retrieveAll(): array {
     $this->setTable();
@@ -273,7 +267,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   /**
    * Check for existence of a table name.
    */
-  private function tableExist($table_name) {
+  protected function tableExist($table_name) {
     $exists = $this->connection->schema()->tableExists($table_name);
     return $exists;
   }

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -150,7 +150,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
       $name = $info->Field;
       $schema['fields'][$name] = array_filter([
         'name' => $name,
-        'description' => $canGetComment ? $this->connection->schema()->getComment($tableName, $name) : '',
+        'title' => $canGetComment ? $this->connection->schema()->getComment($tableName, $name) : '',
         'type' => $this->translateType($info->Type),
         'format' => $this->translateFormat($info->Type),
       ]);

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -46,16 +46,17 @@ class DatabaseTableTest extends TestCase {
     $expectedSchema = [
       "fields" => [
         "record_number" => [
-          "type" => "serial",
-          "unsigned" => TRUE,
-          "not null" => TRUE,
+          "name" => "record_number",
+          "type" => "number",
         ],
         "first_name" => [
-          "type" => "text",
+          "name" => "first_name",
+          "type" => "string",
           "description" => "First Name",
         ],
         "last_name" => [
-          "type" => "text",
+          "name" => "last_name",
+          "type" => "string",
           "description" => "lAST nAME",
         ],
       ],
@@ -70,8 +71,9 @@ class DatabaseTableTest extends TestCase {
   public function testRetrieveAll() {
 
     $fieldInfo = [
-      (object) ['Field' => "first_name"],
-      (object) ['Field' => "last_name"],
+      (object) ['Field' => "record_number", 'Type' => 'int(10)', 'Key' => 'PRI'],
+      (object) ['Field' => "first_name", 'Type' => 'varchar(10)'],
+      (object) ['Field' => "last_name", 'Type' => 'tinytext'],
     ];
 
     $sequence = (new Sequence())
@@ -365,8 +367,9 @@ class DatabaseTableTest extends TestCase {
    */
   private function getConnectionChain() {
     $fieldInfo = [
-      (object) ['Field' => "first_name"],
-      (object) ['Field' => "last_name"],
+      (object) ['Field' => "record_number", 'Type' => 'int(10)', 'Key' => 'PRI'],
+      (object) ['Field' => "first_name", 'Type' => 'varchar(10)'],
+      (object) ['Field' => "last_name", 'Type' => 'tinytext'],
     ];
 
     $chain = (new Chain($this))
@@ -375,8 +378,10 @@ class DatabaseTableTest extends TestCase {
       ->add(Connection::class, 'query', Statement::class)
       ->add(Statement::class, 'fetchAll', $fieldInfo)
       ->add(Schema::class, "tableExists", TRUE)
-      ->add(Schema::class, 'getComment',
-        (new Sequence())->add('First Name')->add('lAST nAME')
+      ->add(Schema::class, 'getComment', (new Sequence())
+        ->add('')
+        ->add('First Name')
+        ->add('lAST nAME')
       )
       ->add(Schema::class, 'dropTable', NULL);
 

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -52,12 +52,12 @@ class DatabaseTableTest extends TestCase {
         "first_name" => [
           "name" => "first_name",
           "type" => "string",
-          "description" => "First Name",
+          "title" => "First Name",
         ],
         "last_name" => [
           "name" => "last_name",
           "type" => "string",
-          "description" => "lAST nAME",
+          "title" => "lAST nAME",
         ],
       ],
     ];


### PR DESCRIPTION
We initially implemented dataset column types in #3686 as full frictionless table schemas, but the change was too disruptive. Stashing that code here to come back to for a v2.

From the original PR:

...we are adopting the [Frictionless table schema](https://specs.frictionlessdata.io/table-schema/) as a standard for describing column metadata elsewhere in the application, and it seems like a good moment to implement this in the datastore API for outgoing data as well. So we will see the schema object change slightly in these responses. Because this is a breaking change I believe we should make this a minor release (2.12) and be careful about deploying until there is a frontend fix for it. So let's not be too hasty about merging this! If the disruption seems to be too great we can always pull back a bit from the frictionless adoption and keep using existing paradigms for this endpoint for now.

For instance, this:
```json
  "schema": {
    "d7b7e4f8-a947-57a2-b995-6d462a714880": {
      "fields": {
        "objectid": {
          "type": "text",
          "description": "﻿OBJECTID"
        },
        "roadway": {
          "type": "text",
          "description": "ROADWAY"
        },
        "road_side": {
          "type": "text",
          "description": "ROAD_SIDE"
        },
        "lncd": {
          "type": "text",
          "description": "LNCD"
        },
        "descr": {
          "type": "text",
          "description": "DESCR"
        },
        "begin_post": {
          "type": "text",
          "description": "BEGIN_POST"
        },
        "end_post": {
          "type": "text",
          "description": "END_POST"
        },
        "shape_leng": {
          "type": "text",
          "description": "Shape_Leng"
        }
      },
      "primary key": [
        "record_number"
      ]
    }
  }
```
will now look like this:

```json
  "schema": {
    "d7b7e4f8-a947-57a2-b995-6d462a714880": {
      "fields": [
        {
          "name": "objectid",
          "title": "﻿OBJECTID",
          "type": "number"
        },
        {
          "name": "roadway",
          "title": "ROADWAY",
          "type": "string"
        },
        {
          "name": "road_side",
          "title": "ROAD_SIDE",
          "type": "string"
        },
        {
          "name": "lncd",
          "title": "LNCD",
          "type": "string"
        },
        {
          "name": "descr",
          "title": "DESCR",
          "type": "string"
        },
        {
          "name": "begin_post",
          "title": "Begin post",
          "type": "number"
        },
        {
          "name": "end_post",
          "title": "End post",
          "type": "number"
        },
        {
          "name": "shape_leng",
          "title": "The shape length",
          "type": "number"
        }
      ]
    }
```

