### PR TITLE
Move admin_toolbar to recommended project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "minimum-stability": "dev",
     "description": "DKAN Open Data Catalog",
     "require": {
-        "drupal/admin_toolbar": "^3",
         "drupal/moderated_content_bulk_publish": "~2.0.20",
         "drupal/search_api": "^1.15",
         "drupal/select_or_other": "dev-4.x#ae0585ff8c",

--- a/modules/metastore/modules/metastore_admin/metastore_admin.info.yml
+++ b/modules/metastore/modules/metastore_admin/metastore_admin.info.yml
@@ -4,7 +4,6 @@ type: module
 core_version_requirement: ^9.1
 dependencies:
   - metastore
-  - admin_toolbar
   - breakpoint
   - system
   - toolbar


### PR DESCRIPTION
The admin_toolbar module is not required for DKAN's functionality although almost all sites will have it installed for convenience.

We've moved the admin_toolbar dependency to the DKAN recommended project branches (all merged):

- https://github.com/GetDKAN/recommended-project/pull/30
- https://github.com/GetDKAN/recommended-project/pull/29
- https://github.com/GetDKAN/recommended-project/pull/31
- https://github.com/GetDKAN/recommended-project/pull/28

To allow the dependency to be moved, the Cypress tests that require admin toolbar are temporarily being skipped (https://github.com/GetDKAN/dkan/pull/3935) Once this is committed, we should re-enable those.

As part of the notes for the next release, we should let users of DKAN know to add admin_toolbar and config_update to their project composer files.

WCMS-14268 needs to be completed before open data sites can take advantage of the release containing this change.
