### PR TITLE
Convert CSV chunks to utf-8 and strip BOM if present

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "guzzlehttp/guzzle" : "^6.5.8 || ^7.4.5",
         "ilbee/csv-response": "^1.1.1",
         "m1x0n/opis-json-schema-error-presenter": "^0.5.3",
-        "fylax/forceutf8": "~3.0",
         "npm-asset/select2": "^4.0",
         "oomphinc/composer-installers-extender": "^2.0",
         "ramsey/uuid" : "^3.8.0",

--- a/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
+++ b/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
@@ -308,8 +308,8 @@ class ImportJob extends AbstractPersistentJob {
       }
       $chunk = $this->toUtf8($chunk, $filename, $file_encoding);
 
-      // Strip the BOM from the first chunk.
-      if ($chunksProcessed === 0) {
+      // Strip the BOM from the first chunk, if it has one.
+      if ($chunksProcessed === 0 && Unicode::encodingFromBOM($chunk)) {
         $chunk = mb_substr($chunk, 1);
       }
 
@@ -330,20 +330,20 @@ class ImportJob extends AbstractPersistentJob {
    * @param string $filename
    *   Filename of the parsed file.
    * @param string $from_encoding
-   *   File encoding if available.
+   *   String encoding if available. Pass empty string to guess.
    *
-   * @return string $chunk
+   * @return string
    *   Updated file chunk.
    *
    * @throws \Exception
    */
   public static function toUtf8(string $chunk, string $filename, string $from_encoding = ''): string {
-    // Do we have an encoding?
+    // Do we have an encoding? Guess one if not.
     if (empty($from_encoding)) {
       $from_encoding = mb_detect_encoding($chunk, mb_detect_order(), TRUE) ?? '';
     }
     // Is it already UTF-8?
-    if (strtolower($from_encoding) == 'utf-8') {
+    if (strtolower($from_encoding) === 'utf-8') {
       return $chunk;
     }
     // Convert.

--- a/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
+++ b/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
@@ -344,7 +344,7 @@ class ImportJob extends AbstractPersistentJob {
     else {
       // Fallback to detect encoding.
       $encoding = mb_detect_encoding($chunk, mb_detect_order(), TRUE);
-      if ($encoding !== 'UTF-8') {
+      if (!in_array($encoding, ['UTF-8', 'ASCII'])) {
         $chunk = mb_convert_encoding($chunk, 'UTF-8', mb_list_encodings());
         if (!$chunk) {
           throw new \Exception('Could not convert from ' . $encoding . ' to UTF-8 in ' . $filename);

--- a/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
+++ b/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
@@ -209,7 +209,8 @@ class ImportJob extends AbstractPersistentJob {
     try {
       $this->assertTextFile($filename);
       $this->parseAndStore($filename, static::getEncodingFromBom($filename), $this->getTimeLimit() ? (time() + $this->getTimeLimit()) : PHP_INT_MAX);
-    } catch (\Exception $e) {
+    }
+    catch (\Exception $e) {
       return $this->setResultError($e->getMessage());
     }
 

--- a/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
+++ b/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
@@ -297,7 +297,8 @@ class ImportJob extends AbstractPersistentJob {
     while (time() < $maximumExecutionTime) {
       $chunk = fread($h, self::BYTES_PER_CHUNK);
 
-      if (!$chunk) {
+      // Fread() can return an empty string or FALSE if we're done.
+      if (empty($chunk)) {
         $this->getResult()->setStatus(Result::DONE);
         $this->parser->finish();
         break;

--- a/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
+++ b/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
@@ -365,7 +365,7 @@ class ImportJob extends AbstractPersistentJob {
       $from_encoding = mb_detect_encoding($chunk, mb_detect_order(), TRUE) ?? '';
     }
     // Is it already UTF-8?
-    if (!in_array($from_encoding, ['UTF-8', 'ASCII'])) {
+    if (strtolower($from_encoding) === 'utf-8') {
       return $chunk;
     }
     // Convert. Iconv does not work for some files.

--- a/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
+++ b/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
@@ -365,11 +365,13 @@ class ImportJob extends AbstractPersistentJob {
       $from_encoding = mb_detect_encoding($chunk, mb_detect_order(), TRUE) ?? '';
     }
     // Is it already UTF-8?
-    if (strtolower($from_encoding) === 'utf-8') {
+    if (!in_array($from_encoding, ['UTF-8', 'ASCII'])) {
       return $chunk;
     }
-    // Convert.
-    if (($chunk = Unicode::convertToUtf8($chunk, $from_encoding)) === FALSE) {
+    // Convert. Iconv does not work for some files.
+    $chunk = mb_convert_encoding($chunk, 'UTF-8', mb_list_encodings());
+
+    if ($chunk === FALSE) {
       // Shout if the conversion didn't work.
       throw new \Exception('Could not convert from ' . $from_encoding . ' to UTF-8 in ' . $filename);
     }

--- a/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
+++ b/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
@@ -282,6 +282,7 @@ class ImportJob extends AbstractPersistentJob {
    *   The file name including path.
    * @param mixed $maximumExecutionTime
    *   Maximum time to parse for before exiting.
+   *
    * @throws \Exception
    */
   protected function parseAndStore($filename, $maximumExecutionTime) {
@@ -312,8 +313,7 @@ class ImportJob extends AbstractPersistentJob {
   }
 
   /**
-   * Ensure string is UTF-8 and encode it if necessary.
-   * Strip BOM if present.
+   * Ensure string is UTF-8 and encode it if necessary. Strip BOM if present.
    *
    * @param string $chunk
    *   Chunk of file being parsed.
@@ -323,7 +323,9 @@ class ImportJob extends AbstractPersistentJob {
    *   The index of the chunk being parsed.
    * @param string $bom_encoding
    *   File encoding from BOM if available.
+   *
    * @return string $chunk
+   *   Updated file chunk.
    *
    * @throws \Exception
    */

--- a/modules/datastore/tests/data/utf8-bom.csv
+++ b/modules/datastore/tests/data/utf8-bom.csv
@@ -1,0 +1,6 @@
+﻿Measure Name,Measure Date Range
+How often the home health team gave care in a professional way,"July 1, 2021 - June 30, 2022"
+How well did the home health team communicate with patients,"July 1, 2021 - June 30, 2022"
+"Did the home health team discuss medicines, pain, and home safety with patients","July 1, 2021 - June 30, 2022"
+How do patients rate the overall care from the home health agency,"July 1, 2021 - June 30, 2022"
+Would patients recommend the home health agency to friends and family,"July 1, 2021 - June 30, 2022"

--- a/modules/datastore/tests/src/Unit/Plugin/QueueWorker/ImportJobTest.php
+++ b/modules/datastore/tests/src/Unit/Plugin/QueueWorker/ImportJobTest.php
@@ -36,7 +36,7 @@ class ImportJobTest extends TestCase {
   /**
    *
    */
-  private function getDatastore(DatastoreResource $resource) {
+  private function getDatastore(DatastoreResource $resource): ImportJob {
     $storage = new Memory();
     $config = [
       "resource" => $resource,
@@ -304,28 +304,14 @@ class ImportJobTest extends TestCase {
     $datastore = $this->getDatastore($resource);
     $datastore->run();
 
-    $schema = $datastore->getStorage()->getSchema();
-    $fields = array_keys($schema['fields']);
-    $first_column = 'measure_name';
+    $storage = $datastore->getStorage();
+    $this->assertEquals(5, $storage->count());
 
-    $this->assertEquals($first_column, $fields[0]);
-  }
-
-  public function providerToUtf8() {
-    return [
-      'plain_vanilla' => [ 'abc', 'abc', ''],
-      'malformed_bom' => [ 'abc', "\xEF\xBB\xBFabc", 'UTF-8'],
-      'weird chinese stuff' => [ '뽡扣', "\xEF\xBB\xBFabc", 'UTF-16BE'],
-      'weird chinese stuff no bom' => [ 'abc', '뽡扣', ''],
-    ];
-  }
-
-  /**
-   * @dataProvider providerToUtf8
-   * @covers ::toUtf8
-   */
-  public function testToUtf8($expect, $chunk, $bom_encoding) {
-    $this->assertSame($expect, ImportJob::toUtf8($chunk, 'filename', 0, $bom_encoding));
+    $schema = $storage->getSchema();
+    $this->assertSame(
+      ['measure_name', 'measure_date_range'],
+      array_keys($schema['fields'])
+    );
   }
 
 }

--- a/modules/datastore/tests/src/Unit/Plugin/QueueWorker/ImportJobTest.php
+++ b/modules/datastore/tests/src/Unit/Plugin/QueueWorker/ImportJobTest.php
@@ -311,4 +311,21 @@ class ImportJobTest extends TestCase {
     $this->assertEquals($first_column, $fields[0]);
   }
 
+  public function providerToUtf8() {
+    return [
+      'plain_vanilla' => [ 'abc', 'abc', ''],
+      'malformed_bom' => [ 'abc', "\xEF\xBB\xBFabc", 'UTF-8'],
+      'weird chinese stuff' => [ '뽡扣', "\xEF\xBB\xBFabc", 'UTF-16BE'],
+      'weird chinese stuff no bom' => [ 'abc', '뽡扣', ''],
+    ];
+  }
+
+  /**
+   * @dataProvider providerToUtf8
+   * @covers ::toUtf8
+   */
+  public function testToUtf8($expect, $chunk, $bom_encoding) {
+    $this->assertSame($expect, ImportJob::toUtf8($chunk, 'filename', 0, $bom_encoding));
+  }
+
 }

--- a/modules/datastore/tests/src/Unit/Plugin/QueueWorker/ImportJobTest.php
+++ b/modules/datastore/tests/src/Unit/Plugin/QueueWorker/ImportJobTest.php
@@ -314,4 +314,19 @@ class ImportJobTest extends TestCase {
     );
   }
 
+  public function providerToUtf8() {
+    return [
+      'plain, no bom' => ['abc', 'abc', ''],
+      'plain, with bom' => ['abc', 'abc', 'UTF-8'],
+      'non utf-8 with bom' => ['abc', '뽡扣', 'UTF-16BE']
+    ];
+  }
+
+  /**
+   * @dataProvider providerToUtf8
+   * @covers ::toUtf8
+   */
+  public function testToUtf8($expected, $chunk, $from_encoding) {
+    $this->assertSame($expected, ImportJob::toUtf8($chunk, 'filename', $from_encoding));
+  }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <phpunit
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
   bootstrap="/var/www/html/vendor/weitzman/drupal-test-traits/src/bootstrap.php"
   colors="true"
   stopOnFailure="false"
@@ -26,31 +26,23 @@
       <directory>.</directory>
     </testsuite>
     <testsuite name="DkanUnitTests">
-      <directory>tests/src/Unit</directory>
       <directory>modules/common/tests/src/Unit</directory>
       <directory>modules/metastore/tests/src/Unit</directory>
-      <directory>modules/metastore/modules/metastore/tests/src/Unit</directory>
       <directory>modules/metastore/modules/metastore_search/tests/src/Unit</directory>
-      <directory>modules/metastore/modules/metastore_admin/tests/src/Unit</directory>
       <directory>modules/datastore/tests/src/Unit</directory>
       <directory>modules/datastore/modules/datastore_mysql_import/tests/src/Unit</directory>
       <directory>modules/frontend/tests/src/Unit</directory>
       <directory>modules/dkan_js_frontend/tests/src</directory>
       <directory>modules/harvest/tests/src/Unit</directory>
-      <directory>modules/harvest/modules/harvest_dashboard/tests/src/Unit</directory>
       <directory>modules/json_form_widget/tests/src/Unit</directory>
     </testsuite>
     <testsuite name="DkanFunctionalTests">
       <directory>modules/common/tests/src/Functional</directory>
       <directory>modules/metastore/tests/src/Functional</directory>
-      <directory>modules/metastore/modules/metastore/tests/src/Functional</directory>
       <directory>modules/metastore/modules/metastore_search/tests/src/Functional</directory>
       <directory>modules/metastore/modules/metastore_admin/tests/src/Functional</directory>
       <directory>modules/datastore/tests/src/Functional</directory>
-      <directory>modules/frontend/tests/src/Functional</directory>
       <directory>modules/dkan_js_frontend/tests/src</directory>
-      <directory>modules/harvest/tests/src/Functional</directory>
-      <directory>modules/harvest/modules/harvest_dashboard/tests/src/Functional</directory>
       <directory>tests/src/Functional</directory>
     </testsuite>
   </testsuites>


### PR DESCRIPTION
This removes the dependency on fylax/forceutf8. It uses a combination of the core Unicode functions and mbstring as a replacement. It also strips the BOM at the beginning of the file if present.

Quick mention that Unicode::convertToUtf8 does not work with PDC files, so while this may be passing tests, it would break the PDC datastore imports.

It does still need working tests.

Related ticket: https://jira.cms.gov/browse/WCMS-14692

- [ ] Test coverage exists
- [ ] Documentation exists


