### PR TITLE
Add specific permission to administer data-dictionary settings

### DIFF
--- a/modules/metastore/metastore.permissions.yml
+++ b/modules/metastore/metastore.permissions.yml
@@ -1,3 +1,8 @@
 'post put delete datasets through the api':
   title: 'post, put, and delete datasets through the api'
   description: 'post, put, and delete datasets through the api'
+'administer dkan dictionary settings':
+  title: 'Administer DKAN Dictionary Settings'
+  description: 'Administer dkan dictionary settings'
+
+

--- a/modules/metastore/metastore.permissions.yml
+++ b/modules/metastore/metastore.permissions.yml
@@ -1,8 +1,8 @@
 'post put delete datasets through the api':
-  title: 'post, put, and delete datasets through the api'
-  description: 'post, put, and delete datasets through the api'
-'administer dkan dictionary settings':
-  title: 'Administer DKAN Dictionary Settings'
-  description: 'Administer dkan dictionary settings'
+  title: 'Metastore: post, put, patch, and delete datasets through the api'
+  description: 'post, put, patch, and delete datasets through the api'
+'administer data dictionary settings':
+  title: 'Metastore: Administer Data Dictionary Settings'
+  description: 'Administer data dictionary settings'
 
 

--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -173,4 +173,4 @@ metastore.data_dictionary.settings:
     _title: 'Data-Dictionary Settings'
     _form: '\Drupal\metastore\Form\DataDictionarySettingsForm'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'administer dkan dictionary settings'

--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -173,4 +173,4 @@ metastore.data_dictionary.settings:
     _title: 'Data-Dictionary Settings'
     _form: '\Drupal\metastore\Form\DataDictionarySettingsForm'
   requirements:
-    _permission: 'administer dkan dictionary settings'
+    _permission: 'administer data dictionary settings'

--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -173,4 +173,4 @@ metastore.data_dictionary.settings:
     _title: 'Data-Dictionary Settings'
     _form: '\Drupal\metastore\Form\DataDictionarySettingsForm'
   requirements:
-    _permission: 'administer site configuration'
+    _permission: 'access administration pages'


### PR DESCRIPTION
Some sites may not want users who manage data publishing to have the very broad 'Administer site configuration' permission in order to access the data dictionary settings screen.

## QA Steps

- [ ] Add the new _administer data dictionary settings_ permission to an existing role
- [ ] Create a user with that role
- [ ] Log in as the new user
- [ ] Confirm you have access to the following page: /admin/dkan/data-dictionary/settings
