### PR TITLE
Get datastore query maximum row limit from config

### DIFF
--- a/modules/datastore/docs/query.json
+++ b/modules/datastore/docs/query.json
@@ -74,7 +74,6 @@
         },
         "limit": {
             "type": "integer",
-            "maximum": 500,
             "description": "Limit for maximum number of records returned. Pass zero for no limit (may be restricted by user permissions).",
             "default": 500
         },

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -305,7 +305,7 @@ class QueryController implements ContainerInjectionInterface {
     }
     try {
       $payloadJson = RequestParamNormalizer::fixTypes($payloadJson, file_get_contents(__DIR__ . "/../../docs/query.json"));
-      $rows_limit = $this->configFactory->get('datastore.settings')->get('rows_limit');
+      $rows_limit = (int) $this->configFactory->get('datastore.settings')->get('rows_limit') ?: 500;
       $datastoreQuery = new DatastoreQuery($payloadJson, $rows_limit);
       $result = $this->datastoreService->runQuery($datastoreQuery);
     }

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -305,7 +305,7 @@ class QueryController implements ContainerInjectionInterface {
     }
     try {
       $payloadJson = RequestParamNormalizer::fixTypes($payloadJson, file_get_contents(__DIR__ . "/../../docs/query.json"));
-      $rows_limit = (int) $this->configFactory->get('datastore.settings')->get('rows_limit') ?: 500;
+      $rows_limit = $this->configFactory->get('datastore.settings')->get('rows_limit');
       $datastoreQuery = new DatastoreQuery($payloadJson, $rows_limit);
       $result = $this->datastoreService->runQuery($datastoreQuery);
     }

--- a/modules/datastore/src/Service/DatastoreQuery.php
+++ b/modules/datastore/src/Service/DatastoreQuery.php
@@ -14,6 +14,8 @@ class DatastoreQuery extends RootedJsonData {
    *
    * @param string $json
    *   JSON query string from API payload.
+   * @param int $rows_limit
+   *   Maxmimum rows of data to return.
    */
   public function __construct(string $json, int $rows_limit = 500) {
     $schema = file_get_contents(__DIR__ . "/../../docs/query.json");

--- a/modules/datastore/src/Service/DatastoreQuery.php
+++ b/modules/datastore/src/Service/DatastoreQuery.php
@@ -17,7 +17,7 @@ class DatastoreQuery extends RootedJsonData {
    * @param int $rows_limit
    *   Maxmimum rows of data to return.
    */
-  public function __construct(string $json, int $rows_limit = 500) {
+  public function __construct(string $json, int $rows_limit) {
     $schema = file_get_contents(__DIR__ . "/../../docs/query.json");
     $q = json_decode($schema);
     $q->properties->limit->maximum = $rows_limit;

--- a/modules/datastore/src/Service/DatastoreQuery.php
+++ b/modules/datastore/src/Service/DatastoreQuery.php
@@ -15,8 +15,11 @@ class DatastoreQuery extends RootedJsonData {
    * @param string $json
    *   JSON query string from API payload.
    */
-  public function __construct(string $json) {
+  public function __construct(string $json, int $rows_limit = 500) {
     $schema = file_get_contents(__DIR__ . "/../../docs/query.json");
+    $q = json_decode($schema);
+    $q->properties->limit->maximum = $rows_limit;
+    $schema = json_encode($q);
     parent::__construct($json, $schema);
     $this->populateDefaults();
   }


### PR DESCRIPTION
Allow site admins to set the maximum number of rows returned on a datastore query.

## QA Steps

- [ ] Visit /admin/dkan/sql-endpoint
- [ ] Set the value to something above 500
- [ ] Run a query with the limit set to the number you set in config
- [ ] Confirm the query works and is returning the expected number of rows

- [ ] Run a query with no limit specified
- [ ] Confirm it defaults to limit=500

- [ ] Run a query with the limit set to a number above the maximum value
- [ ] Confirm you get a JSON Schema validation failed error

## To Dos

- Add tests
- Move the config to live at `admin/dkan/datastore`
- Update documentation