### PR TITLE
Run cypress tests in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ commands:
                   dktl exec:composer -- update --no-interaction --ansi
 
 jobs:
-  phpunit_dredd:
+  phpunit:
     machine:
       image: circleci/classic:latest
     parameters:
@@ -112,7 +112,7 @@ jobs:
                   dktl xdebug:start
                   sed -i "/=debug/s/=.*/=coverage/" src/docker/etc/php/xdebug.ini
                   dktl dkan:test-phpunit-coverage $CC_TEST_REPORTER_ID
-  cypress_backend:
+  cypress:
     machine:
       image: circleci/classic:latest
     parameters:
@@ -148,15 +148,15 @@ workflows:
   version: 2
   install_and_test:
     jobs:
-      - phpunit_dredd:
-          name: install_test_phpunit_dredd
-      - cypress_backend:
-          name: install_test_cypress_backend
+      - phpunit:
+          name: install_test_phpunit
+      - cypress:
+          name: install_test_cypress
   upgrade_and_test:
     jobs:
-      - phpunit_dredd:
-          name: upgrade_test_phpunit_dredd
+      - phpunit:
+          name: upgrade_test_phpunit
           upgrade: true
-      - cypress_backend:
-          name: upgrade_test_cypress_backend
+      - cypress:
+          name: upgrade_test_cypress
           upgrade: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,53 +78,6 @@ commands:
                   dktl exec:composer -- update --no-interaction --ansi
 
 jobs:
-  build:
-    machine:
-      image: circleci/classic:latest
-    parameters:
-      upgrade:
-        description: "If true, will install the latest stable version and test upgrade"
-        default: false
-        type: boolean
-    environment:
-      TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "4.2.5"
-    steps:
-      - checkout:
-          path: dkan
-      - run:
-          name: Set up composer config
-          command: |
-            mkdir ~/.composer
-            bash -c 'echo "{\"github-oauth\": {\"github.com\": \"$GITHUB_TOKEN\"}}"' > ~/.composer/auth.json
-      - dktl
-      - when:
-          condition: << parameters.upgrade >>
-          steps:
-            - run:
-                name: Initialize with latest stable tag to upgrade from
-                command: |
-                  TAG="$(git --git-dir=dkan/.git describe --abbrev=0 --tags)"
-                  echo "Testing upgrade from tag: ${TAG}"
-                  git --git-dir=dkan/.git --work-tree=dkan checkout "${TAG}"
-                  dktl init --dkan-local
-                  # Switch expected composer dependency to the same release
-                  dktl exec:composer -- require "getdkan/dkan:${TAG}" --no-update --ansi
-      - unless:
-          condition: << parameters.upgrade >>
-          steps:
-            - run:
-                name: Initialize Project
-                command: dktl init --dkan-local
-      - run:
-          name: Make DKAN
-          command: dktl make
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - dkan-tools
-            - project
-            - .composer
   phpunit_dredd:
     machine:
       image: circleci/classic:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,12 +139,14 @@ jobs:
             mv $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split --split-by=timings) dkan/cypress/tmp || true
             rm dkan/cypress/integration/* && mv dkan/cypress/tmp/* dkan/cypress/integration
             dktl dkan:test-cypress --headless --browser=chromium --reporter=junit --reporter-options "mochaFile=results/output.xml,toConsole=true"
+            ls dkan/cypress
+            ls dkan/cypress/results
       - store_artifacts:
-          path: docroot/modules/contrib/dkan/cypress/screenshots
+          path: dkan/cypress/screenshots
       - store_artifacts:
-          path: docroot/modules/contrib/dkan/cypress/videos
+          path: dkan/cypress/videos
       - store_test_results:
-          path: docroot/modules/contrib/dkan/cypress/results
+          path: dkan/cypress/results
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,6 @@ commands:
         description: "If true, will install the latest stable version and test upgrade"
         default: false
         type: boolean
-    environment:
-      TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "4.2.5"
     steps:
       - checkout:
           path: dkan
@@ -138,6 +135,7 @@ jobs:
         type: boolean
     environment:
       TEST_RESULTS: /tmp/test-results
+      DKTL_VERSION: "4.2.5"
     steps:
       - prepare_build:
           upgrade: << parameters.upgrade >>
@@ -171,7 +169,7 @@ jobs:
         type: boolean
     environment:
       TEST_RESULTS: /tmp/test-results
-    parallelism: 4
+      DKTL_VERSION: "4.2.5"
     steps:
       - prepare_build:
           upgrade: << parameters.upgrade >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,8 +137,8 @@ jobs:
           command: |
             mkdir dkan/cypress/integration/tmp
             mv $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split) dkan/cypress/integration/tmp || true
-            ls dkan/cypress/tmp
-            dktl dc exec cli ls /var/www/dkan/cypress/tmp
+            ls dkan/cypress/integration/tmp
+            dktl dc exec cli ls /var/www/dkan/cypress/integration/tmp
             dktl dkan:test-cypress --headless --browser=chromium --spec cypress/integration/tmp/*
       - store_artifacts:
           path: docroot/modules/contrib/dkan/cypress/screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,11 +140,11 @@ jobs:
       - run:
           name: Run DKAN cypress tests
           command: |
-            mkdir dkan/cypress/tmp
-            mv $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split) dkan/cypress/tmp || true
+            mkdir dkan/cypress/integration/tmp
+            mv $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split) dkan/cypress/integration/tmp || true
             ls dkan/cypress/tmp
             dktl dc exec cli ls /var/www/dkan/cypress/tmp
-            dktl dkan:test-cypress --headless --browser=chromium --spec cypress/tmp/*
+            dktl dkan:test-cypress --headless --browser=chromium --spec cypress/integration/tmp/*
       - store_artifacts:
           path: docroot/modules/contrib/dkan/cypress/screenshots
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
         type: boolean
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "phpunit-testuser"
+      DKTL_VERSION: "4.2.8"
     steps:
       - prepare_build:
           upgrade: << parameters.upgrade >>
@@ -123,7 +123,7 @@ jobs:
     parallelism: 4
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "phpunit-testuser"
+      DKTL_VERSION: "4.2.8"
     steps:
       - prepare_build:
           upgrade: << parameters.upgrade >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,6 @@ jobs:
           command: |
             mkdir dkan/cypress/integration/tmp
             mv $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split) dkan/cypress/integration/tmp || true
-            ls dkan/cypress/tmp
             dktl dc exec cli ls /var/www/dkan/cypress/tmp
             dktl dkan:test-cypress --headless --browser=chromium --spec cypress/integration/tmp/*
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
         type: boolean
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "4.2.7"
+      DKTL_VERSION: "phpunit-testuser"
     steps:
       - prepare_build:
           upgrade: << parameters.upgrade >>
@@ -123,7 +123,7 @@ jobs:
     parallelism: 4
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "4.2.7"
+      DKTL_VERSION: "phpunit-testuser"
     steps:
       - prepare_build:
           upgrade: << parameters.upgrade >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ jobs:
         description: "If true, will install the latest stable version and test upgrade"
         default: false
         type: boolean
+    parallelism: 2
     environment:
       TEST_RESULTS: /tmp/test-results
       DKTL_VERSION: "4.2.5"
@@ -136,6 +137,7 @@ jobs:
           command: |
             mkdir dkan/cypress/integration/tmp
             mv $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split) dkan/cypress/integration/tmp || true
+            ls dkan/cypress/tmp
             dktl dc exec cli ls /var/www/dkan/cypress/tmp
             dktl dkan:test-cypress --headless --browser=chromium --spec cypress/integration/tmp/*
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
         type: boolean
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "cypress-in-cli"
+      DKTL_VERSION: "4.2.7"
     steps:
       - prepare_build:
           upgrade: << parameters.upgrade >>
@@ -123,7 +123,7 @@ jobs:
     parallelism: 4
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "cypress-in-cli"
+      DKTL_VERSION: "4.2.7"
     steps:
       - prepare_build:
           upgrade: << parameters.upgrade >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,9 +142,8 @@ jobs:
           command: |
             mkdir dkan/cypress/tmp
             mv $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split) dkan/cypress/tmp || true
-            ls dkan
-            ls dkan/cypress
             ls dkan/cypress/tmp
+            dktl dc exec cli ls /var/www/dkan/cypress/tmp
             dktl dkan:test-cypress --headless --browser=chromium --spec cypress/tmp/*
       - store_artifacts:
           path: docroot/modules/contrib/dkan/cypress/screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,14 +136,14 @@ jobs:
           name: Run DKAN cypress tests
           command: |
             mkdir dkan/cypress/integration/tmp
-            mv $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split) dkan/cypress/integration/tmp || true
-            ls dkan/cypress/integration/tmp
-            dktl dc exec cli ls /var/www/dkan/cypress/integration/tmp
-            dktl dkan:test-cypress --headless --browser=chromium --spec cypress/integration/tmp/*
+            mv $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split --split-by=timings) dkan/cypress/integration/tmp || true
+            dktl dkan:test-cypress --headless --browser=chromium --spec=cypress/integration/tmp/* --reporter=junit --reporter-options "mochaFile=results/output.xml,toConsole=true"
       - store_artifacts:
           path: docroot/modules/contrib/dkan/cypress/screenshots
       - store_artifacts:
           path: docroot/modules/contrib/dkan/cypress/videos
+      - store_test_results:
+          path: docroot/modules/contrib/dkan/cypress/result
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
         description: "If true, will install the latest stable version and test upgrade"
         default: false
         type: boolean
-    parallelism: 2
+    parallelism: 4
     environment:
       TEST_RESULTS: /tmp/test-results
       DKTL_VERSION: "4.2.5"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,25 +9,6 @@ commands:
             if [ ! -d ~/dkan-tools ]; then git clone -b $DKTL_VERSION https://github.com/GetDKAN/dkan-tools.git ~/dkan-tools; fi
             export PATH=~/dkan-tools/bin:$PATH
             echo "export PATH=~/dkan-tools/bin:$PATH" >> $BASH_ENV
-  export_images:
-    steps:
-      - run:
-          name: Export each dkan-tools image to tar
-          command: |
-            mkdir ~/images
-            docker save getdkan/dkan-web > ~/images/web.tar
-            docker save getdkan/dkan-cli > ~/images/cli.tar
-            docker save drydockcloud/drupal-acquia-mysql > ~/images/db.tar
-  import_images:
-    steps:
-      - run:
-          name: Import each persisted tar file as image
-          command: |
-            docker load --input ~/images/web.tar
-            docker load --input ~/images/cli.tar
-            docker load --input ~/images/db.tar
-            docker images
-            rm ~/images/*
   prepare_site:
     parameters:
       upgrade:
@@ -102,11 +83,9 @@ jobs:
       - run:
           name: Make DKAN
           command: dktl make
-      - export_images
       - persist_to_workspace:
           root: ~/
           paths:
-            - images
             - dkan-tools
             - project
             - .composer
@@ -123,7 +102,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - import_images
       - dktl
       - prepare_site:
           upgrade: << parameters.upgrade >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,46 @@ commands:
             if [ ! -d ~/dkan-tools ]; then git clone -b $DKTL_VERSION https://github.com/GetDKAN/dkan-tools.git ~/dkan-tools; fi
             export PATH=~/dkan-tools/bin:$PATH
             echo "export PATH=~/dkan-tools/bin:$PATH" >> $BASH_ENV
+  prepare_build:
+    parameters:
+      upgrade:
+        description: "If true, will install the latest stable version and test upgrade"
+        default: false
+        type: boolean
+    environment:
+      TEST_RESULTS: /tmp/test-results
+      DKTL_VERSION: "4.2.5"
+    steps:
+      - checkout:
+          path: dkan
+      - run:
+          name: Set up composer config
+          command: |
+            mkdir ~/.composer
+            bash -c 'echo "{\"github-oauth\": {\"github.com\": \"$GITHUB_TOKEN\"}}"' > ~/.composer/auth.json
+      - dktl
+      - when:
+          condition: << parameters.upgrade >>
+          steps:
+            - run:
+                name: Initialize with latest stable tag to upgrade from
+                command: |
+                  TAG="$(git --git-dir=dkan/.git describe --abbrev=0 --tags)"
+                  echo "Testing upgrade from tag: ${TAG}"
+                  git --git-dir=dkan/.git --work-tree=dkan checkout "${TAG}"
+                  dktl init --dkan-local
+                  # Switch expected composer dependency to the same release
+                  dktl exec:composer -- require "getdkan/dkan:${TAG}" --no-update --ansi
+      - unless:
+          condition: << parameters.upgrade >>
+          steps:
+            - run:
+                name: Initialize Project
+                command: dktl init --dkan-local
+      - run:
+          name: Make DKAN
+          command: dktl make
+
   prepare_site:
     parameters:
       upgrade:
@@ -39,7 +79,6 @@ commands:
                 name: Just in case, run a composer update
                 command: |
                   dktl exec:composer -- update --no-interaction --ansi
-
 
 jobs:
   build:
@@ -100,6 +139,8 @@ jobs:
     environment:
       TEST_RESULTS: /tmp/test-results
     steps:
+      - prepare_build:
+          upgrade: << parameters.upgrade >>
       - attach_workspace:
           at: ~/
       - dktl
@@ -132,6 +173,8 @@ jobs:
       TEST_RESULTS: /tmp/test-results
     parallelism: 4
     steps:
+      - prepare_build:
+          upgrade: << parameters.upgrade >>
       - attach_workspace:
           at: ~/
       - dktl
@@ -154,28 +197,15 @@ workflows:
   version: 2
   install_and_test:
     jobs:
-      - build:
-          name: install_build
       - phpunit_dredd:
           name: install_test_phpunit_dredd
-          requires:
-            - install_build
       - cypress_backend:
           name: install_test_cypress_backend
-          requires:
-            - install_build
   upgrade_and_test:
     jobs:
-      - build:
-          name: upgrade_build
-          upgrade: true
       - phpunit_dredd:
           name: upgrade_test_phpunit_dredd
           upgrade: true
-          requires:
-            - upgrade_build
       - cypress_backend:
           name: upgrade_test_cypress_backend
           upgrade: true
-          requires:
-            - upgrade_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,6 @@ jobs:
             ls dkan
             ls dkan/cypress
             ls dkan/cypress/tmp
-            tree
             dktl dkan:test-cypress --headless --browser=chromium --spec cypress/tmp/*
       - store_artifacts:
           path: docroot/modules/contrib/dkan/cypress/screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,25 @@ commands:
             if [ ! -d ~/dkan-tools ]; then git clone -b $DKTL_VERSION https://github.com/GetDKAN/dkan-tools.git ~/dkan-tools; fi
             export PATH=~/dkan-tools/bin:$PATH
             echo "export PATH=~/dkan-tools/bin:$PATH" >> $BASH_ENV
+  export_images:
+    steps:
+      - run:
+          name: Export each dkan-tools image to tar
+          command: |
+            mkdir ~/images
+            docker save getdkan/dkan-web > ~/images/web.tar
+            docker save getdkan/dkan-cli > ~/images/cli.tar
+            docker save drydockcloud/drupal-acquia-mysql > ~/images/db.tar
+  import_images:
+    steps:
+      - run:
+          name: Import each persisted tar file as image
+          command: |
+            docker load --input ~/images/web.tar
+            docker load --input ~/images/cli.tar
+            docker load --input ~/images/db.tar
+            docker images
+            rm ~/images/*
   prepare_site:
     parameters:
       upgrade:
@@ -83,9 +102,11 @@ jobs:
       - run:
           name: Make DKAN
           command: dktl make
+      - export_images
       - persist_to_workspace:
           root: ~/
           paths:
+            - images
             - dkan-tools
             - project
             - .composer
@@ -102,6 +123,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - import_images
       - dktl
       - prepare_site:
           upgrade: << parameters.upgrade >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,8 +139,6 @@ jobs:
             mv $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split --split-by=timings) dkan/cypress/tmp || true
             rm dkan/cypress/integration/* && mv dkan/cypress/tmp/* dkan/cypress/integration
             dktl dkan:test-cypress --headless --browser=chromium --reporter=junit --reporter-options "mochaFile=cypress/results/output.xml"
-            ls dkan/cypress
-            ls dkan/cypress/results
       - store_artifacts:
           path: dkan/cypress/screenshots
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
             mkdir dkan/cypress/tmp && mkdir dkan/cypress/results
             mv $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split --split-by=timings) dkan/cypress/tmp || true
             rm dkan/cypress/integration/* && mv dkan/cypress/tmp/* dkan/cypress/integration
-            dktl dkan:test-cypress --headless --browser=chromium --reporter=junit --reporter-options "mochaFile=results/output.xml,toConsole=true"
+            dktl dkan:test-cypress --headless --browser=chromium --reporter=junit --reporter-options "mochaFile=cypress/results/output.xml"
             ls dkan/cypress
             ls dkan/cypress/results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,7 @@ jobs:
         type: boolean
     environment:
       TEST_RESULTS: /tmp/test-results
+    parallelism: 4
     steps:
       - attach_workspace:
           at: ~/
@@ -139,7 +140,9 @@ jobs:
       - run:
           name: Run DKAN cypress tests
           command: |
-            dktl dkan:test-cypress --headless --browser=chromium
+            mkdir dkan/cypress/tmp
+            cp $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split) dkan/cypress/tmp || true
+            dktl dkan:test-cypress --headless --browser=chromium --spec cypress/tmp/*
       - store_artifacts:
           path: docroot/modules/contrib/dkan/cypress/screenshots
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,15 +135,16 @@ jobs:
       - run:
           name: Run DKAN cypress tests
           command: |
-            mkdir dkan/cypress/integration/tmp
-            mv $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split --split-by=timings) dkan/cypress/integration/tmp || true
-            dktl dkan:test-cypress --headless --browser=chromium --spec=cypress/integration/tmp/* --reporter=junit --reporter-options "mochaFile=results/output.xml,toConsole=true"
+            mkdir dkan/cypress/tmp && mkdir dkan/cypress/results
+            mv $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split --split-by=timings) dkan/cypress/tmp || true
+            rm dkan/cypress/integration/* && mv dkan/cypress/tmp/* dkan/cypress/integration
+            dktl dkan:test-cypress --headless --browser=chromium --reporter=junit --reporter-options "mochaFile=results/output.xml,toConsole=true"
       - store_artifacts:
           path: docroot/modules/contrib/dkan/cypress/screenshots
       - store_artifacts:
           path: docroot/modules/contrib/dkan/cypress/videos
       - store_test_results:
-          path: docroot/modules/contrib/dkan/cypress/result
+          path: docroot/modules/contrib/dkan/cypress/results
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
         type: boolean
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "4.2.5"
+      DKTL_VERSION: "cypress-in-cli"
     steps:
       - prepare_build:
           upgrade: << parameters.upgrade >>
@@ -123,7 +123,7 @@ jobs:
     parallelism: 4
     environment:
       TEST_RESULTS: /tmp/test-results
-      DKTL_VERSION: "4.2.5"
+      DKTL_VERSION: "cypress-in-cli"
     steps:
       - prepare_build:
           upgrade: << parameters.upgrade >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,11 @@ jobs:
           name: Run DKAN cypress tests
           command: |
             mkdir dkan/cypress/tmp
-            cp $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split) dkan/cypress/tmp || true
+            mv $(circleci tests glob dkan/cypress/integration/*.spec.js | circleci tests split) dkan/cypress/tmp || true
+            ls dkan
+            ls dkan/cypress
+            ls dkan/cypress/tmp
+            tree
             dktl dkan:test-cypress --headless --browser=chromium --spec cypress/tmp/*
       - store_artifacts:
           path: docroot/modules/contrib/dkan/cypress/screenshots

--- a/cypress/integration/08_admin_views.spec.js
+++ b/cypress/integration/08_admin_views.spec.js
@@ -1,3 +1,5 @@
+import * as dkan from '../support/helpers/dkan'
+
 context('Admin content and dataset views', () => {
     let baseurl = Cypress.config().baseUrl;
     beforeEach(() => {
@@ -15,6 +17,8 @@ context('Admin content and dataset views', () => {
     })
 
     it('The admin content screen has bulk operations options.', () => {
+        // Make sure there is at least one dataset in the view
+        dkan.createDatasetWithModerationState('Testing bulk operations', 'published')
         cy.visit(baseurl + "/admin/dkan/datasets")
         cy.get('#edit-action').select('Archive current revision',{ force: true }).should('have.value', 'archive_current')
         cy.get('#edit-action').select('Delete content',{ force: true }).should('have.value', 'node_delete_action')


### PR DESCRIPTION
Two changes to our CircleCI builds:

1. Stop using a shared build job before splitting into cypress and phpunit jobs. Since the images need to be re-downloaded this adds an extra two minutes to the overall build.
2. Add parallelization to the cypress job.

This change, along with using cypress pre-installed on our images, has reduced the total build time from over 16 minutes to around 7.

We are also now submitting junit reports to circleci after tests. This should improve times even more over time as CircleCI processes the test data and adjusts how it splits the cypress tests (so far no insights are available and the split is not taking timing data into account). 