### PR TITLE
Metastore API integration tests

### DIFF
--- a/modules/common/tests/src/Functional/Api1TestBase.php
+++ b/modules/common/tests/src/Functional/Api1TestBase.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\Tests\common\Functional;
+
+use Drupal\Tests\common\Traits\CleanUp;
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use Opis\JsonSchema\Schema;
+use Opis\JsonSchema\Validator;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+abstract class Api1TestBase extends ExistingSiteBase {
+  use CleanUp;
+
+  protected $http;
+  protected $baseUrl;
+  protected $spec;
+  protected $auth;
+  protected $endpoint;
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->removeHarvests();
+    $this->removeAllNodes();
+    $this->removeAllMappedFiles();
+    $this->removeAllFileFetchingJobs();
+    $this->flushQueues();
+    $this->removeFiles();
+    $this->removeDatastoreTables();
+    $this->baseUrl = getenv('SIMPLETEST_BASE_URL');
+    $this->http = new Client(['base_uri' => $this->baseUrl]);
+    $this->auth = ['testuser', '2jqzOAnXS9mmcLasy'];
+    $this->endpoint = $this->getEndpoint();
+
+    // Load the API spec for use by tests.
+    $response = $this->http->request('GET', 'api/1');
+    $this->spec = json_decode($response->getBody());
+  }
+
+  public function tearDown(): void {
+    parent::setUp();
+    $this->http = NULL;
+  }
+
+  protected function assertJsonIsValid($schema, $json) {
+    $opiSchema = is_string($schema) ? Schema::fromJsonString($schema) : new Schema($schema);
+    $validator = new Validator();
+    $data = is_string($json) ? json_decode($json) : $json;
+    $result = $validator->schemaValidation($data, $opiSchema);
+    $this->assertTrue($result->isValid());
+  }
+
+  abstract public function getEndpoint(): string;
+
+  protected function post($data, $httpErrors = TRUE) {
+    return $this->http->post($this->endpoint, [
+      RequestOptions::JSON => $data,
+      RequestOptions::AUTH => $this->auth,
+      RequestOptions::HTTP_ERRORS => $httpErrors,
+    ]);
+  }
+}

--- a/modules/metastore/src/Service.php
+++ b/modules/metastore/src/Service.php
@@ -529,8 +529,11 @@ class Service implements ContainerInjectionInterface {
       }
     }
 
-    if (isset($array['distribution'][0]['%Ref:downloadURL'])) {
-      unset($array['distribution'][0]['%Ref:downloadURL']);
+    if (!empty($array['distribution'])) {
+      $array['distribution'] = array_map(function ($dist) {
+        unset($dist['%Ref:downloadURL']);
+        return $dist;
+      }, $array['distribution']);
     }
 
     $object->set('$', $array);

--- a/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Drupal\Tests\metastore\Functional\Api1;
+
+use Drupal\Tests\common\Functional\Api1TestBase;
+use GuzzleHttp\RequestOptions;
+
+class DatasetItemTest extends Api1TestBase {
+
+  public function getEndpoint():string {
+    return 'api/1/metastore/schemas/dataset/items';
+  }
+
+  public function testList() {
+    $this->post($this->getSampleDataset(0));
+    $this->post($this->getSampleDataset(1));
+
+    $responseSchema = $this->spec->paths->{'/api/1/metastore/schemas/{schema_id}/items'}
+      ->get->responses->{"200"}->content->{"application/json"}->schema;
+    $response = $this->http->request('GET', $this->endpoint);
+    $responseBody = json_decode($response->getBody());
+    $this->assertEquals(2, count($responseBody));
+    $this->assertTrue(is_object($responseBody[1]));
+    $this->assertJsonIsValid($responseSchema, $responseBody);
+  }
+
+  public function testGetItem() {
+    $dataset = $this->getSampleDataset();
+    $this->post($dataset);
+    $this->assertDatasetGet($dataset);
+    $datasetId = 'abc-123';
+    $response = $this->http->get("$this->endpoint/$datasetId", [
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(404, $response->getStatusCode());
+
+    $responseBody = json_decode($response->getBody());
+    $responseSchema = $this->spec->components->responses->{"404IdNotFound"};
+    $this->assertJsonIsValid($responseSchema, $responseBody);
+  }
+
+  public function testPost() {
+    $dataset = $this->getSampleDataset();
+    $response = $this->post($dataset);
+    $this->assertEquals(201, $response->getStatusCode());
+
+    $responseBody = json_decode($response->getBody());
+    $responseSchema = $this->spec->components->schemas->metastoreWriteResponse;
+
+    $this->assertJsonIsValid($responseSchema, $responseBody);
+    $this->assertDatasetGet($dataset);
+
+    // Now try a duplicate.
+    $response = $this->post($dataset, FALSE);
+    $this->assertEquals(409, $response->getStatusCode());
+    // @todo Fuly validate response once documented.
+  }
+
+  public function testPatch() {
+    $dataset = $this->getSampleDataset();
+    $this->post($dataset);
+    $datasetId = $dataset->identifier;
+
+    $newTitle = (object) ['title' => 'Modified Title'];
+    $response = $this->http->patch("$this->endpoint/$datasetId", [
+      RequestOptions::JSON => $newTitle,
+      RequestOptions::AUTH => $this->auth,
+    ]);
+
+    $this->assertEquals(200, $response->getStatusCode());
+
+    $responseBody = json_decode($response->getBody());
+    $responseSchema = $this->spec->components->schemas->metastoreWriteResponse;
+    $this->assertJsonIsValid($responseSchema, $responseBody);
+
+    $dataset->title = $newTitle->title;
+    $this->assertDatasetGet($dataset);
+
+    // Now, try with a non-existent identifier.
+    $datasetId = "abc-123";
+    $newTitle = (object) ['title' => 'Modified Title'];
+
+    $response = $this->http->patch("$this->endpoint/$datasetId", [
+      RequestOptions::HTTP_ERRORS => FALSE,
+      RequestOptions::JSON => $newTitle,
+      RequestOptions::AUTH => $this->auth,
+    ]);
+
+    $this->assertEquals(412, $response->getStatusCode());
+
+    $responseBody = json_decode($response->getBody());
+    $responseSchema = $this->spec->components->responses->{"412MetadataObjectNotFound"};
+    $this->assertJsonIsValid($responseSchema, $responseBody);
+  }
+
+  public function testPut() {
+    $dataset = $this->getSampleDataset();
+    $this->post($dataset);
+
+    $datasetId = $dataset->identifier;
+    $newDataset = $this->getSampleDataset(1);
+    $newDataset->identifier = $datasetId;
+
+    $response = $this->http->put("$this->endpoint/$datasetId", [
+      RequestOptions::JSON => $newDataset,
+      RequestOptions::AUTH => $this->auth,
+    ]);
+    $this->assertEquals(200, $response->getStatusCode());
+    $responseBody = json_decode($response->getBody());
+    $responseSchema = $this->spec->components->schemas->metastoreWriteResponse;
+    $this->assertJsonIsValid($responseSchema, $responseBody);
+    $this->assertDatasetGet($newDataset);
+
+    // Now try with mismatched identifiers.
+    $datasetId = 'abc-123';
+    $response = $this->http->put("$this->endpoint/$datasetId", [
+      RequestOptions::JSON => $newDataset,
+      RequestOptions::AUTH => $this->auth,
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(409, $response->getStatusCode());
+  }
+
+  private function assertDatasetGet($dataset) {
+    $id = $dataset->identifier;
+    $responseSchema = $this->spec->components->schemas->dataset;
+    $response = $this->http->get("$this->endpoint/$id");
+    $responseBody = json_decode($response->getBody());
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertJsonIsValid($responseSchema, $responseBody);
+    $this->assertEquals($dataset, $responseBody);
+  }
+
+  private function getSampleDataset(int $n = 0) {
+    $sampleJson = file_get_contents('/var/www/docroot/modules/contrib/dkan/modules/sample_content/sample_content.json');
+    $sampleDatasets = json_decode($sampleJson);
+    return $sampleDatasets->dataset[$n];
+  }
+
+}

--- a/modules/metastore/tests/src/Functional/Api1/SchemaTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/SchemaTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\Tests\metastore\Functional\Api1;
+
+use Drupal\Tests\common\Functional\Api1TestBase;
+
+class SchemaTest extends Api1TestBase {
+
+  public function getEndpoint(): string {
+    return 'api/1/metastore/schemas';
+  }
+
+  public function testList() {
+    $response = $this->http->request('GET', $this->endpoint);
+    $responseBody = json_decode($response->getBody());
+    $this->assertEquals("http://dkan/api/v1/schema/dataset", $responseBody->dataset->id);
+  }
+
+  public function testGetItem() {
+    $response = $this->http->request('GET', "$this->endpoint/dataset");
+    $responseBody = json_decode($response->getBody());
+    $this->assertEquals("http://dkan/api/v1/schema/dataset", $responseBody->id);
+  }
+
+}


### PR DESCRIPTION
New PHPUnit-based integration tests for API based on network requests. They live under Functional for compatibility with [Drupal test traits](https://gitlab.com/weitzman/drupal-test-traits) but are more properly understood conceptually as a combination of integration tests and [contract tests](https://pactflow.io/blog/what-is-contract-testing/).

Hopefully this pattern can continue to be implemented in the rest of the API, and we can share as much code as possible in base classes or even automate aspects of test creation through OpenAPI documentation.