### PR TITLE
Prepend paths in api docs, based on $settings['dkan_api_base']

### DIFF
--- a/modules/common/common.services.yml
+++ b/modules/common/common.services.yml
@@ -3,6 +3,7 @@ services:
     class: \Drupal\common\DkanApiDocsGenerator
     arguments:
       - '@plugin.manager.dkan_api_docs'
+      - '@settings'
 
   dkan.common.job_store:
     class: \Drupal\common\Storage\JobStoreFactory
@@ -32,7 +33,7 @@ services:
       - [setDatastore, ['@?dkan.datastore.service']]
       - [setResourceMapper, ['@?dkan.metastore.resource_mapper']]
       - [setImportInfo, ['@?dkan.datastore.import_info']]
-  
+
   plugin.manager.dkan_api_docs:
     class: \Drupal\common\Plugin\DkanApiDocsPluginManager
     parent: default_plugin_manager

--- a/modules/common/src/DkanApiDocsGenerator.php
+++ b/modules/common/src/DkanApiDocsGenerator.php
@@ -59,8 +59,9 @@ class DkanApiDocsGenerator {
       $spec = array_merge_recursive($spec, $pluginSpec);
     }
 
-    // Add 'dkan_api_base' setting to prefix the API path if your routing does not start
-    // with your site's root URL (e.g. "data" for API paths to use "/data/api/1").
+    // Add 'dkan_api_base' setting to prefix the API path if your routing
+    // does not start with your site's root URL (e.g. "data" for API paths
+    // to use "/data/api/1").
     if ($dkanApiBase = $this->settings->get('dkan_api_base')) {
       $spec = ApiDocsPathModifier::prepend($spec, $dkanApiBase);
     }

--- a/modules/common/src/DkanApiDocsGenerator.php
+++ b/modules/common/src/DkanApiDocsGenerator.php
@@ -59,6 +59,8 @@ class DkanApiDocsGenerator {
       $spec = array_merge_recursive($spec, $pluginSpec);
     }
 
+    // Add 'dkan_api_base' setting to prefix the API path if your routing does not start
+    // with your site's root URL (e.g. "data" for API paths to use "/data/api/1").
     if ($dkanApiBase = $this->settings->get('dkan_api_base')) {
       $spec = ApiDocsPathModifier::prepend($spec, $dkanApiBase);
     }

--- a/modules/common/src/DkanApiDocsGenerator.php
+++ b/modules/common/src/DkanApiDocsGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\common;
 
+use Drupal\common\Util\ApiDocsPathModifier;
 use Drupal\Core\Site\Settings;
 use Drupal\common\Plugin\DkanApiDocsPluginManager;
 use Drupal\common\Plugin\OpenApiSpec;
@@ -59,32 +60,10 @@ class DkanApiDocsGenerator {
     }
 
     if ($dkanApiBase = $this->settings->get('dkan_api_base')) {
-      $spec = $this->prependDkanApiBase($spec, $dkanApiBase);
+      $spec = ApiDocsPathModifier::prepend($spec, $dkanApiBase);
     }
 
     return new OpenApiSpec(json_encode($spec));
-  }
-
-  /**
-   * Prepend each path in the API Docs.
-   *
-   * @param array $spec
-   *   Original spec.
-   * @param string $dkanApiBase
-   *   The missing part of the url we want to prepend.
-   *
-   * @return array
-   *   Spec with modified paths.
-   */
-  private function prependDkanApiBase(array $spec, string $dkanApiBase = ''): array {
-
-    $modifiedPaths = [];
-    foreach ($spec['paths'] as $path => $value) {
-      $modifiedPaths[$dkanApiBase . $path] = $value;
-    }
-    $spec['paths'] = $modifiedPaths;
-
-    return $spec;
   }
 
   /**

--- a/modules/common/src/DkanApiDocsGenerator.php
+++ b/modules/common/src/DkanApiDocsGenerator.php
@@ -30,6 +30,8 @@ class DkanApiDocsGenerator {
    *
    * @param \Drupal\common\Plugin\DkanApiDocsPluginManager $dkanApiDocsPluginManager
    *   The DKAN API Docs Plugin Manager service.
+   * @param \Drupal\Core\Site\Settings $settings
+   *   The Drupal settings service.
    */
   public function __construct(DkanApiDocsPluginManager $dkanApiDocsPluginManager, Settings $settings) {
     $this->docManager = $dkanApiDocsPluginManager;

--- a/modules/common/src/Util/ApiDocsPathModifier.php
+++ b/modules/common/src/Util/ApiDocsPathModifier.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\common\Util;
+
+/**
+ * Helper class to modify the API docs' path.
+ */
+class ApiDocsPathModifier {
+
+  /**
+   * Prepend a path fragment to paths in an API docs spec.
+   *
+   * @param array $spec
+   *   Original spec.
+   * @param string $pathFragment
+   *   What we want to prepend to the urls.
+   *
+   * @return array
+   *   Spec with modified paths.
+   */
+  public static function prepend(array $spec, string $pathFragment): array {
+
+    $newPaths = [];
+    foreach ($spec['paths'] as $oldPath => $value) {
+      $newPaths[$pathFragment . $oldPath] = $value;
+    }
+    $spec['paths'] = $newPaths;
+
+    return $spec;
+  }
+
+}

--- a/modules/common/tests/src/Unit/DkanApiDocsGeneratorTest.php
+++ b/modules/common/tests/src/Unit/DkanApiDocsGeneratorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\Tests\common\Unit;
+
+use Drupal\Core\Site\Settings;
+use Drupal\common\DkanApiDocsGenerator;
+use Drupal\common\Plugin\DkanApiDocsBase;
+use Drupal\common\Plugin\DkanApiDocsPluginManager;
+use Drupal\common\Plugin\OpenApiSpec;
+use MockChain\Chain;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for DkanApiDocsGenerator.
+ */
+class DkanApiDocsGeneratorTest extends TestCase {
+
+  /**
+   *
+   */
+  public function testBuildSpecWithoutDkanApiBase() {
+
+    $generator = new DkanApiDocsGenerator(
+      $this->getManagerChain()->getMock(),
+      new Settings([])
+    );
+    $result = $generator->buildSpec();
+
+    $paths = array_keys($result->get('$.paths'));
+    $expected = [
+      '/api/1/some/path',
+    ];
+    $this->assertEquals($expected, $paths);
+  }
+
+  /**
+   *
+   */
+  public function testBuildSpecWithDkanApiBase() {
+
+    $dkanApiPath = '/foo/bar';
+
+    $generator = new DkanApiDocsGenerator(
+      $this->getManagerChain()->getMock(),
+      new Settings(['dkan_api_base' => $dkanApiPath])
+    );
+    $result = $generator->buildSpec();
+
+    $paths = array_keys($result->get('$.paths'));
+    $expected = [
+      $dkanApiPath . '/api/1/some/path',
+    ];
+    $this->assertEquals($expected, $paths);
+  }
+
+  /**
+   *
+   */
+  private function getSpec(): array {
+    return [
+      'openapi' => '3.0.2',
+      'info' => [
+        'title' => '',
+        'version' => '',
+      ],
+      'paths' => [
+        '/api/1/some/path' => new \stdClass(),
+      ],
+    ];
+  }
+
+  private function getManagerChain() {
+    $definitions = [
+      ['id' => 'api-1-some-path'],
+    ];
+
+    $spec = $this->getSpec();
+
+    return (new Chain($this))
+      ->add(DkanApiDocsPluginManager::class, 'getDefinitions', $definitions)
+      ->addd('createInstance', DkanApiDocsBase::class)
+      ->add(DkanApiDocsBase::class, 'spec', $spec);
+  }
+
+}

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -90,6 +90,7 @@ services:
     arguments:
       - '@dkan.common.docs_generator'
       - '@dkan.metastore.service'
+      - '@settings'
 
   dkan.metastore.api_response:
     class: \Drupal\metastore\MetastoreApiResponse

--- a/modules/metastore/src/DatasetApiDocs.php
+++ b/modules/metastore/src/DatasetApiDocs.php
@@ -3,6 +3,7 @@
 namespace Drupal\metastore;
 
 use Drupal\common\DkanApiDocsGenerator;
+use Drupal\common\Util\ApiDocsPathModifier;
 use Drupal\Core\Site\Settings;
 
 /**
@@ -123,7 +124,9 @@ class DatasetApiDocs {
 
     $this->alterDatastoreParameters($datasetSpec, $identifier);
     $this->modifySqlEndpoints($datasetSpec, $identifier);
-    $this->prependDkanApiBase($datasetSpec);
+    if ($dkanApiBase = $this->settings->get('dkan_api_base')) {
+      $datasetSpec = ApiDocsPathModifier::prepend($datasetSpec, $dkanApiBase);
+    }
 
     return $datasetSpec;
   }
@@ -312,27 +315,6 @@ class DatasetApiDocs {
     $data = $this->metastore->swapReferences($this->metastore->get("dataset", $identifier));
 
     return $data->{"$.distribution"} ?? [];
-  }
-
-  /**
-   * Alter the dataset-specific paths based on settings' dkan_api_base.
-   *
-   * @param array $spec
-   *   The dataset specific openapi.
-   */
-  private function prependDkanApiBase(array &$spec) {
-
-    $dkanApiBase = $this->settings->get('dkan_api_base');
-
-    if (!$dkanApiBase) {
-      return;
-    }
-
-    $modifiedPaths = [];
-    foreach ($spec['paths'] as $path => $value) {
-      $modifiedPaths[$dkanApiBase . $path] = $value;
-    }
-    $spec['paths'] = $modifiedPaths;
   }
 
 }


### PR DESCRIPTION
Based on a user-defined `$settings['dkan_api_base']` value (i.e. `/provider-data`) in a `settings*.php` file, prepend that value to the API paths documentation.

- [x] Test coverage exists