### PR TITLE
Fulltext searching in datastore query

### DIFF
--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -256,6 +256,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
       // Portion of the message => User friendly message.
       'Column not found' => 'Column not found',
       'Mixing of GROUP columns' => 'You may not mix simple properties and aggregation expressions in a single query. If one of your properties includes an expression with a sum, count, avg, min or max operator, remove other properties from your query and try again',
+      'Can\'t find FULLTEXT index matching the column list' => 'You have attempted a fulltext match against a column that is not indexed for fulltext searching',
     ];
     foreach ($messages as $portion => $message) {
       if (strpos($unsanitizedMessage, $portion) !== FALSE) {

--- a/modules/common/src/Storage/SelectFactory.php
+++ b/modules/common/src/Storage/SelectFactory.php
@@ -32,7 +32,7 @@ class SelectFactory {
   private $dbQuery;
 
   /**
-   * Iterator for "words" named placeholder
+   * Iterator for "words" named placeholder.
    *
    * @var int
    */

--- a/modules/common/src/Storage/SelectFactory.php
+++ b/modules/common/src/Storage/SelectFactory.php
@@ -278,7 +278,7 @@ class SelectFactory {
     $properties = explode(',', $condition->property);
     $fields = [];
     foreach ($properties as $property) {
-      $fields[] = (isset($condition->collection) ? $condition->collection : $this->alias)
+      $fields[] = ($condition->collection ?? $this->alias)
       . '.'
       . $property;
     }

--- a/modules/common/src/Storage/SelectFactory.php
+++ b/modules/common/src/Storage/SelectFactory.php
@@ -32,6 +32,13 @@ class SelectFactory {
   private $dbQuery;
 
   /**
+   * Iterator for "words" named placeholder
+   *
+   * @var int
+   */
+  private $wordsIterator = 0;
+
+  /**
    * Constructor function.
    *
    * @param Drupal\Core\Database\Connection $connection
@@ -284,8 +291,9 @@ class SelectFactory {
     }
     $fields_list = implode(',', $fields);
 
-    $where = "MATCH($fields_list) AGAINST (:words IN BOOLEAN MODE)";
-    $statementObj->where($where, [':words' => $condition->value]);
+    $where = "MATCH($fields_list) AGAINST (:words{$this->wordsIterator} IN BOOLEAN MODE)";
+    $statementObj->where($where, [":words{$this->wordsIterator}" => $condition->value]);
+    $this->wordsIterator++;
   }
 
   /**

--- a/modules/common/tests/src/Unit/Storage/QueryDataProvider.php
+++ b/modules/common/tests/src/Unit/Storage/QueryDataProvider.php
@@ -37,6 +37,7 @@ class QueryDataProvider {
       'likeConditionQuery',
       'containsConditionQuery',
       'startsWithConditionQuery',
+      'matchConditionQuery',
       'arrayConditionQuery',
       'nestedConditionGroupQuery',
       'sortQuery',
@@ -376,6 +377,31 @@ class QueryDataProvider {
 
       case self::VALUES:
         return ['value%'];
+    }
+  }
+
+  public static function matchConditionQuery($return) {
+    switch ($return) {
+      case self::QUERY_OBJECT:
+        $query = new Query();
+        $query->conditions = [
+          (object) [
+            "collection" => "t",
+            "property" => "field1",
+            "value" => "value",
+            "operator" => "match",
+          ],
+        ];
+        return $query;
+
+      case self::SQL:
+        return "WHERE (MATCH(t.field1) AGAINST (:words IN BOOLEAN MODE))";
+
+      case self::EXCEPTION:
+        return '';
+
+      case self::VALUES:
+        return ['value'];
     }
   }
 

--- a/modules/common/tests/src/Unit/Storage/QueryDataProvider.php
+++ b/modules/common/tests/src/Unit/Storage/QueryDataProvider.php
@@ -391,17 +391,23 @@ class QueryDataProvider {
             "value" => "value",
             "operator" => "match",
           ],
+          (object) [
+            "collection" => "t",
+            "property" => "field2",
+            "value" => "value2",
+            "operator" => "match",
+          ],
         ];
         return $query;
 
       case self::SQL:
-        return "WHERE (MATCH(t.field1) AGAINST (:words IN BOOLEAN MODE))";
+        return "WHERE ((MATCH(t.field1) AGAINST (:words0 IN BOOLEAN MODE))) AND ((MATCH(t.field2) AGAINST (:words1 IN BOOLEAN MODE)))";
 
       case self::EXCEPTION:
         return '';
 
       case self::VALUES:
-        return ['value'];
+        return ['value', 'value2'];
     }
   }
 

--- a/modules/datastore/docs/query.json
+++ b/modules/datastore/docs/query.json
@@ -206,7 +206,8 @@
                         "in",
                         "not in",
                         "contains",
-                        "starts with"
+                        "starts with",
+                        "match"
                     ],
                     "default": "="
                  }

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -180,7 +180,6 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    *
    * @param string $tableName
    *   The table name.
-   *
    * @param array $fieldsInfo
    *   Array of fields info from DESCRIBE query.
    *

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -186,7 +186,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    * @return array
    *   Full Drupal Schema API array.
    */
-  protected function buildTableSchema(string $tableName, array $fieldsInfo) {
+  protected function buildTableSchema(string $tableName, array $fieldsInfo): array {
     // Add descriptions to schema from column comments.
     $canGetComment = method_exists($this->connection->schema(), 'getComment');
     $schema = ['fields' => []];
@@ -210,7 +210,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    * @param array $schema
    *   Drupal Schema API array.
    */
-  protected function addIndexInfo(array &$schema) {
+  protected function addIndexInfo(array &$schema): void {
     if ($this->connection->getConnectionOptions()['driver'] != 'mysql') {
       return;
     }

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -190,6 +190,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
   protected function buildTableSchema(string $tableName, array $fieldsInfo) {
     // Add descriptions to schema from column comments.
     $canGetComment = method_exists($this->connection->schema(), 'getComment');
+    $schema = ['fields' => []];
     foreach ($fieldsInfo as $info) {
       $name = $info->Field;
       $schema['fields'][$name] = $this->translateType($info->Type, ($info->Extra ?? NULL));
@@ -201,7 +202,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     // Add index information to schema if available.
     $this->addIndexInfo($schema);
 
-    return $schema ?? ['fields' => []];
+    return $schema;
   }
 
   /**

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -186,7 +186,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    * @return array
    *   Full Drupal Schema API array.
    */
-  protected function buildTableSchema(string $tableName, array $fieldsInfo): array {
+  protected function buildTableSchema(string $tableName, array $fieldsInfo) {
     // Add descriptions to schema from column comments.
     $canGetComment = method_exists($this->connection->schema(), 'getComment');
     $schema = ['fields' => []];

--- a/modules/datastore/src/Storage/SqliteDatabaseTable.php
+++ b/modules/datastore/src/Storage/SqliteDatabaseTable.php
@@ -25,7 +25,7 @@ class SqliteDatabaseTable extends DatabaseTable {
   /**
    * {@inheritdoc}
    */
-  protected function buildTableSchema($tableName, $fieldsInfo) {
+  protected function buildTableSchema($tableName, $fieldsInfo):array {
     foreach ($fieldsInfo as $info) {
       $name = $info->name;
       $schema['fields'][$name] = $this->translateType(strtolower($info->type), $info);

--- a/modules/datastore/src/Storage/SqliteDatabaseTable.php
+++ b/modules/datastore/src/Storage/SqliteDatabaseTable.php
@@ -25,7 +25,7 @@ class SqliteDatabaseTable extends DatabaseTable {
   /**
    * {@inheritdoc}
    */
-  protected function buildTableSchema($tableName, $fieldsInfo):array {
+  protected function buildTableSchema($tableName, $fieldsInfo) {
     foreach ($fieldsInfo as $info) {
       $name = $info->name;
       $schema['fields'][$name] = $this->translateType(strtolower($info->type), $info);

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -39,8 +39,10 @@ class DatabaseTableTest extends TestCase {
    *
    */
   public function testGetSchema() {
+    $connectionChain = $this->getConnectionChain();
+
     $databaseTable = new DatabaseTable(
-      $this->getConnectionChain()->getMock(),
+      $connectionChain->getMock(),
       $this->getResource()
     );
 
@@ -65,6 +67,17 @@ class DatabaseTableTest extends TestCase {
           "type" => "text",
           "description" => "lAST nAME",
           "mysql_type" => "text",
+        ],
+      ],
+      "indexes" => [
+        "idx1" => [
+          "first_name",
+        ],
+      ],
+      "fulltext indexes" => [
+        "ftx1" => [
+          "first_name",
+          "last_name",
         ],
       ],
     ];
@@ -415,6 +428,27 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
+   *
+   */
+  public function testNoFulltextIndexFound() {
+    $query = new Query();
+
+    $connectionChain = $this->getConnectionChain()
+      ->add(Connection::class, 'select', Select::class, 'select_1')
+      ->add(Select::class, 'fields', Select::class)
+      ->add(Select::class, 'condition', Select::class)
+      ->add(Select::class, 'execute', new DatabaseExceptionWrapper("SQLSTATE[HY000]: General error: 1191 Can't find FULLTEXT index matching the column list..."));
+
+    $databaseTable = new DatabaseTable(
+      $connectionChain->getMock(),
+      $this->getResource()
+    );
+
+    $this->expectExceptionMessage("You have attempted a fulltext match against a column that is not indexed for fulltext searching");
+    $databaseTable->query($query);
+  }
+
+  /**
    * Private.
    */
   private function getConnectionChain() {
@@ -435,11 +469,32 @@ class DatabaseTableTest extends TestCase {
       ]
     ];
 
+    $indexInfo = [
+      (object) [
+        'Key_name' => "idx1",
+        'Column_name' => 'first_name',
+        'Index_type' => 'FOO',
+      ],
+      (object) [
+        'Key_name' => "ftx1",
+        'Column_name' => 'first_name',
+        'Index_type' => 'FULLTEXT',
+      ],
+      (object) [
+        'Key_name' => "ftx2",
+        'Column_name' => 'first_name',
+        'Index_type' => 'FULLTEXT',
+      ],
+    ];
+
     $chain = (new Chain($this))
       // Construction.
       ->add(Connection::class, "schema", Schema::class)
       ->add(Connection::class, 'query', StatementWrapper::class)
-      ->add(StatementWrapper::class, 'fetchAll', $fieldInfo)
+      ->add(Connection::class, 'getConnectionOptions', ['driver' => 'mysql'])
+      ->add(StatementWrapper::class, 'fetchAll',
+        (new Sequence())->add($fieldInfo)->add($indexInfo)
+      )
       ->add(Schema::class, "tableExists", TRUE)
       ->add(Schema::class, 'getComment',
         (new Sequence())->add(NULL)->add('First Name')->add('lAST nAME')


### PR DESCRIPTION
This is a somewhat experimental feature for now and will not be fully documented until we have used it a bit more in the wild. But this allows fulltext boolean match queries against a datastore resource in MySQL if the column(s) being queries are properly indexed.

This PR also adds two new keys to the schema object in the datastore response. One is `indexes` which lists all standard indexes on the database table, as per the Drupal Schema API spec. Another is `fulltext indexes`, which follows the same pattern. This is not part of the official Drupal Schema spec but I felt was needed to signal to the user what columns are available for fulltext searching, and matches the rest of the spec as closely as possible.

## QA steps

This will need to be test locally since for now we need to create the fulltext indexes manually. Set up a local site with the demo content.

1. Ensure that you have a datastore at /api/1/datastore/query/d460252e-d42c-474a-9ea9-5287b1d595f6/0
2. Try running a query before indexing. You should get a 400 error "You have attempted a fulltext match against a column that is not indexed for fulltext searching."
```http
POST https://fulltext-query.ddev.site/api/1/datastore/query/d460252e-d42c-474a-9ea9-5287b1d595f6/0

{
  "conditions": [
    {
      "property": "city",
      "operator": "match",
      "value": "York"
    }
  ]
}
```
3. Use `drush dkan:dataset-info d460252e-d42c-474a-9ea9-5287b1d595f6` to get the table name of the datastore. Let's say its `datastore_efee6d8c0ee35d0b1a161743806d018d`.
4. Connect to your db CLI with `drush sqlc`.
5. Create a fulltext index on the city field: 
```sql
ALTER TABLE datastore_efee6d8c0ee35d0b1a161743806d018d ADD FULLTEXT INDEX `cityfulltext` (`city`);
```
6. Retry the query from step 2.
7. Confirm that you see a result and got a single hit for "New York."
8. Try again with a wildcard:
```http
POST https://fulltext-query.ddev.site/api/1/datastore/query/d460252e-d42c-474a-9ea9-5287b1d595f6/0

{
  "conditions": [
    {
      "property": "city",
      "operator": "match",
      "value": "Yor*"
    }
  ]
}
```
9. Confirm that you still get a hit for "New York".
10. Check the `schema` object in the response and confirm that the fulltext index is listed properly.
11. Now let's try an index with two columns. Go back to the db CLI and let's create a second index that combines city and state:
```sql
ALTER TABLE datastore_efee6d8c0ee35d0b1a161743806d018d ADD FULLTEXT INDEX `citystate` (`city`, `state`);
```
12. We can try a few queries that should demonstrate how this can be leveraged:
```http
POST https://fulltext-query.ddev.site/api/1/datastore/query/d460252e-d42c-474a-9ea9-5287b1d595f6/0

{
  "conditions": [
    {
      "property": "city,state",
      "operator": "match",
      "value": "San"
    }
  ]
}
```
```http
POST https://fulltext-query.ddev.site/api/1/datastore/query/d460252e-d42c-474a-9ea9-5287b1d595f6/0

{
  "conditions": [
    {
      "property": "city,state",
      "operator": "match",
      "value": "Texas"
    }
  ]
}
```
13. Confirm that in both cases you get multiple hits from both city and state fields. Also confirm that the newer fulltext index is included correctly in the schema object.