### PR TITLE
Add checks to json_form_widget

### DIFF
--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -137,7 +137,6 @@ class ValueHandler {
         $data = array_merge($data, $this->flattenArraysInArrays($value));
       }
     }
-
     return !empty($data) ? $data : FALSE;
   }
 

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -132,10 +132,12 @@ class ValueHandler {
     if ($subschema->type === "object") {
       return $this->getObjectInArrayData($formValues, $property, $subschema);
     }
-
-    foreach ($formValues[$property][$property] as $value) {
-      $data = array_merge($data, $this->flattenArraysInArrays($value));
+    if (isset($formValues[$property][$property])) {
+      foreach ($formValues[$property][$property] as $value) {
+        $data = array_merge($data, $this->flattenArraysInArrays($value));
+      }
     }
+
     return !empty($data) ? $data : FALSE;
   }
 

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -179,7 +179,7 @@ class WidgetRouter implements ContainerInjectionInterface {
       $element = $this->handleSelectOtherDefaultValue($element, $element['#options']);
       $element['#input_type'] = isset($spec->other_type) ? $spec->other_type : 'textfield';
     }
-    $element['#other_option'] = isset($element['#other_option']) ? $element['#other_option'] : FALSE;
+    $element['#other_option'] = isset($element['#other_option']) ?? FALSE;
 
     if ($element['#type'] === 'select2') {
       $element['#multiple'] = isset($spec->multiple) ? TRUE : FALSE;

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -179,9 +179,8 @@ class WidgetRouter implements ContainerInjectionInterface {
       $element = $this->handleSelectOtherDefaultValue($element, $element['#options']);
       $element['#input_type'] = isset($spec->other_type) ? $spec->other_type : 'textfield';
     }
-    if (!isset($element['#other_option'])) {
-      $element['#other_option'] = '';
-    }
+    $element['#other_option'] = isset($element['#other_option']) ? $element['#other_option'] : FALSE;
+
     if ($element['#type'] === 'select2') {
       $element['#multiple'] = isset($spec->multiple) ? TRUE : FALSE;
       $element['#autocreate'] = isset($spec->allowCreate) ? TRUE : FALSE;

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -179,6 +179,9 @@ class WidgetRouter implements ContainerInjectionInterface {
       $element = $this->handleSelectOtherDefaultValue($element, $element['#options']);
       $element['#input_type'] = isset($spec->other_type) ? $spec->other_type : 'textfield';
     }
+    if (!isset($element['#other_option'])) {
+      $element['#other_option'] = '';
+    }
     if ($element['#type'] === 'select2') {
       $element['#multiple'] = isset($spec->multiple) ? TRUE : FALSE;
       $element['#autocreate'] = isset($spec->allowCreate) ? TRUE : FALSE;

--- a/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
@@ -560,6 +560,7 @@ class SchemaUiHandlerTest extends TestCase {
           'arcgis' => 'arcgis',
           'csv' => 'csv',
         ],
+        '#other_option' => '',
         '#default_value' => 'csv',
       ],
     ];
@@ -604,6 +605,7 @@ class SchemaUiHandlerTest extends TestCase {
         ],
         '#default_value' => 'https://url.to.api.or.file',
         '#input_type' => 'textfield',
+        '#other_option' => '',
       ],
     ];
     $form = $ui_handler->applySchemaUi($form);
@@ -675,6 +677,7 @@ class SchemaUiHandlerTest extends TestCase {
             'Option 1' => 'Option 1',
             'Option 2' => 'Option 2',
           ],
+          '#other_option' => '',
           '#multiple' => TRUE,
           '#autocreate' => TRUE,
           '#target_type' => 'node',
@@ -737,6 +740,7 @@ class SchemaUiHandlerTest extends TestCase {
           'Option 1' => 'Option 1',
           'Option 2' => 'Option 2',
         ],
+        '#other_option' => '',
         '#multiple' => TRUE,
         '#autocreate' => TRUE,
         '#target_type' => 'node',
@@ -828,6 +832,7 @@ class SchemaUiHandlerTest extends TestCase {
               'Option 1' => 'Option 1',
               'Option 2' => 'Option 2',
             ],
+            '#other_option' => '',
             '#multiple' => TRUE,
             '#autocreate' => TRUE,
             '#target_type' => 'node',
@@ -881,6 +886,7 @@ class SchemaUiHandlerTest extends TestCase {
               'Option 1' => 'Option 1',
               'Option 2' => 'Option 2',
             ],
+            '#other_option' => '',
             '#multiple' => TRUE,
             '#autocreate' => TRUE,
             '#target_type' => 'node',


### PR DESCRIPTION
Fixes errors on the dataset form:
`Warning: Undefined array key "#other_option" in Drupal\select_or_other\Element\ElementBase::addSelectField()`

`Warning: foreach() argument must be of type array|object, null given`

`Warning: Undefined array key "references" in Drupal\json_form_widget\ValueHandler->handleArrayValues()`