### PR TITLE
Check if referenced node is already published before publishing again

### DIFF
--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -415,12 +415,12 @@ class Referencer {
     ]);
 
     if ($node = reset($nodes)) {
-      // If an existing but orphaned data node is found,
-      // change the state back to published.
-      // @todo if the referencing node is in a draft state, do not publish the
-      // referenced node.
-      $node->set('moderation_state', 'published');
-      $node->save();
+      // @todo if referencing node in draft state, don't publish referenced node
+      // If an existing referenced node is found but unpublished, publish it.
+      if ($node->get('moderation_state')->value !== "published") {
+        $node->set('moderation_state', 'published');
+        $node->save();
+      }
       return $node->uuid();
     }
     return NULL;

--- a/modules/metastore/tests/src/Unit/Reference/ReferencerTest.php
+++ b/modules/metastore/tests/src/Unit/Reference/ReferencerTest.php
@@ -6,6 +6,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\File\FileSystem;
 use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\Core\StreamWrapper\PublicStream;
@@ -19,6 +20,7 @@ use Drupal\metastore\ResourceMapper;
 use Drupal\metastore\Storage\DataFactory;
 use Drupal\metastore\Storage\NodeData;
 use Drupal\metastore\Storage\ResourceMapperDatabaseTable;
+use Drupal\node\Entity\Node;
 use Drupal\node\NodeStorage;
 
 use GuzzleHttp\Exception\RequestException;
@@ -64,23 +66,23 @@ class ReferencerTest extends TestCase {
 
   private function mockReferencer($existing = TRUE) {
     if ($existing) {
-      $node = new class {
-        public function uuid() {
-          return '0398f054-d712-4e20-ad1e-a03193d6ab33';
-        }
-        public function set() {}
-        public function save() {}
-      };
+      $node = (new Chain($this))
+        ->add(Node::class, 'get', FieldItemListInterface::class)
+          ->addd('uuid', '0398f054-d712-4e20-ad1e-a03193d6ab33')
+        ->add(FieldItemListInterface::class, 'getString', 'orphaned')
+        ->add(Node::class, 'set')
+        ->add(Node::class, 'save')
+        ->getMock();
     }
     else {
-      $node = new class {
-        public function uuid() {
-          return NULL;
-        }
-        public function set() {}
-        public function save() {}
-        public function setRevisionLogMessage() {}
-      };
+      $node = (new Chain($this))
+        ->add(Node::class, 'get', FieldItemListInterface::class)
+          ->addd('uuid', null)
+        ->add(FieldItemListInterface::class, 'getString', 'orphaned')
+        ->add(Node::class, 'set')
+        ->add(Node::class, 'save')
+        ->add(Node::class, 'setRevisionLogMessage')
+        ->getMock();
     }
 
     $storageFactory = (new Chain($this))
@@ -387,13 +389,13 @@ class ReferencerTest extends TestCase {
    */
   public function testMimeTypeDetection(): void {
     // Initialize mock node class.
-    $node = new class {
-      public function uuid() {
-        return '0398f054-d712-4e20-ad1e-a03193d6ab33';
-      }
-      public function set() {}
-      public function save() {}
-    };
+    $node = (new Chain($this))
+      ->add(Node::class, 'get', FieldItemListInterface::class)
+      ->addd('uuid', '0398f054-d712-4e20-ad1e-a03193d6ab33')
+      ->add(FieldItemListInterface::class, 'getString', 'orphaned')
+      ->add(Node::class, 'set')
+      ->add(Node::class, 'save')
+      ->getMock();
 
     // Create a mock file storage class.
     $storage = new class {


### PR DESCRIPTION
Every time a dataset or data dictionary is saved, all its references (themes, tags, etc) are checked. If they do not exist, they are created. If they do exist, they are set to published and resaved. This creates a new revision of every associated data node every time the dataset is saved. 

This logic executed even if the theme/tag/etc was already published. This PR merely reduces the amount of additional node saves by only publishing/saving if the referenced node is unpublished.

