### PR TITLE
Switch to comma-separated values for search API sorts

### DIFF
--- a/modules/metastore/modules/metastore_search/docs/openapi_spec.json
+++ b/modules/metastore/modules/metastore_search/docs/openapi_spec.json
@@ -72,23 +72,30 @@
                     {
                         "name": "sort",
                         "in": "query",
-                        "description": "Which property to sort results on. Use array format to sort on multiple properties, e.g. sort[0]=field1&sort[1]=field2",
+                        "description": "Which property to sort results on.",
                         "schema": {
-                            "type": "string"
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "default": "title"
+                            }
                         },
-                        "style": "form"
+                        "style": "form",
+                        "explode": false
                     },
                     {
                         "name": "sort-order",
                         "in": "query",
-                        "description": "Sort results in ascending or descending order. If sorting on multiple properties, use array format to map to sort values, e.g. sort-order[0]=asc&sort-order[1]=desc",
+                        "description": "Sort results in ascending or descending order. Allowed values: <em>asc, desc</em>",
                         "schema": {
-                            "type": "string",
-                            "default": "asc",
-                            "enum": [ "asc", "desc"]
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "default": "asc"
+                            }
                         },
-                        "example": "desc",
-                        "style": "form"
+                        "style": "form",
+                        "explode": false
                     },
                     {
                         "name": "facets",

--- a/modules/metastore/modules/metastore_search/src/Plugin/DkanApiDocs/MetastoreSearchApiDocs.php
+++ b/modules/metastore/modules/metastore_search/src/Plugin/DkanApiDocs/MetastoreSearchApiDocs.php
@@ -82,7 +82,10 @@ class MetastoreSearchApiDocs extends DkanApiDocsBase {
   public function spec() {
     $spec = $this->getDoc('metastore_search');
 
-    $spec['paths']['/api/1/search']['get']['parameters'][3]['schema']['enum'] = $this->getIndexedFields();
+    $propList = $this->t('Available properties: %list', [
+      '%list' => implode(", ", $this->getIndexedFields()),
+    ]);
+    $spec['paths']['/api/1/search']['get']['parameters'][3]['description'] .= " $propList";
 
     $facetTypes = $this->getFacetTypes();
     foreach ($facetTypes as $type => $example) {

--- a/modules/metastore/modules/metastore_search/src/QueryBuilderTrait.php
+++ b/modules/metastore/modules/metastore_search/src/QueryBuilderTrait.php
@@ -159,9 +159,11 @@ trait QueryBuilderTrait {
     $fields = array_keys($index->getFields());
 
     $sorts = $params['sort'] ?? [];
-    if (!is_array($sorts)) {
-      $sorts = [$sorts];
+    if (is_string($sorts)) {
+      // @todo Move this into Util class to share with FacetsCommonTrait.
+      $sorts = array_map('trim', str_getcsv($sorts));
     }
+
     if (empty($sorts)) {
       $query->sort('search_api_relevance', Query::SORT_DESC);
     }
@@ -194,8 +196,8 @@ trait QueryBuilderTrait {
     $default = QueryInterface::SORT_ASC;
 
     $orders = $params['sort-order'] ?? [];
-    if (!is_array($orders)) {
-      $orders = [$orders];
+    if (is_string($orders)) {
+      $orders = array_map('trim', str_getcsv($orders));
     }
 
     if (!isset($orders[$index]) || !in_array($orders[$index], $allowed)) {


### PR DESCRIPTION
Slight redux of #3758 adding support for comma-separated multi-value (array) parameters `sort` and `sort-order`. This is more consistent with the other parameters in the DKAN search API.

## QA Steps

1. In the [QA site](https://dkan-qa-3760.ci.civicactions.net/), create a new dataset called with the title "Afghanistan Election Districts".
2. Retrieve https://dkan-qa-3760.ci.civicactions.net/api/1/search?sort=title,modified&sort-order=asc,asc
3. Confirm that there are two "Afghanistan Election Districts" datasets, at the top of the search results, and that the sample content one, with modified date `2012-10-30`, is first.
4. Retrieve https://dkan-qa-3760.ci.civicactions.net/api/1/search?sort=title,modified&sort-order=asc,desc
5. Now confirm that the two Afghanistan datasets are still on top, but the sample dataset should be second.

## Note

While no longer documented, the "deepObject" syntax described in #3758 will actually still work.
