### PR TITLE
Cache tags on dataset docs endpoint

### DIFF
--- a/modules/metastore/src/Controller/MetastoreController.php
+++ b/modules/metastore/src/Controller/MetastoreController.php
@@ -355,13 +355,20 @@ class MetastoreController implements ContainerInjectionInterface {
    *
    * @param string $identifier
    *   Dataset identifier.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request object.
    *
    * @return \Symfony\Component\HttpFoundation\JsonResponse
    *   A JSON response.
    */
-  public function getDocs($identifier) : JsonResponse {
+  public function getDocs($identifier, Request $request) : JsonResponse {
     try {
-      return $this->apiResponse->cachedJsonResponse($this->docs->getDatasetSpecific($identifier));
+      return $this->apiResponse->cachedJsonResponse(
+        $this->docs->getDatasetSpecific($identifier),
+        200,
+        ['dataset' => [$identifier]],
+        $request->query
+      );
     }
     catch (\Exception $e) {
       return $this->getResponseFromException($e);

--- a/modules/metastore/tests/src/Functional/MetastoreApiPageCacheTest.php
+++ b/modules/metastore/tests/src/Functional/MetastoreApiPageCacheTest.php
@@ -69,9 +69,13 @@ class MetastoreApiPageCacheTest extends ExistingSiteBase {
     // Request once, should not return cached version.
     $response = $client->request('GET', 'api/1/metastore/schemas/dataset/items/111');
     $this->assertEquals("MISS", $response->getHeaders()['X-Drupal-Cache'][0]);
+    $response = $client->request('GET', 'api/1/metastore/schemas/dataset/items/111/docs');
+    $this->assertEquals("MISS", $response->getHeaders()['X-Drupal-Cache'][0]);
 
     // Request again, should return cached version.
     $response = $client->request('GET', 'api/1/metastore/schemas/dataset/items/111');
+    $this->assertEquals("HIT", $response->getHeaders()['X-Drupal-Cache'][0]);
+    $response = $client->request('GET', 'api/1/metastore/schemas/dataset/items/111/docs');
     $this->assertEquals("HIT", $response->getHeaders()['X-Drupal-Cache'][0]);
 
     // Importing the datastore should invalidate the cache.
@@ -105,13 +109,15 @@ class MetastoreApiPageCacheTest extends ExistingSiteBase {
 
     // Editing the dataset should invalidate the cache.
     $datasetRootedJsonData->{'$.description'} = "Add a description.";
-    $datasetRootedJsonData->{'$.modified'} = "2021-04-06";
+    $datasetRootedJsonData->{'$.modified'} = "2021-05-07";
     $this->httpVerbHandler('put', $datasetRootedJsonData, json_decode($datasetRootedJsonData));
 
     // Importing the datastore should invalidate the cache.
     $this->runQueues($queues);
 
     $response = $client->request('GET', 'api/1/metastore/schemas/dataset/items/111');
+    $this->assertEquals("MISS", $response->getHeaders()['X-Drupal-Cache'][0]);
+    $response = $client->request('GET', 'api/1/metastore/schemas/dataset/items/111/docs');
     $this->assertEquals("MISS", $response->getHeaders()['X-Drupal-Cache'][0]);
     $response = $client->request('GET', 'api/1/datastore/query/111/0');
     $this->assertEquals("MISS", $response->getHeaders()['X-Drupal-Cache'][0]);

--- a/modules/metastore/tests/src/Unit/MetastoreControllerTest.php
+++ b/modules/metastore/tests/src/Unit/MetastoreControllerTest.php
@@ -108,7 +108,7 @@ class MetastoreControllerTest extends TestCase {
     $mockChain->add(DatasetApiDocs::class, 'getDatasetSpecific', $spec);
 
     $controller = MetastoreController::create($mockChain->getMock());
-    $response = $controller->getDocs(1);
+    $response = $controller->getDocs(1, new Request());
     $this->assertEquals($json, $response->getContent());
   }
 


### PR DESCRIPTION
Cache tags were not being applied to the dataset-specific openapi docs, causing inconsistencies in the docs section on dataset pages after an update.

## QA Steps

Replace the domain with what's appropriate for where you're testing. Use a site with the demo content loaded

1. Load docs twice and confirm that the X-Drupal-Cache header reports a `HIT`: `GET http://docscache.localtest.me/api/1/metastore/schemas/dataset/items/5dc1cfcf-8028-476c-a020-f58ec6dd621c/docs`

2. Make a change to the dataset:
```HTTP
PATCH http://docscache.localtest.me/api/1/metastore/schemas/dataset/items/5dc1cfcf-8028-476c-a020-f58ec6dd621c
Authorization: Basic admin:adminpassword

{
  "modified": "2021-05-08"
}
```

3. Load docs again and confirm you get a `MISS` on first request: `GET http://docscache.localtest.me/api/1/metastore/schemas/dataset/items/5dc1cfcf-8028-476c-a020-f58ec6dd621c/docs`