### PR TITLE
Update to m1x0n/opis-json-schema-error-presenter ^0.5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "getdkan/sql-parser": "^2.0.0",
         "guzzlehttp/guzzle" : "^6.5.8 || ^7.4.5",
         "ilbee/csv-response": "^1.1.1",
-        "m1x0n/opis-json-schema-error-presenter": "^0.5.2",
+        "m1x0n/opis-json-schema-error-presenter": "^0.5.3",
         "neitanod/forceutf8": "~2.0",
         "npm-asset/select2": "^4.0",
         "oomphinc/composer-installers-extender": "^2.0",


### PR DESCRIPTION
Fixes 13808 where we're making all the dependencies work with PHP 8.1.

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform to confirm that the feature or fix is working. Include as much details as possible so that the reviewer doesn't lose time figuring out how to perform steps.
