### PR TITLE
1.x docs clarification

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ templates_path = ['_templates']
 master_doc = 'index'
 
 # General information about the project.
-project = u'DKAN Docs'
+project = u'DKAN 7.x-1.x Docs'
 copyright = u'2019'
 author = u'DKAN Team'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-DKAN Open Data Portal
-=====================
+DKAN Open Data Portal for Drupal 7
+==================================
 
 This is the central site for technical/developer documentation of DKAN. DKAN is a Drupal-based open data portal and catalog. Development sponsored by `CivicActions <https://civicactions.com/dkan/>`_ .
 


### PR DESCRIPTION
make it clear that the readthedocs documentation is for the 1.x branch