### PR TITLE
Use "Data: Create new content" permission for data-dictionary menu access

### DIFF
--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -165,7 +165,7 @@ metastore.data_dictionary:
     _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
     _title: 'Data-Dictionary'
   requirements:
-    _permission: 'administer site configuration'
+    _permission: 'create data content'
 
 metastore.data_dictionary.settings:
   path: '/admin/dkan/data-dictionary/settings'


### PR DESCRIPTION
Currently only administrators have access to the **DKAN > Data-Dictionary** menu. This changes that so that data-publishers and anyone with permission to create data content also have access.

- [x] Test coverage exists
- [x] Documentation exists

## QA Steps

- [ ] Ensure that as a user with the "Data: Create new content" permission you have access to the **DKAN > Data-Dictionary** menu.