### PR TITLE
Fix how datastore DB connection settings are applied

### DIFF
--- a/modules/datastore/src/Storage/DatabaseConnectionFactory.php
+++ b/modules/datastore/src/Storage/DatabaseConnectionFactory.php
@@ -27,11 +27,9 @@ class DatabaseConnectionFactory extends DatabaseConnectionFactoryBase implements
    * {@inheritdoc}
    */
   protected function buildConnectionInfo(): array {
-    return parent::buildConnectionInfo() + [
-      'pdo' => [
-        \PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => FALSE,
-      ],
-    ];
+    $connection_info = parent::buildConnectionInfo();
+    $connection_info['pdo'][\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = FALSE;
+    return $connection_info;
   }
 
 }


### PR DESCRIPTION
Fix faulty array merge when DB connection settings are generated. Since 2.13.11 CSV downloads were not working (headers would be sent but no data on any datasets larger than a few thousand rows) because the PDO::MYSQL_ATTR_USE_BUFFERED_QUERY connection setting was not being set correctly.