### PR TITLE
Catch case changes in file names when harvesting

### DIFF
--- a/modules/common/src/Storage/Query.php
+++ b/modules/common/src/Storage/Query.php
@@ -119,12 +119,14 @@ class Query implements
    *   Property to filter on.
    * @param string $value
    *   Property value to filter against.
+   * @param bool $case
+   *   Case sensitive filter?
    */
-  public function conditionByIsEqualTo(string $property, string $value) {
+  public function conditionByIsEqualTo(string $property, string $value, bool $case = FALSE) {
     $this->conditions[] = (object) [
       'property' => $property,
       'value' => $value,
-      'operator' => 'LIKE',
+      'operator' => $case ? 'LIKE BINARY' : 'LIKE',
     ];
   }
 

--- a/modules/common/tests/src/Unit/Storage/SelectFactoryTest.php
+++ b/modules/common/tests/src/Unit/Storage/SelectFactoryTest.php
@@ -31,6 +31,23 @@ class SelectFactoryTest extends TestCase {
       $this->assertContains($sql, $this->selectToString($db_query));
     }
   }
+  
+  /**
+   * Test two variations of Query::testConditionByIsEqualTo()
+   */
+  public function testConditionByIsEqualTo() {
+    $query = new Query();
+    $query->conditionByIsEqualTo('prop1', 'value1');
+    $db_query = $this->selectFactory->create($query);
+    $this->assertStringContainsString('t.prop1 LIKE :db_condition_placeholder_0', $this->selectToString($db_query));
+  }
+
+  public function testConditionByIsEqualToCaseInsensitive() {
+    $query = new Query();
+    $query->conditionByIsEqualTo('prop1', 'value1', TRUE);
+    $db_query2 = $this->selectFactory->create($query2);
+    $this->assertStringContainsString('t.prop1 LIKE BINARY :db_condition_placeholder_0', $this->selectToString($db_query2));
+  }
 
   /**
    *

--- a/modules/common/tests/src/Unit/Storage/SelectFactoryTest.php
+++ b/modules/common/tests/src/Unit/Storage/SelectFactoryTest.php
@@ -45,8 +45,8 @@ class SelectFactoryTest extends TestCase {
   public function testConditionByIsEqualToCaseInsensitive() {
     $query = new Query();
     $query->conditionByIsEqualTo('prop1', 'value1', TRUE);
-    $db_query2 = $this->selectFactory->create($query2);
-    $this->assertStringContainsString('t.prop1 LIKE BINARY :db_condition_placeholder_0', $this->selectToString($db_query2));
+    $db_query = $this->selectFactory->create($query);
+    $this->assertStringContainsString('t.prop1 LIKE BINARY :db_condition_placeholder_0', $this->selectToString($db_query));
   }
 
   /**

--- a/modules/metastore/src/ResourceMapper.php
+++ b/modules/metastore/src/ResourceMapper.php
@@ -227,7 +227,7 @@ class ResourceMapper {
    */
   public function filePathExists($filePath) {
     $query = new Query();
-    $query->conditionByIsEqualTo('filePath', $filePath);
+    $query->conditionByIsEqualTo('filePath', $filePath, TRUE);
     $results = $this->getStore()->query($query);
     if (!empty($results)) {
       throw new AlreadyRegistered(json_encode($results));


### PR DESCRIPTION
## QA Steps

* copy the h1.json.txt file from this ticket (drop the .txt) to your _/src/site/files_ directory
 * run `dktl drush dkan:harvest:register '\{"identifier":"h1","extract":{"type":"\\Harvest\\ETL\\Extract\\DataJson","uri":"http://dkan.localtest.me/sites/default/files/h1.json"},"transforms":[],"load":\{"type":"\\Drupal\\harvest\\Load\\Dataset"}}'`
 * then `dktl drush dkan:harvest:run h1`
 * look at the harvested dataset in the edit form, notice the case of the filename
 * edit the h1.json file: change downloadURL to 

"http://demo.getdkan.org/sites/default/files/distribution/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/bike_lane.csv"

  * run the harvest again
  * look at the dataset in the edit form, confirm the filepath was updated



[h1.json.txt](https://github.com/GetDKAN/dkan/files/7530904/h1.json.txt)


