### PR TITLE
Move config_update dependency to recommended project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "description": "DKAN Open Data Catalog",
     "require": {
         "drupal/admin_toolbar": "^3",
-        "drupal/config_update": "^1.7 || 2.x-dev",
         "drupal/moderated_content_bulk_publish": "~2.0.20",
         "drupal/search_api": "^1.15",
         "drupal/select_or_other": "dev-4.x#ae0585ff8c",


### PR DESCRIPTION
Move config_update module dependency out of DKAN's composer and into project/recommended-project composer files.

The config_update removal is required in order to allow D10 tests to run successfully, so until this is merged, https://github.com/GetDKAN/recommended-project/pull/28 will fail and we cannot subsequently run D10 tests for https://github.com/GetDKAN/dkan/pull/3931

This is quite a blocker.

WCMS-14268 needs to be completed before open data sites can take advantage of the release containing this change.

- [ ] Test coverage exists
- [ ] Documentation exists
