### PR TITLE
Generate sitemap for DKAN URLs

### DIFF
--- a/modules/dkan_js_frontend/README.md
+++ b/modules/dkan_js_frontend/README.md
@@ -5,6 +5,9 @@ This module provides a way to access a decoupled JavaScript frontend at defined 
 ## Defining Paths
 The paths used are defined by the `dkan_js_frontend.config` yml. In the routes array add any path you want this module to use with a string structured like `unique_path_name,/the_path`. The first part is used by Drupal to store paths and the second is the actual path the JS frontend will show at.
 
+### Sitemap Generation - the [Simple XML sitemap module](https://www.drupal.org/project/simple_sitemap)
+If the Drupal [Simple XML sitemap module](https://www.drupal.org/project/simple_sitemap) is installed, the DKAN JS Frontend module will automatically add static routes and dataset routes listed in the `dkan_js_frontend.config` yml to the default sitemap.
+
 ## JS/CSS
 The module assumes Create React App (CRA) has been loaded into the `/src/frontend` folder of the site. This can be changed by updating the `dkan_js_frontend.config` keys of `css_folder` and `js_folder` with the new directory path. 
 

--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -7,6 +7,16 @@ use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
+const DKAN_JS_FRONTEND_MISSING_DATASET_ROUTE_ERROR = 'Missing required DKAN route "dataset"; unable to build sitemap for dataset URLs.';
+const DKAN_JS_FRONTEND_DEFAULT_STATIC_LINK = [
+  'priority' => '0.7',
+  'changefreq' => 'daily',
+];
+const DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK = [
+  'priority' => '0.5',
+  'changefreq' => 'weekly',
+];
+
 /**
  * Implements hook_library_info_build().
  * Collects all CSS/JS files in the paths set in config 
@@ -92,7 +102,7 @@ function dkan_js_frontend_simple_sitemap_arbitrary_links_alter(array &$arbitrary
     _dkan_js_frontend_add_dataset_links($arbitrary_links, $dataset_route);
   }
   else {
-    \Drupal::logger('dkan_js_frontend')->warning('Missing required DKAN route "dataset"; unable to build sitemap for dataset URLs.');
+    \Drupal::logger('dkan_js_frontend')->error(DKAN_JS_FRONTEND_MISSING_DATASET_ROUTE_ERROR);
   }
 }
 
@@ -109,10 +119,8 @@ function _dkan_js_frontend_add_static_links(array &$arbitrary_links, RouteCollec
   foreach ($routes as $route) {
     // Add this link to the sitemap if it's not a dynamic route.
     if (empty($route->compile()->getPathVariables())) {
-      $arbitrary_links[] = [
+      $arbitrary_links[] = DKAN_JS_FRONTEND_DEFAULT_STATIC_LINK + [
         'url' => $route->getPath(),
-        'priority' => '0.7',
-        'changefreq' => 'daily',
       ];
     }
   }
@@ -136,10 +144,8 @@ function _dkan_js_frontend_add_dataset_links(array &$arbitrary_links, Route $dat
   $dataset_uuids = \Drupal::service('dkan.metastore.service')->getRangeUuids('dataset');
   // Add dataset routes using the fetched UUIDs.
   foreach ($dataset_uuids as $uuid) {
-    $arbitrary_links[] = [
+    $arbitrary_links[] = DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK + [
       'url' => $url_generator->generate('dataset', ['id' => $uuid], UrlGeneratorInterface::ABSOLUTE_PATH),
-      'priority' => '0.5',
-      'changefreq' => 'weekly',
     ];
   }
 }

--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -1,6 +1,11 @@
 <?php
 
-use Drupal\Core\Site\Settings;
+use Drupal\simple_sitemap\Entity\SimpleSitemapInterface;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
 
 /**
  * Implements hook_library_info_build().
@@ -67,4 +72,74 @@ function dkan_js_frontend_theme($existing, $type, $theme, $path) {
     ],
   ];
 
+}
+
+/**
+ * Implements hook_simple_sitemap_arbitrary_links_alter().
+ */
+function dkan_js_frontend_simple_sitemap_arbitrary_links_alter(array &$arbitrary_links, SimpleSitemapInterface $sitemap): void {
+  // Ignore anything that isn't the default sitemap.
+  if ($sitemap->id() !== 'default') {
+    return;
+  }
+
+  // Gather DKAN routes.
+  $routes = \Drupal::service('dkan_js_frontend.route_provider')->routes();
+
+  _dkan_js_frontend_add_static_links($arbitrary_links, $routes);
+  // If the 'dataset' route exists, add links for the dataset route.
+  if ($dataset_route = $routes->get('dataset')) {
+    _dkan_js_frontend_add_dataset_links($arbitrary_links, $dataset_route);
+  }
+  else {
+    \Drupal::logger('dkan_js_frontend')->warning('Missing required DKAN route "dataset"; unable to build sitemap for dataset URLs.');
+  }
+}
+
+/**
+ * Generate links for static routes.
+ *
+ * @param array $arbitrary_links
+ *   Multi-dimensional array for storing arbitrary site links.
+ * @param \Symfony\Component\Routing\RouteCollection $routes
+ *   Collection of DKAN routes.
+ */
+function _dkan_js_frontend_add_static_links(array &$arbitrary_links, RouteCollection $routes): void {
+  // Loop through routes and add to sitemap.
+  foreach ($routes as $route) {
+    // Add this link to the sitemap if it's not a dynamic route.
+    if (empty($route->compile()->getPathVariables())) {
+      $arbitrary_links[] = [
+        'url' => $route->getPath(),
+        'priority' => '0.7',
+        'changefreq' => 'daily',
+      ];
+    }
+  }
+}
+
+/**
+ * Generate dynamic links for dataset routes.
+ *
+ * @param array $arbitrary_links
+ *   Multi-dimensional array for storing arbitrary site links.
+ * @param \Symfony\Component\Routing\Route $routes
+ *   Collection of DKAN routes.
+ */
+function _dkan_js_frontend_add_dataset_links(array &$arbitrary_links, Route $dataset_route): void {
+  // Build route URL generator.
+  $route_collection = new RouteCollection();
+  $route_collection->add('dataset', $dataset_route);
+  $url_generator = new UrlGenerator($route_collection, new RequestContext());
+
+  // Fetch dataset UUIDs.
+  $dataset_uuids = \Drupal::service('dkan.metastore.service')->getRangeUuids('dataset');
+  // Add dataset routes using the fetched UUIDs.
+  foreach ($dataset_uuids as $uuid) {
+    $arbitrary_links[] = [
+      'url' => $url_generator->generate('dataset', ['id' => $uuid], UrlGeneratorInterface::ABSOLUTE_PATH),
+      'priority' => '0.5',
+      'changefreq' => 'weekly',
+    ];
+  }
 }

--- a/modules/dkan_js_frontend/dkan_js_frontend.services.yml
+++ b/modules/dkan_js_frontend/dkan_js_frontend.services.yml
@@ -2,6 +2,4 @@ services:
   dkan_js_frontend.route_provider:
       class: Drupal\dkan_js_frontend\Routing\RouteProvider
       arguments:
-        - '@app.root'
-        - '@entity.query.sql'
         - '@config.factory'

--- a/modules/dkan_js_frontend/src/Routing/RouteProvider.php
+++ b/modules/dkan_js_frontend/src/Routing/RouteProvider.php
@@ -28,7 +28,7 @@ class RouteProvider {
   /**
    * Routes.
    */
-  public function routes() {
+  public function routes(): RouteCollection {
     $routes = new RouteCollection();
     $this->addIndexPage($routes);
     $routes->addRequirements(['_access' => 'TRUE']);

--- a/modules/dkan_js_frontend/src/Routing/RouteProvider.php
+++ b/modules/dkan_js_frontend/src/Routing/RouteProvider.php
@@ -3,7 +3,6 @@
 namespace Drupal\dkan_js_frontend\Routing;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Entity\Query\QueryFactoryInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -12,16 +11,17 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class RouteProvider {
 
-  private $appRoot;
-  private $entityQuery;
-  private $configFactory;
+  /**
+   * Route-URL pairs, separated by a comma.
+   *
+   * @var string[]
+   */
+  protected $routes;
 
   /**
    * Constructor.
    */
-  public function __construct(string $appRoot, QueryFactoryInterface $entityQuery, ConfigFactoryInterface $configFactory) {
-    $this->appRoot = $appRoot;
-    $this->entityQuery = $entityQuery;
+  public function __construct(ConfigFactoryInterface $configFactory) {
     $this->routes = $configFactory->get('dkan_js_frontend.config')->get('routes');
   }
 

--- a/modules/dkan_js_frontend/tests/src/Unit/Routing/RouteProviderJSTest.php
+++ b/modules/dkan_js_frontend/tests/src/Unit/Routing/RouteProviderJSTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Drupal\Tests\RouteProvider\Unit\Routing;
+
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\Query\QueryFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
@@ -38,7 +40,7 @@ class RouteProviderJSTest extends TestCase {
       ->add(ImmutableConfig::class, 'get', $options)
       ->getMock();
 
-    $reactAppProvider = new RouteProvider(__DIR__ . "/../../../cra", $queryFactory, $configFactory);
+    $reactAppProvider = new RouteProvider($configFactory);
 
     /** @var \Symfony\Component\Routing\RouteCollection $routes */
     $reactappRoutes = $reactAppProvider->routes();

--- a/modules/dkan_js_frontend/tests/src/Unit/SimpleSitemapArbitraryLinksAlterTest.php
+++ b/modules/dkan_js_frontend/tests/src/Unit/SimpleSitemapArbitraryLinksAlterTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Drupal\Tests\RouteProvider\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\DependencyInjection\Container;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityTypeRepository;
+use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\Core\Logger\LoggerChannelInterface;
+
+use Drupal\dkan_js_frontend\Routing\RouteProvider;
+use Drupal\metastore\Service;
+use Drupal\simple_sitemap\Entity\SimpleSitemapInterface;
+
+use MockChain\Chain;
+use MockChain\Options;
+use PHPUnit\Framework\TestCase;
+
+$module_path = substr(__DIR__, 0, strpos(__DIR__, '/dkan_js_frontend/')) . '/dkan_js_frontend';
+require_once($module_path . '/dkan_js_frontend.module');
+
+/**
+ * Test dkan_js_frontend_simple_sitemap_arbitrary_links_alter() function.
+ */
+class SimpleSitemapArbitraryLinksAlterTest extends TestCase {
+
+  /**
+   * Test sitemap generation of static links.
+   */
+  public function testSitemapStaticLinks(): void {
+    $configFactory = (new Chain($this))
+      ->add(ConfigFactoryInterface::class, 'get', ImmutableConfig::class)
+      ->add(ImmutableConfig::class, 'get', ['home,/home', 'about,/about'])
+      ->getMock();
+    $containerOptions = (new Options())
+      ->add('dkan.metastore.service', Service::class)
+      ->add('dkan_js_frontend.route_provider', new RouteProvider($configFactory))
+      ->add('entity_type.repository', EntityTypeRepository::class)
+      ->add('entity_type.manager', EntityTypeManagerInterface::class)
+      ->add('logger.factory', LoggerChannelFactory::class)
+      ->index(0);
+    $container = (new Chain($this))
+      ->add(Container::class, 'get', $containerOptions)
+      ->getMock();
+    \Drupal::setContainer($container);
+
+    $arbitrary_links = [];
+    $simpleSitemap = (new Chain($this))
+      ->add(SimpleSitemapInterface::class, 'id', 'default')
+      ->getMock();
+    dkan_js_frontend_simple_sitemap_arbitrary_links_alter($arbitrary_links, $simpleSitemap);
+
+    $this->assertEquals($arbitrary_links, [
+      DKAN_JS_FRONTEND_DEFAULT_STATIC_LINK + ['url' => '/home'],
+      DKAN_JS_FRONTEND_DEFAULT_STATIC_LINK + ['url' => '/about'],
+    ]);
+  }
+
+  /**
+   * Test sitemap generation of dataset links.
+   */
+  public function testSitemapDatasetLinks(): void {
+    $configFactory = (new Chain($this))
+      ->add(ConfigFactoryInterface::class, 'get', ImmutableConfig::class)
+      ->add(ImmutableConfig::class, 'get', ['dataset,/dataset/{id}'])
+      ->getMock();
+    $containerOptions = (new Options())
+      ->add('dkan.metastore.service', Service::class)
+      ->add('dkan_js_frontend.route_provider', new RouteProvider($configFactory))
+      ->add('entity_type.repository', EntityTypeRepository::class)
+      ->add('entity_type.manager', EntityTypeManagerInterface::class)
+      ->add('dkan.metastore.service', Service::class)
+      ->index(0);
+    $container = (new Chain($this))
+      ->add(Container::class, 'get', $containerOptions)
+      ->add(Service::class, 'getRangeUuids', [1, 2])
+      ->getMock();
+    \Drupal::setContainer($container);
+
+    $arbitrary_links = [];
+    $simpleSitemap = (new Chain($this))
+      ->add(SimpleSitemapInterface::class, 'id', 'default')
+      ->getMock();
+    dkan_js_frontend_simple_sitemap_arbitrary_links_alter($arbitrary_links, $simpleSitemap);
+
+    $this->assertEquals($arbitrary_links, [
+      DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK + ['url' => '/dataset/1'],
+      DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK + ['url' => '/dataset/2'],
+    ]);
+  }
+
+  /**
+   * Test sitemap error when a dataset route is not found.
+   */
+  public function testSitemapErrorNoDatasetRouteFound(): void {
+    $configFactory = (new Chain($this))
+      ->add(ConfigFactoryInterface::class, 'get', ImmutableConfig::class)
+      ->add(ImmutableConfig::class, 'get', [])
+      ->getMock();
+    $containerOptions = (new Options())
+      ->add('dkan.metastore.service', Service::class)
+      ->add('dkan_js_frontend.route_provider', new RouteProvider($configFactory))
+      ->add('entity_type.repository', EntityTypeRepository::class)
+      ->add('entity_type.manager', EntityTypeManagerInterface::class)
+      ->add('logger.factory', LoggerChannelFactory::class)
+      ->add('dkan.metastore.service', Service::class)
+      ->index(0);
+    $containerChain = (new Chain($this))
+      ->add(Container::class, 'get', $containerOptions)
+      ->add(LoggerChannelFactory::class, 'get', LoggerChannelInterface::class)
+      ->add(LoggerChannelInterface::class, 'error', NULL, 'error');
+    \Drupal::setContainer($containerChain->getMock());
+
+    $arbitrary_links = [];
+    $simpleSitemap = (new Chain($this))
+      ->add(SimpleSitemapInterface::class, 'id', 'default')
+      ->getMock();
+    dkan_js_frontend_simple_sitemap_arbitrary_links_alter($arbitrary_links, $simpleSitemap);
+
+    $this->assertEquals($containerChain->getStoredInput('error')[0], DKAN_JS_FRONTEND_MISSING_DATASET_ROUTE_ERROR);
+  }
+
+}

--- a/modules/dkan_js_frontend/tests/src/Unit/SimpleSitemapArbitraryLinksAlterTest.php
+++ b/modules/dkan_js_frontend/tests/src/Unit/SimpleSitemapArbitraryLinksAlterTest.php
@@ -122,4 +122,17 @@ class SimpleSitemapArbitraryLinksAlterTest extends TestCase {
     $this->assertEquals($containerChain->getStoredInput('error')[0], DKAN_JS_FRONTEND_MISSING_DATASET_ROUTE_ERROR);
   }
 
+  /**
+   * Ensure the $arbitrary_links array is not modified for non-default sitemaps.
+   */
+  public function testArbitraryLinksNotModifiedForNonDefaultSitemap(): void {
+    $arbitrary_links = [];
+    $simpleSitemap = (new Chain($this))
+      ->add(SimpleSitemapInterface::class, 'id', 'test')
+      ->getMock();
+    dkan_js_frontend_simple_sitemap_arbitrary_links_alter($arbitrary_links, $simpleSitemap);
+
+    $this->assertEmpty($arbitrary_links);
+  }
+
 }

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -129,17 +129,19 @@ class Service implements ContainerInjectionInterface {
   /**
    * Get range of object UUIDs of the given schema ID.
    *
+   * If no start or length is specified, all dataset UUIDs will be returned.
+   *
    * @param string $schema_id
    *   The schema ID to be counted.
-   * @param int $start
-   *   Schema object offset.
-   * @param int $length
-   *   Number of objects to fetch.
+   * @param int|null $start
+   *   Schema object offset or null for all.
+   * @param int|null $length
+   *   Number of objects to fetch or null for all.
    *
    * @return string[]
    *   Range of object UUIDs of the given schema_id.
    */
-  public function getRangeUuids(string $schema_id, int $start, int $length): array {
+  public function getRangeUuids(string $schema_id, ?int $start = NULL, ?int $length = NULL): array {
     return $this->getStorage($schema_id)->retrieveRangeUuids($start, $length);
   }
 

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -128,25 +128,29 @@ abstract class Data implements MetastoreStorageInterface {
   /**
    * Get range of object UUIDs of this metastore's schema ID.
    *
-   * @param int $start
-   *   Schema object offset.
-   * @param int $length
-   *   Number of objects to fetch.
+   * If no start or length is specified, all dataset UUIDs will be returned.
+   *
+   * @param int|null $start
+   *   Schema object offset or null for all.
+   * @param int|null $length
+   *   Number of objects to fetch or null for all.
    *
    * @return string[]
    *   Range of object UUIDs of the given schema_id.
    */
-  public function retrieveRangeUuids(int $start, int $length): array {
-    $ids = $this->entityStorage->getQuery()
+  public function retrieveRangeUuids(?int $start = NULL, ?int $length = NULL): array {
+    $ids_query = $this->entityStorage->getQuery()
       ->accessCheck(FALSE)
       ->condition('type', $this->bundle)
-      ->condition('field_data_type', $this->schemaId)
-      ->range($start, $length)
-      ->execute();
+      ->condition('field_data_type', $this->schemaId);
+
+    if (isset($start, $length)) {
+      $ids_query = $ids_query->range($start, $length);
+    }
 
     return array_map(function ($entity) {
       return $entity->uuid();
-    }, $this->entityStorage->loadMultiple($ids));
+    }, $this->entityStorage->loadMultiple($ids_query->execute()));
   }
 
   /**


### PR DESCRIPTION
fixes WCMS-7259

- [X] Test coverage exists
- [x] Documentation exists

## QA Steps

- [x] Install `simple_sitemap` module.
- [x] Run cron to allow sitemap to be generated.
- [x] Navigate to `/sitemap.xml` and ensure a valid sitemap has been created with static links and dataset links.
