### PR TITLE
Fix jobstore error when dropping datastore using Drush

### DIFF
--- a/modules/datastore/src/Drush.php
+++ b/modules/datastore/src/Drush.php
@@ -144,7 +144,7 @@ class Drush extends DrushCommands {
    * Drop a datastore.
    *
    * @param string $uuid
-   *   The uuid of a dataset.
+   *   The uuid of a dataset resource.
    *
    * @command dkan:datastore:drop
    * @aliases dkan-datastore:drop
@@ -152,6 +152,14 @@ class Drush extends DrushCommands {
    */
   public function drop($uuid) {
     try {
+      // Retrieve the UUID for the dataset's resource before dropping the
+      // dataset's resource mapper table entry.
+      $resource = $this->resourceLocalizer->get($uuid);
+      if (!isset($resource)) {
+        throw new \UnexpectedValueException("Resource not found with uuid {$uuid}");
+      }
+      $resource_uuid = $resource->getUniqueIdentifier();
+      // Drop the datastore table and corresponding resource mapper table entry.
       $this->datastoreService->drop($uuid);
       $this->logger->notice("Successfully dropped the datastore for {$uuid}");
     }
@@ -168,8 +176,8 @@ class Drush extends DrushCommands {
       $this->logger->debug($e->getMessage());
       return;
     }
-
-    $this->jobstorePrune($uuid);
+    // Drop any remaining jobstore entries for this resource.
+    $this->jobstorePrune($resource_uuid);
   }
 
   /**

--- a/modules/datastore/src/TableTrait.php
+++ b/modules/datastore/src/TableTrait.php
@@ -12,13 +12,7 @@ trait TableTrait {
   /**
    * Delete jobstore entries related to a datastore.
    */
-  public function jobstorePrune($uuid) {
-    if (!isset($this->resourceLocalizer)) {
-      \Drupal::logger('datastore')->error('ResourceLocalizer is not set.');
-      return;
-    }
-    $resource = $this->resourceLocalizer->get($uuid);
-    $ref_uuid = $resource->getUniqueIdentifier();
+  public function jobstorePrune($ref_uuid) {
     $jobs = [
       [
         "id" => substr(str_replace('__', '_', $ref_uuid), 0, -11),


### PR DESCRIPTION
- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Create a dataset with a CSV resource file.
- [ ] Import the dataset's datastore.
- [ ] Run the `drush dkan:datastore:drop {resource_id}` command.
- [ ] Ensure you do not receive the following error:
```
[error]  Error: Call to a member function getUniqueIdentifier() on null in Drupal\datastore\Drush->jobstorePrune() (line 21 of /mnt/www/html/datamedicaidstg/docroot/modules/contrib/dkan/modules/datastore/src/TableTrait.php) #0 /mnt/www/html/datamedicaidstg/docroot/modules/contrib/dkan/modules/datastore/src/Drush.php(172): Drupal\datastore\Drush->jobstorePrune('7fc7f550ef83021...')
#1 [internal function]: Drupal\datastore\Drush->drop('7fc7f550ef83021...', Array)
#2 /mnt/www/html/datamedicaidstg/vendor/consolidation/annotated-command/src/CommandProcessor.php(257): call_user_func_array(Array, Array)
#3 /mnt/www/html/datamedicaidstg/vendor/consolidation/annotated-command/src/CommandProcessor.php(212): Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback(Array, Object(Consolidation\AnnotatedCommand\CommandData))
#4 /mnt/www/html/datamedicaidstg/vendor/consolidation/annotated-command/src/CommandProcessor.php(176): Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter(Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#5 /mnt/www/html/datamedicaidstg/vendor/consolidation/annotated-command/src/AnnotatedCommand.php(302): Consolidation\AnnotatedCommand\CommandProcessor->process(Object(Symfony\Component\Console\Output\ConsoleOutput), Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#6 /mnt/www/html/datamedicaidstg/vendor/symfony/console/Command/Command.php(255): Consolidation\AnnotatedCommand\AnnotatedCommand->execute(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /mnt/www/html/datamedicaidstg/vendor/symfony/console/Application.php(1005): Symfony\Component\Console\Command\Command->run(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /mnt/www/html/datamedicaidstg/vendor/symfony/console/Application.php(255): Symfony\Component\Console\Application->doRunCommand(Object(Consolidation\AnnotatedCommand\AnnotatedCommand), Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /mnt/www/html/datamedicaidstg/vendor/symfony/console/Application.php(148): Symfony\Component\Console\Application->doRun(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 /mnt/www/html/datamedicaidstg/vendor/drush/drush/src/Runtime/Runtime.php(118): Symfony\Component\Console\Application->run(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 /mnt/www/html/datamedicaidstg/vendor/drush/drush/src/Runtime/Runtime.php(48): Drush\Runtime\Runtime->doRun(Array, Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /mnt/www/html/datamedicaidstg/vendor/drush/drush/drush.php(72): Drush\Runtime\Runtime->run(Array)
#13 /mnt/www/html/datamedicaidstg/vendor/drush/drush/drush(4): require('/mnt/www/html/d...')
#14 {main}. 
Error: Call to a member function getUniqueIdentifier() on null in Drupal\datastore\Drush->jobstorePrune() (line 21 of /mnt/www/html/datamedicaidstg/docroot/modules/contrib/dkan/modules/datastore/src/TableTrait.php).
```