### PR TITLE
Remove mention of deprecated themes in the frontend module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
         type: string
       addon_branch:
         description: 'Repo branch name for the dkan-ddev-addon you want to test against.'
-        default: 'main'
+        default: 'remove-bartik'
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'
@@ -49,7 +49,7 @@ commands:
             which ddev
             ddev --version
             ddev config --project-name test-$CIRCLE_WORKFLOW_JOB_ID --project-type drupal9 --docroot docroot --create-docroot
-            ddev get https://github.com/GetDKAN/dkan-ddev-addon/tarball/remove-bartik
+            ddev get https://github.com/GetDKAN/dkan-ddev-addon/archive/refs/heads/<< parameters.addon_branch >>.tar.gz
             # Modify config to use our PHP version.
             sed -i 's/^php_version.*$/php_version: "<< parameters.php_version >>"/' .ddev/config.dkan.yaml
             # Clear out omit_containers.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
             which ddev
             ddev --version
             ddev config --project-name test-$CIRCLE_WORKFLOW_JOB_ID --project-type drupal9 --docroot docroot --create-docroot
-            ddev get https://github.com/GetDKAN/dkan-ddev-addon/archive/refs/heads/<< parameters.addon_branch >>.tar.gz
+            ddev get https://github.com/GetDKAN/dkan-ddev-addon/tarball/remove-bartik
             # Modify config to use our PHP version.
             sed -i 's/^php_version.*$/php_version: "<< parameters.php_version >>"/' .ddev/config.dkan.yaml
             # Clear out omit_containers.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
         type: string
       addon_branch:
         description: 'Repo branch name for the dkan-ddev-addon you want to test against.'
-        default: 'remove-bartik'
+        default: 'main'
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "dkan-frontend": {
             "type": "vcs",
             "url": "https://github.com/GetDKAN/data-catalog-app",
-            "ref": "1.1.0"
+            "ref": "1.3.0"
         },
         "installer-types": [
             "bower-asset",

--- a/modules/dkan_js_frontend/README.md
+++ b/modules/dkan_js_frontend/README.md
@@ -20,5 +20,4 @@ This is a React app that will use the [Data Catalog Components](https://github.c
 ## Tips
 If you are setting the JS frontend as the main frontend for your site, like on the demo DKAN site, you will want to do the following:
 
-* Turn off Bartik and enable Stark as your frontend theme. This will remove any issues of the Bartik CSS mixing with the JS frontend CSS.
 * Set the `404` and `home` paths for the site to `/home`. This will make it so whenever Drupal returns a page not found it will load the JS frontend and visiting the root url the JS site will be loaded instead of a default Drupal node.


### PR DESCRIPTION
combine with https://github.com/GetDKAN/dkan-ddev-addon/pull/30

**QA:**
1. checkout this branch
2. `ddev get https://github.com/GetDKAN/dkan-ddev-addon/archive/refs/heads/frontend-command-refresh.tar.gz`
3. `ddev dkan-frontend-install`
4. `ddev dkan-frontend-build`
5. `ddev launch`

**AC:**

- Frontend app builds from the 1.3.0 tag
- Header and footer are blue (looks similar to the current demo site)
- No drupal drop background image.