### PR TITLE
Add tsv support to datstore_mysql_import

### DIFF
--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -34,7 +34,7 @@ class MysqlImport extends ImportJob {
     $file_path = \Drupal::service('file_system')->realpath($this->resource->getFilePath());
 
     $mimeType = $this->resource->getMimeType();
-    $delimiter = $mimeType == 'text/tab-separated-values' ? '/t' : ',';
+    $delimiter = $mimeType == 'text/tab-separated-values' ? "\t" : ",";
 
     if ($file_path === FALSE) {
       return $this->setResultError(sprintf('Unable to resolve file name "%s" for resource with identifier "%s".', $this->resource->getFilePath(), $this->resource->getId()));

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -32,13 +32,19 @@ class MysqlImport extends ImportJob {
   protected function runIt() {
     // Attempt to resolve resource file name from file path.
     $file_path = \Drupal::service('file_system')->realpath($this->resource->getFilePath());
+
+    $delimiter = ",";
+    if ($this->resource->getMimeType() == 'text/tab-separated-values') {
+      $delimiter = "\t";
+    }
+
     if ($file_path === FALSE) {
       return $this->setResultError(sprintf('Unable to resolve file name "%s" for resource with identifier "%s".', $this->resource->getFilePath(), $this->resource->getId()));
     }
 
     // Read the columns and EOL character sequence from the CSV file.
     try {
-      [$columns, $column_lines] = $this->getColsFromFile($file_path);
+      [$columns, $column_lines] = $this->getColsFromFile($file_path, $delimiter);
     }
     catch (FileException $e) {
       return $this->setResultError($e->getMessage());
@@ -61,7 +67,7 @@ class MysqlImport extends ImportJob {
     // Construct and execute a SQL import statement using the information
     // gathered from the CSV file being imported.
     $this->getDatabaseConnectionCapableOfDataLoad()->query(
-      $this->getSqlStatement($file_path, $this->dataStorage->getTableName(), array_keys($spec), $eol, $header_line_count));
+      $this->getSqlStatement($file_path, $this->dataStorage->getTableName(), array_keys($spec), $eol, $header_line_count, $delimiter));
 
     Database::setActiveConnection();
 
@@ -76,6 +82,9 @@ class MysqlImport extends ImportJob {
    * @param string $file_path
    *   File path.
    *
+   * @param string $delimiter
+   *   File delimiter.
+   *
    * @return array
    *   An array containing only two elements; the CSV columns and the column
    *   lines.
@@ -84,7 +93,8 @@ class MysqlImport extends ImportJob {
    *   On failure to open the file;
    *   on failure to read the first line from the file.
    */
-  protected function getColsFromFile(string $file_path): array {
+  protected function getColsFromFile(string $file_path, string $delimiter): array {
+
     // Ensure the "auto_detect_line_endings" ini setting is enabled before
     // openning the file to ensure Mac style EOL characters are detected.
     $old_ini = ini_set('auto_detect_line_endings', '1');
@@ -100,7 +110,7 @@ class MysqlImport extends ImportJob {
     }
 
     // Attempt to retrieve the columns from the resource file.
-    $columns = fgetcsv($f);
+    $columns = fgetcsv($f, 0 , $delimiter);
     // Attempt to read the column lines from the resource file.
     $end_pointer = ftell($f);
     rewind($f);
@@ -203,15 +213,17 @@ class MysqlImport extends ImportJob {
    *   End Of Line character for file importation.
    * @param int $header_line_count
    *   Number of lines occupied by the csv header row.
+   * @param $delimiter
+   *  File delimiter.
    *
    * @return string
    *   Generated SQL file import statement.
    */
-  protected function getSqlStatement(string $file_path, string $tablename, array $headers, string $eol, int $header_line_count): string {
+  protected function getSqlStatement(string $file_path, string $tablename, array $headers, string $eol, int $header_line_count, string $delimiter): string {
     return implode(' ', [
       'LOAD DATA LOCAL INFILE \'' . $file_path . '\'',
       'INTO TABLE ' . $tablename,
-      'FIELDS TERMINATED BY \',\'',
+      'FIELDS TERMINATED BY \'' . $delimiter . '\'',
       'OPTIONALLY ENCLOSED BY \'"\'',
       'ESCAPED BY \'\'',
       'LINES TERMINATED BY \'' . $eol . '\'',

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -81,7 +81,6 @@ class MysqlImport extends ImportJob {
    *
    * @param string $file_path
    *   File path.
-   *
    * @param string $delimiter
    *   File delimiter.
    *
@@ -110,7 +109,7 @@ class MysqlImport extends ImportJob {
     }
 
     // Attempt to retrieve the columns from the resource file.
-    $columns = fgetcsv($f, 0 , $delimiter);
+    $columns = fgetcsv($f, 0, $delimiter);
     // Attempt to read the column lines from the resource file.
     $end_pointer = ftell($f);
     rewind($f);
@@ -213,8 +212,8 @@ class MysqlImport extends ImportJob {
    *   End Of Line character for file importation.
    * @param int $header_line_count
    *   Number of lines occupied by the csv header row.
-   * @param $delimiter
-   *  File delimiter.
+   * @param string $delimiter
+   *   File delimiter.
    *
    * @return string
    *   Generated SQL file import statement.

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -33,10 +33,8 @@ class MysqlImport extends ImportJob {
     // Attempt to resolve resource file name from file path.
     $file_path = \Drupal::service('file_system')->realpath($this->resource->getFilePath());
 
-    $delimiter = ",";
-    if ($this->resource->getMimeType() == 'text/tab-separated-values') {
-      $delimiter = "\t";
-    }
+    $mimeType = $this->resource->getMimeType();
+    $delimiter = $mimeType == 'text/tab-separated-values' ? '/t' : ',';
 
     if ($file_path === FALSE) {
       return $this->setResultError(sprintf('Unable to resolve file name "%s" for resource with identifier "%s".', $this->resource->getFilePath(), $this->resource->getId()));

--- a/modules/datastore/modules/datastore_mysql_import/tests/src/Unit/Service/MysqlImportTest.php
+++ b/modules/datastore/modules/datastore_mysql_import/tests/src/Unit/Service/MysqlImportTest.php
@@ -126,6 +126,7 @@ class MysqlImportTest extends TestCase {
 
   protected function getMysqlImporter() {
     $resource = new DataResource(self::HOST . '/text.csv', 'text/csv');
+    $delimiter = ',';
     $databaseTableFactory = $this->getDatabaseTableFactoryMock();
 
     return new class($resource, $databaseTableFactory->getInstance('test')) extends MysqlImport {
@@ -150,8 +151,8 @@ class MysqlImportTest extends TestCase {
         };
       }
 
-      protected function getSqlStatement(string $file_path, string $tablename, array $headers, string $eol, int $header_line_count): string {
-        $this->sqlStatement = parent::getSqlStatement($file_path, $tablename, $headers, $eol, $header_line_count);
+      protected function getSqlStatement(string $file_path, string $tablename, array $headers, string $eol, int $header_line_count, string $delimiter): string {
+        $this->sqlStatement = parent::getSqlStatement($file_path, $tablename, $headers, $eol, $header_line_count, $delimiter);
         return $this->sqlStatement;
       }
 


### PR DESCRIPTION
First draft, ideally we want to allow user to define parser config: delimiter, eol, escape, enclosed.
