### PR TITLE
Fix typo in harvest dashboard permission and display harvest dates using site default timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ DKAN_VERSION=`git rev-parse --abbrev-ref HEAD` doxygen
 - Dataset metadata and resources
 - Web service API endpoints that allow third party applications to work with the datasets
 - Integration with a decoupled [REACT front end](https://github.com/getdkan/data-catalog-frontend)
-- A datastore to store CSV files and make them queryable through an SQL endpoint.
+- A datastore to store CSV files and make them queryable through an SQL endpoint
 
 ---
 

--- a/modules/harvest/harvest.routing.yml
+++ b/modules/harvest/harvest.routing.yml
@@ -95,6 +95,6 @@ dkan.harvest.dashboard:
     _controller: '\Drupal\harvest\DashboardController::harvests'
     _title: Harvests
   requirements:
-    _permission: 'dkan.haverst.dashboard'
+    _permission: 'dkan.harvest.dashboard'
   options:
     _auth: ['basic_auth', 'cookie']

--- a/modules/harvest/src/DashboardController.php
+++ b/modules/harvest/src/DashboardController.php
@@ -38,6 +38,9 @@ class DashboardController {
    * A list of harvests and some status info.
    */
   public function harvests(): array {
+    // Display dates using the site timezone.
+    date_default_timezone_set(date_default_timezone_get());
+
     $rows = [];
     foreach ($this->harvest->getAllHarvestIds() as $harvestId) {
       // @todo Make Harvest Service's private getLastHarvestRunId() public,


### PR DESCRIPTION
Updated harvest.routing.yml so it uses the correct permission defined in the permission yml.

Intended to be a better replacement fix for https://github.com/GetDKAN/dkan/commit/da3eb5908a68bf37a86cdb9fcbaf8bba21a02514 used in PDC.

