### PR TITLE
Remove dependency on indexer module

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ DKAN_VERSION=`git rev-parse --abbrev-ref HEAD` doxygen
 - Dataset metadata and resources
 - Web service API endpoints that allow third party applications to work with the datasets
 - Integration with a decoupled [REACT front end](https://github.com/getdkan/data-catalog-frontend)
-- A datastore to store CSV files and make them queryable through an SQL endpoint
+- A datastore to store CSV files and make them queryable through an SQL endpoint.
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "require": {
         "drupal/admin_toolbar": "^3",
         "drupal/config_update": "^1.6",
-        "drupal/indexer": "1.0.x-dev",
         "drupal/moderated_content_bulk_publish": "~2.0.20",
         "drupal/search_api": "^1.15",
         "drupal/select_or_other": "dev-4.x#ae0585ff8c",

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -3,7 +3,6 @@
 namespace Drupal\common\Storage;
 
 use Drupal\Core\Database\Connection;
-use Drupal\indexer\IndexManager;
 use Drupal\Core\Database\DatabaseExceptionWrapper;
 use Drupal\common\EventDispatcherTrait;
 
@@ -28,13 +27,6 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    * @var \Drupal\Core\Database\Connection
    */
   protected $connection;
-
-  /**
-   * Optional index manager service.
-   *
-   * @var null|\Drupal\indexer\IndexManager
-   */
-  protected $indexManager;
 
   /**
    * Get the full name of datastore db table.
@@ -71,16 +63,6 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
     if ($this->tableExist($this->getTableName())) {
       $this->setSchemaFromTable();
     }
-  }
-
-  /**
-   * Set an optional index manager service.
-   *
-   * @param \Drupal\indexer\IndexManager $indexManager
-   *   Index manager.
-   */
-  public function setIndexManager(IndexManager $indexManager) {
-    $this->indexManager = $indexManager;
   }
 
   /**
@@ -310,10 +292,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   private function tableCreate($table_name, $schema) {
     // Opportunity to further alter the schema before table creation.
     $schema = $this->dispatchEvent(self::EVENT_TABLE_CREATE, $schema);
-    // Add indexes if we have an index manager.
-    if (isset($this->indexManager) && method_exists($this->indexManager, 'modifySchema')) {
-      $schema = $this->indexManager->modifySchema($table_name, $schema);
-    }
+
     $this->connection->schema()->createTable($table_name, $schema);
   }
 

--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -74,8 +74,6 @@ services:
     class: \Drupal\datastore\Storage\DatabaseTableFactory
     arguments:
       - '@dkan.datastore.database'
-    calls:
-      - [setIndexManager, ['@?indexer.indexmanager']]
 
   dkan.datastore.sql_endpoint.service:
     class: \Drupal\datastore\SqlEndpoint\Service

--- a/modules/datastore/src/Storage/DatabaseTableFactory.php
+++ b/modules/datastore/src/Storage/DatabaseTableFactory.php
@@ -4,7 +4,6 @@ namespace Drupal\datastore\Storage;
 
 use Contracts\FactoryInterface;
 use Drupal\Core\Database\Connection;
-use Drupal\indexer\IndexManager;
 
 /**
  * DatabaseTable data object factory.
@@ -19,27 +18,10 @@ class DatabaseTableFactory implements FactoryInterface {
   private $connection;
 
   /**
-   * Optional index manager service.
-   *
-   * @var null|\Drupal\indexer\IndexManager
-   */
-  private $indexManager;
-
-  /**
    * Constructor.
    */
   public function __construct(Connection $connection) {
     $this->connection = $connection;
-  }
-
-  /**
-   * Set an optional index manager service.
-   *
-   * @param \Drupal\indexer\IndexManager $indexManager
-   *   Index manager.
-   */
-  public function setIndexManager(IndexManager $indexManager) {
-    $this->indexManager = $indexManager;
   }
 
   /**
@@ -54,9 +36,6 @@ class DatabaseTableFactory implements FactoryInterface {
 
     $resource = $config['resource'];
     $databaseTable = $this->getDatabaseTable($resource);
-    if ($this->indexManager) {
-      $databaseTable->setIndexManager($this->indexManager);
-    }
 
     return $databaseTable;
   }

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableFactoryTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableFactoryTest.php
@@ -39,35 +39,4 @@ class DatabaseTableFactoryTest extends TestCase {
     $this->assertTrue($object instanceof DatabaseTable);
   }
 
-  /**
-   * Test we can add an indexer service.
-   */
-  public function testIndexer() {
-    $connection = (new Chain($this))
-      ->add(Connection::class, "__destruct", NULL)
-      ->getMock();
-
-    $databaseTable = (new Chain($this))
-      ->add(DatabaseTable::class, "retrieveAll", [])
-      ->addd("setIndexManager")
-      ->getMock();
-    $databaseTable->expects($this->once())
-      ->method('setIndexManager');
-
-    $builder = $this->getMockBuilder(DatabaseTableFactory::class);
-    $factory = $builder->setConstructorArgs([$connection])
-      ->setMethods(["getDatabaseTable"])
-      ->getMock();
-
-    $factory->method("getDatabaseTable")->willReturn($databaseTable);
-
-    $indexerClass = $this->getMockBuilder(IndexManager::class);
-    $indexer = $indexerClass->getMock();
-    $factory->setIndexManager($indexer);
-
-    $resource = new DatastoreResource("blah", "", "text/csv");
-    $object = $factory->getInstance($resource->getId(), ['resource' => $resource]);
-    $this->assertTrue($object instanceof DatabaseTable);
-  }
-
 }

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -86,52 +86,6 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
-   * Ensure indexer service is used during create table code flow.
-   */
-  public function testIndexerService() {
-    // Stub event dispatcher service.
-    $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-    $container = new ContainerBuilder();
-    $container->set('event_dispatcher', $eventDispatcher);
-    \Drupal::setContainer($container);
-
-    $schema = [
-      "fields" => [
-        "record_number" => [
-          "type" => "serial",
-          "unsigned" => TRUE,
-          "not null" => TRUE,
-        ],
-      ],
-    ];
-
-    $connection = $this->getConnectionChain()
-      ->add(Schema::class, "tableExists", FALSE)
-      ->add(Schema::class, "createTable", FALSE)
-      ->add(Connection::class, 'select', Select::class, 'select_1')
-      ->add(Select::class, 'fields', Select::class)
-      ->add(Select::class, 'countQuery', Select::class)
-      ->add(Select::class, 'execute', StatementInterface::class)
-      ->add(StatementInterface::class, 'fetchField', 1)
-      ->getMock();
-
-    $databaseTable = new DatabaseTable(
-      $connection,
-      $this->getResource()
-    );
-
-    $indexerClass = $this->getMockBuilder(IndexManager::class);
-    $indexer = $indexerClass
-      ->onlyMethods(["modifySchema"])
-      ->getMock();
-    $indexer->expects($this->once())
-      ->method('modifySchema');
-    $databaseTable->setIndexManager($indexer);
-    $databaseTable->setSchema($schema);
-    $databaseTable->count();
-  }
-
-  /**
    *
    */
   public function testRetrieveAll() {


### PR DESCRIPTION
The indexer module is only installed in a single OD site, and it is never installed with vanilla DKAN. It is not currently D10 compatible and we're removing it as a dependency in preparation for D10 compatibility.
