### PR TITLE
Change to keyset pagination for streaming large CSVs

### DIFF
--- a/modules/datastore/src/Controller/AbstractQueryController.php
+++ b/modules/datastore/src/Controller/AbstractQueryController.php
@@ -224,6 +224,9 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
         'directly. Set rowIds to true and remove properties from your query to see the full table ' .
         'with row IDs.');
     }
+    if (!empty($data->properties) && !empty($data->rowIds)) {
+      throw new \Exception('The rowIds property cannot be set to true if you are requesting specific properties.');
+    }
     if ($identifier && (!empty($data->resources) || !empty($data->joins))) {
       throw new \Exception('Joins are not available and resources should not be explicitly passed ' .
         'when using the resource query endpoint. Try /api/1/datastore/query.');

--- a/modules/datastore/src/Controller/AbstractQueryController.php
+++ b/modules/datastore/src/Controller/AbstractQueryController.php
@@ -246,7 +246,7 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
 
   protected function checkForRowIdProperty(array $properties) {
     foreach ($properties as $property) {
-      if (is_string($property) && $property = 'record_number') {
+      if (is_string($property) && $property == 'record_number') {
         return TRUE;
       }
       if (isset($property->property) && $property->property == 'record_number') {

--- a/modules/datastore/src/Controller/AbstractQueryController.php
+++ b/modules/datastore/src/Controller/AbstractQueryController.php
@@ -216,6 +216,7 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
   protected function buildDatastoreQuery(Request $request, $identifier = NULL) {
     $json = static::getPayloadJson($request);
     $data = json_decode($json);
+    $this->additionalPayloadValidation($data);
     if ($identifier) {
       $resource = (object) ["id" => $identifier, "alias" => "t"];
       $data->resources = [$resource];
@@ -256,11 +257,11 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     foreach ($data->properties as $property) {
       $hasProperty = (is_string($property) && $property == 'record_number');
       $hasProperty = $hasProperty ?: (isset($property->property) && $property->property == 'record_number');
-    }
-    if ($hasProperty) {
-      throw new \Exception('The record_number property is for internal use and cannot be requested ' .
-      'directly. Set rowIds to true and remove properties from your query to see the full table ' .
-      'with row IDs.');
+      if ($hasProperty) {
+        throw new \Exception('The record_number property is for internal use and cannot be requested ' .
+        'directly. Set rowIds to true and remove properties from your query to see the full table ' .
+        'with row IDs.');
+      }
     }
   }
 

--- a/modules/datastore/src/Controller/AbstractQueryController.php
+++ b/modules/datastore/src/Controller/AbstractQueryController.php
@@ -216,6 +216,22 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
   protected function buildDatastoreQuery(Request $request, $identifier = NULL) {
     $json = static::getPayloadJson($request);
     $data = json_decode($json);
+    if ($identifier) {
+      $resource = (object) ["id" => $identifier, "alias" => "t"];
+      $data->resources = [$resource];
+    }
+    return new DatastoreQuery(json_encode($data), $this->getRowsLimit());
+  }
+
+  /**
+   * Run some additional validation on incoming request.
+   *
+   * @param object $data
+   *   The decoded request data.
+   * @param mixed $identifier
+   *   Resource identifier.
+   */
+  protected function additionalPayloadValidation($data, $identifier = NULL) {
     $this->checkForRowIdProperty($data);
     if (!empty($data->properties) && !empty($data->rowIds)) {
       throw new \Exception('The rowIds property cannot be set to true if you are requesting specific properties.');
@@ -224,11 +240,6 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
       throw new \Exception('Joins are not available and resources should not be explicitly passed ' .
         'when using the resource query endpoint. Try /api/1/datastore/query.');
     }
-    if ($identifier) {
-      $resource = (object) ["id" => $identifier, "alias" => "t"];
-      $data->resources = [$resource];
-    }
-    return new DatastoreQuery(json_encode($data), $this->getRowsLimit());
   }
 
   /**

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -44,7 +44,6 @@ class QueryController extends AbstractQueryController {
       default:
         return $this->metastoreApiResponse->cachedJsonResponse($result->{"$"}, 200, $dependencies, $params);
     }
-
   }
 
   /**

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -3,6 +3,7 @@
 namespace Drupal\datastore\Controller;
 
 use Drupal\datastore\Service\DatastoreQuery;
+use Drupal\datastore\Util\QueryIterator;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use RootedData\RootedJsonData;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -15,19 +16,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 class QueryDownloadController extends AbstractQueryController {
 
   /**
-   * Stream a CSV response.
-   *
-   * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
-   *   A datastore query object.
-   * @param \RootedData\RootedJsonData $result
-   *   The result of the datastore query.
-   * @param array $dependencies
-   *   A dependency array for use by \Drupal\metastore\MetastoreApiResponse.
-   * @param \Symfony\Component\HttpFoundation\ParameterBag|null $params
-   *   The parameter object from the request.
-   *
-   * @return \Symfony\Component\HttpFoundation\Response
-   *   The json response.
+   * {@inheritdoc}
    */
   public function formatResponse(
     DatastoreQuery $datastoreQuery,
@@ -48,11 +37,18 @@ class QueryDownloadController extends AbstractQueryController {
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
   protected function buildDatastoreQuery($request, $identifier = NULL) {
     $data = json_decode(static::getPayloadJson($request));
     if (isset($data->limit)) {
       throw new \Exception("Limits are, temporarily, not allowed in downloads.");
     }
+    if (isset($data->sorts) && count($data->sorts) > 1) {
+      throw new \Exception("Downloads are currently limited to sorting on a single column.");
+    }
+
     return parent::buildDatastoreQuery($request, $identifier);
   }
 
@@ -71,99 +67,29 @@ class QueryDownloadController extends AbstractQueryController {
     $response = $this->initStreamedCsvResponse();
 
     $response->setCallback(function () use ($result, $datastoreQuery) {
-      $count = $result->{'$.count'};
       $rows = $result->{'$.results'};
-      array_unshift($rows, $this->getHeaderRow($result));
 
+      // Open the stream and send the header.
       set_time_limit(0);
       $handle = fopen('php://output', 'wb');
-      $this->sendRows($handle, $rows);
+      $this->sendRows($handle, $this->getHeaderRow($result));
 
       // If we've already sent the full result set we can end now.
-      $progress = (count($rows) - 1);
-      if ($count <= $progress) {
+      if ($result->{'$.count'} <= count($rows)) {
+        $this->sendRows($handle, $rows);
         fclose($handle);
         return TRUE;
       }
 
-      // Otherwise, we iterate.
-      $this->streamIterate($result, $datastoreQuery, $handle);
+      // Otherwise, we're going to redo as an iterator from the beginning.
+      $iterator = new QueryIterator($datastoreQuery, $this->getRowsLimit(), $this->datastoreService);
+      while ($rows = $iterator->pageResult()) {
+        $this->sendRows($handle, $rows);
+      }
 
       fclose($handle);
     });
     return $response;
-  }
-
-  /**
-   * Iterator for CSV streaming.
-   *
-   * This is fairly non-intuitive so some explanation is probably necessary. 
-   *
-   * @param \RootedData\RootedJsonData $result
-   *   The result data from the initial query.
-   * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
-   *   The unmodified datastore query object.
-   * @param resource $handle
-   *   The PHP output stream.
-   */
-  private function streamIterate(RootedJsonData $result, DatastoreQuery $datastoreQuery, $handle) {
-    $pageCount = $progress = count($result->{'$.results'});
-    $pageLimit = $this->getRowsLimit();
-    $iteratorQuery = new DatastoreQuery("$datastoreQuery", $this->getRowsLimit());
-
-    // Disable extra information in response.
-    $iteratorQuery->{"$.count"} = FALSE;
-    $iteratorQuery->{"$.schema"} = FALSE;
-    $iteratorQuery->{"$.keys"} = FALSE;
-    $iteratorQuery->{"$.offset"} = $pageCount;
-
-    // Set up condition-based pagination.
-    $conditionIndex = count($iteratorQuery->{"$.conditions"} ?? []);
-    $lastIndex = $pageCount - 1;
-    $lastRowId = (int) $result->{"$.results.$pageCount.record_number"};
-    $rowIdColumnIndex = $this->addRowIdProperty($iteratorQuery);
-
-    while ($pageCount >= $pageLimit) {
-      $result = $this->datastoreService->runQuery($iteratorQuery);
-      $rows = $result->{"$.results"};
-      $pageCount = count($rows);
-      $lastIndex = $pageCount - 1;
-      $progress += $pageCount;
-      $lastRowId = (int) $rows[$lastIndex][($rowIdColumnIndex !== NULL) ? $rowIdColumnIndex : 0];
-      $this->removeRowIdProperty($rows, $rowIdColumnIndex);
-      $this->sendRows($handle, $rows);
-      $iteratorQuery->{"$.conditions[$conditionIndex]"} = [
-        'property' => 'record_number',
-        'value' => $lastRowId,
-        'operator' => '>',
-      ];
-      $iteratorQuery->{"$.offset"} = 0;
-    }
-  }
-
-  private function addRowIdProperty($iteratorQuery) {
-    $properties = $iteratorQuery->{'$.properties'} ?? null;
-    // if (!is_array($properties)) {
-    //   exit;
-    // }
-    // if (is_array($properties[0])) {
-    //   exit;
-    // }
-    if (!empty($properties) && !in_array('record_number', $properties)) {
-      $properties[] = 'record_number';
-      $iteratorQuery->{'$.properties'} = $properties;
-      return array_search('record_number', $properties);
-    }
-    return NULL;
-  }
-
-  private function removeRowIdProperty(array &$rows, $rowIdColumnIndex) {
-    if ($rowIdColumnIndex === NULL) {
-      return;
-    }
-    array_walk($rows, function (&$row) use ($rowIdColumnIndex) {
-      unset($row[$rowIdColumnIndex]);
-    });
   }
 
   /**
@@ -223,7 +149,7 @@ class QueryDownloadController extends AbstractQueryController {
         $header = $header['alias'] ?? $header['property'];
       }
     });
-    return $header_row;
+    return [$header_row];
   }
 
 }

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -45,9 +45,6 @@ class QueryDownloadController extends AbstractQueryController {
     if (isset($data->limit)) {
       throw new \Exception("Limits are, temporarily, not allowed in downloads.");
     }
-    if (isset($data->sorts) && count($data->sorts) > 1) {
-      throw new \Exception("Downloads are currently limited to sorting on a single column.");
-    }
 
     return parent::buildDatastoreQuery($request, $identifier);
   }

--- a/modules/datastore/src/Util/QueryIterator.php
+++ b/modules/datastore/src/Util/QueryIterator.php
@@ -182,7 +182,7 @@ class QueryIterator {
     // We copy the existing comparison condition, and swap in a "=" operator.
     $mainSortCondition = $pageConditions[$mainSort['property']]['conditions'][0];
     $mainSortCondition['operator'] = '=';
-    // Add an "=" condition to each or the main comparison conditions.
+    // Add an "=" condition to each of the main comparison conditions.
     foreach ($sorts as $sort) {
       $pageConditions[$sort['property']]['conditions'][] = $mainSortCondition;
     }

--- a/modules/datastore/src/Util/QueryIterator.php
+++ b/modules/datastore/src/Util/QueryIterator.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Drupal\datastore\Util;
+
+use Drupal\datastore\Service\DatastoreQuery;
+use RootedData\RootedJsonData;
+
+/**
+ * @package Drupal\datastore
+ *
+ * @todo Dependency injection.
+ */
+class QueryIterator {
+
+  public function __construct($datastoreQuery, $rowsLimit, $datastoreService) {
+    $this->datastoreService = $datastoreService;
+    $iteratorQuery = new DatastoreQuery("$datastoreQuery", $rowsLimit);
+
+    // Disable extra information in response.
+    $iteratorQuery->{"$.count"} = FALSE;
+    $iteratorQuery->{"$.schema"} = FALSE;
+    $iteratorQuery->{"$.keys"} = TRUE;
+    $iteratorQuery->{"$.offset"} = 0;
+
+    // Set up our properties, conditions and sorts.
+    $this->rowIdColumnIndex = $this->addRowIdProperty($iteratorQuery);
+    $this->order = $this->addRowIdSort($iteratorQuery);
+    $this->rowIdConditionIndex = count($iteratorQuery->{"$.conditions"} ?? []);
+
+    $this->query = $iteratorQuery;
+  }
+
+  /**
+   * Return a page of results and advance the query pagination.
+   *
+   * @return array
+   *   An page of of results, ready to be appended to full result set.
+   */
+  public function pageResult() {
+    // Run the query based on current parameters.
+    $result = $this->datastoreService->runQuery($this->query);
+    $rows = $this->prepareRows($result);
+
+    // Set up pagination for next iteration.
+    $this->iterateConditions($result);
+
+    // Return the result rows for this iteration.
+    return $rows;
+  }
+
+  /**
+   * Prepare one page of query results to be returned.
+   *
+   * @param \RootedData\RootedJsonData $result
+   *   Unaltered query result object.
+   *
+   * @return array
+   *   An array of un-keyed result rows, with the iterator artifacts removed.
+   */
+  private function prepareRows(RootedJsonData $result) {
+    $rows = $result->{"$.results"};
+    if (!$this->query->{"$.rowIds"}) {
+      array_walk($rows, function (&$row) {
+          unset($row['record_number']);
+          $row = array_values($row);
+      });
+    }
+    return $rows;
+  }
+
+  /**
+   * Advance the pagination condition(s) once to prepare to request next page.
+   *
+   * Returns nothing, just modifies the iterator query conditions by reference.
+   *
+   * @param \RootedData\RootedJsonData $result
+   *   The full result object from the previous iteration.
+   */
+  private function iterateConditions(RootedJsonData $result) {
+    // Start creating the condition for the next page.
+    $resultRows = $result->{"$.results"};
+    $lastRow = end($resultRows);
+    if (empty($lastRow)) {
+      return;
+    }
+    $lastRowId = $lastRow['record_number'];
+    $rowIdCondition = [
+      'resource' => $this->getPrimaryResource($this->query),
+      'property' => 'record_number',
+      'operator' => $this->order == 'asc' ? '>' : '<',
+      'value' => $lastRowId,
+    ];
+
+    $sorts = $this->query->{"$.sorts"};
+    array_pop($sorts);
+
+    if (empty($sorts)) {
+      $this->query->{"$.conditions[$this->rowIdConditionIndex]"} = $rowIdCondition;
+      return;
+    }
+
+    // If we're still here, we've got sorts and need an OR group.
+    $orGroup = [
+      'groupOperator' => 'or',
+      'conditions' => [$rowIdCondition],
+    ];
+    $andGroup = [
+      'groupOperator' => 'and',
+      'conditions' => [],
+    ];
+
+    // The rowId sort is the last one; remove it and see if anything's left.
+    foreach ($sorts as $sort) {
+      $andCondition = [
+        'resource' => $sort['resource'] ?? $this->getPrimaryResource($this->query),
+        'property' => $sort['property'],
+        'operator' => $this->order == 'asc' ? '>=' : '<=',
+        'value' => $lastRow[$sort['property']],
+      ];
+      $andGroup['conditions'][] = $andCondition;
+
+      $orCondition = $andCondition;
+      $orCondition['operator'] = substr($andCondition['operator'], 0, 1);
+      $orGroup['conditions'][] = $orCondition;
+    }
+    $andGroup['conditions'][] = $orGroup;
+    $this->query->{"$.conditions[$this->rowIdConditionIndex]"} = $andGroup;
+  }
+
+  /**
+   * If properties are being specified, add one for pagination.
+   *
+   * @return int
+   *   The array index of the column to use for pagination.
+   */
+  private function addRowIdProperty($iteratorQuery) {
+    $properties = $iteratorQuery->{'$.properties'} ?? NULL;
+    if (!empty($properties)) {
+      $properties[] = [
+        'property' => 'record_number',
+        'resource' => $this->getPrimaryResource($iteratorQuery),
+      ];
+      $iteratorQuery->{'$.properties'} = $properties;
+      end($properties);
+      return key($properties);
+    }
+    return NULL;
+  }
+
+
+  /**
+   * We need to explicitly sort by the row ID (record_number).
+   *
+   * @return string
+   *   The sort order used. Will be either "asc" or "desc".
+   */
+  private function addRowIdSort($iteratorQuery) {
+    $sorts = $iteratorQuery->{'$.sorts'} ?? [];
+    $orders = [];
+    foreach ($sorts as $sort) {
+      $orders[] = $sort['order'] ?? 'asc';
+    }
+    $orders = array_unique($orders ?: ['asc']);
+    if (count($orders) > 1) {
+      throw new \Exception("Because of how DKAN optimizes queries for large CSV downloads, you may not add sorts with different orders to the same query.");
+    }
+    $order = current($orders);
+    $sorts[] = [
+      'resource' => 't',
+      'property' => 'record_number',
+      'order' => $order,
+    ];
+
+    $iteratorQuery->{'$.sorts'} = $sorts;
+    return $order;
+  }
+
+  private function getPrimaryResource($iteratorQuery) {
+    return $iteratorQuery->{"$.resources[0][alias]"} ?? "t";
+  }
+
+}

--- a/modules/datastore/tests/data/years_colors.csv
+++ b/modules/datastore/tests/data/years_colors.csv
@@ -1,0 +1,6 @@
+1,2010,red
+2,2011,green
+3,2012,blue
+4,2013,indigo
+5,2014,violet
+6,2015,ultraviolet

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -51,13 +51,64 @@ class QueryControllerTest extends TestCase {
       ],
     ]);
 
-    $container = $this->getQueryContainer($data)->getMock();
-    $webServiceApi = QueryController::create($container);
-    $request = $this->mockRequest($data);
-    $result = $webServiceApi->query($request);
+    $result = $this->getQueryResult($data);
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(200, $result->getStatusCode());
+  }
+
+  public function testQueryRowIdProperty() {
+    // Try simple string properties:
+    $data = json_encode(["properties" => ["record_number", "state"]]);
+
+    $result = $this->getQueryResult($data, "2");
+
+    $this->assertTrue($result instanceof JsonResponse);
+    $this->assertEquals(400, $result->getStatusCode());
+    $this->assertStringContainsString('The record_number property is for internal use', $result->getContent());
+
+    // Now try with resource properties:
+    $data = json_encode([
+      "properties" => [
+        [
+          "resource" => "t",
+          "property" => "state",
+        ],
+        [
+          "resource" => "t",
+          "property" => "record_number",
+        ],
+      ],
+    ]);
+
+    $result = $this->getQueryResult($data, "2");
+
+    $this->assertTrue($result instanceof JsonResponse);
+    $this->assertEquals(400, $result->getStatusCode());
+    $this->assertStringContainsString('The record_number property is for internal use', $result->getContent());
+  }
+
+  public function testQueryRowIdSort() {
+    $data = json_encode([
+      "sorts" => [
+        [
+          "resource" => "t",
+          "property" => "state",
+          "direction" => "desc",
+        ],
+        [
+          "resource" => "t",
+          "property" => "record_number",
+          "direction" => "asc",
+        ],
+      ],
+    ]);
+
+    $result = $this->getQueryResult($data, "2");
+
+    $this->assertTrue($result instanceof JsonResponse);
+    $this->assertEquals(400, $result->getStatusCode());
+    $this->assertStringContainsString('The record_number property is for internal use', $result->getContent());
   }
 
   // Make sure nothing fails with no resources.
@@ -71,10 +122,7 @@ class QueryControllerTest extends TestCase {
       ],
     ]);
 
-    $container = $this->getQueryContainer($data)->getMock();
-    $webServiceApi = QueryController::create($container);
-    $request = $this->mockRequest($data);
-    $result = $webServiceApi->query($request);
+    $result = $this->getQueryResult($data);
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(200, $result->getStatusCode());
@@ -85,10 +133,7 @@ class QueryControllerTest extends TestCase {
       "resources" => "nope",
     ]);
 
-    $container = $this->getQueryContainer($data)->getMock();
-    $webServiceApi = QueryController::create($container);
-    $request = $this->mockRequest($data);
-    $result = $webServiceApi->query($request);
+    $result = $this->getQueryResult($data);
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(400, $result->getStatusCode());
@@ -98,10 +143,7 @@ class QueryControllerTest extends TestCase {
   public function testResourceQueryInvalidJson() {
     $data = "{[";
 
-    $container = $this->getQueryContainer($data)->getMock();
-    $webServiceApi = QueryController::create($container);
-    $request = $this->mockRequest($data);
-    $result = $webServiceApi->queryResource("2", $request);
+    $result = $this->getQueryResult($data);
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(400, $result->getStatusCode());
@@ -111,10 +153,7 @@ class QueryControllerTest extends TestCase {
     $data = json_encode([
       "conditions" => "nope",
     ]);
-    $container = $this->getQueryContainer($data)->getMock();
-    $webServiceApi = QueryController::create($container);
-    $request = $this->mockRequest($data);
-    $result = $webServiceApi->queryResource("2", $request);
+    $result = $this->getQueryResult($data, "2");
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(400, $result->getStatusCode());
@@ -127,10 +166,7 @@ class QueryControllerTest extends TestCase {
         "condition" => "t.field1 = s.field1",
       ],
     ]);
-    $container = $this->getQueryContainer($data)->getMock();
-    $webServiceApi = QueryController::create($container);
-    $request = $this->mockRequest($data);
-    $result = $webServiceApi->queryResource("2", $request);
+    $result = $this->getQueryResult($data, "2");
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(400, $result->getStatusCode());
@@ -143,11 +179,7 @@ class QueryControllerTest extends TestCase {
     $data = json_encode([
       "results" => TRUE,
     ]);
-
-    $container = $this->getQueryContainer($data)->getMock();
-    $webServiceApi = QueryController::create($container);
-    $request = $this->mockRequest($data);
-    $result = $webServiceApi->queryResource("2", $request);
+    $result = $this->getQueryResult($data, "2");
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(200, $result->getStatusCode());
@@ -167,10 +199,7 @@ class QueryControllerTest extends TestCase {
       "format" => "csv",
     ]);
 
-    $container = $this->getQueryContainer($data)->getMock();
-    $webServiceApi = QueryController::create($container);
-    $request = $this->mockRequest($data);
-    $result = $webServiceApi->query($request);
+    $result = $this->getQueryResult($data);
 
     $this->assertTrue($result instanceof CsvResponse);
     $this->assertEquals(200, $result->getStatusCode());
@@ -181,6 +210,19 @@ class QueryControllerTest extends TestCase {
     $this->assertContains('data.csv', $result->headers->get('Content-Disposition'));
   }
 
+  private function getQueryResult($data, $id = NULL, $index = NULL) {
+    $container = $this->getQueryContainer($data)->getMock();
+    $webServiceApi = QueryController::create($container);
+    $request = $this->mockRequest($data);
+    if ($id === NULL && $index === NULL) {
+      return $webServiceApi->query($request);
+    }
+    if ($index === NULL) {
+      return $webServiceApi->queryResource($id, $request);
+    }
+    return $webServiceApi->queryDatasetResource($id, $index, $request);
+  }
+
   /**
    *
    */
@@ -189,11 +231,7 @@ class QueryControllerTest extends TestCase {
       "results" => TRUE,
       "format" => "csv",
     ]);
-
-    $container = $this->getQueryContainer($data)->getMock();
-    $webServiceApi = QueryController::create($container);
-    $request = $this->mockRequest($data);
-    $result = $webServiceApi->queryResource("2", $request);
+    $result = $this->getQueryResult($data);
 
     $this->assertTrue($result instanceof CsvResponse);
     $this->assertEquals(200, $result->getStatusCode());
@@ -216,12 +254,8 @@ class QueryControllerTest extends TestCase {
     $data = json_encode([
       "results" => TRUE,
     ]);
-    $info = ['notice' => 'Not found'];
-
-    $container = $this->getQueryContainer($data, "GET", $info)->getMock();
-    $webServiceApi = QueryController::create($container);
-    $request = $this->mockRequest($data);
-    $result = $webServiceApi->queryDatasetResource("2", "0", $request);
+  
+    $result = $this->getQueryResult($data, "2", 0);
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(400, $result->getStatusCode());
@@ -236,10 +270,7 @@ class QueryControllerTest extends TestCase {
     ]);
     $info['latest_revision']['distributions'][0]['distribution_uuid'] = '123';
 
-    $container = $this->getQueryContainer($data, "GET", $info)->getMock();
-    $webServiceApi = QueryController::create($container);
-    $request = $this->mockRequest($data);
-    $result = $webServiceApi->queryDatasetResource("2", "1", $request);
+    $result = $this->getQueryResult($data, "2", 1);
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(400, $result->getStatusCode());
@@ -254,10 +285,7 @@ class QueryControllerTest extends TestCase {
     ]);
     $info['latest_revision']['distributions'][0]['distribution_uuid'] = '123';
 
-    $container = $this->getQueryContainer($data, "GET", $info)->getMock();
-    $webServiceApi = QueryController::create($container);
-    $request = $this->mockRequest($data);
-    $result = $webServiceApi->queryDatasetResource("2", "0", $request);
+    $result = $this->getQueryResult($data, "2", 0);
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(200, $result->getStatusCode());
@@ -312,13 +340,7 @@ class QueryControllerTest extends TestCase {
     $this->assertEmpty($headers->get('last-modified'));
   }
 
-  private function getQueryContainer($data = '', string $method = "POST", array $info = []) {
-    if ($method == "GET") {
-      $request = Request::create("http://example.com?$data", $method);
-    }
-    else {
-      $request = Request::create("http://example.com", $method, [], [], [], [], $data);
-    }
+  private function getQueryContainer($data = '', array $info = []) {
 
     $options = (new Options())
       ->add("dkan.metastore.storage", DataFactory::class)

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -94,12 +94,12 @@ class QueryControllerTest extends TestCase {
         [
           "resource" => "t",
           "property" => "state",
-          "direction" => "desc",
+          "order" => "desc",
         ],
         [
           "resource" => "t",
           "property" => "record_number",
-          "direction" => "asc",
+          "order" => "asc",
         ],
       ],
     ]);
@@ -107,8 +107,7 @@ class QueryControllerTest extends TestCase {
     $result = $this->getQueryResult($data, "2");
 
     $this->assertTrue($result instanceof JsonResponse);
-    $this->assertEquals(400, $result->getStatusCode());
-    $this->assertStringContainsString('The record_number property is for internal use', $result->getContent());
+    $this->assertEquals(200, $result->getStatusCode());
   }
 
   // Make sure nothing fails with no resources.

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -210,8 +210,8 @@ class QueryControllerTest extends TestCase {
     $this->assertContains('data.csv', $result->headers->get('Content-Disposition'));
   }
 
-  private function getQueryResult($data, $id = NULL, $index = NULL) {
-    $container = $this->getQueryContainer($data)->getMock();
+  private function getQueryResult($data, $id = NULL, $index = NULL, $info = []) {
+    $container = $this->getQueryContainer($data, $info)->getMock();
     $webServiceApi = QueryController::create($container);
     $request = $this->mockRequest($data);
     if ($id === NULL && $index === NULL) {
@@ -254,7 +254,7 @@ class QueryControllerTest extends TestCase {
     $data = json_encode([
       "results" => TRUE,
     ]);
-  
+
     $result = $this->getQueryResult($data, "2", 0);
 
     $this->assertTrue($result instanceof JsonResponse);
@@ -270,7 +270,7 @@ class QueryControllerTest extends TestCase {
     ]);
     $info['latest_revision']['distributions'][0]['distribution_uuid'] = '123';
 
-    $result = $this->getQueryResult($data, "2", 1);
+    $result = $this->getQueryResult($data, "2", 1, $info);
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(400, $result->getStatusCode());
@@ -285,7 +285,7 @@ class QueryControllerTest extends TestCase {
     ]);
     $info['latest_revision']['distributions'][0]['distribution_uuid'] = '123';
 
-    $result = $this->getQueryResult($data, "2", 0);
+    $result = $this->getQueryResult($data, "2", 0, $info);
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(200, $result->getStatusCode());

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -73,17 +73,83 @@ class QueryDownloadControllerTest extends TestCase {
         ],
       ],
       "format" => "csv",
-      "properties" => ["state", "year"],
+      // "properties" => ["state", "year"],
       "sorts" => [
         [
           'property' => 'state',
           'order' => 'asc',
         ],
+        [
+          'property' => 'year',
+          'order' => 'desc',
+        ],
       ],
-      "rowIds" => TRUE,
+      'rowIds' => TRUE,
     ];
 
     // Need 2 json responses which get combined on output.
+    $this->queryResultCompare($data);
+  }
+
+  /**
+   * Test streaming of a CSV file from database.
+   */
+  public function testStreamedJoinCsv() {
+    $data = [
+      "resources" => [
+        [
+          "id" => "2",
+          "alias" => "t",
+        ],
+        [
+          "id" => "3",
+          "alias" => "j",
+        ],
+      ],
+      "properties" => [
+        [
+          "resource" => "t",
+          "property" => "state",
+        ],
+        [
+          "resource" => "t",
+          "property" => "year",
+        ],
+        [
+          "resource" => "j",
+          "property" => "color",
+        ],
+      ],
+      "joins" => [
+        [
+          "resource" => 'j',
+          "condition" => [
+            'resource' => 't',
+            'property' => 'year',
+            'value' => [
+              'resource' => 'j',
+              'property' => 'year',
+            ],
+          ],
+        ],
+      ],
+      "format" => "csv",
+      "sorts" => [
+        [
+          'resource' => 'j',
+          'property' => 'color',
+          'order' => 'desc',
+        ],
+        [
+          'property' => 'year',
+          'order' => 'asc',
+        ],
+        [
+          'property' => 'state',
+          'order' => 'desc',
+        ],
+      ],
+    ];
     $this->queryResultCompare($data);
   }
 
@@ -122,7 +188,7 @@ class QueryDownloadControllerTest extends TestCase {
       "limit" => 1000,
     ]);
     // Need 2 json responses which get combined on output.
-    $container = $this->getQueryContainer(50);;
+    $container = $this->getQueryContainer(50);
     $webServiceApi = QueryDownloadController::create($container);
     $request = $this->mockRequest($data);
     $result = $webServiceApi->query($request);
@@ -199,7 +265,7 @@ class QueryDownloadControllerTest extends TestCase {
     $response = $queryController->query($request);
     $csv = $response->getContent();
 
-    $downloadController = QueryDownloadController::create($this->getQueryContainer(50));
+    $downloadController = QueryDownloadController::create($this->getQueryContainer(25));
     ob_start(['self', 'getBuffer']);
     $streamResponse = $downloadController->query($request);
     $streamResponse->sendContent();

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -9,6 +9,7 @@ use Drupal\Core\Cache\Context\CacheContextsManager;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Database\Driver\sqlite\Connection as SqliteConnection;
+use Drupal\datastore\Controller\QueryController;
 use MockChain\Options;
 use Drupal\datastore\Service;
 use PHPUnit\Framework\TestCase;
@@ -47,7 +48,7 @@ class QueryDownloadControllerTest extends TestCase {
    * Test streaming of a CSV file from database.
    */
   public function testStreamedQueryCsv() {
-    $data = json_encode([
+    $data = [
       "resources" => [
         [
           "id" => "2",
@@ -55,23 +56,39 @@ class QueryDownloadControllerTest extends TestCase {
         ],
       ],
       "format" => "csv",
-    ]);
+    ];
     // Need 2 json responses which get combined on output.
-    $container = $this->getQueryContainer()->getMock();
-    $webServiceApi = QueryDownloadController::create($container);
-    $request = $this->mockRequest($data);
-    ob_start(['self', 'getBuffer']);
-    $result = $webServiceApi->query($request);
-    $result->sendContent();
+    $this->queryResultCompare($data);
+  }
 
-    $csv = explode("\n", trim($this->buffer));
-    ob_get_clean();
-    // Basic integrity checks.
-    $this->assertEquals('state,year', $csv[0]);
-    $this->assertEquals('Alabama,2010', $csv[1]);
-    $this->assertEquals('Wyoming,2010', $csv[50]);
-    $this->assertEquals('Arkansas,2014', $csv[105]);
-    $this->assertEquals(count($csv), 106);
+  /**
+   * Test streaming of a CSV file from database.
+   */
+  public function testStreamedOtherSortCsv() {
+    $data = [
+      "resources" => [
+        [
+          "id" => "2",
+          "alias" => "t",
+        ],
+      ],
+      "format" => "csv",
+      "properties" => ["state", "year"],
+      "sorts" => [
+        [
+          'property' => 'state',
+          'order' => 'desc',
+        ],
+        [
+          'property' => 'year',
+          'order' => 'asc',
+        ],
+      ],
+      "rowIds" => TRUE,
+    ];
+
+    // Need 2 json responses which get combined on output.
+    $this->queryResultCompare($data);
   }
 
   /**
@@ -87,7 +104,29 @@ class QueryDownloadControllerTest extends TestCase {
       ],
     ]);
     // Need 2 json responses which get combined on output.
-    $container = $this->getQueryContainer()->getMock();
+    $container = $this->getQueryContainer(50);
+    $webServiceApi = QueryDownloadController::create($container);
+    $request = $this->mockRequest($data);
+    $result = $webServiceApi->query($request);
+    $this->assertEquals(400, $result->getStatusCode());
+  }
+
+  /**
+   * Test CSV stream request with a limit (not allowed).
+   */
+  public function testStreamedLimit() {
+    $data = json_encode([
+      "resources" => [
+        [
+          "id" => "2",
+          "alias" => "t",
+        ],
+      ],
+      "format" => "csv",
+      "limit" => 1000,
+    ]);
+    // Need 2 json responses which get combined on output.
+    $container = $this->getQueryContainer(50);;
     $webServiceApi = QueryDownloadController::create($container);
     $request = $this->mockRequest($data);
     $result = $webServiceApi->query($request);
@@ -98,7 +137,7 @@ class QueryDownloadControllerTest extends TestCase {
    * Ensure that CSV header correct if columns specified.
    */
   public function testStreamedCsvSpecificColumns() {
-    $data = json_encode([
+    $data = [
       "resources" => [
         [
           "id" => "2",
@@ -106,19 +145,36 @@ class QueryDownloadControllerTest extends TestCase {
         ],
       ],
       "format" => "csv",
-      "properties" => ["record_number", "state"],
-    ]);
+      "properties" => ["state", "year"],
+    ];
+    $this->queryResultCompare($data);
+  }
 
-    $container = $this->getQueryContainer()->getMock();
-    $webServiceApi = QueryDownloadController::create($container);
-    $request = $this->mockRequest($data);
-    ob_start(['self', 'getBuffer']);
-    $result = $webServiceApi->query($request);
-    $result->sendContent();
+  /**
+   * Ensure that pagination and CSV header correct if resource-specific columns.
+   */
+  public function testStreamedCsvResourceColumns() {
+    $data = [
+      "resources" => [
+        [
+          "id" => "2",
+          "alias" => "t",
+        ],
+      ],
+      "format" => "csv",
+      "properties" => [
+        [
+          "resource" => "t",
+          "property" => "state",
+        ],
+        [
+          "resource" => "t",
+          "property" => "year",
+        ],
+      ],
+    ];
 
-    $csv = explode("\n", $this->buffer);
-    ob_get_clean();
-    $this->assertEquals('record_number,state', $csv[0]);
+    $this->queryResultCompare($data);
   }
 
 
@@ -126,7 +182,7 @@ class QueryDownloadControllerTest extends TestCase {
    * Ensure that rowIds appear correctly if requested.
    */
   public function testStreamedCsvRowIds() {
-    $data = json_encode([
+    $data = [
       "resources" => [
         [
           "id" => "2",
@@ -134,20 +190,28 @@ class QueryDownloadControllerTest extends TestCase {
         ],
       ],
       "format" => "csv",
-      "rowIds" => true,
-    ]);
+      "rowIds" => TRUE,
+    ];
 
-    $container = $this->getQueryContainer()->getMock();
-    $webServiceApi = QueryDownloadController::create($container);
+    $this->queryResultCompare($data);
+  }
+
+  private function queryResultCompare($data) {
     $request = $this->mockRequest($data);
-    ob_start(['self', 'getBuffer']);
-    $result = $webServiceApi->query($request);
-    $result->sendContent();
 
-    $csv = explode("\n", $this->buffer);
+    $queryController = QueryController::create($this->getQueryContainer(500));
+    $response = $queryController->query($request);
+    $csv = $response->getContent();
+
+    $downloadController = QueryDownloadController::create($this->getQueryContainer(50));
+    ob_start(['self', 'getBuffer']);
+    $streamResponse = $downloadController->query($request);
+    $streamResponse->sendContent();
+    $streamedCsv = $this->buffer;
     ob_get_clean();
-    $this->assertEquals('record_number,state,year', $csv[0]);
-    $this->assertEquals('112,Wyoming,2010', $csv[50]);
+
+    $this->assertEquals(107, count(explode("\n", $streamedCsv)));
+    $this->assertEquals($csv, $streamedCsv);
   }
 
   /**
@@ -159,7 +223,7 @@ class QueryDownloadControllerTest extends TestCase {
    * @return \MockChain\Chain
    *   MockChain chain object.
    */
-  private function getQueryContainer(array $info = []) {
+  private function getQueryContainer(int $rowLimit) {
     $options = (new Options())
       ->add("dkan.metastore.storage", DataFactory::class)
       ->add("dkan.datastore.service", Service::class)
@@ -169,9 +233,27 @@ class QueryDownloadControllerTest extends TestCase {
       ->add('dkan.metastore.api_response', MetastoreApiResponse::class)
       ->index(0);
 
+    $connection = new SqliteConnection(new \PDO('sqlite::memory:'), []);
+
+    $schema2 = [
+      'record_number' => ['type' => 'int', 'not null' => TRUE],
+      'state' => ['type' => 'text'],
+      'year' => ['type' => 'int'],
+    ];
+    $schema3 = [
+      'record_number' => ['type' => 'int', 'not null' => TRUE],
+      'year' => ['type' => 'int'],
+      'color' => ['type' => 'text'],
+    ];
+    $storageMap = [
+      't' => $this->mockDatastoreTable($connection, "2", 'states_with_dupes.csv', $schema2),
+      'j' => $this->mockDatastoreTable($connection, "3", 'years_colors.csv', $schema3
+      ),
+    ];
+
     $chain = (new Chain($this))
       ->add(Container::class, "get", $options)
-      ->add(DatasetInfo::class, "gather", $info)
+      ->add(DatasetInfo::class, "gather", [])
       ->add(MetastoreApiResponse::class, 'getMetastoreItemFactory', NodeDataFactory::class)
       ->add(MetastoreApiResponse::class, 'addReferenceDependencies', NULL)
       ->add(NodeDataFactory::class, 'getInstance', Data::class)
@@ -179,10 +261,10 @@ class QueryDownloadControllerTest extends TestCase {
       ->add(Data::class, 'getCacheTags', ['node:1'])
       ->add(Data::class, 'getCacheMaxAge', 0)
       ->add(ConfigFactoryInterface::class, 'get', ImmutableConfig::class)
-      ->add(Service::class, "getQueryStorageMap", ['t' => $this->mockDatastoreTable()])
-      ->add(ImmutableConfig::class, 'get', 50);
+      ->add(Service::class, "getQueryStorageMap", $storageMap)
+      ->add(ImmutableConfig::class, 'get', $rowLimit);
 
-    return $chain;
+    return $chain->getMock();
   }
 
   /**
@@ -192,7 +274,13 @@ class QueryDownloadControllerTest extends TestCase {
    *   Request body.
    */
   public function mockRequest($data = '') {
-    return Request::create("http://example.com", 'POST', [], [], [], [], $data);
+    if (is_array($data) || is_object($data)) {
+      $body = json_encode($data);
+    }
+    else{
+      $body = $data;
+    }
+    return Request::create("http://example.com", 'POST', [], [], [], [], $body);
   }
 
   /**
@@ -206,26 +294,32 @@ class QueryDownloadControllerTest extends TestCase {
    * @return \Drupal\common\Storage\DatabaseTableInterface
    *   A database table storage class useable for datastore queries.
    */
-  public function mockDatastoreTable() {
-    $connection = new SqliteConnection(new \PDO('sqlite::memory:'), []);
-    $connection->query('CREATE TABLE `datastore_2` (`record_number` INTEGER NOT NULL, state TEXT, year INT);');
+  public function mockDatastoreTable($connection, $id, $csvFile, $fields) {
+    foreach ($fields as $name => $field) {
+      $types[] = $field['type'];
+      $notNull = $field['not null'] ?? FALSE;
+      $createFields[] = "`$name` " . strtoupper($field['type']) . (($notNull) ? ' NOT NULL' : '');
+    }
+    $createFieldsStr = implode(", ", $createFields);
+    $connection->query("CREATE TABLE `datastore_$id` ($createFieldsStr);");
 
     $sampleData = [];
-    $fp = fopen(__DIR__ . '/../../../data/states_with_dupes.csv', 'rb');
+    $fp = fopen(__DIR__ . "/../../../data/$csvFile", 'rb');
     while (!feof($fp)) {
       $sampleData[] = fgetcsv($fp);
     }
     foreach ($sampleData as $row) {
-      $connection->query("INSERT INTO `datastore_2` VALUES ($row[0], '$row[1]', $row[2]);");
+      $values = [];
+      foreach ($row as $key => $value) {
+        $values[] = $types[$key] == "int" ? $value : "'$value'";
+        $valuesStr = implode(", ", $values);
+      }
+      $connection->query("INSERT INTO `datastore_$id` VALUES ($valuesStr);");
     }
 
-    $storage = new SqliteDatabaseTable($connection, new Resource("2", "data.csv", "text/csv"));
+    $storage = new SqliteDatabaseTable($connection, new Resource($id, "data-$id.csv", "text/csv"));
     $storage->setSchema([
-      'fields' => [
-        'record_number' => ['type' => 'int', 'not null' => TRUE],
-        'state' => ['type' => 'text'],
-        'year' => ['type' => 'int'],
-      ],
+      'fields' => $fields,
     ]);
     return $storage;
   }

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -73,7 +73,7 @@ class QueryDownloadControllerTest extends TestCase {
         ],
       ],
       "format" => "csv",
-      // "properties" => ["state", "year"],
+      "properties" => ["state", "year"],
       "sorts" => [
         [
           'property' => 'state',

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -77,10 +77,6 @@ class QueryDownloadControllerTest extends TestCase {
       "sorts" => [
         [
           'property' => 'state',
-          'order' => 'desc',
-        ],
-        [
-          'property' => 'year',
           'order' => 'asc',
         ],
       ],
@@ -196,7 +192,7 @@ class QueryDownloadControllerTest extends TestCase {
     $this->queryResultCompare($data);
   }
 
-  private function queryResultCompare($data) {
+  private function queryResultCompare($data, $countOnly = FALSE) {
     $request = $this->mockRequest($data);
 
     $queryController = QueryController::create($this->getQueryContainer(500));
@@ -210,8 +206,10 @@ class QueryDownloadControllerTest extends TestCase {
     $streamedCsv = $this->buffer;
     ob_get_clean();
 
-    $this->assertEquals(107, count(explode("\n", $streamedCsv)));
-    $this->assertEquals($csv, $streamedCsv);
+    $this->assertEquals(count(explode("\n", $csv)), count(explode("\n", $streamedCsv)));
+    if (!$countOnly) {
+      $this->assertEquals($csv, $streamedCsv);
+    }
   }
 
   /**
@@ -277,7 +275,7 @@ class QueryDownloadControllerTest extends TestCase {
     if (is_array($data) || is_object($data)) {
       $body = json_encode($data);
     }
-    else{
+    else {
       $body = $data;
     }
     return Request::create("http://example.com", 'POST', [], [], [], [], $body);

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -84,7 +84,6 @@ class QueryDownloadControllerTest extends TestCase {
           'order' => 'desc',
         ],
       ],
-      'rowIds' => TRUE,
     ];
 
     // Need 2 json responses which get combined on output.


### PR DESCRIPTION
Starting a cleaner PR to replace #3692. See that PR body for discussion of the performance gains from switching from OFFSET to WHERE for pagination. Briefly, initial tests of swapping the offset iterator for one that used a ">" condition based on the record_number column from the previous row of results gave us these very impressive benchmarks for streaming a 460mb CSV file locally:

|Limit|Offset|Duration|
|-|-|-|
|500|✔️|3:31:05|
|500|❌|2:04|
|20,000|✔️|6:52| 
|20,000|❌|1:18|

The iterator function in #3692 was only a few lines of code and could not accommodate many queries, particularly those with sorting. This new approach is based on ideas from [this discussion](https://stackoverflow.com/questions/56719611/generic-sql-predicate-to-use-for-keyset-pagination-on-multiple-fields) on efficient pagination with multiple ORDER BY clauses.

It introduces a new utility class called QueryIterator that adds record_number property, new sorts and conditions to iterate through multiple pages of results in the streaming response callback for downloading large CSVs. In addition to improved performance, this makes the streaming code more readable.

## Known issues

Because the query is broken up into many pages and simply iterates until no more results are returned, we cannot accept a limit in the query itself. This is not actually a regression, as the previous CSV streaming code overwrote the limit and streamed the full result set anyway. This could be corrected in a future improvement by storing the limit in a local variable before overwriting it in the DatastoreQuery object, keeping a running count of the number of rows returned, and stopping the iterator once that count matches the limit. This would require also changing the validation for the limit property in the DatastoreQuery schema, which currently has a maximum value of whatever the row limit is set to in the DKAN config.

Also, while in most cases the results returned by the QueryIterator should match those returned by the normal query endpoints exactly, there may be some differences with queries that sort by columns that do not have unique values, as the iterator will always sort by record_number in addition to any other sorts. The only way to correct this would be to append a record_number sort to all other queries as well, perhaps moving that particular function from the QueryIterator directly to the main datastore service.