### PR TITLE
Fix dataset-specific docs endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "fmizzell/maquina": "^1.1.0",
         "getdkan/contracts": "^1.0.0",
         "getdkan/csv-parser": "^1.2.3",
-        "getdkan/file-fetcher" : "^4.1.0",
+        "getdkan/file-fetcher" : "4.1.0",
         "getdkan/harvest": "^1.0.0",
         "getdkan/json-schema-provider": "^0.1.2",
         "getdkan/locker": "^1.1.0",

--- a/modules/common/tests/src/Unit/Connection.php
+++ b/modules/common/tests/src/Unit/Connection.php
@@ -77,4 +77,11 @@ class Connection extends CoreConnection {
     return 0;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public static function open(array &$connection_options = []) {
+    return new \stdClass();
+  }
+
 }

--- a/modules/metastore/src/DatasetApiDocs.php
+++ b/modules/metastore/src/DatasetApiDocs.php
@@ -66,11 +66,11 @@ class DatasetApiDocs {
   private $metastore;
 
   /**
-   * Site settings.
+   * Prefix to the API path.
    *
-   * @var \Drupal\Core\Site\Settings
+   * @var string
    */
-  private Settings $settings;
+  private string $dkanApiBase;
 
   /**
    * Constructs a new MetastoreDocsController.
@@ -85,7 +85,7 @@ class DatasetApiDocs {
   public function __construct(DkanApiDocsGenerator $docsGenerator, Service $metastore, Settings $settings) {
     $this->docsGenerator = $docsGenerator;
     $this->metastore = $metastore;
-    $this->settings = $settings;
+    $this->dkanApiBase = $settings->get('dkan_api_base') ?? '';
   }
 
   /**
@@ -106,7 +106,7 @@ class DatasetApiDocs {
       'info' => $fullSpec['info'],
     ];
 
-    $metastorePath = $fullSpec['paths']['/api/1/metastore/schemas/dataset/items/{identifier}']['get'];
+    $metastorePath = $fullSpec['paths'][$this->dkanApiBase . '/api/1/metastore/schemas/dataset/items/{identifier}']['get'];
     unset($metastorePath['parameters'][0]);
     $metastorePath['parameters'] = array_values($metastorePath['parameters']);
     $datasetSpec['paths']["/api/1/metastore/schemas/dataset/items/$identifier"]['get'] = $metastorePath;
@@ -115,17 +115,17 @@ class DatasetApiDocs {
       = $this->getDatastoreIndexPath($fullSpec, $identifier);
 
     $datasetSpec['paths']['/api/1/datastore/query/{distributionId}'] =
-      $fullSpec['paths']['/api/1/datastore/query/{distributionId}'];
+      $fullSpec['paths'][$this->dkanApiBase . '/api/1/datastore/query/{distributionId}'];
 
     $datasetSpec['paths']['/api/1/datastore/sql'] =
-      $fullSpec['paths']['/api/1/datastore/sql'];
+      $fullSpec['paths'][$this->dkanApiBase . '/api/1/datastore/sql'];
 
     $datasetSpec['components'] = $this->datasetSpecificComponents($fullSpec, $identifier);
 
     $this->alterDatastoreParameters($datasetSpec, $identifier);
     $this->modifySqlEndpoints($datasetSpec, $identifier);
-    if ($dkanApiBase = $this->settings->get('dkan_api_base')) {
-      $datasetSpec = ApiDocsPathModifier::prepend($datasetSpec, $dkanApiBase);
+    if ($this->dkanApiBase) {
+      $datasetSpec = ApiDocsPathModifier::prepend($datasetSpec, $this->dkanApiBase);
     }
 
     return $datasetSpec;
@@ -166,7 +166,7 @@ class DatasetApiDocs {
    *   Path array ready to insert.
    */
   private function getDatastoreIndexPath($fullSpec, $identifier) {
-    $datastoreIndexPath = $fullSpec['paths']['/api/1/datastore/query/{datasetId}/{index}'];
+    $datastoreIndexPath = $fullSpec['paths'][$this->dkanApiBase . '/api/1/datastore/query/{datasetId}/{index}'];
     unset($datastoreIndexPath['get']['parameters'][0]);
     $datastoreIndexPath['get']['parameters'] = array_values($datastoreIndexPath['get']['parameters']);
     unset($datastoreIndexPath['post']['parameters'][0]);

--- a/modules/metastore/tests/src/Unit/DatasetApiDocsTest.php
+++ b/modules/metastore/tests/src/Unit/DatasetApiDocsTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Drupal\Tests\metastore\Unit;
+
+use Drupal\Core\Site\Settings;
+use Drupal\common\DkanApiDocsGenerator;
+use Drupal\common\Plugin\DkanApiDocsBase;
+use Drupal\common\Plugin\DkanApiDocsPluginManager;
+use Drupal\metastore\DatasetApiDocs;
+use Drupal\metastore\SchemaRetriever;
+use Drupal\metastore\Service;
+use Drupal\metastore\Storage\DataFactory;
+use Drupal\metastore\ValidMetadataFactory;
+use MockChain\Chain;
+use PHPUnit\Framework\TestCase;
+use RootedData\RootedJsonData;
+
+/**
+ * Unit tests for DatasetApiDocs.
+ */
+class DatasetApiDocsTest extends TestCase {
+
+  /**
+   *
+   */
+  public function testBuildDatasetApiDocsWithDkanApiBase() {
+
+    $dkanApiPath = '/foo/bar';
+
+    $settings = new Settings(['dkan_api_base' => $dkanApiPath]);
+
+    $generator = new DkanApiDocsGenerator(
+      $this->getManagerChain()->getMock(),
+      $settings
+    );
+
+    $service = $this->getServiceChain()->getMock();
+
+    $datasetDoc = new DatasetApiDocs($generator, $service, $settings);
+
+    $spec = $datasetDoc->getDatasetSpecific('123');
+
+    $this->assertTrue(is_array($spec['paths']));
+
+    $paths = array_keys($spec['paths']);
+    $expected_paths = [
+      $dkanApiPath . '/api/1/metastore/schemas/dataset/items/123',
+      $dkanApiPath . '/api/1/datastore/query/123/{index}',
+      $dkanApiPath . '/api/1/datastore/query/{distributionId}',
+      $dkanApiPath . '/api/1/datastore/sql'
+    ];
+    foreach ($expected_paths as $path) {
+      $this->assertContains($path, $paths);
+    }
+  }
+
+  /**
+   *
+   */
+  private function getSpec(): array {
+    return [
+      'openapi' => '3.0.2',
+      'info' => [
+        'title' => '',
+        'version' => '',
+      ],
+      'components' => [
+        'parameters' => [
+          'datasetUuid' => [
+            'name' => 'identifier',
+            'in' => 'path',
+            'required' => true,
+            'schema' => ['type' => 'string'],
+          ],
+          "datastoreDatasetUuid" => [
+            'name' => 'datasetId',
+            'in' => 'path',
+            'required' => true,
+            'schema' => ['type' => 'string'],
+          ],
+          'datastoreDistributionUuid' => [
+            'name' => 'distributionId',
+            'in' => 'path',
+            'required' => true,
+            'schema' => ['type' => 'string'],
+          ],
+          'datastoreDistributionIndex' => [
+            'name' => 'index',
+            'in' => 'path',
+            'required' => true,
+            'schema' => ['type' => 'string'],
+          ]
+        ],
+        'responses' => [
+          '200JsonOrCsvQueryOk' => ['description' => '']
+        ],
+        'schemas' => [
+          'dataset' => [
+            'title' => '',
+            'type' => 'object'
+          ]
+        ]
+      ],
+      'paths' => [
+        '/api/1/metastore/schemas/dataset/items/{identifier}' => [
+          'get' => [
+            'operationId' => 'dataset-get-item',
+            'parameters' => [0 => ['$ref' => '#/components/parameters/datasetUuid']],
+            'responses' => ['200' => ['$ref' => '#/components/responses/200JsonOrCsvQueryOk']]
+          ]
+        ],
+        '/api/1/datastore/query/{datasetId}/{index}' => [
+          'post' => [
+            'operationId' => 'datastore-datasetindex-query-post',
+            'parameters' => [
+              0 => ['$ref' => '#/components/parameters/datasetUuid'],
+              1 => ['$ref' => '#/components/parameters/datastoreDistributionIndex']
+            ],
+            'responses' => ['200' => ['$ref' => '#/components/responses/200JsonOrCsvQueryOk']]
+          ],
+          'get' => [
+            'operationId' => 'datastore-datasetindex-query-get',
+            'parameters' => [
+              0 => ['$ref' => '#/components/parameters/datasetUuid'],
+              1 => ['$ref' => '#/components/parameters/datastoreDistributionIndex']
+            ],
+            'responses' => ['200' => ['$ref' => '#/components/responses/200JsonOrCsvQueryOk']]
+          ]
+        ],
+        '/api/1/datastore/query/{distributionId}' => [
+          'get' => [
+            'operationId' => 'datastore-resource-query-get',
+            'parameters' => [0 => ['$ref' => '#/components/parameters/datastoreDistributionUuid']],
+            'responses' => ['200' => ['$ref' => '#/components/responses/200JsonOrCsvQueryOk']]
+          ]
+        ],
+        '/api/1/datastore/sql' => ['get' => [
+          'operationId' => 'datastore-sql',
+          'responses' => ['200' => ['$ref' => '#/components/responses/200JsonOrCsvQueryOk']]
+        ]]
+      ]
+    ];
+  }
+
+  private function getManagerChain() {
+    $definitions = [
+      'metastore_api_docs' => ['id' => 'metastore_api_docs']
+    ];
+
+    $spec = $this->getSpec();
+
+    return (new Chain($this))
+      ->add(DkanApiDocsPluginManager::class, 'getDefinitions', $definitions)
+        ->addd('createInstance', DkanApiDocsBase::class)
+      ->add(DkanApiDocsBase::class, 'spec', $spec);
+  }
+
+  private function getServiceChain() {
+    $dataset = '
+    {
+      "title": "Test #1",
+      "description": "Yep",
+      "identifier": "123",
+      "accessLevel": "public",
+      "modified": "06-04-2020",
+      "keyword": ["hello"]
+    }';
+
+    return (new Chain($this))
+      ->add(Service::class, 'swapReferences', new RootedJsonData($dataset))
+        ->addd('get', new RootedJsonData($dataset))
+      ->add(SchemaRetriever::class)
+      ->add(DataFactory::class, 'swapReferences', new RootedJsonData($dataset))
+      ->add(ValidMetadataFactory::class, 'get', $dataset);
+  }
+
+}


### PR DESCRIPTION
When the dataset-specific API docs is generated, it's created from the full spec, whose paths were already prefixed with `$settings['dkan_api_base']`. As a result, `$fullSpec['paths']['/api/1/...']` is not found, resulting in breaking the dataset-specific API docs.

This PR attempts to correct that.

Since the prefix is now needed in more than one function, I made it a class property, initialized in the constructor. This allows the removal of the settings property.