### PR TITLE
Fix method_exists() PHP 8 error

### DIFF
--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -304,7 +304,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
     // Opportunity to further alter the schema before table creation.
     $schema = $this->dispatchEvent(self::EVENT_TABLE_CREATE, $schema);
     // Add indexes if we have an index manager.
-    if (method_exists($this->indexManager, 'modifySchema')) {
+    if (isset($this->indexManager) && method_exists($this->indexManager, 'modifySchema')) {
       $schema = $this->indexManager->modifySchema($table_name, $schema);
     }
     $this->connection->schema()->createTable($table_name, $schema);


### PR DESCRIPTION
This ensures that the indexer service exists before attempting to check whether it has a specific method.

- [x] Test coverage exists
- [x] Documentation exists

## QA Steps

This will need to be tested on a site running php 8.
- [ ] Navigate to /api/1
- [ ] Ensure you do not see the following error:
```
TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given in method_exists() (line 307 of /mnt/www/html/datamedicaiddev/docroot/modules/contrib/dkan/modules/common/src/Storage/AbstractDatabaseTable.php) #0 /mnt/www/html/datamedicaiddev/docroot/modules/contrib/dkan/modules/common/src/Storage/AbstractDatabaseTable.php(307): method_exists(NULL, 'modifySchema')
#1 /mnt/www/html/datamedicaiddev/docroot/modules/contrib/dkan/modules/common/src/Storage/AbstractDatabaseTable.php(273): Drupal\common\Storage\AbstractDatabaseTable->tableCreate('jobstore_drupal...', Array)
#2 /mnt/www/html/datamedicaiddev/docroot/modules/contrib/dkan/modules/common/src/Storage/AbstractDatabaseTable.php(83): Drupal\common\Storage\AbstractDatabaseTable->setTable() 
```
