### PR TITLE
Consolidate metastore retrieve/range methods

### DIFF
--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -250,9 +250,14 @@ class DashboardForm extends FormBase {
     // If no filter values were supplied, fetch from the list of all dataset
     // UUIDs.
     else {
-      $total = $this->metastore->count('dataset');
+      $total = $this->metastore->count('dataset', TRUE);
       $currentPage = $this->pagerManager->createPager($total, $this->itemsPerPage)->getCurrentPage();
-      $datasets = $this->metastore->getRangeUuids('dataset', ($currentPage * $this->itemsPerPage), $this->itemsPerPage);
+      $datasets = $this->metastore->getIdentifiers(
+        'dataset',
+        ($currentPage * $this->itemsPerPage),
+        $this->itemsPerPage,
+        TRUE
+      );
     }
 
     return $datasets;

--- a/modules/datastore/src/Plugin/DkanApiDocs/DatastoreApiDocs.php
+++ b/modules/datastore/src/Plugin/DkanApiDocs/DatastoreApiDocs.php
@@ -291,7 +291,7 @@ class DatastoreApiDocs extends DkanApiDocsBase {
    * @todo Page through results in case 20 isn't enough.
    */
   private function getExampleIdentifiers() {
-    $all = $this->metastore->getRange("dataset", 0, 20);
+    $all = $this->metastore->getAll("dataset", 0, 20);
     $i = 0;
     $datastore = FALSE;
     $identifiers = [];

--- a/modules/datastore/tests/src/Unit/Controller/MockStorage.php
+++ b/modules/datastore/tests/src/Unit/Controller/MockStorage.php
@@ -26,4 +26,20 @@ class MockStorage extends Data {
     throw new MissingObjectException("Error retrieving published dataset: distribution {$uuid} not found.");
   }
 
+  public static function getMetadataField() {
+    return 'field_json_metadata';
+  }
+
+  public static function getSchemaIdField() {
+    return 'field_data_type';
+  }
+
+  public static function getEntityType() {
+    return 'node';
+  }
+
+  public static function getBundles() {
+    return 'data';
+  }
+
 }

--- a/modules/datastore/tests/src/Unit/Controller/MockStorage.php
+++ b/modules/datastore/tests/src/Unit/Controller/MockStorage.php
@@ -26,20 +26,4 @@ class MockStorage extends Data {
     throw new MissingObjectException("Error retrieving published dataset: distribution {$uuid} not found.");
   }
 
-  public static function getMetadataField() {
-    return 'field_json_metadata';
-  }
-
-  public static function getSchemaIdField() {
-    return 'field_data_type';
-  }
-
-  public static function getEntityType() {
-    return 'node';
-  }
-
-  public static function getBundles() {
-    return 'data';
-  }
-
 }

--- a/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
+++ b/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
@@ -208,7 +208,7 @@ class DashboardFormTest extends TestCase {
 
     $container = $this->buildContainerChain()
       ->add(MetastoreService::class, 'count', 2)
-      ->add(MetastoreService::class, 'getRangeUuids', [$datasetInfo['latest_revision']['uuid'], $nonHarvestDatasetInfo['latest_revision']['uuid']])
+      ->add(MetastoreService::class, 'getIdentifiers', [$datasetInfo['latest_revision']['uuid'], $nonHarvestDatasetInfo['latest_revision']['uuid']])
       ->add(DatasetInfo::class, 'gather', $datasetInfoOptions);
 
     \Drupal::setContainer($container->getMock());
@@ -244,7 +244,7 @@ class DashboardFormTest extends TestCase {
 
     $container = $this->buildContainerChain()
       ->add(MetastoreService::class, 'count', 1)
-      ->add(MetastoreService::class, 'getRangeUuids', [$datasetInfo['latest_revision']['uuid']])
+      ->add(MetastoreService::class, 'getIdentifiers', [$datasetInfo['latest_revision']['uuid']])
       ->add(DatasetInfo::class, 'gather', $datasetInfo)
       ->getMock();
     \Drupal::setContainer($container);
@@ -290,7 +290,7 @@ class DashboardFormTest extends TestCase {
 
     $container = $this->buildContainerChain()
       ->add(MetastoreService::class, 'count', 1)
-      ->add(MetastoreService::class, 'getRangeUuids', [$datasetInfo['latest_revision']['uuid']])
+      ->add(MetastoreService::class, 'getIdentifiers', [$datasetInfo['latest_revision']['uuid']])
       ->add(DatasetInfo::class, 'gather', $datasetInfo)
       ->getMock();
     \Drupal::setContainer($container);
@@ -341,7 +341,7 @@ class DashboardFormTest extends TestCase {
       ->add(Harvest::class,'getAllHarvestRunInfo', ['test'])
       ->add(Harvest::class,'getHarvestRunInfo', $runInfo)
       ->add(MetastoreService::class, 'count', 0)
-      ->add(MetastoreService::class, 'getRangeUuids', [])
+      ->add(MetastoreService::class, 'getIdentifiers', [])
       ->add(PagerManagerInterface::class,'createPager', Pager::class)
       ->add(DateFormatter::class, 'format', '12/31/2021')
       ->add(PathValidator::class, 'getUrlIfValidWithoutAccessCheck', NULL)

--- a/modules/dkan_js_frontend/dkan_js_frontend.info.yml
+++ b/modules/dkan_js_frontend/dkan_js_frontend.info.yml
@@ -1,4 +1,4 @@
-name: dkan_js_frontend
+name: DKAN JS Frontend
 description: Provides the routing connection between Drupal and a decoupled JavaScript frontend.
 type: module
 core_version_requirement: ^9.1

--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -149,7 +149,7 @@ function _dkan_js_frontend_add_dataset_links(array &$arbitrary_links, Route $dat
   $url_generator = new UrlGenerator($routes, $request_context);
 
   // Fetch dataset UUIDs.
-  $dataset_uuids = \Drupal::service('dkan.metastore.service')->getRangeUuids('dataset');
+  $dataset_uuids = \Drupal::service('dkan.metastore.service')->getIdentifiers('dataset');
   // Add dataset routes using the fetched UUIDs.
   foreach ($dataset_uuids as $uuid) {
     $arbitrary_links[] = DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK + [

--- a/modules/dkan_js_frontend/tests/src/Unit/SimpleSitemapArbitraryLinksAlterTest.php
+++ b/modules/dkan_js_frontend/tests/src/Unit/SimpleSitemapArbitraryLinksAlterTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 $module_path = substr(__DIR__, 0, strpos(__DIR__, '/dkan_js_frontend/')) . '/dkan_js_frontend';
-require_once($module_path . '/dkan_js_frontend.module');
+require_once $module_path . '/dkan_js_frontend.module';
 
 /**
  * Test dkan_js_frontend_simple_sitemap_arbitrary_links_alter() function.
@@ -88,7 +88,7 @@ class SimpleSitemapArbitraryLinksAlterTest extends TestCase {
     $container = (new Chain($this))
       ->add(Container::class, 'get', $containerOptions)
       ->add(RequestStack::class, 'getCurrentRequest', (Request::create(self::BASE_URL)))
-      ->add(Service::class, 'getRangeUuids', [1, 2])
+      ->add(Service::class, 'getIdentifiers', [1, 2])
       ->getMock();
     \Drupal::setContainer($container);
 
@@ -98,7 +98,6 @@ class SimpleSitemapArbitraryLinksAlterTest extends TestCase {
       ->getMock();
     dkan_js_frontend_simple_sitemap_arbitrary_links_alter($arbitrary_links, $simpleSitemap);
 
-    $host = \Drupal::request()->getSchemeAndHttpHost();
     $this->assertEquals($arbitrary_links, [
       DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK + ['url' => self::BASE_URL . '/dataset/1'],
       DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK + ['url' => self::BASE_URL . '/dataset/2'],

--- a/modules/metastore/metastore.module
+++ b/modules/metastore/metastore.module
@@ -96,50 +96,30 @@ function metastore_data_lifecycle(EntityInterface $entity, string $stage) {
  *   Returns true if the entity is used by the metastore.
  */
 function metastore_entity_is_valid_item(EntityInterface $entity) {
-  $storageClass = metastore_storage_class();
+  $storageClass = \Drupal::service('dkan.metastore.storage')::getStorageClass();
 
   // If the storage class used implements the entity storage interface, continue.
   if (!is_a($storageClass, MetastoreEntityStorageInterface::class, true)) {
     return FALSE;
   }
 
+  $storageEntityType = \Drupal::service('dkan.metastore.metastore_item_factory')::getEntityType();
+  $storageBundles = \Drupal::service('dkan.metastore.metastore_item_factory')::getBundles();
+
   // If the type and bundle are correct, return true.
-  if ($entity->getEntityTypeId() != $storageClass::getEntityType()) {
+  if ($entity->getEntityTypeId() != $storageEntityType) {
     return FALSE;
   }
-  if (in_array($entity->bundle(), $storageClass::getBundles())) {
+  if (in_array($entity->bundle(), $storageBundles)) {
     return TRUE;
   }
-}
-
-/**
- * Get the storage class currently in use.
- *
- * @return string
- *   Qualified storage class name.
- */
-function metastore_storage_class() {
-  $storageFactory = \Drupal::service('dkan.metastore.storage');
-  return $storageFactory::getStorageClass();
-}
-
-
-/**
- * Get the field currently used for storing .
- *
- * @return string
- *   Qualified storage class name.
- */
-function metastore_metadata_field() {
-  $itemFactory = \Drupal::service('dkan.metastore.metastore_item_factory');
-  return $itemFactory::getMetadataField();
 }
 
 /**
  * Implements hook_form_alter().
  */
 function metastore_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $fieldName = metastore_metadata_field();
+  $fieldName = \Drupal::service('dkan.metastore.metastore_item_factory')::getMetadataField();
   if (isset($form[$fieldName]['widget'][0]['value']['#default_value'])) {
     $json = $form[$fieldName]['widget'][0]['value']['#default_value'];
     if (empty($json)) {
@@ -156,7 +136,7 @@ function metastore_form_alter(&$form, FormStateInterface $form_state, $form_id) 
  * Implements hook_entity_view_alter.
  */
 function metastore_entity_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
-  $fieldName = metastore_metadata_field();
+  $fieldName = \Drupal::service('dkan.metastore.metastore_item_factory')::getMetadataField();
 
   if (isset($build[$fieldName][0]['#context']['value'])) {
     $json = $build[$fieldName][0]['#context']['value'];

--- a/modules/metastore/metastore.module
+++ b/modules/metastore/metastore.module
@@ -123,11 +123,23 @@ function metastore_storage_class() {
   return $storageFactory::getStorageClass();
 }
 
+
+/**
+ * Get the field currently used for storing .
+ *
+ * @return string
+ *   Qualified storage class name.
+ */
+function metastore_metadata_field() {
+  $itemFactory = \Drupal::service('dkan.metastore.metastore_item_factory');
+  return $itemFactory::getMetadataField();
+}
+
 /**
  * Implements hook_form_alter().
  */
 function metastore_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $fieldName = metastore_storage_class()::getMetadataField();
+  $fieldName = metastore_metadata_field();
   if (isset($form[$fieldName]['widget'][0]['value']['#default_value'])) {
     $json = $form[$fieldName]['widget'][0]['value']['#default_value'];
     if (empty($json)) {
@@ -144,7 +156,7 @@ function metastore_form_alter(&$form, FormStateInterface $form_state, $form_id) 
  * Implements hook_entity_view_alter.
  */
 function metastore_entity_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
-  $fieldName = metastore_storage_class()::getMetadataField();
+  $fieldName = metastore_metadata_field();
 
   if (isset($build[$fieldName][0]['#context']['value'])) {
     $json = $build[$fieldName][0]['#context']['value'];

--- a/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
+++ b/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
@@ -115,11 +115,12 @@ class SearchTest extends TestCase {
     ],
     ];
 
-    $expect2 = [(object) [
-      'type' => 'publisher__name',
-      'name' => 'Steve',
-      'total' => 0,
-    ],
+    $expect2 = [
+      (object) [
+        'type' => 'publisher__name',
+        'name' => 'Steve',
+        'total' => 0,
+      ],
     ];
 
     $container = $this->getCommonMockChain($this)->getMock();
@@ -181,7 +182,8 @@ class SearchTest extends TestCase {
     $getAllOptions = (new Options())
       ->add('keyword', [])
       ->add('theme', [])
-      ->add('publisher', [ServiceTest::getValidMetadataFactory($case)->get(json_encode($facet), 'publisher')]);
+      ->add('publisher', [ServiceTest::getValidMetadataFactory($case)->get(json_encode($facet), 'publisher')])
+      ->index(0);
 
     $getData = ServiceTest::getValidMetadataFactory($case)->get(json_encode($collection), 'dummy_schema_id');
 

--- a/modules/metastore/src/DatasetApiDocs.php
+++ b/modules/metastore/src/DatasetApiDocs.php
@@ -86,9 +86,8 @@ class DatasetApiDocs {
    *   OpenAPI spec.
    */
   public function getDatasetSpecific(string $identifier) {
-    $fullSpec = $this->docsGenerator->buildSpec(
-      ['metastore_api_docs', 'datastore_api_docs']
-    )->{"$"};
+    $specs = ['metastore_api_docs', 'datastore_api_docs'];
+    $fullSpec = $this->docsGenerator->buildSpec($specs)->{"$"};
 
     $datasetSpec = [
       'openapi' => $fullSpec['openapi'],

--- a/modules/metastore/src/Plugin/DkanApiDocs/MetastoreApiDocs.php
+++ b/modules/metastore/src/Plugin/DkanApiDocs/MetastoreApiDocs.php
@@ -215,7 +215,7 @@ class MetastoreApiDocs extends DkanApiDocsBase {
    *   An identifier.
    */
   private function getExampleIdentifier($schemaId) {
-    if ($first = $this->metastore->getRange($schemaId, 0, 1)) {
+    if ($first = $this->metastore->getAll($schemaId, 0, 1)) {
       return $first[0]->{"$.identifier"};
     }
     return FALSE;

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -118,12 +118,14 @@ class Service implements ContainerInjectionInterface {
    *
    * @param string $schema_id
    *   The schema ID to be counted.
+   * @param bool $unpublished
+   *   Whether to include unpublished items.
    *
    * @return int
    *   Object count.
    */
-  public function count(string $schema_id): int {
-    return $this->getStorage($schema_id)->count();
+  public function count(string $schema_id, bool $unpublished = FALSE): int {
+    return $this->getStorage($schema_id)->count($unpublished);
   }
 
   /**
@@ -137,54 +139,33 @@ class Service implements ContainerInjectionInterface {
    *   Schema object offset or null for all.
    * @param int|null $length
    *   Number of objects to fetch or null for all.
+   * @param bool $unpublished
+   *   Whether to include unpublished items.
    *
    * @return string[]
    *   Range of object UUIDs of the given schema_id.
    */
-  public function getRangeUuids(string $schema_id, ?int $start = NULL, ?int $length = NULL): array {
-    return $this->getStorage($schema_id)->retrieveRangeUuids($start, $length);
+  public function getIdentifiers(string $schema_id, ?int $start = NULL, ?int $length = NULL, $unpublished = FALSE): array {
+    return $this->getStorage($schema_id)->retrieveIds($start, $length, $unpublished);
   }
 
   /**
-   * Get all.
-   *
-   * @param string $schema_id
-   *   The {schema_id} slug from the HTTP request.
-   *
-   * @return array
-   *   All objects of the given schema_id.
-   */
-  public function getAll($schema_id): array {
-    $jsonStringsArray = $this->getStorage($schema_id)->retrieveAll();
-    $objects = array_filter($this->jsonStringsArrayToObjects($jsonStringsArray, $schema_id));
-
-    return $this->dispatchEvent(self::EVENT_DATA_GET_ALL, $objects, function ($data) {
-      if (!is_array($data)) {
-        return FALSE;
-      }
-      if (count($data) == 0) {
-        return TRUE;
-      }
-      return reset($data) instanceof RootedJsonData;
-    });
-
-  }
-
-  /**
-   * Get a subset of metastore items according to a range.
+   * Get all items, with optional pagination and status filters.
    *
    * @param string $schema_id
    *   Schema ID.
    * @param int $start
    *   Start offset.
-   * @param int $length
+   * @param int|null $length
    *   Number of items to retrieve.
+   * @param bool $unpublished
+   *   Whether to include unpublished items. Should default to false.
    *
    * @return array
    *   Array of RootedJsonData objects.
    */
-  public function getRange(string $schema_id, int $start, int $length):array {
-    $jsonStringsArray = $this->getStorage($schema_id)->retrieveRange($start, $length);
+  public function getAll(string $schema_id, int $start = 0, ?int $length = NULL, $unpublished = FALSE):array {
+    $jsonStringsArray = $this->getStorage($schema_id)->retrieveAll($start, $length, $unpublished);
     $objects = array_filter($this->jsonStringsArrayToObjects($jsonStringsArray, $schema_id));
 
     return $this->dispatchEvent(self::EVENT_DATA_GET_ALL, $objects, function ($data) {

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -106,7 +106,7 @@ class Service implements ContainerInjectionInterface {
    * @return \Drupal\metastore\Storage\MetastoreStorageInterface
    *   Entity storage.
    */
-  public function getStorage(string $schema_id): MetastoreStorageInterface {
+  private function getStorage(string $schema_id): MetastoreStorageInterface {
     if (!isset($this->storages[$schema_id])) {
       $this->storages[$schema_id] = $this->storageFactory->getInstance($schema_id);
     }

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -106,7 +106,7 @@ class Service implements ContainerInjectionInterface {
    * @return \Drupal\metastore\Storage\MetastoreStorageInterface
    *   Entity storage.
    */
-  private function getStorage(string $schema_id): MetastoreStorageInterface {
+  public function getStorage(string $schema_id): MetastoreStorageInterface {
     if (!isset($this->storages[$schema_id])) {
       $this->storages[$schema_id] = $this->storageFactory->getInstance($schema_id);
     }

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -154,8 +154,8 @@ class Service implements ContainerInjectionInterface {
    *
    * @param string $schema_id
    *   Schema ID.
-   * @param int $start
-   *   Start offset.
+   * @param int|null $start
+   *   Start offset. Null for no range.
    * @param int|null $length
    *   Number of items to retrieve.
    * @param bool $unpublished
@@ -164,7 +164,7 @@ class Service implements ContainerInjectionInterface {
    * @return array
    *   Array of RootedJsonData objects.
    */
-  public function getAll(string $schema_id, int $start = 0, ?int $length = NULL, $unpublished = FALSE):array {
+  public function getAll(string $schema_id, ?int $start = NULL, ?int $length = NULL, $unpublished = FALSE):array {
     $jsonStringsArray = $this->getStorage($schema_id)->retrieveAll($start, $length, $unpublished);
     $objects = array_filter($this->jsonStringsArrayToObjects($jsonStringsArray, $schema_id));
 

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -294,9 +294,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
   }
 
   /**
-   * Inherited.
-   *
-   * {@inheritdoc}.
+   * {@inheritdoc}
    */
   public function remove(string $uuid) {
 
@@ -307,9 +305,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
   }
 
   /**
-   * Inherited.
-   *
-   * {@inheritdoc}.
+   * {@inheritdoc}
    */
   public function store($data, string $uuid = NULL): string {
     $data = json_decode($data);

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -75,7 +75,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
   protected $metadataField;
 
   /**
-   * The entity field or property used to store the schema ID (e.g. "dataset).
+   * The entity field or property used to store the schema ID (e.g. "dataset").
    *
    * @var string
    */

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -344,7 +344,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
    * @return string|null
    *   The content entity UUID, or null if failed.
    */
-  private function updateExistingEntity(ContentEntityInterface $entity, object $data): ?string {
+  private function updateExistingEntity(ContentEntityInterface $entity, \stdClass $data): ?string {
     $entity->{static::getSchemaIdField()} = $this->schemaId;
     $new_data = json_encode($data);
     $entity->{static::getMetadataField()} = $new_data;

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -474,8 +474,6 @@ abstract class Data implements MetastoreEntityStorageInterface {
     if ($workflow instanceof WorkflowInterface) {
       return $workflow->getTypePlugin()->getConfiguration()['default_moderation_state'];
     }
-    // If this failed for some reason, default to published.
-    return 'published';
   }
 
 }

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -344,7 +344,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
    * @return string|null
    *   The content entity UUID, or null if failed.
    */
-  private function updateExistingEntity(ContentEntityInterface $entity, \stdClass $data): ?string {
+  private function updateExistingEntity(ContentEntityInterface $entity, $data): ?string {
     $entity->{static::getSchemaIdField()} = $this->schemaId;
     $new_data = json_encode($data);
     $entity->{static::getMetadataField()} = $new_data;

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -66,9 +66,19 @@ abstract class Data implements MetastoreStorageInterface {
    * @var string
    */
   protected $bundle;
-  
+
+  /**
+   * The entity field or property used to store JSON metadata.
+   *
+   * @var string
+   */
   protected $metadataField;
 
+  /**
+   * The entity field or property used to store the schema ID (e.g. "dataset).
+   *
+   * @var string
+   */
   protected $schemaIdField;
 
   /**

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -143,12 +143,13 @@ abstract class Data implements MetastoreEntityStorageInterface {
    *   An array of Drupal entity IDs, returned from an entity query.
    *
    * @return string[]
-   *   An array of JSON strings containing the metadata.
+   *   An array of JSON strings containing the metadata. Note that array
+   *   keys from $enditityIds will not be preserved.
    */
   protected function entityIdsToJsonStrings(array $entityIds): array {
     return array_map(function ($entity) {
       return $entity->get($this->getMetadataField())->getString();
-    }, $this->entityStorage->loadMultiple($entityIds));
+    }, array_values($this->entityStorage->loadMultiple($entityIds)));
   }
 
   /**
@@ -337,13 +338,13 @@ abstract class Data implements MetastoreEntityStorageInterface {
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   Drupal content entity.
-   * @param string $data
+   * @param object $data
    *   JSON data.
    *
    * @return string|null
    *   The content entity UUID, or null if failed.
    */
-  private function updateExistingEntity(ContentEntityInterface $entity, string $data): ?string {
+  private function updateExistingEntity(ContentEntityInterface $entity, object $data): ?string {
     $entity->{static::getSchemaIdField()} = $this->schemaId;
     $new_data = json_encode($data);
     $entity->{static::getMetadataField()} = $new_data;

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -112,8 +112,8 @@ abstract class Data implements MetastoreEntityStorageInterface {
   /**
    * Create basic query for a list of metastore items.
    *
-   * @param int $start
-   *   Offset. Should default to zero (i.e., no offset).
+   * @param int|null $start
+   *   Offset. NULL if no range, 0 to start at beginning of set.
    * @param int|null $length
    *   Number of items to retrieve. NULL for no limit.
    * @param bool $unpublished
@@ -122,11 +122,11 @@ abstract class Data implements MetastoreEntityStorageInterface {
    * @return \Drupal\Core\Entity\Query\QueryInterface
    *   A Drupal query object.
    */
-  protected function listQueryBase(int $start = 0, ?int $length = NULL, bool $unpublished = FALSE):QueryInterface {
+  protected function listQueryBase(int $start = NULL, ?int $length = NULL, bool $unpublished = FALSE):QueryInterface {
     $query = $this->entityStorage->getQuery()
       ->accessCheck(FALSE)
       ->condition('type', $this->bundle)
-      ->condition(static::getMetadataField(), $this->schemaId)
+      ->condition(static::getSchemaIdField(), $this->schemaId)
       ->range($start, $length);
 
     if ($unpublished === FALSE) {
@@ -161,7 +161,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
   /**
    * {@inheritdoc}
    */
-  public function retrieveAll(int $start = 0, ?int $length = NULL, bool $unpublished = FALSE): array {
+  public function retrieveAll(?int $start = NULL, ?int $length = NULL, bool $unpublished = FALSE): array {
     $entityIds = $this->listQueryBase($start, $length, $unpublished)->execute();
     return $this->entityIdsToJsonStrings($entityIds);
   }
@@ -169,7 +169,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
   /**
    * {@inheritdoc}
    */
-  public function retrieveIds(int $start = 0, ?int $length = NULL, bool $unpublished = FALSE): array {
+  public function retrieveIds(?int $start = NULL, ?int $length = NULL, bool $unpublished = FALSE): array {
 
     $entityIds = $this->listQueryBase($start, $length, $unpublished)->execute();
 
@@ -261,7 +261,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
    * @return \Drupal\Core\Entity\ContentEntityInterface|null
    *   The entity's latest revision, if found.
    */
-  public function getEntityLatestRevision(string $uuid): ContentEntityInterface {
+  public function getEntityLatestRevision(string $uuid) {
 
     $entity_id = $this->getEntityIdFromUuid($uuid);
 

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -14,7 +14,7 @@ use Drupal\workflows\WorkflowInterface;
 /**
  * Abstract metastore storage class, for using Drupal entities.
  */
-abstract class Data implements MetastoreStorageInterface {
+abstract class Data implements MetastoreEntityStorageInterface {
 
   use LoggerTrait;
 

--- a/modules/metastore/src/Storage/MetastoreEntityStorageInterface.php
+++ b/modules/metastore/src/Storage/MetastoreEntityStorageInterface.php
@@ -7,28 +7,4 @@ namespace Drupal\metastore\Storage;
  */
 interface MetastoreEntityStorageInterface extends MetastoreStorageInterface {
 
-  /**
-   * Get the entity type used in this storage class.
-   *
-   * @return string
-   *   Entity type.
-   */
-  public static function getEntityType();
-
-  /**
-   * Get the bundles used in this storage class.
-   *
-   * @return array
-   *   Array of bundle names.
-   */
-  public static function getBundles();
-
-  /**
-   * Get the name of the property or field used to store the JSON metadata.
-   *
-   * @return string
-   *   Field name.
-   */
-  public static function getMetadataField();
-
 }

--- a/modules/metastore/src/Storage/MetastoreStorageInterface.php
+++ b/modules/metastore/src/Storage/MetastoreStorageInterface.php
@@ -11,12 +11,12 @@ interface MetastoreStorageInterface {
    * Count objects of the current schema ID.
    *
    * @param bool $unpublished
-   *   Whether to include unpublished items. Should default to false.
+   *   Whether to include unpublished items.
    *
    * @return int
    *   Count.
    */
-  public function count(bool $unpublished): int;
+  public function count(bool $unpublished = FALSE): int;
 
   /**
    * Retrieve a metadata string by ID, regardless of whether it is published.
@@ -53,7 +53,7 @@ interface MetastoreStorageInterface {
    * @return string[]
    *   An array of JSON strings representing metadata objects.
    */
-  public function retrieveAll(?int $start, ?int $length, bool $unpublished): array;
+  public function retrieveAll(?int $start = NULL, ?int $length = NULL, bool $unpublished = FALSE): array;
 
   /**
    * Retrieve just identifiers.
@@ -93,10 +93,10 @@ interface MetastoreStorageInterface {
    * @param string $uuid
    *   Identifier.
    *
-   * @return string
-   *   Identifier.
+   * @return bool
+   *   True if success.
    */
-  public function publish(string $uuid) : string;
+  public function publish(string $uuid): bool;
 
   /**
    * Remove.

--- a/modules/metastore/src/Storage/MetastoreStorageInterface.php
+++ b/modules/metastore/src/Storage/MetastoreStorageInterface.php
@@ -2,16 +2,24 @@
 
 namespace Drupal\metastore\Storage;
 
-use Contracts\BulkRetrieverInterface;
-use Contracts\StorerInterface;
-
 /**
  * Interface for all metastore storage classes.
  */
-interface MetastoreStorageInterface extends StorerInterface, BulkRetrieverInterface {
+interface MetastoreStorageInterface {
 
   /**
-   * Retrieve.
+   * Count objects of the current schema ID.
+   *
+   * @param bool $unpublished
+   *   Whether to include unpublished items. Should default to false.
+   *
+   * @return int
+   *   Count.
+   */
+  public function count(bool $unpublished): int;
+
+  /**
+   * Retrieve a metadata string by ID, regardless of whether it is published.
    *
    * @param string $id
    *   The identifier for the data.
@@ -22,25 +30,45 @@ interface MetastoreStorageInterface extends StorerInterface, BulkRetrieverInterf
   public function retrieve(string $id);
 
   /**
-   * Retrieve all.
+   * Retrieve the json metadata from an entity only if it is published.
    *
-   * @return array
-   *   An array of metadata objects.
+   * @param string $uuid
+   *   The identifier.
+   *
+   * @return string|null
+   *   The entity's json metadata, or NULL if the entity was not found.
    */
-  public function retrieveAll(): array;
+  public function retrievePublished(string $uuid) : ?string;
 
   /**
-   * Retrieve a limited range of metadata items.
+   * Retrieve all metadata items.
+   *
+   * @param int $start
+   *   Offset. Should default to zero (i.e., no offset).
+   * @param int|null $length
+   *   Number of items to retrieve. NULL for no limit.
+   * @param bool $unpublished
+   *   Whether to include unpublished items in the results.
+   *
+   * @return string[]
+   *   An array of JSON strings representing metadata objects.
+   */
+  public function retrieveAll(int $start, ?int $length, bool $unpublished): array;
+
+  /**
+   * Retrieve just identifiers.
    *
    * @param int $start
    *   Offset.
-   * @param int $length
-   *   Number to retrieve.
+   * @param int|null $length
+   *   Number of identifiers to retrieve. NULL for no limit.
+   * @param bool $unpublished
+   *   Whether to include unpublished items in the results.
    *
-   * @return array
-   *   An array of metadata objects.
+   * @return string[]
+   *   An array of metastore item identifiers.
    */
-  public function retrieveRange(int $start, int $length): array;
+  public function retrieveIds(int $start, ?int $length, bool $unpublished): array;
 
   /**
    * Retrieve all metadata items that contain a particular exact string.
@@ -58,17 +86,6 @@ interface MetastoreStorageInterface extends StorerInterface, BulkRetrieverInterf
    *   An array of metadata objects.
    */
   public function retrieveContains(string $string, bool $caseSensitive): array;
-
-  /**
-   * Retrieve the json metadata from an entity only if it is published.
-   *
-   * @param string $uuid
-   *   The identifier.
-   *
-   * @return string|null
-   *   The entity's json metadata, or NULL if the entity was not found.
-   */
-  public function retrievePublished(string $uuid) : ?string;
 
   /**
    * Publish the latest version of a data entity.

--- a/modules/metastore/src/Storage/MetastoreStorageInterface.php
+++ b/modules/metastore/src/Storage/MetastoreStorageInterface.php
@@ -43,8 +43,8 @@ interface MetastoreStorageInterface {
   /**
    * Retrieve all metadata items.
    *
-   * @param int $start
-   *   Offset. Should default to zero (i.e., no offset).
+   * @param int|null $start
+   *   Offset. NULL for no range, zero for beginning of set.
    * @param int|null $length
    *   Number of items to retrieve. NULL for no limit.
    * @param bool $unpublished
@@ -53,12 +53,12 @@ interface MetastoreStorageInterface {
    * @return string[]
    *   An array of JSON strings representing metadata objects.
    */
-  public function retrieveAll(int $start, ?int $length, bool $unpublished): array;
+  public function retrieveAll(?int $start, ?int $length, bool $unpublished): array;
 
   /**
    * Retrieve just identifiers.
    *
-   * @param int $start
+   * @param int|null $start
    *   Offset.
    * @param int|null $length
    *   Number of identifiers to retrieve. NULL for no limit.
@@ -68,7 +68,7 @@ interface MetastoreStorageInterface {
    * @return string[]
    *   An array of metastore item identifiers.
    */
-  public function retrieveIds(int $start, ?int $length, bool $unpublished): array;
+  public function retrieveIds(?int $start, ?int $length, bool $unpublished): array;
 
   /**
    * Retrieve all metadata items that contain a particular exact string.

--- a/modules/metastore/src/Storage/NodeData.php
+++ b/modules/metastore/src/Storage/NodeData.php
@@ -17,6 +17,8 @@ class NodeData extends Data {
     $this->bundle = 'data';
     $this->bundleKey = "type";
     $this->labelKey = "title";
+    $this->schemaIdField = "field_data_type";
+    $this->metadataField = "field_json_metadata";
     parent::__construct($schemaId, $entityTypeManager);
   }
 
@@ -25,43 +27,15 @@ class NodeData extends Data {
    */
   public function retrieveContains(string $string, bool $caseSensitive = TRUE): array {
 
-    $query = $this->listQueryBase()->condition(static::getMetadataField(), $string, 'CONTAINS');
+    $query = $this->listQueryBase()->condition($this->metadataField, $string, 'CONTAINS');
     if ($caseSensitive) {
       $query->addTag('case_sensitive');
     }
     $entityIds = $query->execute();
 
     return array_map(function ($entity) {
-      return $entity->get(static::getMetadataField())->getString();
+      return $entity->get($this->metadataField)->getString();
     }, $this->entityStorage->loadMultiple($entityIds));
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function getEntityType() {
-    return 'node';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function getBundles() {
-    return ['data'];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function getMetadataField() {
-    return 'field_json_metadata';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function getSchemaIdField() {
-    return 'field_data_type';
   }
 
   /**
@@ -78,7 +52,7 @@ class NodeData extends Data {
   public function retrieveByHash($hash, $schema_id) {
     $nodes = $this->getEntityStorage()->loadByProperties([
       $this->labelKey => $hash,
-      'field_data_type' => $schema_id,
+      $this->schemaIdField => $schema_id,
     ]);
     if ($node = reset($nodes)) {
       return $node->uuid();

--- a/modules/metastore/src/Storage/NodeData.php
+++ b/modules/metastore/src/Storage/NodeData.php
@@ -48,6 +48,9 @@ class NodeData extends Data {
    *
    * @return string|null
    *   The uuid of the item with that hash.
+   *
+   * @todo This method is not consistent with others in this class, and
+   * may not be needed at all. Fix or remove.
    */
   public function retrieveByHash($hash, $schema_id) {
     $nodes = $this->getEntityStorage()->loadByProperties([

--- a/modules/metastore/tests/src/Functional/Storage/NodeDataDatasetTest.php
+++ b/modules/metastore/tests/src/Functional/Storage/NodeDataDatasetTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Drupal\Tests\metastore\Functional\Storage;
+
+use Drupal\common\Resource;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\datastore\Service\ResourceLocalizer;
+use Drupal\harvest\Load\Dataset;
+use Drupal\harvest\Service as Harvester;
+use Drupal\metastore\Exception\MissingObjectException;
+use Drupal\metastore\Service as Metastore;
+use Drupal\metastore_search\Search;
+use Drupal\node\NodeStorage;
+use Drupal\search_api\Entity\Index;
+use Drupal\Tests\common\Traits\CleanUp;
+use Drupal\Tests\metastore\Unit\ServiceTest;
+use Harvest\ETL\Extract\DataJson;
+use RootedData\RootedJsonData;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * NodeData Functional Tests.
+ *
+ * @package Drupal\Tests\dkan\Functional
+ * @group dkan
+ */
+class NodeDataDatasetTest extends ExistingSiteBase {
+  use CleanUp;
+
+  private const S3_PREFIX = 'https://dkan-default-content-files.s3.amazonaws.com/phpunit';
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->removeHarvests();
+    $this->removeAllNodes();
+    $this->removeAllMappedFiles();
+    $this->removeAllFileFetchingJobs();
+    $this->flushQueues();
+    $this->removeFiles();
+    $this->removeDatastoreTables();
+    $this->setDefaultModerationState("draft");
+
+    $this->validMetadataFactory = ServiceTest::getValidMetadataFactory($this);
+  }
+
+  /**
+   * Test resource removal on distribution deleting.
+   */
+  public function testStorageRetrieveMethods() {
+
+    // Post a dataset with a single distribution.
+    $this->datasetPostTwoAndUnpublishOne();
+    $datasetStorage = $this->getMetastore()->getStorage('dataset');
+
+    $this->assertEquals(1, $datasetStorage->count());
+    $this->assertEquals(2, $datasetStorage->count(TRUE));
+
+    $allPublished = $datasetStorage->retrieveAll();
+    $datasetData = json_decode($allPublished[0]);
+    $this->assertEquals("123", $datasetData->identifier);
+    $this->assertEquals(1, count($allPublished));
+
+    $all = $datasetStorage->retrieveAll(NULL, NULL, TRUE);
+    $this->assertEquals(2, count($all));
+
+    $rangeUnpublished = $datasetStorage->retrieveAll(0, 1, TRUE);
+    $this->assertEquals(1, count($rangeUnpublished));
+
+    $allIds = $datasetStorage->retrieveIds(NULL, NULL, TRUE);
+    $this->assertEquals(2, count($allIds));
+    $this->assertEquals("456", $allIds[1]);
+
+    $this->expectException(MissingObjectException::class);
+    $datasetStorage->retrievePublished('abc');
+
+  }
+
+    /**
+   * Test resource removal on distribution deleting.
+   */
+  public function testBadPublish() {
+    $this->datasetPostTwoAndUnpublishOne();
+    $datasetStorage = $this->getMetastore()->getStorage('dataset');
+
+    $result = $datasetStorage->publish("123");
+    $this->assertFalse($result);
+
+    $this->expectException(MissingObjectException::class);
+    $datasetStorage->publish("abc");
+  }
+
+  private function datasetPostTwoAndUnpublishOne() {
+    $datasetRootedJsonData = $this->getData("123", 'Test Published', ['district_centerpoints_small.csv']);
+    $dataset = json_decode($datasetRootedJsonData);
+
+    $uuid = $this->getMetastore()->post('dataset', $datasetRootedJsonData);
+    $this->getMetastore()->publish('dataset', $uuid);
+
+    $this->assertEquals(
+      $dataset->identifier,
+      $uuid
+    );
+
+    $datasetRootedJsonData = $this->getMetastore()->get('dataset', $uuid);
+    $this->assertIsString("$datasetRootedJsonData");
+
+    $retrievedDataset = json_decode($datasetRootedJsonData);
+
+    $this->assertEquals(
+      $retrievedDataset->identifier,
+      $uuid
+    );
+
+    $datasetRootedJsonData = $this->getData("456", 'Test Unpublished', ['district_centerpoints_small.csv']);
+    $this->getMetastore()->post('dataset', $datasetRootedJsonData);
+  }
+
+  /**
+   * Generate dataset metadata, possibly with multiple distributions.
+   *
+   * @param string $identifier
+   *   Dataset identifier.
+   * @param string $title
+   *   Dataset title.
+   * @param array $downloadUrls
+   *   Array of resource files URLs for this dataset.
+   *
+   * @return \RootedData\RootedJsonData
+   *   Json encoded string of this dataset's metadata, or FALSE if error.
+   */
+  private function getData(string $identifier, string $title, array $downloadUrls): RootedJsonData {
+
+    $data = new \stdClass();
+    $data->title = $title;
+    $data->description = "Some description.";
+    $data->identifier = $identifier;
+    $data->accessLevel = "public";
+    $data->modified = "06-04-2020";
+    $data->keyword = ["some keyword"];
+    $data->distribution = [];
+
+    foreach ($downloadUrls as $key => $downloadUrl) {
+      $distribution = new \stdClass();
+      $distribution->title = "Distribution #{$key} for {$identifier}";
+      $distribution->downloadURL = $this->getDownloadUrl($downloadUrl);
+      $distribution->mediaType = "text/csv";
+
+      $data->distribution[] = $distribution;
+    }
+
+    return $this->validMetadataFactory->get(json_encode($data), 'dataset');
+  }
+
+  private function getMetastore(): Metastore {
+    return \Drupal::service('dkan.metastore.service');
+  }
+
+  private function setDefaultModerationState($state = 'published') {
+    /** @var \Drupal\Core\Config\ConfigFactory $config */
+    $config = \Drupal::service('config.factory');
+    $defaultModerationState = $config->getEditable('workflows.workflow.dkan_publishing');
+    $defaultModerationState->set('type_settings.default_moderation_state', $state);
+    $defaultModerationState->save();
+  }
+
+  private function getDownloadUrl(string $filename) {
+    return self::S3_PREFIX . '/' . $filename;
+  }
+
+}

--- a/modules/metastore/tests/src/Functional/Storage/NodeDataDatasetTest.php
+++ b/modules/metastore/tests/src/Functional/Storage/NodeDataDatasetTest.php
@@ -90,7 +90,7 @@ class NodeDataDatasetTest extends ExistingSiteBase {
   }
 
   private function datasetPostTwoAndUnpublishOne() {
-    $datasetRootedJsonData = $this->getData("123", 'Test Published', ['district_centerpoints_small.csv']);
+    $datasetRootedJsonData = $this->getData("123", 'Test Published', []);
     $dataset = json_decode($datasetRootedJsonData);
 
     $uuid = $this->getMetastore()->post('dataset', $datasetRootedJsonData);
@@ -111,7 +111,7 @@ class NodeDataDatasetTest extends ExistingSiteBase {
       $uuid
     );
 
-    $datasetRootedJsonData = $this->getData("456", 'Test Unpublished', ['district_centerpoints_small.csv']);
+    $datasetRootedJsonData = $this->getData("456", 'Test Unpublished', []);
     $this->getMetastore()->post('dataset', $datasetRootedJsonData);
   }
 

--- a/modules/metastore/tests/src/Functional/Storage/NodeDataTest.php
+++ b/modules/metastore/tests/src/Functional/Storage/NodeDataTest.php
@@ -2,20 +2,11 @@
 
 namespace Drupal\Tests\metastore\Functional\Storage;
 
-use Drupal\common\Resource;
-use Drupal\Core\Queue\QueueFactory;
-use Drupal\datastore\Service\ResourceLocalizer;
-use Drupal\harvest\Load\Dataset;
-use Drupal\harvest\Service as Harvester;
 use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore\Service as Metastore;
 use Drupal\metastore\Service;
-use Drupal\metastore_search\Search;
-use Drupal\node\NodeStorage;
-use Drupal\search_api\Entity\Index;
 use Drupal\Tests\common\Traits\CleanUp;
 use Drupal\Tests\metastore\Unit\ServiceTest;
-use Harvest\ETL\Extract\DataJson;
 use RootedData\RootedJsonData;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
 

--- a/modules/metastore/tests/src/Functional/Storage/NodeDataTest.php
+++ b/modules/metastore/tests/src/Functional/Storage/NodeDataTest.php
@@ -42,7 +42,7 @@ class NodeDataTest extends ExistingSiteBase {
 
     // Post a dataset with a single distribution.
     $this->datasetPostTwoAndUnpublishOne();
-    $datasetStorage = $this->getMetastore()->getStorage('dataset');
+    $datasetStorage = $this->getStorage('dataset');
 
     $this->assertEquals(1, $datasetStorage->count());
     $this->assertEquals(2, $datasetStorage->count(TRUE));
@@ -72,7 +72,7 @@ class NodeDataTest extends ExistingSiteBase {
    */
   public function testBadPublish() {
     $this->datasetPostTwoAndUnpublishOne();
-    $datasetStorage = $this->getMetastore()->getStorage('dataset');
+    $datasetStorage = $this->getStorage('dataset');
 
     $result = $datasetStorage->publish("123");
     $this->assertFalse($result);
@@ -86,7 +86,7 @@ class NodeDataTest extends ExistingSiteBase {
    */
   public function testRetrieveByHash() {
     $this->datasetPostTwoAndUnpublishOne();
-    $keywordStorage = $this->getMetastore()->getStorage('keyword');
+    $keywordStorage = $this->getStorage('keyword');
 
     $keyword = 'some keyword';
     $hash = Service::metadataHash($keyword);
@@ -159,6 +159,10 @@ class NodeDataTest extends ExistingSiteBase {
 
   private function getMetastore(): Metastore {
     return \Drupal::service('dkan.metastore.service');
+  }
+
+  private function getStorage($schemaId) {
+    return \Drupal::service('dkan.metastore.storage')->getInstance($schemaId);
   }
 
   private function setDefaultModerationState($state = 'published') {

--- a/modules/metastore/tests/src/Functional/Storage/NodeDataTest.php
+++ b/modules/metastore/tests/src/Functional/Storage/NodeDataTest.php
@@ -9,6 +9,7 @@ use Drupal\harvest\Load\Dataset;
 use Drupal\harvest\Service as Harvester;
 use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore\Service as Metastore;
+use Drupal\metastore\Service;
 use Drupal\metastore_search\Search;
 use Drupal\node\NodeStorage;
 use Drupal\search_api\Entity\Index;
@@ -24,7 +25,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
  * @package Drupal\Tests\dkan\Functional
  * @group dkan
  */
-class NodeDataDatasetTest extends ExistingSiteBase {
+class NodeDataTest extends ExistingSiteBase {
   use CleanUp;
 
   private const S3_PREFIX = 'https://dkan-default-content-files.s3.amazonaws.com/phpunit';
@@ -75,7 +76,7 @@ class NodeDataDatasetTest extends ExistingSiteBase {
 
   }
 
-    /**
+  /**
    * Test resource removal on distribution deleting.
    */
   public function testBadPublish() {
@@ -87,6 +88,20 @@ class NodeDataDatasetTest extends ExistingSiteBase {
 
     $this->expectException(MissingObjectException::class);
     $datasetStorage->publish("abc");
+  }
+
+  /**
+   * Test resource removal on distribution deleting.
+   */
+  public function testRetrieveByHash() {
+    $this->datasetPostTwoAndUnpublishOne();
+    $keywordStorage = $this->getMetastore()->getStorage('keyword');
+
+    $keyword = 'some keyword';
+    $hash = Service::metadataHash($keyword);
+    $keywordId = $keywordStorage->retrieveByHash($hash, 'keyword');
+    $keywordMetadata = json_decode($keywordStorage->retrieve($keywordId));
+    $this->assertEquals($keyword, $keywordMetadata->data);
   }
 
   private function datasetPostTwoAndUnpublishOne() {

--- a/modules/metastore/tests/src/Unit/Commands/MetastoreCommandsTest.php
+++ b/modules/metastore/tests/src/Unit/Commands/MetastoreCommandsTest.php
@@ -21,7 +21,7 @@ class MetastoreCommandsTest extends TestCase {
   public function testPublish() {
     $dataFactory = (new Chain($this))
       ->add(DataFactory::class, 'getInstance', Data::class)
-      ->add(Data::class, 'publish', '12345')
+      ->add(Data::class, 'publish', TRUE)
       ->getMock();
 
     $loggerChain = (new Chain($this))

--- a/modules/metastore/tests/src/Unit/ServiceTest.php
+++ b/modules/metastore/tests/src/Unit/ServiceTest.php
@@ -336,20 +336,20 @@ EOF;
   }
 
   /**
-   * Test \Drupal\metastore\Service::getRangeUuids() method.
+   * Test \Drupal\metastore\Service::getIdentifiers() method.
    */
-  public function testGetRangeUuids(): void {
-    // Set constant which should be returned by the ::getRangeUuids() method.
+  public function testGetIdentifiers(): void {
+    // Set constant which should be returned by the ::getIdentifiers() method.
     $uuids = ['a', 'b', 'c'];
 
-    // Create mock chain for testing ::getRangeUuids() method.
+    // Create mock chain for testing ::getIdentifiers() method.
     $container = self::getCommonMockChain($this)
-      ->add(NodeData::class, 'retrieveRangeUuids', $uuids);
+      ->add(NodeData::class, 'retrieveIds', $uuids);
 
     // Create metastore service object.
     $service = Service::create($container->getMock());
     // Ensure count matches return value.
-    $this->assertEquals($uuids, $service->getRangeUuids('test', 1, 5));
+    $this->assertEquals($uuids, $service->getIdentifiers('test', 1, 5));
   }
 
   /**

--- a/modules/metastore/tests/src/Unit/ServiceTest.php
+++ b/modules/metastore/tests/src/Unit/ServiceTest.php
@@ -298,11 +298,11 @@ EOF;
   public function testPublish() {
     $container = self::getCommonMockChain($this)
       ->add(NodeData::class, "retrieve", "1")
-      ->add(NodeData::class, "publish", "1");
+      ->add(NodeData::class, "publish", TRUE);
 
     $service = Service::create($container->getMock());
     $result = $service->publish('dataset', 1);
-    $this->assertEquals("1", $result);
+    $this->assertTrue($result);
   }
 
   /**

--- a/modules/metastore/tests/src/Unit/Storage/DataTest.php
+++ b/modules/metastore/tests/src/Unit/Storage/DataTest.php
@@ -21,7 +21,6 @@ class DataTest extends TestCase {
 
     $data = new NodeData('dataset', $this->getEtmChain()->getMock());
     $this->assertInstanceOf(NodeStorage::class, $data->getEntityStorage());
-    $this->assertEquals('field_json_metadata', $data->getMetadataField());
   }
 
   public function testPublishDatasetNotFound() {

--- a/modules/metastore/tests/src/Unit/Storage/DataTest.php
+++ b/modules/metastore/tests/src/Unit/Storage/DataTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\metastore\Unit\Storage;
 
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\metastore\Storage\NodeData;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeStorage;
@@ -37,7 +38,8 @@ class DataTest extends TestCase {
   public function testPublishDraftDataset() {
 
     $etmMock = $this->getEtmChain()
-      ->add(Node::class, 'get', 'draft')
+      ->add(Node::class, 'get', FieldItemListInterface::class)
+      ->add(FieldItemListInterface::class, 'getString', 'draft')
       ->add(Node::class, 'set')
       ->add(Node::class, 'save')
       ->getMock();
@@ -50,7 +52,8 @@ class DataTest extends TestCase {
   public function testPublishDatasetAlreadyPublished() {
 
     $etmMock = $this->getEtmChain()
-      ->add(Node::class, 'get', 'published')
+      ->add(Node::class, 'get', FieldItemListInterface::class)
+      ->add(FieldItemListInterface::class, 'getString', 'published')
       ->getMock();
 
     $nodeData = new NodeData('dataset', $etmMock);

--- a/modules/metastore/tests/src/Unit/Storage/DataTest.php
+++ b/modules/metastore/tests/src/Unit/Storage/DataTest.php
@@ -92,10 +92,10 @@ class DataTest extends TestCase {
   }
 
   /**
-   * Test \Drupal\metastore\Storage\Data::retrieveRangeUuids() method.
+   * Test \Drupal\metastore\Storage\Data::retrieveIds() method.
    */
   public function testRetrieveRangeUuids(): void {
-    // Generate dataset nodes for testing ::retrieveRangeUuids().
+    // Generate dataset nodes for testing ::retrieveIds().
     $nodes = [];
     $uuids = [];
 
@@ -109,7 +109,7 @@ class DataTest extends TestCase {
       $uuids[$i] = $nodes[$i]->uuid();
     }
 
-    // Create mock chain for testing ::retrieveRangeUuids() method.
+    // Create mock chain for testing ::retrieveIds() method.
     $etmMock = $this->getEtmChain()
       ->add(NodeStorage::class, 'loadMultiple', $nodes)
       ->getMock();
@@ -117,7 +117,7 @@ class DataTest extends TestCase {
     // Create Data object.
     $nodeData = new NodeData('dataset', $etmMock);
     // Ensure the returned uuids match those belonging to the generated nodes.
-    $this->assertEquals($uuids, $nodeData->retrieveRangeUuids(1, 5));
+    $this->assertEquals($uuids, $nodeData->retrieveIds(1, 5));
   }
 
 }

--- a/tests/src/Functional/DatasetTest.php
+++ b/tests/src/Functional/DatasetTest.php
@@ -65,7 +65,7 @@ class DatasetTest extends ExistingSiteBase {
   /**
    * Test the resource purger when the default moderation state is 'published'.
    */
-  public function test3() {
+  public function testResourcePurgePublished() {
 
     // Post then update a dataset with multiple, changing resources.
     $this->storeDatasetRunQueues(111, '1.1', ['1.csv', '2.csv']);
@@ -79,7 +79,7 @@ class DatasetTest extends ExistingSiteBase {
   /**
    * Test the resource purger when the default moderation state is 'draft'.
    */
-  public function test4() {
+  public function testResourcePurgeDraft() {
     $this->setDefaultModerationState('draft');
 
     // Post, update and publish a dataset with multiple, changing resources.
@@ -120,7 +120,7 @@ class DatasetTest extends ExistingSiteBase {
   /**
    * Test removal of datasets by a subsequent harvest.
    */
-  public function test5() {
+  public function testHarvestOrphan() {
 
     $plan = $this->getPlan('test5', 'catalog-step-1.json');
     $harvester = $this->getHarvester();
@@ -146,9 +146,9 @@ class DatasetTest extends ExistingSiteBase {
     $this->assertEquals($expected, $result['status']['load']);
 
     $this->assertEquals('published', $this->getModerationState('1'));
-    $this->assertEquals('published' , $this->getModerationState('2'));
-    $this->assertEquals('orphaned' , $this->getModerationState('3'));
-    $this->assertEquals('published' , $this->getModerationState('4'));
+    $this->assertEquals('published', $this->getModerationState('2'));
+    $this->assertEquals('orphaned', $this->getModerationState('3'));
+    $this->assertEquals('published', $this->getModerationState('4'));
   }
 
   /**
@@ -290,7 +290,7 @@ class DatasetTest extends ExistingSiteBase {
    * @param array $downloadUrls
    *   Array of resource files URLs for this dataset.
    *
-   * @return string|false
+   * @return \RootedData\RootedJsonData
    *   Json encoded string of this dataset's metadata, or FALSE if error.
    */
   private function getData(string $identifier, string $title, array $downloadUrls): RootedJsonData {


### PR DESCRIPTION
Fixes multiple inconsistencies and limitations in the metastore service retrieve methods. Makes it easier to use the metastore service and underlying storage classes to retrieve lists of metadata items or identifiers and either include or exclude unpublished items.

## QA Steps

1. Install demo
2. Install and enable simple_sitemap
3. Run cron. Confirm you see all datasets in /sitemap.xml, including `cedcd327-4e5d-43f9-8eb1-c11850fa7c55`
4. Unpublish the "Florida Bike Lanes" dataset
5. Run cron (or regenerate the sitemap in the admin UI)
6. Confirm `cedcd327-4e5d-43f9-8eb1-c11850fa7c55` is now excluded from /sitemap.xml
7. Confirm `cedcd327-4e5d-43f9-8eb1-c11850fa7c55` is still listed in the Datastore Import Status page as "unpublished"

## Note

* This PR changes several public methods around retrieval, and also changes the signature for the MetastoreStorageInterface::publish method (returns bool instead of string). 
* For this reason, review carefully and make sure you agree with the change, and be sure to make the next release after merge a point, bumping us to (as of this writing) 2.13.