### PR TITLE
Multiple sorts in search

### DIFF
--- a/modules/metastore/modules/metastore_search/docs/openapi_spec.json
+++ b/modules/metastore/modules/metastore_search/docs/openapi_spec.json
@@ -72,7 +72,7 @@
                     {
                         "name": "sort",
                         "in": "query",
-                        "description": "Which property to sort results on.",
+                        "description": "Which property to sort results on. Use array format to sort on multiple properties, e.g. sort[0]=field1&sort[1]=field2",
                         "schema": {
                             "type": "string"
                         },
@@ -81,7 +81,7 @@
                     {
                         "name": "sort-order",
                         "in": "query",
-                        "description": "Sort results in ascending or descending order.",
+                        "description": "Sort results in ascending or descending order. If sorting on multiple properties, use array format to map to sort values, e.g. sort-order[0]=asc&sort-order[1]=desc",
                         "schema": {
                             "type": "string",
                             "default": "asc",

--- a/modules/metastore/modules/metastore_search/src/QueryBuilderTrait.php
+++ b/modules/metastore/modules/metastore_search/src/QueryBuilderTrait.php
@@ -158,12 +158,19 @@ trait QueryBuilderTrait {
   private function setSort(QueryInterface $query, array $params, IndexInterface $index): QueryInterface {
     $fields = array_keys($index->getFields());
 
-    if (isset($params['sort']) && in_array($params['sort'], $fields)) {
-      $query->sort($params['sort'], $this->getSortOrder($params));
-      return $query;
+    $sorts = $params['sort'] ?? [];
+    if (!is_array($sorts)) {
+      $sorts = [$sorts];
+    }
+    if (empty($sorts)) {
+      $query->sort('search_api_relevance', Query::SORT_DESC);
+    }
+    foreach ($sorts as $index => $sort) {
+      if (in_array($sort, $fields)) {
+        $query->sort($sort, $this->getSortOrder($params, $index));
+      }
     }
 
-    $query->sort('search_api_relevance', Query::SORT_DESC);
     return $query;
   }
 
@@ -176,16 +183,23 @@ trait QueryBuilderTrait {
    * @return mixed
    *   String describing sort order as ascending or descending.
    */
-  private function getSortOrder(array $params) {
+  private function getSortOrder(array $params, int $index = 0) {
+    $allowed = [
+      strtolower(QueryInterface::SORT_ASC),
+      strtolower(QueryInterface::SORT_DESC),
+    ];
     $default = QueryInterface::SORT_ASC;
-    if (!isset($params['sort-order'])) {
+
+    $orders = $params['sort-order'] ?? [];
+    if (!is_array($orders)) {
+      $orders = [$orders];
+    }
+
+    if (!isset($orders[$index]) || !in_array($orders[$index], $allowed)) {
       return $default;
     }
-    if ($params['sort-order'] != 'asc' && $params['sort-order'] != 'desc') {
-      return $default;
-    }
-    return ($params['sort-order'] == 'asc') ? QueryInterface::SORT_ASC :
-      QueryInterface::SORT_DESC;
+
+    return strtoupper($orders[$index]);
   }
 
   /**

--- a/modules/metastore/modules/metastore_search/src/QueryBuilderTrait.php
+++ b/modules/metastore/modules/metastore_search/src/QueryBuilderTrait.php
@@ -179,6 +179,9 @@ trait QueryBuilderTrait {
    *
    * @param array $params
    *   Search parameters.
+   * @param int $index
+   *   The array index to match the sort order to the sort field, in case
+   *   of multiple sorts.
    *
    * @return mixed
    *   String describing sort order as ascending or descending.


### PR DESCRIPTION
In some cases we may want to sort by multiple fields in the search results. This gives the API the ability to receive multiple values for both sort and sort-order.

## QA Steps

Because the search API returns full datasets it can be hard to read the results of test requests. These QA steps will work on the command line if you have the [jq](https://stedolan.github.io/jq/) utility installed in your local shell.

1. In a local instance with sample content or the [QA site](https://dkan-qa-3758.ci.civicactions.net/), create a new dataset called with the title "Afghanistan Election Districts".
2. `curl "[site-url]/api/1/search?sort[0]=title&sort[1]=modified&sort-order[0]=asc&sort-order[1]=asc" | jq '.results[] | {"title","identifier","modified"}'`
3. Confirm that there are two "Afghanistan Election Districts" datasets, at the top of the search results, and that the sample content one, with modified date `2012-10-30`, is first.
4. `curl "[site-url]/api/1/search?sort[0]=title&sort[1]=modified&sort-order[0]=asc&sort-order[1]=desc" | jq '.results[] | {"title","identifier","modified"}'`
5. Now confirm that the two Afghanistan datasets are still on top, but the sample dataset should be second.

## Known issues

I don't believe the search service is being properly tested by our unit test suite, even though it registers as having 100% coverage. I would like to do a second PR with new tests and consolidating the QueryBuilderTrait into Search.