### PR TITLE
Data-Dictionary Creation Form

### DIFF
--- a/modules/json_form_widget/config/schema/json_form_widget.schema.yml
+++ b/modules/json_form_widget/config/schema/json_form_widget.schema.yml
@@ -1,7 +1,4 @@
 field.widget.settings.json_form_widget:
   type: mapping
   label: 'JSON Form widget settings'
-  mapping:
-    schema:
-      type: string
-      label: 'Schema'
+  mapping: {  }

--- a/modules/json_form_widget/src/FormBuilder.php
+++ b/modules/json_form_widget/src/FormBuilder.php
@@ -74,13 +74,11 @@ class FormBuilder implements ContainerInjectionInterface {
   /**
    * Set schema.
    *
-   * @codeCoverageIgnore
+   * @param string $schema_name
+   *   Metadata schema name.
    */
-  public function setSchema($schema_name, $type = NULL) {
+  public function setSchema(string $schema_name): void {
     try {
-      if (!empty($type) && $type !== $schema_name) {
-        $schema_name = $type;
-      }
       $schema = $this->schemaRetriever->retrieve($schema_name);
       $this->schema = json_decode($schema);
       $this->schemaUiHandler->setSchemaUi($schema_name);

--- a/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidget.php
+++ b/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidget.php
@@ -22,8 +22,6 @@ use Drupal\json_form_widget\ValueHandler;
  *     "string_long"
  *   }
  * )
- *
- * @codeCoverageIgnore
  */
 class JsonFormWidget extends WidgetBase {
 
@@ -118,7 +116,7 @@ class JsonFormWidget extends WidgetBase {
       $default_data = json_decode($item->value);
     }
     $type = $form_state->getformObject()->getEntity()->get('field_data_type')->value;
-    $type = isset($type) ? $type : $this->getSchema();
+    $type = $type ?? $this->getSchema();
     $this->builder->setSchema($this->getSchema(), $type);
     $json_form = $this->builder->getJsonForm($default_data, $form_state);
 
@@ -134,7 +132,7 @@ class JsonFormWidget extends WidgetBase {
     $field_name = $form_state->get('json_form_widget_field');
     // @todo there is duplicated code here.
     $type = $form_state->getformObject()->getEntity()->get('field_data_type')->value;
-    $type = isset($type) ? $type : $this->getSchema();
+    $type = $type ?? $this->getSchema();
     $this->builder->setSchema($this->getSchema(), $type);
     $schema = $this->builder->getSchema();
 
@@ -165,6 +163,7 @@ class JsonFormWidget extends WidgetBase {
    * Get form data schema.
    *
    * @return string
+   *   Data schema.
    */
   protected function getSchema(): string {
     return $this->schema ?? self::DEFAULT_SCHEMA;

--- a/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidget.php
+++ b/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidget.php
@@ -115,7 +115,7 @@ class JsonFormWidget extends WidgetBase {
     foreach ($items as $item) {
       $default_data = json_decode($item->value);
     }
-    $type = $this->getSchemaId();
+    $type = $this->getSchemaId($form_state);
     // Copy the item type to the entity.
     $form_state->getFormObject()->getEntity()->set('field_data_type', $type);
     // Set the schema for the form builder.
@@ -132,7 +132,7 @@ class JsonFormWidget extends WidgetBase {
    */
   public function extractFormValues(FieldItemListInterface $items, array $form, FormStateInterface $form_state) {
     // Set the schema for the form builder.
-    $this->builder->setSchema($this->getSchemaId());
+    $this->builder->setSchema($this->getSchemaId($form_state));
 
     $field_name = $form_state->get('json_form_widget_field');
     $schema = $this->builder->getSchema();
@@ -171,7 +171,10 @@ class JsonFormWidget extends WidgetBase {
   protected function getSchemaId(?FormStateInterface $form_state = NULL): string {
     // Extract the metastore item type from form state if provided.
     if (isset($form_state)) {
-      return $form_state->getFormObject()->getEntity()->field_data_type->value;
+      $entity = $form_state->getFormObject()->getEntity();
+      if (isset($entity->field_data_type->value)) {
+        return $entity->field_data_type->value;
+      }
     }
     // Otherwise use form state provided in request query, or the default
     // schema if one is not found.

--- a/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidget.php
+++ b/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidget.php
@@ -162,7 +162,7 @@ class JsonFormWidget extends WidgetBase {
   /**
    * Get form data schema ID.
    *
-   * @param FormStateInterface|null $form_state
+   * @param \Drupal\Core\Form\FormStateInterface|null $form_state
    *   Form state.
    *
    * @return string

--- a/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidget.php
+++ b/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidget.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\json_form_widget\Plugin\Field\FieldWidget;
 
+use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -117,7 +118,10 @@ class JsonFormWidget extends WidgetBase {
     }
     $type = $this->getSchemaId($form_state);
     // Copy the item type to the entity.
-    $form_state->getFormObject()->getEntity()->set('field_data_type', $type);
+    $form_entity = $form_state->getFormObject()->getEntity();
+    if ($form_entity instanceof FieldableEntityInterface) {
+      $form_entity->set('field_data_type', $type);
+    }
     // Set the schema for the form builder.
     $this->builder->setSchema($type);
     // Attempt to build the form.
@@ -171,9 +175,9 @@ class JsonFormWidget extends WidgetBase {
   protected function getSchemaId(?FormStateInterface $form_state = NULL): string {
     // Extract the metastore item type from form state if provided.
     if (isset($form_state)) {
-      $entity = $form_state->getFormObject()->getEntity();
-      if (isset($entity->field_data_type->value)) {
-        return $entity->field_data_type->value;
+      $form_entity = $form_state->getFormObject()->getEntity();
+      if ($form_entity instanceof FieldableEntityInterface && isset($form_entity->field_data_type->value)) {
+        return $form_entity->field_data_type->value;
       }
     }
     // Otherwise use form state provided in request query, or the default

--- a/modules/metastore/config/optional/core.entity_form_display.node.data.default.yml
+++ b/modules/metastore/config/optional/core.entity_form_display.node.data.default.yml
@@ -22,8 +22,7 @@ content:
     third_party_settings: {  }
   field_json_metadata:
     weight: 6
-    settings:
-      schema: dataset
+    settings: {  }
     third_party_settings: {  }
     type: json_form_widget
     region: content

--- a/modules/metastore/metastore.links.menu.yml
+++ b/modules/metastore/metastore.links.menu.yml
@@ -5,9 +5,26 @@ dkan.metastore.config_properties:
   parent: system.admin_dkan
   weight: 14
 
-datastore.data_dictionary_settings_form:
-  title: Data-Dictionary settings
-  description: Data-Dictionary settings.
+metastore.data_dictionary:
+  title: Data-Dictionary
+  description: Data-Dictionary Pages
   parent: system.admin_dkan
-  route_name: datastore.data_dictionary_settings
+  route_name: metastore.data_dictionary
   weight: 13
+
+metastore.data_dictionary.create:
+  title: Create
+  description: Create Data-Dictionary
+  parent: metastore.data_dictionary
+  route_name: node.add
+  route_parameters:
+    node_type: data
+    schema: data-dictionary
+  weight: 1
+
+metastore.data_dictionary.settings_form:
+  title: Settings
+  description: Data-Dictionary Settings
+  parent: metastore.data_dictionary
+  route_name: metastore.data_dictionary.settings
+  weight: 2

--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -159,8 +159,16 @@ dkan.metastore.config_properties:
   options:
     _admin_route: TRUE
 
-datastore.data_dictionary_settings:
+metastore.data_dictionary:
   path: '/admin/dkan/data-dictionary'
+  defaults:
+    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+    _title: 'Data-Dictionary'
+  requirements:
+    _permission: 'administer site configuration'
+
+metastore.data_dictionary.settings:
+  path: '/admin/dkan/data-dictionary/settings'
   defaults:
     _title: 'Data-Dictionary Settings'
     _form: '\Drupal\metastore\Form\DataDictionarySettingsForm'

--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -255,7 +255,7 @@ class LifeCycle {
   /**
    * Dataset pre-save life cycle method.
    *
-   * @param MetastoreItemInterface $data
+   * @param \Drupal\metastore\MetastoreItemInterface $data
    *   Dataset metastore item.
    */
   protected function datasetPresave(MetastoreItemInterface $data): void {
@@ -265,7 +265,7 @@ class LifeCycle {
   /**
    * Sanitize and reference metadata.
    *
-   * @param MetastoreItemInterface $data
+   * @param \Drupal\metastore\MetastoreItemInterface $data
    *   Metastore item.
    */
   protected function referenceMetadata(MetastoreItemInterface $data): void {
@@ -301,7 +301,7 @@ class LifeCycle {
   /**
    * Data-Dictionary pre-save life cycle method.
    *
-   * @param MetastoreItemInterface $data
+   * @param \Drupal\metastore\MetastoreItemInterface $data
    *   Data-Dictionary metastore item.
    */
   protected function datadictionaryPresave(MetastoreItemInterface $data): void {


### PR DESCRIPTION
fixes WCMS-8856

Add menu-item and page for creating a data-dictionary.

- [x] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Login to DKAN.
- [ ] Navigate to **DKAN > Data-Dictionary > Create**.
- [ ] Use the form too create a data-dictionary.
- [ ] Navigate to the datasets list page.
- [ ] Filter for data-dictionaries.
- [ ] Ensure the data-dictionary the you created shows up in the list.