### PR TITLE
Delay establishing datastore DB connection

### DIFF
--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -36,14 +36,13 @@ services:
     parent: logger.channel_base
     arguments: ['datastore']
 
-  dkan.datastore.database:
-    class: \Drupal\Core\Database\Connection
-    factory: \Drupal\datastore\Storage\DatabaseConnectionFactory::getConnection
+  dkan.datastore.database_connection_factory:
+    class: \Drupal\datastore\Storage\DatabaseConnectionFactory
 
   dkan.datastore.database_table_factory:
     class: \Drupal\datastore\Storage\DatabaseTableFactory
     arguments:
-      - '@dkan.datastore.database'
+      - '@dkan.datastore.database_connection_factory'
     calls:
       - [setIndexManager, ['@?indexer.indexmanager']]
 

--- a/modules/datastore/src/Plugin/QueueWorker/Import.php
+++ b/modules/datastore/src/Plugin/QueueWorker/Import.php
@@ -82,9 +82,9 @@ class Import extends QueueWorkerBase implements ContainerFactoryPluginInterface 
    *   A logger channel factory instance.
    * @param \Drupal\metastore\Reference\ReferenceLookup $referenceLookup
    *   The reference lookup service.
-   * @param \Drupal\datastore\Storage\DatabaseConnectionFactory
+   * @param \Drupal\datastore\Storage\DatabaseConnectionFactory $connectionFactory
    *   A database connection factory instance.
-   * @param \Drupal\Core\Database\Connection $defaultDatabaseConnection
+   * @param \Drupal\Core\Database\Connection $defaultConnection
    *   An instance of the default database connection.
    */
   public function __construct(
@@ -96,7 +96,7 @@ class Import extends QueueWorkerBase implements ContainerFactoryPluginInterface 
     LoggerChannelFactoryInterface $loggerFactory,
     ReferenceLookup $referenceLookup,
     DatabaseConnectionFactory $connectionFactory,
-    Connection $defaultDatabaseConnection
+    Connection $defaultConnection
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->datastore = $datastore;
@@ -110,7 +110,7 @@ class Import extends QueueWorkerBase implements ContainerFactoryPluginInterface 
     // duration of the time the queue is being processed.
     $timeout = (int) $plugin_definition['cron']['lease_time'];
     $timeout_command = 'SET SESSION wait_timeout = ' . $timeout;
-    $defaultDatabaseConnection->query($timeout_command);
+    $defaultConnection->query($timeout_command);
     $connectionFactory->addInitCommand($timeout_command);
   }
 

--- a/modules/datastore/src/Plugin/QueueWorker/Import.php
+++ b/modules/datastore/src/Plugin/QueueWorker/Import.php
@@ -61,7 +61,7 @@ class Import extends QueueWorkerBase implements ContainerFactoryPluginInterface 
   /**
    * File system service.
    *
-   * @var \Drupal\Core\File\FileSystemInterface;
+   * @var \Drupal\Core\File\FileSystemInterface
    */
   protected $fileSystem;
 

--- a/modules/datastore/src/Storage/DatabaseConnectionFactory.php
+++ b/modules/datastore/src/Storage/DatabaseConnectionFactory.php
@@ -5,21 +5,27 @@ namespace Drupal\datastore\Storage;
 use Drupal\Core\Database\Database;
 
 /**
- * Create second datastore endpoint at runtime with unbuffered queries.
- *
- * @return \Drupal\Core\Database\Connection
- *   New datastore connection object.
+ * Creates a datastore DB connection with unbuffered queries.
  */
 class DatabaseConnectionFactory {
 
   /**
-   * Gets the connection object for the specified database key and target.
+   * Create a database connection factory object.
    */
-  public static function getConnection() {
+  public function __construct() {
     $info = Database::getConnectionInfo();
     $datastoreInfo = $info['default'];
     $datastoreInfo['pdo'][\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = FALSE;
     Database::addConnectionInfo('datastore', 'default', $datastoreInfo);
+  }
+
+  /**
+   * Gets the connection object for the specified database key and target.
+   *
+   * @return \Drupal\Core\Database\Connection
+   *   New datastore connection object.
+   */
+  public function getConnection() {
     return Database::getConnection('default', 'datastore');
   }
 

--- a/modules/datastore/src/Storage/DatabaseConnectionFactory.php
+++ b/modules/datastore/src/Storage/DatabaseConnectionFactory.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\datastore\Storage;
 
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Database;
 
 /**
@@ -10,13 +11,29 @@ use Drupal\Core\Database\Database;
 class DatabaseConnectionFactory {
 
   /**
+   * Connection info.
+   *
+   * @var array
+   */
+  protected $connectionInfo;
+
+  /**
    * Create a database connection factory object.
    */
   public function __construct() {
     $info = Database::getConnectionInfo();
-    $datastoreInfo = $info['default'];
-    $datastoreInfo['pdo'][\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = FALSE;
-    Database::addConnectionInfo('datastore', 'default', $datastoreInfo);
+    $this->connectionInfo = $info['default'];
+    $this->connectionInfo['pdo'][\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = FALSE;
+  }
+
+  /**
+   * Add init command used when create a database connection.
+   *
+   * @param string $command
+   *   Connection initialization command.
+   */
+  public function addInitCommand(string $command): void {
+    $this->connectionInfo['init_commands'][] = $command;
   }
 
   /**
@@ -25,7 +42,8 @@ class DatabaseConnectionFactory {
    * @return \Drupal\Core\Database\Connection
    *   New datastore connection object.
    */
-  public function getConnection() {
+  public function getConnection(): Connection {
+    Database::addConnectionInfo('datastore', 'default', $this->connectionInfo);
     return Database::getConnection('default', 'datastore');
   }
 

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -179,7 +179,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    * @param array $schema
    *   Database table schema array.
    */
-  public function setSchema(array $schema): void {
+  public function setSchema($schema) {
     $fields = $schema['fields'];
     $new_field = [
       $this->primaryKey() =>

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -47,6 +47,12 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     $this->databaseConnectionFactory = $databaseConnectionFactory;
   }
 
+  /**
+   * Get datastore database connection.
+   *
+   * @return \Drupal\Core\Database\Connection
+   *   Database connection instance.
+   */
   protected function getConnection(): Connection {
     if (!isset($this->connection)) {
       $this->connection = $this->databaseConnectionFactory->getConnection();
@@ -54,7 +60,13 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     return $this->connection;
   }
 
-  public function getSchema() {
+  /**
+   * Get table schema.
+   *
+   * @return array
+   *   Database table schema array.
+   */
+  public function getSchema(): array {
     if (!isset($this->schema) && $this->tableExist($this->getTableName())) {
       $this->setSchemaFromTable();
     }
@@ -72,7 +84,15 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     return new TableSummary($numOfColumns, $columns, $numOfRows);
   }
 
-  public function jsonSerialize() {
+  /**
+   * Specify data which should be serialized to JSON.
+   *
+   * This method is used if json_encode() is called on an object of this class.
+   *
+   * @return object
+   *   Object instance representing this tables serializable content.
+   */
+  public function jsonSerialize(): object {
     return (object) ['resource' => $this->resource];
   }
 
@@ -153,7 +173,13 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     $this->setSchema($schema);
   }
 
-  public function setSchema($schema) {
+  /**
+   * Provide schema for this database table.
+   *
+   * @param array $schema
+   *   Database table schema array.
+   */
+  public function setSchema(array $schema): void {
     $fields = $schema['fields'];
     $new_field = [
       $this->primaryKey() =>

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -6,7 +6,6 @@ use Drupal\Core\Database\Connection;
 
 use Drupal\common\LoggerTrait;
 use Drupal\common\Storage\AbstractDatabaseTable;
-use Drupal\datastore\Storage\DatabaseConnectionFactory;
 
 use Dkan\Datastore\Resource;
 
@@ -48,9 +47,6 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     $this->databaseConnectionFactory = $databaseConnectionFactory;
   }
 
-  /**
-   * @inheritdoc
-   */
   protected function getConnection(): Connection {
     if (!isset($this->connection)) {
       $this->connection = $this->databaseConnectionFactory->getConnection();
@@ -58,9 +54,6 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     return $this->connection;
   }
 
-  /**
-   * @inheritdoc
-   */
   public function getSchema() {
     if (!isset($this->schema) && $this->tableExist($this->getTableName())) {
       $this->setSchemaFromTable();
@@ -79,11 +72,6 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     return new TableSummary($numOfColumns, $columns, $numOfRows);
   }
 
-  /**
-   * Inherited.
-   *
-   * {@inheritdoc}
-   */
   public function jsonSerialize() {
     return (object) ['resource' => $this->resource];
   }
@@ -165,9 +153,6 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     $this->setSchema($schema);
   }
 
-  /**
-   * {@inheritdoc}
-   */
   public function setSchema($schema) {
     $fields = $schema['fields'];
     $new_field = [

--- a/modules/datastore/src/Storage/DatabaseTableFactory.php
+++ b/modules/datastore/src/Storage/DatabaseTableFactory.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\datastore\Storage;
 
-use Contracts\FactoryInterface;
-
-use Drupal\datastore\Storage\DatabaseConnectionFactory;
 use Drupal\indexer\IndexManager;
+
+use Contracts\FactoryInterface;
+use Dkan\Datastore\Resource;
 
 /**
  * Class DatabaseTableFactory.
@@ -36,7 +36,7 @@ class DatabaseTableFactory implements FactoryInterface {
   /**
    * Create DatabaseTableFactory instance.
    *
-   * @param \Drupal\datastore\Storage\DatabaseConnectionFactory
+   * @param \Drupal\datastore\Storage\DatabaseConnectionFactory $databaseConnectionFactory
    *   Database connection factory service instance.
    */
   public function __construct(DatabaseConnectionFactory $databaseConnectionFactory) {
@@ -82,8 +82,8 @@ class DatabaseTableFactory implements FactoryInterface {
    * @return \Drupal\datastore\Storage\DatabaseTable
    *   Database table instance.
    */
-  protected function getDatabaseTable($resource): DatabaseTable {
-    return new DatabaseTable($this->databaseConnectionFactory->getConnection(), $resource);
+  protected function getDatabaseTable(Resource $resource): DatabaseTable {
+    return new DatabaseTable($this->databaseConnectionFactory, $resource);
   }
 
 }

--- a/modules/datastore/src/Storage/DatabaseTableFactory.php
+++ b/modules/datastore/src/Storage/DatabaseTableFactory.php
@@ -3,29 +3,44 @@
 namespace Drupal\datastore\Storage;
 
 use Contracts\FactoryInterface;
-use Drupal\Core\Database\Connection;
+
+use Drupal\datastore\Storage\DatabaseConnectionFactory;
 use Drupal\indexer\IndexManager;
 
 /**
  * Class DatabaseTableFactory.
  */
 class DatabaseTableFactory implements FactoryInterface {
-  private $connection;
+
+  /**
+   * Database connection factory service.
+   *
+   * @var \Drupal\datastore\Storage\DatabaseConnectionFactory
+   */
+  protected $databaseConnectionFactory;
 
   /**
    * Optional index manager service.
    *
-   * @var null|\Drupal\indexer\IndexManager
+   * @var \Drupal\indexer\IndexManager|null
    */
-  private $indexManager;
-
-  private $databaseTables = [];
+  protected $indexManager;
 
   /**
-   * Constructor.
+   * Database table instances.
+   *
+   * @var \Drupal\datastore\Storage\DatabaseTable[]
    */
-  public function __construct(Connection $connection) {
-    $this->connection = $connection;
+  protected $databaseTables = [];
+
+  /**
+   * Create DatabaseTableFactory instance.
+   *
+   * @param \Drupal\datastore\Storage\DatabaseConnectionFactory
+   *   Database connection factory service instance.
+   */
+  public function __construct(DatabaseConnectionFactory $databaseConnectionFactory) {
+    $this->databaseConnectionFactory = $databaseConnectionFactory;
   }
 
   /**
@@ -39,8 +54,6 @@ class DatabaseTableFactory implements FactoryInterface {
   }
 
   /**
-   * Inherited.
-   *
    * @inheritdoc
    */
   public function getInstance(string $identifier, array $config = []) {
@@ -61,11 +74,16 @@ class DatabaseTableFactory implements FactoryInterface {
   }
 
   /**
-   * Protected.
+   * Generate database table for the given resource.
+   *
+   * @param \Dkan\Datastore\Resource $resource
+   *   The datastore resource being imported.
+   *
+   * @return \Drupal\datastore\Storage\DatabaseTable
+   *   Database table instance.
    */
-  protected function getDatabaseTable($resource) {
-    $databaseTable = new DatabaseTable($this->connection, $resource);
-    return $databaseTable;
+  protected function getDatabaseTable($resource): DatabaseTable {
+    return new DatabaseTable($this->databaseConnectionFactory->getConnection(), $resource);
   }
 
 }


### PR DESCRIPTION
Do not establish a connection to the database for datastore interactions
until absolutely necessary to prevent the DB connection from expiring
before it's used.

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

TBD
