### PR TITLE
Order facets by count, name

### DIFF
--- a/modules/metastore/modules/metastore_search/src/Search.php
+++ b/modules/metastore/modules/metastore_search/src/Search.php
@@ -150,6 +150,9 @@ class Search implements ContainerInjectionInterface {
    */
   public static function orderFacets(array &$facets): void {
     usort($facets, function ($a, $b) {
+      if (!isset($a->name, $b->name, $a->total, $b->total)) {
+        throw new \InvalidArgumentException("Facets much name and total properties.");
+      }
       if ($a->total == $b->total) {
         return strcmp($a->name, $b->name);
       }

--- a/modules/metastore/modules/metastore_search/src/Search.php
+++ b/modules/metastore/modules/metastore_search/src/Search.php
@@ -138,7 +138,25 @@ class Search implements ContainerInjectionInterface {
       $facets = $this->getFacetsFromIndex($params, $this->index, $query);
     }
 
+    static::orderFacets($facets);
     return $facets;
+  }
+
+  /**
+   * Order the facet array by total (desc) then name (asc)
+   *
+   * @param array $facets
+   *   Array of facet objects with properties "total", "name" and "type".
+   */
+  public static function orderFacets(array &$facets): void {
+    usort($facets, function ($a, $b) {
+      if ($a->total == $b->total) {
+        return strcmp($a->name, $b->name);
+      }
+      else {
+        return $b->total - $a->total;
+      }
+    });
   }
 
   /**
@@ -147,7 +165,7 @@ class Search implements ContainerInjectionInterface {
    * @param \Drupal\search_api\Query\ResultSet $result
    *   Result set.
    *
-   * @return array
+   * @return null|array
    *   Filtered results.
    */
   private function getData(ResultSet $result) {
@@ -158,7 +176,7 @@ class Search implements ContainerInjectionInterface {
         $id = $item->getId();
         $id = str_replace('dkan_dataset/', '', $id);
         try {
-          return json_decode($metastore->get('dataset', $id));
+          return json_decode((string) $metastore->get('dataset', $id));
         }
         catch (\Exception $e) {
           return NULL;

--- a/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
+++ b/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
@@ -105,6 +105,32 @@ class SearchTest extends TestCase {
   }
 
   /**
+   * Test the Service::orderFacets method.
+   */
+  public function testOrderFacets() {
+    $in = [
+      (object) ['name' => 'Ana', 'total' => 1],
+      (object) ['name' => 'Bob', 'total' => 2],
+      (object) ['name' => 'Chris', 'total' => 3],
+      (object) ['name' => 'Dana', 'total' => 3],
+      (object) ['name' => 'Ed', 'total' => 3],
+    ];
+
+    // orderFacets() should order descending by count, then ascending by name.
+    $out = [
+      (object) ['name' => 'Chris', 'total' => 3],
+      (object) ['name' => 'Dana', 'total' => 3],
+      (object) ['name' => 'Ed', 'total' => 3],      
+      (object) ['name' => 'Bob', 'total' => 2],
+      (object) ['name' => 'Ana', 'total' => 1],
+    ];
+
+    Search::orderFacets($in);
+
+    $this->assertEquals($out, $in);
+  }
+
+  /**
    * Test for facets().
    */
   public function testFacets() {

--- a/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
+++ b/modules/metastore/modules/metastore_search/tests/src/Unit/SearchTest.php
@@ -128,6 +128,15 @@ class SearchTest extends TestCase {
     Search::orderFacets($in);
 
     $this->assertEquals($out, $in);
+
+    $no_name = [
+      (object) ['field1' => 'foo', 'field2' => 'bar'],
+      (object) ['field1' => 'x', 'field2' => 'y'],
+    ];
+
+    // Passing facets without name or total properties will throw exception.
+    $this->expectException(\InvalidArgumentException::class);
+    Search::orderFacets($no_name);
   }
 
   /**


### PR DESCRIPTION
There is no consistent order to the facets returned by the API. This orders them first by total/count, then secondarily by "name". 

If further customization is needed this can be handled by frontend clients.

## QA Steps

- Check QA site and confirm facets now follow expected order.
