### PR TITLE
Upgrade Views Bulk Operations (VBO) to 4.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "drupal/search_api": "^1.15",
         "drupal/select_or_other": "1.x-dev",
         "drupal/select2": "1.x-dev",
-        "drupal/views_bulk_operations": "^3.6",
+        "drupal/views_bulk_operations": "^4.0",
         "ext-json": "*",
         "ezyang/htmlpurifier" : "^4.11",
         "fmizzell/maquina": "^1.1.0",


### PR DESCRIPTION
VBO 8.x-3.13 is no longer supported.

## QA Steps

- [ ] Visit /admin/reports/updates
- [ ] Confirm the VBO module is at 4.1.0
