### PR TITLE
Docs contrib instructions and minor sphinx  fixes.

### DIFF
--- a/docs/source/components/index.rst
+++ b/docs/source/components/index.rst
@@ -4,7 +4,7 @@ Components
 .. toctree::
    :maxdepth: 1
 
-  dkan_metastore
-  dkan_datastore
-  dkan_harvest
-  dkan_api
+   dkan_metastore
+   dkan_datastore
+   dkan_harvest
+   dkan_api

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,7 +66,6 @@ from sphinx.highlighting import lexers
 from pygments.lexers.web import PhpLexer
 lexers["php"] = PhpLexer(startinline=True, linenos=1)
 lexers["php-annotations"] = PhpLexer(startinline=True, linenos=1)
-primary_domain = "php"
 
 # The suffix of source filenames.
 source_suffix = ['.rst', '.md']

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -16,7 +16,7 @@ or RST format depending on your preference.
 In some cases, `README.md` files are pulled into the docs site from elsewhere in the repository. This is accomplished
 with an include directive.
 
-  .. code-block::
+  .. code-block:: restructuredtext
 
       .. include:: ../../../path/to/README.md
         :parser: myst_parser.sphinx_
@@ -44,7 +44,7 @@ Terminal commands
 ^^^^^^^^^^^^^^^^^
 Terminal commands should be expressed in a full code block:
 
-  .. code-block::
+  .. code-block:: console
 
     drush cim -y
     drush cr
@@ -54,7 +54,7 @@ Code blocks
 ^^^^^^^^^^^^^^^^^
 Code blocks are also expressed as... code blocks:
 
-  .. code-block::
+  .. code-block:: php
 
     /**
     * Adds declared endpoint to list.
@@ -72,7 +72,7 @@ Code objects
 When referring to **`$variables`**, **`function_names()`** and **`classNames`** inline, use bold inline code style.
 This can be achieved in markdown like this:
 
-  .. code-block::
+  .. code-block:: restructuredtext
 
     **`This text`** will be code-styled and bold
 
@@ -94,16 +94,31 @@ local platform.
 
 Install the dependencies for this project. Make sure you are in the `/docs` directory:
 
-  .. code-block::
+  .. code-block:: console
 
     cd docs
-    sudo pip install -r requirements.txt
+    pip install -r requirements.txt
 
 Now you should be able to build the Sphinx site by typing
 
-  .. code-block::
+  .. code-block:: console
 
     make html
+
+.. tip::
+
+  Depending on your local environment, the tools installed by pip may not be available in the make process' PATH.
+  If the ``make`` command produces an error like
+
+    .. code-block:: console
+
+      /bin/sh: line 1: sphinx-build: command not found
+
+  you can pass it the full ``sphinx-build`` command explicitly like this:
+
+    .. code-block:: console
+
+      SPHINXBUILD=$(which sphinx-build) make html
 
 The documentation will build in `docs/build/html`, you can then open the
 `dkan/docs/build/html/index.html` file in a browser to preview your changes.
@@ -112,6 +127,6 @@ The documentation will build in `docs/build/html`, you can then open the
 Sometimes changes to indexes are not picked up very well. If you see issues with the sidebar
 table of contents, delete the `docs/build` directory by running:
 
-  .. code-block::
+  .. code-block:: console
 
     make clean

--- a/docs/source/developer-guide/index.rst
+++ b/docs/source/developer-guide/index.rst
@@ -4,6 +4,6 @@ Developer Guide
 .. toctree::
    :maxdepth: 1
 
-  decoupled_frontend
-  dev_metastore
-  dev_search
+   decoupled_frontend
+   dev_metastore
+   dev_search

--- a/docs/source/introduction/index.rst
+++ b/docs/source/introduction/index.rst
@@ -4,5 +4,5 @@ Introduction
 .. toctree::
    :maxdepth: 2
 
-  overview
-  glossary
+   overview
+   glossary

--- a/docs/source/user-guide/index.rst
+++ b/docs/source/user-guide/index.rst
@@ -4,11 +4,11 @@ User Guide
 .. toctree::
    :maxdepth: 1
 
-  guide_dataset
-  guide_data_dictionaries
-  guide_indexes
-  guide_api
-  guide_datastore_settings
-  guide_metastore_properties
-  guide_harvest
-  guide_queues
+   guide_dataset
+   guide_data_dictionaries
+   guide_indexes
+   guide_api
+   guide_datastore_settings
+   guide_metastore_properties
+   guide_harvest
+   guide_queues


### PR DESCRIPTION
The main thing here is to add a tip to build the docs without using `sudo` for `pip`. 

Also cleaned up a few things in the RST and related files that were throwing errors in the sphinx build.