### PR TITLE
Remove unnecessary timezone override from harvest dashboard

### DIFF
--- a/modules/harvest/src/DashboardController.php
+++ b/modules/harvest/src/DashboardController.php
@@ -38,9 +38,6 @@ class DashboardController {
    * A list of harvests and some status info.
    */
   public function harvests(): array {
-
-    date_default_timezone_set('EST');
-
     $rows = [];
     foreach ($this->harvest->getAllHarvestIds() as $harvestId) {
       // @todo Make Harvest Service's private getLastHarvestRunId() public,


### PR DESCRIPTION
- [x] Test coverage exists
- [x] Documentation exists

## QA Steps

- [ ] Navigate to regional settings (`/admin/config/regional/settings`).
- [ ] Set a timezone.
- [ ] Uncheck the "Users may set their own time zone" option.
- [ ] Rebuild cache.
- [ ] Navigate to the harvest dashboard.
- [ ] Ensure the "Last Run" dates for harvests are showing up in the appropriate timezone (this may require running a harvest).
