### PR TITLE
Check to see if an item is already published before publishing it again.

### DIFF
--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -418,8 +418,10 @@ class Referencer {
       // If an existing but orphaned data node is found,
       // change the state back to published.
       // @ToDo: if the referencing node is in a draft state, do not publish the referenced node.
-      $node->set('moderation_state', 'published');
-      $node->save();
+      if ($node->get('moderation_state')->value !== "published") {
+        $node->set('moderation_state', 'published');
+        $node->save();
+      }
       return $node->uuid();
     }
     return NULL;


### PR DESCRIPTION
fixes [org/repo/issue#]
When checking if a referenced node already exists, don't publish it if it is already published.