### PR TITLE
Use Simple Sitemap base URL setting

### DIFF
--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -1,5 +1,6 @@
 <?php
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
@@ -95,14 +96,30 @@ function dkan_js_frontend_simple_sitemap_arbitrary_links_alter(array &$arbitrary
   // Gather DKAN routes.
   $routes = \Drupal::service('dkan_js_frontend.route_provider')->routes();
 
-  _dkan_js_frontend_add_static_links($arbitrary_links, $routes);
+  $request_context = _dkan_js_frontend_build_request_context();
+  _dkan_js_frontend_add_static_links($arbitrary_links, $routes, $request_context);
   // If the 'dataset' route exists, add links for the dataset route.
   if ($dataset_route = $routes->get('dataset')) {
-    _dkan_js_frontend_add_dataset_links($arbitrary_links, $dataset_route);
+    _dkan_js_frontend_add_dataset_links($arbitrary_links, $dataset_route, $request_context);
   }
   else {
     \Drupal::logger('dkan_js_frontend')->error(DKAN_JS_FRONTEND_MISSING_DATASET_ROUTE_ERROR);
   }
+}
+
+/**
+ * Build request context for sitemap.
+ *
+ * @return \Drupal\Core\Routing\RequestContext
+ *   Request context containing base URL for sitemap URL generation.
+ */
+function _dkan_js_frontend_build_request_context(): RequestContext {
+  $base_url = \Drupal::service('simple_sitemap.settings')->get('base_url');
+  // Attempt to create request from base URL specified in sitemap settings; if
+  // no base URL is specified, fall back to the current request.
+  $request = isset($base_url) ? Request::create($base_url) : \Drupal::request();
+  // Build request context from request.
+  return (new RequestContext())->fromRequest($request);
 }
 
 /**
@@ -112,11 +129,10 @@ function dkan_js_frontend_simple_sitemap_arbitrary_links_alter(array &$arbitrary
  *   Multi-dimensional array for storing arbitrary site links.
  * @param \Symfony\Component\Routing\RouteCollection $routes
  *   Collection of DKAN routes.
+ * @param \Drupal\Core\Routing\RequestContext
+ *   Request context containing base URL for sitemap URL generation.
  */
-function _dkan_js_frontend_add_static_links(array &$arbitrary_links, RouteCollection $routes): void {
-  // Build request context from request.
-  $request = \Drupal::request();
-  $request_context = (new RequestContext())->fromRequest($request);
+function _dkan_js_frontend_add_static_links(array &$arbitrary_links, RouteCollection $routes, RequestContext $request_context): void {
   // Build route URL generator.
   $url_generator = new UrlGenerator($routes, $request_context);
   // Loop through routes and add to sitemap.
@@ -137,14 +153,13 @@ function _dkan_js_frontend_add_static_links(array &$arbitrary_links, RouteCollec
  *   Multi-dimensional array for storing arbitrary site links.
  * @param \Symfony\Component\Routing\Route $routes
  *   Collection of DKAN routes.
+ * @param \Drupal\Core\Routing\RequestContext
+ *   Request context containing base URL for sitemap URL generation.
  */
-function _dkan_js_frontend_add_dataset_links(array &$arbitrary_links, Route $dataset_route): void {
+function _dkan_js_frontend_add_dataset_links(array &$arbitrary_links, Route $dataset_route, RequestContext $request_context): void {
   // Build route collection.
   $routes = new RouteCollection();
   $routes->add('dataset', $dataset_route);
-  // Build request context from request.
-  $request = \Drupal::request();
-  $request_context = (new RequestContext())->fromRequest($request);
   // Build route URL generator.
   $url_generator = new UrlGenerator($routes, $request_context);
 

--- a/modules/dkan_js_frontend/tests/src/Unit/Routing/RouteProviderJSTest.php
+++ b/modules/dkan_js_frontend/tests/src/Unit/Routing/RouteProviderJSTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\RouteProvider\Unit\Routing;
+namespace Drupal\Tests\dkan_js_frontend\Unit\Routing;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\Query\QueryFactoryInterface;

--- a/modules/dkan_js_frontend/tests/src/Unit/SimpleSitemapArbitraryLinksAlterTest.php
+++ b/modules/dkan_js_frontend/tests/src/Unit/SimpleSitemapArbitraryLinksAlterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\RouteProvider\Unit;
+namespace Drupal\Tests\dkan_js_frontend\Unit;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
@@ -50,10 +50,12 @@ class SimpleSitemapArbitraryLinksAlterTest extends TestCase {
       ->add('entity_type.manager', EntityTypeManagerInterface::class)
       ->add('logger.factory', LoggerChannelFactory::class)
       ->add('request_stack', RequestStack::class)
+      ->add('simple_sitemap.settings', SimpleSitemapSettingsInterface::class)
       ->index(0);
     $container = (new Chain($this))
       ->add(Container::class, 'get', $containerOptions)
       ->add(RequestStack::class, 'getCurrentRequest', (Request::create(self::BASE_URL)))
+      ->add(SimpleSitemapSettingsInterface::class, 'get', NULL)
       ->getMock();
     \Drupal::setContainer($container);
 
@@ -84,11 +86,13 @@ class SimpleSitemapArbitraryLinksAlterTest extends TestCase {
       ->add('entity_type.manager', EntityTypeManagerInterface::class)
       ->add('dkan.metastore.service', Service::class)
       ->add('request_stack', RequestStack::class)
+      ->add('simple_sitemap.settings', SimpleSitemapSettingsInterface::class)
       ->index(0);
     $container = (new Chain($this))
       ->add(Container::class, 'get', $containerOptions)
       ->add(RequestStack::class, 'getCurrentRequest', (Request::create(self::BASE_URL)))
       ->add(Service::class, 'getIdentifiers', [1, 2])
+      ->add(SimpleSitemapSettingsInterface::class, 'get', NULL)
       ->getMock();
     \Drupal::setContainer($container);
 
@@ -120,12 +124,14 @@ class SimpleSitemapArbitraryLinksAlterTest extends TestCase {
       ->add('logger.factory', LoggerChannelFactory::class)
       ->add('dkan.metastore.service', Service::class)
       ->add('request_stack', RequestStack::class)
+      ->add('simple_sitemap.settings', SimpleSitemapSettingsInterface::class)
       ->index(0);
     $containerChain = (new Chain($this))
       ->add(Container::class, 'get', $containerOptions)
       ->add(LoggerChannelFactory::class, 'get', LoggerChannelInterface::class)
       ->add(LoggerChannelInterface::class, 'error', NULL, 'error')
-      ->add(RequestStack::class, 'getCurrentRequest', (Request::create(self::BASE_URL)));
+      ->add(RequestStack::class, 'getCurrentRequest', (Request::create(self::BASE_URL)))
+      ->add(SimpleSitemapSettingsInterface::class, 'get', NULL);
     \Drupal::setContainer($containerChain->getMock());
 
     $arbitrary_links = [];

--- a/modules/dkan_js_frontend/tests/src/Unit/SimpleSitemapSettingsInterface.php
+++ b/modules/dkan_js_frontend/tests/src/Unit/SimpleSitemapSettingsInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\Tests\dkan_js_frontend\Unit;
+
+/**
+ * Settings service mock interface.
+ */
+interface SimpleSitemapSettingsInterface {
+
+  /**
+   * Returns a specific setting or a default value if setting does not exist.
+   *
+   * @param string $name
+   *   Name of the setting, like 'max_links'.
+   * @param mixed $default
+   *   Value to be returned if the setting does not exist in the configuration.
+   *
+   * @return mixed
+   *   The current setting from configuration or a default value.
+   */
+  public function get(string $name, $default = NULL);
+
+}


### PR DESCRIPTION
Fixes bug where sitemap base URL not being picked up by dkan_js_frontend arbitrary link URL generation.

## QA Steps

1. Install and enable the `dkan_js_frontend` and `simple_sitemap` modules.
2. As an admin go to `/admin/config/search/simplesitemap/settings`.
3. Fill in the Default base URL field.
4. Navigate to `/admin/config/search/simplesitemap`.
5. Click the "Rebuild queue & generate" button.
6. View the sitemap at `/sitemap.xml` and confirm the base url from the config is in use.