### PR TITLE
Unbuffered datastore queries for download

### DIFF
--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -224,21 +224,27 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    *   Query object.
    * @param string $alias
    *   (Optional) alias for primary table.
+   * @param bool $fetch
+   *   Fetch the rows if true, just return the result statement if not.
+   *
+   * @return array|\Drupal\Core\Database\StatementInterface
+   *   Array of results if $fetch is true, otherwise result of
+   *   Select::execute() (prepared Statement object or null).
    */
-  public function query(Query $query, string $alias = 't'): array {
+  public function query(Query $query, string $alias = 't', $fetch = TRUE) {
     $this->setTable();
     $query->collection = $this->getTableName();
     $selectFactory = new SelectFactory($this->connection, $alias);
     $db_query = $selectFactory->create($query);
 
     try {
-      $result = $db_query->execute()->fetchAll();
+      $result = $db_query->execute();
     }
     catch (DatabaseExceptionWrapper $e) {
       throw new \Exception($this->sanitizedErrorMessage($e->getMessage()));
     }
 
-    return $result;
+    return $fetch ? $result->fetchAll() : $result;
   }
 
   /**

--- a/modules/common/src/Storage/Query.php
+++ b/modules/common/src/Storage/Query.php
@@ -68,7 +68,7 @@ class Query implements
    *
    * @var int|null
    */
-  public $limit = 500;
+  public $limit;
 
   /**
    * Number of records to offset by or skip before returning first record.

--- a/modules/common/src/Storage/SelectFactory.php
+++ b/modules/common/src/Storage/SelectFactory.php
@@ -330,13 +330,11 @@ class SelectFactory {
    *   A DKAN query object.
    */
   private function setQueryLimitAndOffset(Select $db_query, Query $query) {
-    if (isset($query->limit)) {
-      if (isset($query->offset)) {
-        $db_query->range($query->offset, $query->limit);
-      }
-      else {
-        $db_query->range(0, $query->limit);
-      }
+    if (isset($query->limit) && $query->limit !== NULL) {
+      $db_query->range(($query->offset ?? 0), ($query->limit));
+    }
+    elseif (isset($query->offset) && $query->offset) {
+      $db_query->range(($query->offset));
     }
   }
 

--- a/modules/common/tests/src/Unit/Storage/QueryDataProvider.php
+++ b/modules/common/tests/src/Unit/Storage/QueryDataProvider.php
@@ -65,7 +65,7 @@ class QueryDataProvider {
         return $query;
 
       case self::SQL:
-        return "SELECT t.* FROM {table} t LIMIT 500 OFFSET 0";
+        return "SELECT t.* FROM {table} t";
 
       case self::EXCEPTION:
         return FALSE;
@@ -428,7 +428,7 @@ class QueryDataProvider {
         return $query;
 
       case self::SQL:
-        return "LIMIT 500 OFFSET 5";
+        return "OFFSET 5";
 
       case self::EXCEPTION:
         return FALSE;

--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -37,7 +37,7 @@ services:
     arguments: ['datastore']
 
   dkan.datastore.database:
-    class: \Drupal\datastore\Storage\DatabaseTableFactory
+    class: \Drupal\Core\Database\Connection
     factory: \Drupal\datastore\Storage\DatabaseConnectionFactory::getConnection
 
   dkan.datastore.database_table_factory:

--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -36,10 +36,14 @@ services:
     parent: logger.channel_base
     arguments: ['datastore']
 
+  dkan.datastore.database:
+    class: \Drupal\datastore\Storage\DatabaseTableFactory
+    factory: \Drupal\datastore\Storage\DatabaseConnectionFactory::getConnection
+
   dkan.datastore.database_table_factory:
     class: \Drupal\datastore\Storage\DatabaseTableFactory
     arguments:
-      - '@database'
+      - '@dkan.datastore.database'
     calls:
       - [setIndexManager, ['@?indexer.indexmanager']]
 

--- a/modules/datastore/docs/query.json
+++ b/modules/datastore/docs/query.json
@@ -74,8 +74,7 @@
         },
         "limit": {
             "type": "integer",
-            "description": "Limit for maximum number of records returned. Pass zero for no limit (may be restricted by user permissions).",
-            "default": 500
+            "description": "Limit for maximum number of records returned. Pass zero for no limit (may be restricted by user permissions)."
         },
         "offset": {
             "type": "integer",

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -44,7 +44,6 @@ class QueryController extends AbstractQueryController {
       default:
         return $this->metastoreApiResponse->cachedJsonResponse($result->{"$"}, 200, $dependencies, $params);
     }
-
   }
 
   /**

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -3,7 +3,6 @@
 namespace Drupal\datastore\Controller;
 
 use Drupal\datastore\Service\DatastoreQuery;
-use Drupal\datastore\Util\QueryIterator;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use RootedData\RootedJsonData;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -103,8 +102,8 @@ class QueryDownloadController extends AbstractQueryController {
    *
    * @param resource $handle
    *   The file handler.
-   * @param array $rows
-   *   Rows of data to send as CSV.
+   * @param array $row
+   *   Row of data to send as CSV.
    */
   private function sendRow($handle, array $row) {
     fputcsv($handle, $row);

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -3,6 +3,7 @@
 namespace Drupal\datastore\Controller;
 
 use Drupal\datastore\Service\DatastoreQuery;
+use Drupal\datastore\Util\QueryIterator;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use RootedData\RootedJsonData;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -15,19 +16,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 class QueryDownloadController extends AbstractQueryController {
 
   /**
-   * Stream a CSV response.
-   *
-   * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
-   *   A datastore query object.
-   * @param \RootedData\RootedJsonData $result
-   *   The result of the datastore query.
-   * @param array $dependencies
-   *   A dependency array for use by \Drupal\metastore\MetastoreApiResponse.
-   * @param \Symfony\Component\HttpFoundation\ParameterBag|null $params
-   *   The parameter object from the request.
-   *
-   * @return \Symfony\Component\HttpFoundation\Response
-   *   The json response.
+   * {@inheritdoc}
    */
   public function formatResponse(
     DatastoreQuery $datastoreQuery,
@@ -49,6 +38,21 @@ class QueryDownloadController extends AbstractQueryController {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  protected function buildDatastoreQuery($request, $identifier = NULL) {
+    $json = static::getPayloadJson($request);
+    $data = json_decode($json);
+    $this->additionalPayloadValidation($data);
+    if ($identifier) {
+      $resource = (object) ["id" => $identifier, "alias" => "t"];
+      $data->resources = [$resource];
+    }
+    $data->results = FALSE;
+    return new DatastoreQuery(json_encode($data));
+  }
+
+  /**
    * Set up the Streamed Response callback.
    *
    * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
@@ -63,59 +67,21 @@ class QueryDownloadController extends AbstractQueryController {
     $response = $this->initStreamedCsvResponse();
 
     $response->setCallback(function () use ($result, $datastoreQuery) {
-      $count = $result->{'$.count'};
-      $rows = $result->{'$.results'};
-      array_unshift($rows, $this->getHeaderRow($result));
-
+      // Open the stream and send the header.
       set_time_limit(0);
       $handle = fopen('php://output', 'wb');
-      $this->sendRows($handle, $rows);
+      $this->sendRow($handle, [$this->getHeaderRow($result)]);
 
-      // If we've already sent the full result set we can end now.
-      $progress = (count($rows) - 1);
-      if ($count <= $progress) {
-        fclose($handle);
-        return TRUE;
+      // Otherwise, we're going to redo as an iterator from the beginning.
+      $result = $this->datastoreService->runResultsQuery($datastoreQuery, FALSE);
+
+      while ($row = $result->fetchAssoc()) {
+        $this->sendRow($handle, array_values($row));
       }
-
-      // Otherwise, we iterate.
-      $this->streamIterate($result, $datastoreQuery, $handle);
 
       fclose($handle);
     });
     return $response;
-  }
-
-  /**
-   * Iterator for CSV streaming.
-   *
-   * @param \RootedData\RootedJsonData $result
-   *   The result data from the initial query.
-   * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
-   *   The unmodified datastore query object.
-   * @param resource $handle
-   *   The PHP output stream.
-   */
-  private function streamIterate(RootedJsonData $result, DatastoreQuery $datastoreQuery, $handle) {
-    $pageCount = $progress = count($result->{'$.results'});
-    $pageLimit = $this->getRowsLimit();
-    $iteratorQuery = clone $datastoreQuery;
-
-    // Disable extra information in response.
-    $iteratorQuery->{"$.count"} = FALSE;
-    $iteratorQuery->{"$.schema"} = FALSE;
-    $iteratorQuery->{"$.keys"} = FALSE;
-
-    $i = 1;
-    while ($pageCount >= $pageLimit) {
-      $iteratorQuery->{"$.offset"} = $pageLimit * $i;
-      $result = $this->datastoreService->runQuery($iteratorQuery);
-      $rows = $result->{"$.results"};
-      $this->sendRows($handle, $rows);
-      $pageCount = count($rows);
-      $progress += $pageCount;
-      $i++;
-    }
   }
 
   /**
@@ -140,10 +106,8 @@ class QueryDownloadController extends AbstractQueryController {
    * @param array $rows
    *   Rows of data to send as CSV.
    */
-  private function sendRows($handle, array $rows) {
-    foreach ($rows as $row) {
-      fputcsv($handle, $row);
-    }
+  private function sendRow($handle, array $row) {
+    fputcsv($handle, $row);
     ob_flush();
     flush();
   }
@@ -170,6 +134,11 @@ class QueryDownloadController extends AbstractQueryController {
     if (empty($header_row) || !is_array($header_row)) {
       throw new \Exception("Could not generate header for CSV.");
     }
+    array_walk($header_row, function (&$header) {
+      if (is_array($header)) {
+        $header = $header['alias'] ?? $header['property'];
+      }
+    });
     return $header_row;
   }
 

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -69,7 +69,7 @@ class QueryDownloadController extends AbstractQueryController {
       // Open the stream and send the header.
       set_time_limit(0);
       $handle = fopen('php://output', 'wb');
-      $this->sendRow($handle, [$this->getHeaderRow($result)]);
+      $this->sendRow($handle, $this->getHeaderRow($result));
 
       // Otherwise, we're going to redo as an iterator from the beginning.
       $result = $this->datastoreService->runResultsQuery($datastoreQuery, FALSE);

--- a/modules/datastore/src/Service.php
+++ b/modules/datastore/src/Service.php
@@ -325,10 +325,10 @@ class Service implements ContainerInjectionInterface {
    * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
    *   DatastoreQuery object.
    *
-   * @return array
-   *   Array of result objects.
+   * @return array|\Drupal\Core\Database\StatementInterface|
+   *   Array of result objects or result statement of $fetch is false.
    */
-  private function runResultsQuery(DatastoreQuery $datastoreQuery) {
+  public function runResultsQuery(DatastoreQuery $datastoreQuery, $fetch = TRUE) {
     $primaryAlias = $datastoreQuery->{"$.resources[0].alias"};
     if (!$primaryAlias) {
       return [];
@@ -344,9 +344,9 @@ class Service implements ContainerInjectionInterface {
 
     $query = QueryFactory::create($datastoreQuery, $storageMap);
 
-    $result = $storageMap[$primaryAlias]->query($query, $primaryAlias);
+    $result = $storageMap[$primaryAlias]->query($query, $primaryAlias, $fetch);
 
-    if ($datastoreQuery->{"$.keys"} === FALSE) {
+    if ($datastoreQuery->{"$.keys"} === FALSE && is_array($result)) {
       $result = array_map([$this, 'stripRowKeys'], $result);
     }
     return $result;

--- a/modules/datastore/src/Service.php
+++ b/modules/datastore/src/Service.php
@@ -327,7 +327,7 @@ class Service implements ContainerInjectionInterface {
    * @param bool $fetch
    *   Perform fetchAll and return array if true, else just statement (cursor).
    *
-   * @return array|\Drupal\Core\Database\StatementInterface|
+   * @return array|\Drupal\Core\Database\StatementInterface
    *   Array of result objects or result statement of $fetch is false.
    */
   public function runResultsQuery(DatastoreQuery $datastoreQuery, $fetch = TRUE) {

--- a/modules/datastore/src/Service.php
+++ b/modules/datastore/src/Service.php
@@ -324,6 +324,8 @@ class Service implements ContainerInjectionInterface {
    *
    * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
    *   DatastoreQuery object.
+   * @param bool $fetch
+   *   Perform fetchAll and return array if true, else just statement (cursor).
    *
    * @return array|\Drupal\Core\Database\StatementInterface|
    *   Array of result objects or result statement of $fetch is false.

--- a/modules/datastore/src/Service/DatastoreQuery.php
+++ b/modules/datastore/src/Service/DatastoreQuery.php
@@ -14,14 +14,16 @@ class DatastoreQuery extends RootedJsonData {
    *
    * @param string $json
    *   JSON query string from API payload.
-   * @param int $rows_limit
+   * @param int|null $rows_limit
    *   Maxmimum rows of data to return.
    */
-  public function __construct(string $json, int $rows_limit = 500) {
+  public function __construct(string $json, $rows_limit = NULL) {
     $schema = file_get_contents(__DIR__ . "/../../docs/query.json");
     $q = json_decode($schema);
-    $q->properties->limit->maximum = $rows_limit;
-    $q->properties->limit->default = $rows_limit;
+    if ($rows_limit !== NULL) {
+      $q->properties->limit->maximum = $rows_limit;
+      $q->properties->limit->default = $rows_limit;
+    }
     $schema = json_encode($q);
     parent::__construct($json, $schema);
     $this->populateDefaults();

--- a/modules/datastore/src/Storage/DatabaseConnectionFactory.php
+++ b/modules/datastore/src/Storage/DatabaseConnectionFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\datastore\Storage;
+
+use Drupal\Core\Database\Database;
+
+/**
+ * Create second datastore endpoint at runtime with unbuffered queries.
+ *
+ * @return \Drupal\Core\Database\Connection
+ *   New datastore connection object.
+ */
+class DatabaseConnectionFactory {
+
+  /**
+   * Gets the connection object for the specified database key and target.
+   */
+  public static function getConnection() {
+    $info = Database::getConnectionInfo();
+    $datastoreInfo = $info['default'];
+    $datastoreInfo['pdo'][\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = FALSE;
+    Database::addConnectionInfo('datastore', 'default', $datastoreInfo);
+    return Database::getConnection('default', 'datastore');
+  }
+
+}

--- a/modules/datastore/src/Storage/QueryFactory.php
+++ b/modules/datastore/src/Storage/QueryFactory.php
@@ -66,8 +66,10 @@ class QueryFactory {
     $this->populateQueryConditions($query);
     $this->populateQueryJoins($query);
     $this->populateQuerySorts($query);
-    $query->limit = $this->datastoreQuery->{"$.limit"};
-    $query->offset = $this->datastoreQuery->{"$.offset"};
+    if ($this->datastoreQuery->{"$.limit"}) {
+      $query->limit = $this->datastoreQuery->{"$.limit"};
+    }
+    $query->offset = $this->datastoreQuery->{"$.offset"} ?? 0;
     $query->showDbColumns = TRUE;
 
     return $query;

--- a/modules/datastore/tests/data/years_colors.csv
+++ b/modules/datastore/tests/data/years_colors.csv
@@ -1,0 +1,6 @@
+1,2010,red
+2,2011,green
+3,2012,blue
+4,2013,indigo
+5,2014,violet
+6,2015,ultraviolet


### PR DESCRIPTION
Another approach to #3646. Previously we'd been trying to optimize our CSV streaming by breaking up the query into multiple chunks, but adding any sorting to queries on columns other than the primary key does not scale with this. Sorting large tables will always be slow, and will need to be repeated on every iteration. This may only add a few seconds, but as tables get larger that time increases _and_ the number of times it is repeated increases.

A better solution may be to use [unbuffered queries](https://www.php.net/manual/en/mysqlinfo.concepts.buffering.php), to run the entire query just once and then stream the results directly from the database server. By default, Drupal and most other PHP/MySQL projects will always use buffered queries, meaning that the entire result set is passed to PHP immediately.

Here, we create a second database connection object based on default but adding the `PDO::MYSQL_ATTR_USE_BUFFERED_QUERY` attribute. This will be used by all datastore module database operations, which should be fine but we should look out for any unexpected side effects. 

## Known issues, misc

This adds to the pieces of DKAN that assume we are using MySQL as the underlying database. It would be good to have a fallback in case not, or to make it more obvious how one might add support for PostgreSQL or other PDO drivers. Most database backends have some equivalent to this cursor-based fetching, but it's not standardized in PDO.

## QA Steps

Coming... in general, just download some big CSVs and make sure they work!