### PR TITLE
Remove calls to deprecated 'destroy' method

### DIFF
--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -293,7 +293,7 @@ class DatabaseTableTest extends TestCase {
   /**
    *
    */
-  public function testDestroy() {
+  public function testDestruct() {
     $connectionChain = $this->getConnectionChain();
 
     $databaseTable = new DatabaseTable(

--- a/modules/harvest/src/Service.php
+++ b/modules/harvest/src/Service.php
@@ -142,14 +142,14 @@ class Service implements ContainerInjectionInterface {
   /**
    * Public.
    *
-   * @todo the destroy method should be part of some interface.
+   * @todo the destruct method should be part of some interface.
    */
   public function revertHarvest($id) {
     $run_store = $this->storeFactory->getInstance("harvest_{$id}_runs");
-    if (!method_exists($run_store, "destroy")) {
-      throw new \Exception("Storage of class " . get_class($run_store) . " does not implement destroy method.");
+    if (!method_exists($run_store, "destruct")) {
+      throw new \Exception("Storage of class " . get_class($run_store) . " does not implement destruct method.");
     }
-    $run_store->destroy();
+    $run_store->destruct();
     $harvester = $this->getHarvester($id);
     return $harvester->revert();
   }

--- a/modules/harvest/tests/src/Unit/ServiceTest.php
+++ b/modules/harvest/tests/src/Unit/ServiceTest.php
@@ -185,7 +185,7 @@ class ServiceTest extends TestCase {
               /**
                *
                */
-              public function destroy() {
+              public function destruct() {
                 $this->storage = [];
               }
 


### PR DESCRIPTION

- [X] Test coverage exists
- [X] Documentation exists

## QA Steps

- [ ] Ensure calling the `drush dkan:harvest:revert` command works.
- [ ] Ensure deleting a dataset clears out the `dkan_metastore_resource_mapper` and `jobstore` tables.
