### PR TITLE
Index the current, published dataset revision

### DIFF
--- a/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
+++ b/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
@@ -75,7 +75,7 @@ class DkanDataset extends DatasourcePluginBase {
 
     foreach (array_combine($ids, $ids) as $id) {
       try {
-        // We only want published revisions to be indexed.
+        // Only index published revisions.
         $items[$id] = new Dataset($dataStorage->retrieve($id, TRUE));
       }
       // This is thrown if there is no published revision.

--- a/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
+++ b/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
@@ -78,7 +78,7 @@ class DkanDataset extends DatasourcePluginBase {
         // We only want published revisions to be indexed.
         $items[$id] = new Dataset($dataStorage->retrieve($id, TRUE));
       }
-        // Thrown if there is no published revision.
+      // Thrown if there is no published revision.
       catch (MissingObjectException $missingObjectException) {
         continue;
       }

--- a/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
+++ b/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
@@ -78,7 +78,7 @@ class DkanDataset extends DatasourcePluginBase {
         // We only want published revisions to be indexed.
         $items[$id] = new Dataset($dataStorage->retrieve($id, TRUE));
       }
-      // Thrown if there is no published revision.
+      // This is thrown if there is no published revision.
       catch (MissingObjectException $missingObjectException) {
         continue;
       }

--- a/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
+++ b/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
@@ -71,7 +71,7 @@ class DkanDataset extends DatasourcePluginBase {
     $dataStorage = $dataStorageFactory->getInstance('dataset');
 
     $items = array_map(function ($id) use ($dataStorage) {
-      return new Dataset($dataStorage->retrieve($id));
+      return new Dataset($dataStorage->retrieve($id, TRUE));
     }, array_combine($ids, $ids));
 
     return $items;

--- a/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
+++ b/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
@@ -3,6 +3,7 @@
 namespace Drupal\metastore_search\Plugin\search_api\datasource;
 
 use Drupal\Core\TypedData\ComplexDataInterface;
+use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore_search\ComplexData\Dataset;
 use Drupal\node\Entity\Node;
 use Drupal\search_api\Datasource\DatasourcePluginBase;
@@ -70,9 +71,18 @@ class DkanDataset extends DatasourcePluginBase {
     /** @var \Drupal\metastore\Storage\Data $dataStorage */
     $dataStorage = $dataStorageFactory->getInstance('dataset');
 
-    $items = array_map(function ($id) use ($dataStorage) {
-      return new Dataset($dataStorage->retrieve($id, TRUE));
-    }, array_combine($ids, $ids));
+    $items = [];
+
+    foreach (array_combine($ids, $ids) as $id) {
+      try {
+        // We only want published revisions to be indexed.
+        $items[$id] = new Dataset($dataStorage->retrieve($id, TRUE));
+      }
+        // Thrown if there is no published revision.
+      catch (MissingObjectException $missingObjectException) {
+        continue;
+      }
+    }
 
     return $items;
   }


### PR DESCRIPTION
Currently, search api indexes the most recent revision of a dataset - whether or not that revision is published. To recreate this problem:

- Have a local DKAN installation with the default sample content that is fully search indexed.
- Search datasets for "Florida". Should see one result: "Florida Bike Lanes".
- Create a new revision of the "Florida Bike Lanes" dataset, replacing every instance of "Florida" with "Missouri". Save this revision as a DRAFT
- Re-index the site. 
- Search datasets for "Florida". No results.
- Search datasets for "Missouri". Get the Florida result even though Missouri does not appear anywhere in the published revision.

- [ ] Test coverage exists
- [ ] Documentation exists

Note: looks like the functional tests need to be updated.

## QA Steps

- Checkout the PR branch into a vanilla DKAN site with the sample content.
- Create a new revision of the "Florida Bike Lanes" dataset, replacing every instance of "Florida" with "Missouri". Save this revision as a DRAFT
- Re-index search api. Make sure to fully clear the index before reindexing and then clear the drush cache.
- Search datasets for "Florida". => Get one result
- Search datasets for "Missouri". => No results
