### PR TITLE
Doc cleanup

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "DKAN"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v2.0.0
+PROJECT_NUMBER         = $(DKAN_VERSION)
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/Doxyfile
+++ b/Doxyfile
@@ -920,7 +920,8 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = "build README.md"
+EXCLUDE                = "modules/datastore/modules/datastore_mysql_import/README.md" \
+                         "modules/dkan_js_frontend/README.md"
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -937,7 +938,9 @@ EXCLUDE_SYMLINKS       = NO
 # exclude all test directories for example use the pattern */test/*
 
 EXCLUDE_PATTERNS       = */vendor/composer/* \
-*/vendor/getdkan/procrastinator/test/* */metastore_form/js/* */tests/*
+                         */vendor/getdkan/procrastinator/test/* \
+                         */metastore_form/js/*  \
+                         */tests/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@
 ## Documentation
 DKAN's documentation lives at [docs.getdkan.com](https://docs.getdkan.com/)
 
+To generate the docs with a specfic version number, run:
+```
+DKAN_VERSION='v2.1.0' doxygen
+```
+To supply the current branch, run:
+```
+DKAN_VERSION=`git rev-parse --abbrev-ref HEAD` doxygen
+```
+
 ---
 
 ## Features

--- a/docs_assets/pages/1.0_start.md
+++ b/docs_assets/pages/1.0_start.md
@@ -26,9 +26,7 @@ The DKAN team maintains a CLI tool to manage initial setup and local development
 
 DKAN tools bases new projects off of a [composer project](https://github.com/GetDKAN/recommended-project) that you can also use to start a project using your own toolset:
 
-```
-composer create-project getdkan/recommended-project my-project
-```
+    composer create-project getdkan/recommended-project my-project
 
 Or simply create a project however you prefer and add a requirement for `getdkan/dkan`. **Do note** that a bug in Drupal core cron may cause problems with data imports, and applying [this patch](https://www.drupal.org/project/drupal/issues/3230541#comment-14206814) is highly recommended. The patch will be applied automatically if you use the recommended project.
 
@@ -36,6 +34,4 @@ Or simply create a project however you prefer and add a requirement for `getdkan
 
 If you already have an existing Drupal site, install DKAN with [composer](https://www.drupal.org/node/2718229). You can find the [latest DKAN release here](https://github.com/GetDKAN/dkan/releases). Composer will download the module and all of the  dependencies it requires for the backend. For more details [click here](https://github.com/GetDKAN/dkan-tools/tree/master#adding-dkan-to-an-existing-drupal-site).
 
-```
-composer require 'getdkan/dkan'
-```
+    composer require 'getdkan/dkan'

--- a/docs_assets/pages/3.1_metastore.md
+++ b/docs_assets/pages/3.1_metastore.md
@@ -20,7 +20,7 @@ Some more details of DKAN's metastore:
 
 Replacing the dataset schema in DKAN allows you to add fields and conform to additional (or completely different) specifications. As long as you provide a valid JSON schema, any information going into the metastore will be validated against it.
 
-To change the schema being used, copy the `schema` directory from the DKAN repo and place it in the root of your Drupal installation. Then make any modifications necessary to the `dataset.json` file inside the `collections` directory.
+To change the schema being used, copy the contents of the `schema` directory from the DKAN repo and place it in the root of your Drupal installation (src/schema). Then make any modifications necessary to the `dataset.json` file inside the `collections` directory.
 
 @warning
-  Warning: The schema is actively used by the catalog to verify the validity of the data. Making changes to the schema after data is present in the catalog should be done with, care as non-backward-compatible changes to the schema could cause issues. Look at Drupal::metastore::SchemaRetriever::findSchemaDirectory() for context.
+  Warning: The schema is actively used by the catalog to verify the validity of the data. Making changes to the schema after data is present in the catalog should be done with care as non-backward-compatible changes to the schema could cause issues. Look at Drupal::metastore::SchemaRetriever::findSchemaDirectory() for context.

--- a/docs_assets/pages/3.3_harvest.md
+++ b/docs_assets/pages/3.3_harvest.md
@@ -4,13 +4,16 @@ The DKAN **Harvest** module provides integration with the [harvest](https://gith
 
 For example, [Data.gov](https://data.gov/) harvests all of its datasets from the [data.json](https://project-open-data.cio.gov/v1.1/schema/) files of [hundreds of U.S. federal, state and local data portals](https://catalog.data.gov/harvest).
 
-A "harvest" is the execution of a @ref HarvestPlan.
+A [harvest](glossary.html#term_harvest) is the execution of a [Harvest Plan](glossary.html#term_harvestplan).
+
 ## Drush Commands
-* @ref dkanharveststatus
-* @ref dkanharvestinfo
-* @ref dkanharvestlist       
 * @ref dkanharvestregister
-* @ref dkanharvestderegister    
-* @ref dkanharvestrun 
+* @ref dkanharvestderegister
+* @ref dkanharvestrun
 * @ref dkanharvestrunall
 * @ref dkanharvestrevert
+* @ref dkanharveststatus
+* @ref dkanharvestinfo
+* @ref dkanharvestlist
+* @ref dkanharvestpublish
+* @ref dkanharvestarchive

--- a/docs_assets/pages/4.0_commands.md
+++ b/docs_assets/pages/4.0_commands.md
@@ -4,15 +4,21 @@
 
 @subpage dkandatastoredrop
 
+@subpage dkandatastoredropall
+
 @subpage dkandatastoreimport
 
 @subpage dkandatastorelist
+
+@subpage dkanharvestarchive
 
 @subpage dkanharvestderegister
 
 @subpage dkanharvestinfo
 
 @subpage dkanharvestlist
+
+@subpage dkanharvestpublish
 
 @subpage dkanharvestregister
 

--- a/docs_assets/pages/5.0_glossary.md
+++ b/docs_assets/pages/5.0_glossary.md
@@ -4,7 +4,11 @@
 #### Dataset
 A dataset is an identifiable collection of structured data objects (distribution list) unified by some criteria (authorship, subject, scope, spatial or temporal extent…) this is called metadata.
 
-@anchor HarvestPlan
+@anchor term_harvest
+#### Harvest
+test
+
+@anchor term_harvestplan
 #### Harvest Plan
 The harvest plan is the configuration used to import data into your catalog.
 \ref https://github.com/GetDKAN/harvest/blob/master/schema/schema.json

--- a/docs_assets/pages/dkan_dataset_info.md
+++ b/docs_assets/pages/dkan_dataset_info.md
@@ -4,10 +4,4 @@ View information about a dataset.
 
 #### Arguments
 
-- **uuid**. The uuid of a dataset.
-
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.
+- **uuid** The uuid of a dataset.

--- a/docs_assets/pages/dkan_datastore_drop.md
+++ b/docs_assets/pages/dkan_datastore_drop.md
@@ -4,13 +4,8 @@ Drop a datastore.
 
 #### Arguments
 
-- **uuid**. The uuid of a dataset.
+- **uuid** The uuid of a dataset.
 
 #### Aliases
 
 - dkan-datastore:drop
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.

--- a/docs_assets/pages/dkan_datastore_dropall.md
+++ b/docs_assets/pages/dkan_datastore_dropall.md
@@ -1,0 +1,3 @@
+@page dkandatastoredropall dkan:datastore:drop-all
+
+Drop a ALL datastore tables.

--- a/docs_assets/pages/dkan_datastore_import.md
+++ b/docs_assets/pages/dkan_datastore_import.md
@@ -4,14 +4,9 @@ Import a datastore.
 
 #### Arguments
 
-- **uuid**. The uuid of a resource.
-- **[deferred]**. Whether or not the process should be deferred to a queue.
+- **uuid** The uuid of a resource.
+- **deferred** Whether or not the process should be deferred to a queue.
 
 #### Aliases
 
 - dkan-datastore:import
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.

--- a/docs_assets/pages/dkan_datastore_list.md
+++ b/docs_assets/pages/dkan_datastore_list.md
@@ -4,15 +4,10 @@ List information about all datastores.
 
 #### Options
 
-- [ --format= **FORMAT** ].  The format of the data. (default: **table**)
-- [ --status= **STATUS** ]. Show imports of the given status.
-- [ --uuid-only ]. Only the list of uuids.
+- **format** The format of the data. (default: **table**)
+- **status** Show imports of the given status.
+- **uuid-only** Only the list of uuids.
 
 #### Aliases
 
 - dkan-datastore:list
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.

--- a/docs_assets/pages/dkan_harvest_archive.md
+++ b/docs_assets/pages/dkan_harvest_archive.md
@@ -1,0 +1,7 @@
+@page dkanharvestarchive dkan:harvest:archive
+
+Archives (unpublish) harvested entities.
+
+#### Arguments
+
+- **harvestId** The id of the harvest source.

--- a/docs_assets/pages/dkan_harvest_deregister.md
+++ b/docs_assets/pages/dkan_harvest_deregister.md
@@ -4,13 +4,8 @@ Deregister a harvest.
 
 #### Arguments
 
-- **id**.
+- **harvestId** The harvest id
 
 #### Aliases
 
 - dkan-harvest:deregister
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.

--- a/docs_assets/pages/dkan_harvest_info.md
+++ b/docs_assets/pages/dkan_harvest_info.md
@@ -4,14 +4,9 @@ Give information about a previous harvest run.
 
 #### Arguments
 
-- **id**. The harvest id.
-- **[run_id]**. The run's id.
+- **harvestId** The harvest id.
+- **runId** The run's id.
 
 #### Aliases
 
 - dkan-harvest:info
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.

--- a/docs_assets/pages/dkan_harvest_list.md
+++ b/docs_assets/pages/dkan_harvest_list.md
@@ -5,8 +5,3 @@ List available harvests.
 #### Aliases
 
 - dkan-harvest:list
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.

--- a/docs_assets/pages/dkan_harvest_publish.md
+++ b/docs_assets/pages/dkan_harvest_publish.md
@@ -1,0 +1,7 @@
+@page dkanharvestpublish dkan:harvest:publish
+
+Publishes harvested entities.
+
+#### Arguments
+
+- **harvestId**. The id of the harvest source.

--- a/docs_assets/pages/dkan_harvest_register.md
+++ b/docs_assets/pages/dkan_harvest_register.md
@@ -4,19 +4,23 @@ Register a new harvest.
 
 #### Arguments
 
-- **harvest_plan**. Harvest plan configuration as JSON, wrapped in single quotes, do not add spaces between elements.
+- Harvest plan configuration as a JSON string. Wrap in single quotes, do not add spaces between elements.
 
-#### Example
+#### Options
+- **identifier** The harvest id.
+- **extract-type** Extract type.
+- **extract-uri** Extract URI.
+- **transform** A transform class to apply. You may pass multiple transforms.
+- **load-type** Load class.
 
-<code>
-dkan-harvest:register '{"identifier":"example","extract":{"type":"\\Harvest\\ETL\\Extract\\DataJson","uri":"https://source/data.json"},"transforms":[],"load":{"type":"\\Drupal\\harvest\\Load\\Dataset"}}'
-</code>
+#### Usage
+
+    dkan-harvest:register '{"identifier":"myHarvestId","extract":{"type":"\\Harvest\\ETL\\Extract\\DataJson","uri":"http://example.com/data.json"},"transforms":[],"load":{"type":"\\Drupal\\harvest\\Load\\Dataset"}}'
+
+Or
+
+    dkan:harvest:register --identifier=myHarvestId --extract-uri=http://example.com/data.json
 
 #### Aliases
 
 - dkan-harvest:register
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.

--- a/docs_assets/pages/dkan_harvest_revert.md
+++ b/docs_assets/pages/dkan_harvest_revert.md
@@ -1,20 +1,15 @@
 @page dkanharvestrevert dkan:harvest:revert
 
-Revert a harvest, i.e. unpublish all of its harvested entities.
+Revert a harvest, i.e. remove harvested entities and unpublish orhpaned keywords, themes, and distributions.
 
 #### Arguments
 
-- **id**. The source to revert.
+- **harvestId** The source to revert.
 
-#### Example
+#### Usage
 
-- <code>dkan:harvest:revert id</code>
+    dkan:harvest:revert myHarvestId
 
 #### Aliases
 
 - dkan-harvest:revert
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.

--- a/docs_assets/pages/dkan_harvest_run-all.md
+++ b/docs_assets/pages/dkan_harvest_run-all.md
@@ -5,8 +5,3 @@ Run all pending harvests.
 #### Aliases
 
 - dkan-harvest:run-all
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.

--- a/docs_assets/pages/dkan_harvest_run.md
+++ b/docs_assets/pages/dkan_harvest_run.md
@@ -4,13 +4,8 @@ Run a harvest.
 
 #### Arguments
 
-- **id**. The harvest id.
+- **harvestId** The harvest id.
 
 #### Aliases
 
 - dkan-harvest:run
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.

--- a/docs_assets/pages/dkan_harvest_status.md
+++ b/docs_assets/pages/dkan_harvest_status.md
@@ -4,14 +4,9 @@ Show status of of a particular harvest run.
 
 #### Arguments
 
-- **harvest_id**. The id of the harvest source.
-- **[run_id]**. The run's id. Optional. Show the status for the latest run if not provided.
+- **harvestId** The id of the harvest source.
+- **runId** The run's id. Optional. Show the status for the latest run if not provided.
 
-#### Example
+#### Usage
 
-- <code>dkan:harvest:status test 1599157120</code>.
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.
+    dkan:harvest:status myHarvestId 1599157120

--- a/docs_assets/pages/dkan_metadata-form_sync.md
+++ b/docs_assets/pages/dkan_metadata-form_sync.md
@@ -5,8 +5,3 @@ Synchronize the module with the React app.
 #### Aliases
 
 - dkan-metadata-form:sync
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.

--- a/docs_assets/pages/dkan_metastore-search_rebuild-tracker.md
+++ b/docs_assets/pages/dkan_metastore-search_rebuild-tracker.md
@@ -1,8 +1,3 @@
 @page dkanmetastoresearchrebuildtracker dkan:metastore-search:rebuild-tracker
 
 Rebuild the search api tracker for the dkan index.
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.

--- a/docs_assets/pages/dkan_metastore_publish.md
+++ b/docs_assets/pages/dkan_metastore_publish.md
@@ -4,9 +4,4 @@ Publish the latest version of a dataset.
 
 #### Arguments
 
-- **uuid**. Dataset identifier.
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.
+- **uuid** Dataset identifier.

--- a/docs_assets/pages/dkan_sample-content_create.md
+++ b/docs_assets/pages/dkan_sample-content_create.md
@@ -1,8 +1,3 @@
 @page dkansamplecontentcreate dkan:sample-content:create
 
 Create sample content.
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.

--- a/docs_assets/pages/dkan_sample-content_remove.md
+++ b/docs_assets/pages/dkan_sample-content_remove.md
@@ -1,8 +1,3 @@
 @page dkansamplecontentremove dkan:sample-content:remove
 
 Remove sample content.
-
-@note <i class="fas fa-fire" style="color: #42b983"></i> Legend
-    - An argument or option with square brackets is optional.
-    - Any default value is listed at end of arg/option description.
-    - An ellipsis indicates that an argument accepts multiple values separated by a space.

--- a/docs_assets/pages/tut_dataset.md
+++ b/docs_assets/pages/tut_dataset.md
@@ -6,23 +6,21 @@ You will need to authenticate with a user account possessing the 'api user' role
 
 Run a POST to `/api/1/metastore/schemas/dataset/items` with a json formatted request body, the minimal elements are:
 
-<code>
-{
-  "title": "My new dataset",
-  "description": "Description for my new dataset.",
-  "identifier": "11111111-1111-4111-1111-111111111111",
-  "accessLevel": "public",
-  "modified": "2020-02-02",
-  "keyword": [
-    "test"
-  ]
-}
-</code>
+    {
+      "title": "My new dataset",
+      "description": "Description for my new dataset.",
+      "identifier": "11111111-1111-4111-1111-111111111111",
+      "accessLevel": "public",
+      "modified": "2020-02-02",
+      "keyword": [
+        "test"
+      ]
+    }
 
 ## GUI
 
 1. Log in to the site.
-2. Navigate to Admin > Content > Datasets.
+2. Navigate to Admin > DKAN > Datasets.
 3. Click the "+ Add new dataset" button.
-4. Use the _Download URL_ field to enter a url to your file.
+4. Use the _Download URL_ field to enter a url to your file or upload a local file.
 5. Fill in the form and click "submit".

--- a/docs_assets/pages/tut_harvest.md
+++ b/docs_assets/pages/tut_harvest.md
@@ -1,20 +1,20 @@
 @page tut_harvest How to create a harvest
 
-Use drush commands to harvest data into your catalog.
+Use drush commands to [harvest](glossary.html#term_harvest) data into your catalog.
 
 ## Register a harvest
 
-1. Register a new @ref HarvestPlan. A harvest plan is configuration as JSON, wrapped in single quotes, do not add spaces between elements:
+1. Register a new [Harvest Plan](glossary.html#term_harvestplan).
   - Create a unique name as the **identifier**
-  - Provide the **extract** object with type and uri values: type being the class that matches the data structure, (most likely "\\Harvest\\ETL\\Extract\\DataJson"), and the full URI for the source endpoint (such as `http://source/data.json` or `file://source/data.json`)
-  - Provide the **load** object that defines the type of content you want to create, most likely datasets, so use: "\\Drupal\\harvest\\Load\\Dataset"
+  - Provide the **extract** object with type and uri values: type being the class that matches the data structure, default is "\\Harvest\\ETL\\Extract\\DataJson")
+  - Provide the full URI for the data source (such as `http://example.com/data.json` or `file://source/data.json`)
+  - Provide the **load** object that defines the type of content you want to create, default is: "\\Drupal\\harvest\\Load\\Dataset"
 
 2. If you would also like to make changes to the data you are harvesting, you can create custom  **transforms** that will modify the data before saving to your catalog. Add multiple transforms as an array.
 
   **Example**
-  \code{.bash}
-  drush dkan:harvest:register '{"identifier":"example","extract":{"type":"\\Harvest\\ETL\\Extract\\DataJson","uri":"https://source/data.json"},"transforms":[],"load":{"type":"\\Drupal\\harvest\\Load\\Dataset"}}'
-  \endcode
+
+      drush dkan:harvest:register --identifier=myHarvestId --extract-uri=http://example.com/data.json
 
   You can view a list of all registered harvest plans with @ref dkanharvestlist
 
@@ -23,12 +23,14 @@ Use drush commands to harvest data into your catalog.
   Transforms allow you to modify what you are harvesting. [Click here](https://github.com/GetDKAN/socrata_harvest) to see an example of how you can create a custom module to add a transform class.
   @par
   **Example with a transform item**
-  \code{.bash}
-  drush dkan-harvest:register '{"identifier":"example","extract":{"type":"\\Harvest\\ETL\\Extract\\DataJson","uri":"https://source/data.json"},"transforms":["\\Drupal\\custom_module\\Transform\\CustomTransform"],"load":{"type":"\\Drupal\\harvest\\Load\\Dataset"}}'
-  \endcode
+
+      drush dkan:harvest:register --identifier=myHarvestId --extract-uri=http://example.com/data.json  --transform="\\Drupal\\custom_module\\Transform\\CustomTransform"
+
 
 ## Run the harvest
-Once you have registered a harvest source, run the import, passing in the identifier as an arguement `drush dkan:harvest:run example`
+Once you have registered a harvest source, run the import, passing in the identifier as an arguement
+
+    drush dkan:harvest:run example
 
 ## View the status of the harvest
 Navigate to `admin/dkan/harvest` to view the status of the extraction, the date the harvest was run, and the number of datasets that were added by the harvest. By clicking on the harvest ID, you will also see specific information about each dataset, and the status of the datastore import.

--- a/docs_assets/pages/tut_metastore_properties.md
+++ b/docs_assets/pages/tut_metastore_properties.md
@@ -10,6 +10,4 @@ When the value of these elements change or become outdated, the corresponding da
 
 If you prefer to run it manually, you may do so with:
 
-```
-drush queue-run orphan_reference_processor
-```
+    drush queue-run orphan_reference_processor


### PR DESCRIPTION
Was originally going to add documentation for the hidden state (#3718) but realized there is not really a good place to add it and docs need a general workflow section (along with a lot of other stuff!). But, noticed some places the docs could be cleaned up:

1. The readme files of two newer modules were accidentally being picked up and placed in the TOC root. We may want to figure out a way to incorporate these later but for now this seems out of place, so these were hidden.
2. The version number was stuck at 2.0.0. I replaced this in the doxyfile to be a variable called `DKAN_VERSION`.

To generate the docs with a arbitrary version number, you could run..

```sh
DKAN_VERSION=`v2.1.0` doxygen
```
from the DKAN root dir. To supply the current branch, you could use:

```sh
DKAN_VERSION=`git rev-parse --abbrev-ref HEAD` doxygen
```

The demo site script has already recieved a PR to use this: GetDKAN/jenkins_release_n_update_builds#2