### PR TITLE
Migrate phpunit.xml to new schema

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,93 +1,89 @@
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.6/phpunit.xsd"
-    bootstrap="/var/www/vendor/weitzman/drupal-test-traits/src/bootstrap.php"
-    colors="true"
-    stopOnFailure="false"
-    stopOnError="false"
-    verbose="true">
-
-    <testsuites>
-        <testsuite name="DKAN Test Suite">
-            <directory>modules/common/tests/src</directory>
-            <directory>modules/metastore/tests/src</directory>
-            <directory>modules/metastore/modules/metastore/tests/src</directory>
-            <directory>modules/metastore/modules/metastore_search/tests/src</directory>
-            <directory>modules/metastore/modules/metastore_admin/tests/src</directory>
-            <directory>modules/datastore/tests/src</directory>
-            <directory>modules/datastore/modules/datastore_mysql_import/tests/src</directory>
-            <directory>modules/frontend/tests/src</directory>
-            <directory>modules/dkan_js_frontend/tests/src</directory>
-            <directory>modules/harvest/tests/src</directory>
-            <directory>modules/harvest/modules/harvest_dashboard/tests/src</directory>
-            <directory>modules/json_form_widget/tests/src</directory>
-            <directory>tests/src</directory>
-        </testsuite>
-        <testsuite name="DkanUnitTests">
-          <directory>tests/src/Unit</directory>
-          <directory>modules/common/tests/src/Unit</directory>
-          <directory>modules/metastore/tests/src/Unit</directory>
-          <directory>modules/metastore/modules/metastore/tests/src/Unit</directory>
-          <directory>modules/metastore/modules/metastore_search/tests/src/Unit</directory>
-          <directory>modules/metastore/modules/metastore_admin/tests/src/Unit</directory>
-          <directory>modules/datastore/tests/src/Unit</directory>
-          <directory>modules/datastore/modules/datastore_mysql_import/tests/src/Unit</directory>
-          <directory>modules/frontend/tests/src/Unit</directory>
-          <directory>modules/dkan_js_frontend/tests/src</directory>
-          <directory>modules/harvest/tests/src/Unit</directory>
-          <directory>modules/harvest/modules/harvest_dashboard/tests/src/Unit</directory>
-          <directory>modules/json_form_widget/tests/src/Unit</directory>
-        </testsuite>
-        <testsuite name="DkanFunctionalTests">
-          <directory>modules/common/tests/src/Functional</directory>
-          <directory>modules/metastore/tests/src/Functional</directory>
-          <directory>modules/metastore/modules/metastore/tests/src/Functional</directory>
-          <directory>modules/metastore/modules/metastore_search/tests/src/Functional</directory>
-          <directory>modules/metastore/modules/metastore_admin/tests/src/Functional</directory>
-          <directory>modules/datastore/tests/src/Functional</directory>
-          <directory>modules/frontend/tests/src/Functional</directory>
-          <directory>modules/dkan_js_frontend/tests/src</directory>
-          <directory>modules/harvest/tests/src/Functional</directory>
-          <directory>modules/harvest/modules/harvest_dashboard/tests/src/Functional</directory>
-          <directory>tests/src/Functional</directory>
-        </testsuite>
-    </testsuites>
-
-    <groups>
-        <exclude>
-            <group>requires-database</group>
-        </exclude>
-    </groups>
-
-    <php>
-        <!-- These variables may alternatively be set as environment variables. -->
-        <!-- E.g., `DRUPAL_VERSION=V8 ./vendor/bin/phpunit` -->
-        <env name="DRUPAL_ROOT" value="/var/www/docroot"/>
-        <env name="DTT_BASE_URL" value="http://web"/>
-        <env name="SIMPLETEST_BASE_URL" value="http://web"/>
-        <env name="SIMPLETEST_DB" value="mysql://drupal:123@db/drupal"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
-    </php>
-    <filter>
-        <!-- whitelist needed for code coverage generation to work -->
-        <whitelist>
-          <directory>modules/common/src</directory>
-          <directory>modules/metastore/src</directory>
-          <directory>modules/metastore/modules/metastore/src</directory>
-          <directory>modules/metastore/modules/metastore_search/src</directory>
-          <directory>modules/metastore/modules/metastore_admin/src</directory>
-          <directory>modules/datastore/src</directory>
-          <directory>modules/datastore/modules/datastore_fast_import/src</directory>
-          <directory>modules/frontend/src</directory>
-          <directory>modules/harvest/src</directory>
-          <directory>modules/harvest/modules/harvest_dashboard/src</directory>
-          <directory>modules/json_form_widget/src</directory>
-          <!-- By definition test classes have no tests. -->
-          <exclude>
-            <directory>modules/common/src/Tests</directory>
-            <directory suffix="Test.php">./</directory>
-            <directory suffix="TestBase.php">./</directory>
-          </exclude>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+  bootstrap="/var/www/vendor/weitzman/drupal-test-traits/src/bootstrap.php"
+  colors="true"
+  stopOnFailure="false"
+  stopOnError="false"
+  verbose="true">
+  <coverage>
+    <include>
+      <directory>modules/common/src</directory>
+      <directory>modules/metastore/src</directory>
+      <directory>modules/metastore/modules/metastore/src</directory>
+      <directory>modules/metastore/modules/metastore_search/src</directory>
+      <directory>modules/metastore/modules/metastore_admin/src</directory>
+      <directory>modules/datastore/src</directory>
+      <directory>modules/datastore/modules/datastore_fast_import/src</directory>
+      <directory>modules/frontend/src</directory>
+      <directory>modules/harvest/src</directory>
+      <directory>modules/harvest/modules/harvest_dashboard/src</directory>
+      <directory>modules/json_form_widget/src</directory>
+    </include>
+    <exclude>
+      <directory>modules/common/src/Tests</directory>
+      <directory suffix="Test.php">./</directory>
+      <directory suffix="TestBase.php">./</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="DKAN Test Suite">
+      <directory>modules/common/tests/src</directory>
+      <directory>modules/metastore/tests/src</directory>
+      <directory>modules/metastore/modules/metastore/tests/src</directory>
+      <directory>modules/metastore/modules/metastore_search/tests/src</directory>
+      <directory>modules/metastore/modules/metastore_admin/tests/src</directory>
+      <directory>modules/datastore/tests/src</directory>
+      <directory>modules/datastore/modules/datastore_mysql_import/tests/src</directory>
+      <directory>modules/frontend/tests/src</directory>
+      <directory>modules/dkan_js_frontend/tests/src</directory>
+      <directory>modules/harvest/tests/src</directory>
+      <directory>modules/harvest/modules/harvest_dashboard/tests/src</directory>
+      <directory>modules/json_form_widget/tests/src</directory>
+      <directory>tests/src</directory>
+    </testsuite>
+    <testsuite name="DkanUnitTests">
+      <directory>tests/src/Unit</directory>
+      <directory>modules/common/tests/src/Unit</directory>
+      <directory>modules/metastore/tests/src/Unit</directory>
+      <directory>modules/metastore/modules/metastore/tests/src/Unit</directory>
+      <directory>modules/metastore/modules/metastore_search/tests/src/Unit</directory>
+      <directory>modules/metastore/modules/metastore_admin/tests/src/Unit</directory>
+      <directory>modules/datastore/tests/src/Unit</directory>
+      <directory>modules/datastore/modules/datastore_mysql_import/tests/src/Unit</directory>
+      <directory>modules/frontend/tests/src/Unit</directory>
+      <directory>modules/dkan_js_frontend/tests/src</directory>
+      <directory>modules/harvest/tests/src/Unit</directory>
+      <directory>modules/harvest/modules/harvest_dashboard/tests/src/Unit</directory>
+      <directory>modules/json_form_widget/tests/src/Unit</directory>
+    </testsuite>
+    <testsuite name="DkanFunctionalTests">
+      <directory>modules/common/tests/src/Functional</directory>
+      <directory>modules/metastore/tests/src/Functional</directory>
+      <directory>modules/metastore/modules/metastore/tests/src/Functional</directory>
+      <directory>modules/metastore/modules/metastore_search/tests/src/Functional</directory>
+      <directory>modules/metastore/modules/metastore_admin/tests/src/Functional</directory>
+      <directory>modules/datastore/tests/src/Functional</directory>
+      <directory>modules/frontend/tests/src/Functional</directory>
+      <directory>modules/dkan_js_frontend/tests/src</directory>
+      <directory>modules/harvest/tests/src/Functional</directory>
+      <directory>modules/harvest/modules/harvest_dashboard/tests/src/Functional</directory>
+      <directory>tests/src/Functional</directory>
+    </testsuite>
+  </testsuites>
+  <groups>
+    <exclude>
+      <group>requires-database</group>
+    </exclude>
+  </groups>
+  <php>
+    <!-- These variables may alternatively be set as environment variables. -->
+    <!-- E.g., `DRUPAL_VERSION=V8 ./vendor/bin/phpunit` -->
+    <env name="DRUPAL_ROOT" value="/var/www/docroot"/>
+    <env name="DTT_BASE_URL" value="http://web"/>
+    <env name="SIMPLETEST_BASE_URL" value="http://web"/>
+    <env name="SIMPLETEST_DB" value="mysql://drupal:123@db/drupal"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+  </php>
 </phpunit>


### PR DESCRIPTION
We are running PHPUnit 9 now but still using the v4 schema.

## QA Steps

Just confirm PHPUnit tests run with the same number of assertions as last commit in 2.x (644 at last count) 

![image](https://user-images.githubusercontent.com/309671/141902382-ff02009b-88e7-4f73-ac17-72021588a269.png)
