### PR TITLE
Indexer needs to run after the alter event

### DIFF
--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -296,12 +296,12 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    * Create a table given a name and schema.
    */
   private function tableCreate($table_name, $schema) {
+    // Opportunity to further alter the schema before table creation.
+    $schema = $this->dispatchEvent(self::EVENT_TABLE_CREATE, $schema);
     // Add indexes if we have an index manager.
     if (method_exists($this->indexManager, 'modifySchema')) {
       $schema = $this->indexManager->modifySchema($table_name, $schema);
     }
-    // Opportunity to further alter the schema before table creation.
-    $schema = $this->dispatchEvent(self::EVENT_TABLE_CREATE, $schema);
     $this->connection->schema()->createTable($table_name, $schema);
   }
 


### PR DESCRIPTION
If the listeners change the field types then this could leave the indexer adding invalid indexes - for example trying to add a prefix index on a date field.