### PR TITLE
Suport GROUP BY clause in datastore queries

### DIFF
--- a/modules/common/src/Storage/Query.php
+++ b/modules/common/src/Storage/Query.php
@@ -64,6 +64,13 @@ class Query implements
   public $joins = [];
 
   /**
+   * Fields to group by in query.
+   *
+   * @var string[]
+   */
+  public $groupby = [];
+
+  /**
    * Limit for maximum number of records returned.
    *
    * @var int|null

--- a/modules/common/src/Storage/SelectFactory.php
+++ b/modules/common/src/Storage/SelectFactory.php
@@ -55,6 +55,7 @@ class SelectFactory {
 
     $this->setQueryProperties($query);
     $this->setQueryConditions($query);
+    $this->setQueryGroupBy($query);
     $this->setQueryOrderBy($query);
     $this->setQueryLimitAndOffset($query);
     $this->setQueryJoins($query);
@@ -281,6 +282,16 @@ class SelectFactory {
       }
     }
     $statementObj->condition($group);
+  }
+
+  /**
+   * Set fields to group by on DB query.
+   *
+   * @param Query $query
+   *   A DKAN query object.
+   */
+  private function setQueryGroupBy(Query $query) {
+    array_map([$this->dbQuery, 'groupBy'], $query->groupby);
   }
 
   /**

--- a/modules/common/tests/src/Unit/Storage/QueryDataProvider.php
+++ b/modules/common/tests/src/Unit/Storage/QueryDataProvider.php
@@ -43,6 +43,7 @@ class QueryDataProvider {
       'joinsQuery',
       'joinWithPropertiesFromBothQuery',
       'countQuery',
+      'groupByQuery',
     ];
     $data = [];
     foreach ($tests as $test) {
@@ -535,6 +536,57 @@ class QueryDataProvider {
       case self::EXCEPTION:
         return '';
     }
+  }
+
+  /**
+   * Provides an example groupby query object, SQL string, and exception string.
+   *
+   * @param int $returnType
+   *   Expected groupby query return value type.
+   *
+   * @return Query|string
+   */
+  public static function groupByQuery(int $returnType) {
+    switch ($returnType) {
+      case self::QUERY_OBJECT:
+        $query = new Query();
+        $query->properties = [
+          (object) [
+            'collection' => 't',
+            'property' => 'prop',
+          ],
+          (object) [
+            'alias' => 'sum',
+            'expression' => (object) [
+              'operator' => 'sum',
+              'operands' => [
+                (object) [
+                  'collection' => 't',
+                  'property' => 'summable',
+                ],
+              ],
+            ],
+          ],
+        ];
+        $query->conditions = [
+          (object) [
+            'collection' => 't',
+            'property' => 'filterable',
+            'value' => 'value',
+            'operator' => '=',
+          ],
+        ];
+        $query->groupby = ['prop'];
+        return $query;
+
+      case self::SQL:
+        return 'SELECT t.prop AS prop, (SUM(t.summable)) AS sum FROM {table} t WHERE t.filterable = :db_condition_placeholder_0 GROUP BY prop';
+
+      case self::EXCEPTION:
+        return '';
+    }
+
+    throw new \UnexpectedValueException('Unknown return type provided.');
   }
 
 }

--- a/modules/datastore/docs/query.json
+++ b/modules/datastore/docs/query.json
@@ -72,6 +72,18 @@
                 "required": ["resource", "condition"]
             }
         },
+        "groups": {
+            "type": "array",
+            "description": "Properties or aliases from the properties array to group results by.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "resource": { "$ref": "#/definitions/resource" },
+                    "property": { "$ref": "#/definitions/property" }
+                },
+                "required": [ "property" ]                
+            }
+        },
         "limit": {
             "type": "integer",
             "description": "Limit for maximum number of records returned. Pass zero for no limit (may be restricted by user permissions)."
@@ -197,7 +209,7 @@
             "properties": {
                 "operator": {
                     "type": "string",
-                    "description": "Expression operator. Note that performing expressions on text or other non-numeric data types my yeild unexpected results.",
+                    "description": "Expression operator. Note that performing expressions on text or other non-numeric data types my yield unexpected results.",
                     "enum": [
                         "+",
                         "-",

--- a/modules/datastore/docs/query.json
+++ b/modules/datastore/docs/query.json
@@ -76,12 +76,10 @@
             "type": "array",
             "description": "Properties or aliases from the properties array to group results by.",
             "items": {
-                "type": "object",
-                "properties": {
-                    "resource": { "$ref": "#/definitions/resource" },
-                    "property": { "$ref": "#/definitions/property" }
-                },
-                "required": [ "property" ]                
+                "anyOf": [
+                    { "$ref": "#/definitions/resource" },
+                    { "$ref": "#/definitions/resourceProperty" }
+                ]
             }
         },
         "limit": {

--- a/modules/datastore/docs/query.json
+++ b/modules/datastore/docs/query.json
@@ -72,9 +72,9 @@
                 "required": ["resource", "condition"]
             }
         },
-        "groups": {
+        "groupings": {
             "type": "array",
-            "description": "Properties or aliases from the properties array to group results by.",
+            "description": "Properties or aliases to group results by.",
             "items": {
                 "anyOf": [
                     { "$ref": "#/definitions/resource" },

--- a/modules/datastore/src/Storage/QueryFactory.php
+++ b/modules/datastore/src/Storage/QueryFactory.php
@@ -92,7 +92,6 @@ class QueryFactory {
     }
     $props = $this->extractPropertyNames($this->datastoreQuery->{"$.properties"} ?? []);
     if ($ungrouped = array_diff($props, $groups)) {
-      \Drupal::logger('dkan')->notice('<pre>' . print_r($ungrouped, TRUE) . '</pre>');
       throw new \Exception('Un-grouped properties found in aggregate query: ' . implode(', ', $ungrouped));
     }
     $query->groupby = $groups;

--- a/modules/datastore/src/Storage/QueryFactory.php
+++ b/modules/datastore/src/Storage/QueryFactory.php
@@ -86,11 +86,11 @@ class QueryFactory {
    *   When ungrouped properties are found in the datastore query.
    */
   private function populateQueryGroupBy(Query $query): void {
-    $groups = $this->extractPropertyNames($this->datastoreQuery->{"$.groups"});
+    $groups = $this->extractPropertyNames($this->datastoreQuery->{"$.groups"} ?? []);
     if (empty($groups)) {
       return;
     }
-    $props = $this->extractPropertyNames($this->datastoreQuery->{"$.properties"});
+    $props = $this->extractPropertyNames($this->datastoreQuery->{"$.properties"} ?? []);
     if ($ungrouped = array_diff($props, $groups)) {
       \Drupal::logger('dkan')->notice('<pre>' . print_r($ungrouped, TRUE) . '</pre>');
       throw new \Exception('Un-grouped properties found in aggregate query: ' . implode(', ', $ungrouped));

--- a/modules/datastore/src/Storage/QueryFactory.php
+++ b/modules/datastore/src/Storage/QueryFactory.php
@@ -77,7 +77,7 @@ class QueryFactory {
   }
 
   /**
-   * Helper function for adding datastore groups to the given query.
+   * Helper function for adding group by clauses to the given query.
    *
    * @param Drupal\common\Storage\Query $query
    *   DKAN query object we're building.
@@ -86,15 +86,15 @@ class QueryFactory {
    *   When ungrouped properties are found in the datastore query.
    */
   private function populateQueryGroupBy(Query $query): void {
-    $groups = $this->extractPropertyNames($this->datastoreQuery->{"$.groups"} ?? []);
-    if (empty($groups)) {
+    $groupings = $this->extractPropertyNames($this->datastoreQuery->{"$.groupings"} ?? []);
+    if (empty($groupings)) {
       return;
     }
     $props = $this->extractPropertyNames($this->datastoreQuery->{"$.properties"} ?? []);
-    if ($ungrouped = array_diff($props, $groups)) {
+    if ($ungrouped = array_diff($props, $groupings)) {
       throw new \Exception('Un-grouped properties found in aggregate query: ' . implode(', ', $ungrouped));
     }
-    $query->groupby = $groups;
+    $query->groupby = $groupings;
   }
 
   /**

--- a/modules/datastore/src/Storage/QueryFactory.php
+++ b/modules/datastore/src/Storage/QueryFactory.php
@@ -65,6 +65,7 @@ class QueryFactory {
     $this->populateQueryProperties($query);
     $this->populateQueryConditions($query);
     $this->populateQueryJoins($query);
+    $this->populateQueryGroupBy($query);
     $this->populateQuerySorts($query);
     if ($this->datastoreQuery->{"$.limit"}) {
       $query->limit = $this->datastoreQuery->{"$.limit"};
@@ -73,6 +74,69 @@ class QueryFactory {
     $query->showDbColumns = TRUE;
 
     return $query;
+  }
+
+  /**
+   * Helper function for adding datastore groups to the given query.
+   *
+   * @param Drupal\common\Storage\Query $query
+   *   DKAN query object we're building.
+   *
+   * @throws \Exception
+   *   When ungrouped properties are found in the datastore query.
+   */
+  private function populateQueryGroupBy(Query $query): void {
+    $groups = $this->extractPropertyNames($this->datastoreQuery->{"$.groups"});
+    if (empty($groups)) {
+      return;
+    }
+    $props = $this->extractPropertyNames($this->datastoreQuery->{"$.properties"});
+    if ($ungrouped = array_diff($props, $groups)) {
+      \Drupal::logger('dkan')->notice('<pre>' . print_r($ungrouped, TRUE) . '</pre>');
+      throw new \Exception('Un-grouped properties found in aggregate query: ' . implode(', ', $ungrouped));
+    }
+    $query->groupby = $groups;
+  }
+
+  /**
+   * Extract list of property names from an array of properties.
+   *
+   * Properties can be either objects, associative-arrays, or strings. If a
+   * property is an object or associative-array, the property name is stored in
+   * the "property" field. If a property is a string, the string itself is a
+   * property name.
+   *
+   * @param array $props
+   *   List of query properties (which can be a string, associative array, or
+   *   object, see above).
+   *
+   * @return string[]
+   *   List of extracted property names.
+   *
+   * @throws \Exception
+   *   When an invaid property is encountered.
+   */
+  protected function extractPropertyNames(array $props): array {
+    return array_filter(array_map(function ($prop) {
+      if (is_string($prop)) {
+        return $prop;
+      }
+      // If prop is an array, convert it to an object.
+      if (is_array($prop)) {
+        $prop = (object) $prop;
+      }
+      if (is_object($prop)) {
+        if (isset($prop->property)) {
+          return $prop->property;
+        }
+        // If this property object is an expression, ignore it.
+        if (isset($prop->expression)) {
+          return NULL;
+        }
+        throw new \Exception('Invalid property object is neither a property or expression.');
+      }
+      throw new \Exception('Invalid type for resource property, expected string or object, found "' . gettype($prop) . '".');
+    }, $props));
   }
 
   /**

--- a/modules/datastore/src/Storage/QueryFactory.php
+++ b/modules/datastore/src/Storage/QueryFactory.php
@@ -132,9 +132,7 @@ class QueryFactory {
         if (isset($prop->expression)) {
           return NULL;
         }
-        throw new \Exception('Invalid property object is neither a property or expression.');
       }
-      throw new \Exception('Invalid type for resource property, expected string or object, found "' . gettype($prop) . '".');
     }, $props));
   }
 

--- a/modules/datastore/tests/data/query/groupByQuery.json
+++ b/modules/datastore/tests/data/query/groupByQuery.json
@@ -31,7 +31,7 @@
             "operator": "="
         }
     ],
-    "groups": [
+    "groupings": [
         {
             "resource": "t",
             "property": "prop"

--- a/modules/datastore/tests/data/query/groupByQuery.json
+++ b/modules/datastore/tests/data/query/groupByQuery.json
@@ -1,0 +1,40 @@
+{
+    "resources": [
+        {
+            "id": "asdf",
+            "alias": "t"
+        }
+    ],
+    "properties": [
+        {
+            "resource": "t",
+            "property": "prop"
+        },
+        {
+            "alias": "sum",
+            "expression": {
+                "operator": "sum",
+                "operands": [
+                    {
+                        "resource": "t",
+                        "property": "summable"
+                    }
+                ]
+            }
+        }
+    ],
+    "conditions": [
+        {
+            "resource": "t",
+            "property": "filterable",
+            "value": "value",
+            "operator": "="
+        }
+    ],
+    "groups": [
+        {
+            "resource": "t",
+            "property": "prop"
+        }
+    ]
+}

--- a/modules/datastore/tests/data/query/ungroupedGroupByQuery.json
+++ b/modules/datastore/tests/data/query/ungroupedGroupByQuery.json
@@ -1,0 +1,41 @@
+{
+    "resources": [
+        {
+            "id": "asdf",
+            "alias": "t"
+        }
+    ],
+    "properties": [
+        "prop",
+        {
+            "resource": "t",
+            "property": "prop2"
+        },
+        {
+            "alias": "sum",
+            "expression": {
+                "operator": "sum",
+                "operands": [
+                    {
+                        "resource": "t",
+                        "property": "summable"
+                    }
+                ]
+            }
+        }
+    ],
+    "conditions": [
+        {
+            "resource": "t",
+            "property": "filterable",
+            "value": "value",
+            "operator": "="
+        }
+    ],
+    "groups": [
+        {
+            "resource": "t",
+            "property": "prop"
+        }
+    ]
+}

--- a/modules/datastore/tests/data/query/ungroupedGroupByQuery.json
+++ b/modules/datastore/tests/data/query/ungroupedGroupByQuery.json
@@ -32,7 +32,7 @@
             "operator": "="
         }
     ],
-    "groups": [
+    "groupings": [
         {
             "resource": "t",
             "property": "prop"

--- a/modules/datastore/tests/src/Unit/Service/DatastoreQueryTest.php
+++ b/modules/datastore/tests/src/Unit/Service/DatastoreQueryTest.php
@@ -117,6 +117,18 @@ class DatastoreQueryTest extends TestCase {
     $datastoreService->runQuery($datastoreQuery);
   }
 
+  /**
+   * Ensure if an ungrouped property is specified, the query fails.
+   */
+  public function testUngroupedPropertyInGroupByQueryFails(): void {
+    $this->expectExceptionMessage('Un-grouped properties found in aggregate query: prop2');
+    $container = $this->getCommonMockChain();
+    \Drupal::setContainer($container->getMock());
+    $datastoreService = Service::create($container->getMock());
+    $datastoreQuery = $this->getDatastoreQueryFromJson('ungroupedGroupByQuery');
+    $datastoreService->runQuery($datastoreQuery);
+  }
+
   public function testRowIdsQuery() {
     $container = $this->getCommonMockChain()
       ->add(DatabaseTable::class, "getSchema", [
@@ -150,14 +162,15 @@ class DatastoreQueryTest extends TestCase {
    */
   public function queryCompareProvider() {
     return [
-      ["propertiesQuery"],
-      ["expressionQuery"],
-      ["arrayConditionQuery"],
-      ["likeConditionQuery"],
-      ["nestedExpressionQuery"],
-      ["nestedConditionGroupQuery"],
-      ["sortQuery"],
-      ["joinWithPropertiesFromBothQuery"],
+      ['propertiesQuery'],
+      ['expressionQuery'],
+      ['arrayConditionQuery'],
+      ['likeConditionQuery'],
+      ['nestedExpressionQuery'],
+      ['nestedConditionGroupQuery'],
+      ['sortQuery'],
+      ['joinWithPropertiesFromBothQuery'],
+      ['groupByQuery'],
     ];
   }
 


### PR DESCRIPTION
Adds support for SQL `GROUP BY ` clauses in datastore queries via new `groups` property. For instance, for a table of objects with a column called `color`, we could ask for the count of every color with this query:

```json
{
    "properties": [
        "color",
        {
            "alias": "count",
            "expression": {
                "operator": "count",
                "operands": [
                    "record_number"
                ]
            }
        }
    ],
    "groupings": ["color"]
}
```

## QA Steps

1. Create a dataset using the following csv file: https://gist.githubusercontent.com/clayliddell/7a7ead939be578d5303ffcfc60247e12/raw/bd2768564bc3a0a592f25312bc606beceb10c7d1/colors.csv.
2. Perform a request against the /api/1/datastore/query/{datasetId}/{index} endpoint with the created dataset ID and the above JSON payload.
3. Ensure the API response contains the following result:
```json
{
  "results": [
    {
      "color": "blue",
      "count": "2"
    },
    {
      "color": "green",
      "count": "3"
    },
    {
      "color": "red",
      "count": "1"
    },
    {
      "color": "yellow",
      "count": "1"
    }
  ]
}
```