### PR TITLE
PDC specific customizations (Reference only)

### DIFF
--- a/modules/common/docs/openapi_spec.json
+++ b/modules/common/docs/openapi_spec.json
@@ -65,5 +65,27 @@
             }
         }
     },
-    "paths": {}
+    "paths": {
+        "/api/1": {
+            "get": {
+                "operationId": "docs-get-complete",
+                "summary": "Complete json documentation",
+                "tags": [
+                    "Documentation"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/modules/common/src/DkanApiDocsGenerator.php
+++ b/modules/common/src/DkanApiDocsGenerator.php
@@ -50,6 +50,7 @@ class DkanApiDocsGenerator {
    */
   public function buildSpec(array $plugins = []) {
     $docPluginDefinitions = $this->docManager->getDefinitions();
+    uasort($docPluginDefinitions, 'Drupal\Component\Utility\SortArray::sortByWeightElement');
     $spec = [];
     if (!empty($plugins)) {
       $this->filterPluginDefinitions($docPluginDefinitions, $plugins);

--- a/modules/common/src/Plugin/DkanApiDocs/CommonApiDocs.php
+++ b/modules/common/src/Plugin/DkanApiDocs/CommonApiDocs.php
@@ -9,6 +9,7 @@ use Drupal\common\Plugin\DkanApiDocsBase;
  *
  * @DkanApiDocs(
  *  id = "common_dkan_api_docs",
+ *  weight = 3,
  *  description = "Base API docs plugin."
  * )
  */

--- a/modules/common/src/Storage/SelectFactory.php
+++ b/modules/common/src/Storage/SelectFactory.php
@@ -333,6 +333,14 @@ class SelectFactory {
       $condition->operator = 'like';
       $condition->value = "{$condition->value}%";
     }
+    elseif ($condition->operator == 'is_empty') {
+      $condition->operator = '=';
+      $condition->value = '';
+    }
+    elseif ($condition->operator == 'not_empty') {
+      $condition->operator = '<>';
+      $condition->value = '';
+    }
   }
 
   /**

--- a/modules/datastore/docs/openapi_spec.json
+++ b/modules/datastore/docs/openapi_spec.json
@@ -94,7 +94,7 @@
                 "operationId": "datastore-list",
                 "summary": "List datastores",
                 "description": "Returns a list of all stored importers, with data about their file fetcher and status.\n",
-                "tags": ["Datastore: import"],
+                "tags": ["Datastore"],
                 "security": [
                     {
                         "basic_auth": []
@@ -120,7 +120,7 @@
                 "operationId": "datastore-import",
                 "summary": "Datastore import",
                 "description": "Immediately starts the import process for a datastore.\n",
-                "tags": ["Datastore: import"],
+                "tags": ["Datastore"],
                 "security": [
                     {
                         "basic_auth": []
@@ -164,7 +164,7 @@
                 "operationId": "datastore-get",
                 "summary": "Datastore statistics",
                 "description": "Returns the numbers of rows and columns, and a list of columns headers from the datastore.\n",
-                "tags": ["Datastore: import"],
+                "tags": ["Datastore"],
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/datastoreUuid"
@@ -201,7 +201,7 @@
                 "operationId": "datastore-delete",
                 "summary": "Delete a datastore",
                 "description": "Delete one or more datastores. If the uuid parameter is that of a resource, delete that resource. If the uuid parameter is that of a dataset, delete all resources of that dataset.\n",
-                "tags": ["Datastore: import"],
+                "tags": ["Datastore"],
                 "security": [
                     {
                         "basic_auth": []
@@ -236,7 +236,7 @@
             "post": {
                 "operationId": "datastore-query-post",
                 "summary": "Query one or more datastore resources",
-                "tags": ["Datastore: query"],
+                "tags": ["Datastore"],
                 "requestBody": {
                     "required": true,
                     "content": {
@@ -254,7 +254,7 @@
                 "operationId": "datastore-query-get",
                 "summary": "Query one or more datastore resources",
                 "description": "Simple GET equivalent of a POST query. Note that parameters containing arrays or objects are not yet supported by SwaggerUI. For conditions, sorts, and other complex parameters, write your query in JSON and then convert to a nested query string. See [this web tool](https://www.convertonline.io/convert/json-to-query-string) for an example.",
-                "tags": ["Datastore: query"],
+                "tags": ["Datastore"],
                 "parameters": [],
                 "responses": {
                     "200": { "$ref": "#/components/responses/200JsonOrCsvQueryOk"},
@@ -266,7 +266,7 @@
             "post": {
                 "operationId": "datastore-query-download-post",
                 "summary": "Query one or more datastore resources for file download",
-                "tags": ["Datastore: query"],
+                "tags": ["Datastore"],
                 "requestBody": {
                     "required": true,
                     "content": {
@@ -285,7 +285,7 @@
                 "operationId": "datastore-query-download-get",
                 "summary": "Query one or more datastore resources for file download with get",
                 "description": "Simple GET equivalent of a POST query. Note that parameters containing arrays or objects are not yet supported by SwaggerUI. For conditions, sorts, and other complex parameters, write your query in JSON and then convert to a nested query string. See [this web tool](https://www.convertonline.io/convert/json-to-query-string) for an example.",
-                "tags": ["Datastore: query"],
+                "tags": ["Datastore"],
                 "parameters": [],
                 "responses": {
                     "200": { "$ref": "#/components/responses/200DatastoreCsvOk" },
@@ -298,7 +298,7 @@
             "post": {
                 "operationId": "datastore-resource-query-post",
                 "summary": "Query a single datastore resource",
-                "tags": ["Datastore: query"],
+                "tags": ["Datastore"],
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/datastoreDistributionUuid"
@@ -322,7 +322,7 @@
                 "operationId": "datastore-resource-query-get",
                 "summary": "Query a single datastore resource with get",
                 "description": "Simple GET equivalent of a POST query. Note that parameters containing arrays or objects are not yet supported by SwaggerUI. For conditions, sorts, and other complex parameters, write your query in JSON and then convert to a nested query string. See [this web tool](https://www.convertonline.io/convert/json-to-query-string) for an example.",
-                "tags": ["Datastore: query"],
+                "tags": ["Datastore"],
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/datastoreDistributionUuid"
@@ -339,7 +339,7 @@
             "post": {
                 "operationId": "datastore-datasetindex-query-post",
                 "summary": "Query a single datastore resource",
-                "tags": ["Datastore: query"],
+                "tags": ["Datastore"],
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/datastoreDatasetUuid"
@@ -366,7 +366,7 @@
                 "operationId": "datastore-datasetindex-query-get",
                 "summary": "Query a single datastore resource with get",
                 "description": "Simple GET equivalent of a POST query -- see the POST endpoint documentation for full query schema. A few basic parameters are provided here as examples. For more reliable queries, write your query in JSON and then convert to a query string. See [this web tool](https://www.convertonline.io/convert/json-to-query-string) for an example.",
-                "tags": ["Datastore: query"],
+                "tags": ["Datastore"],
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/datastoreDatasetUuid"
@@ -387,7 +387,7 @@
                 "operationId": "datastore-resource-query-download-get",
                 "summary": "Query a single datastore resource for file download",
                 "description": "Like the other datastore query GET endpoints, additional parameters may be added by serializing a query JSON object (documented in the POST endpoints) into a query string.",
-                "tags": ["Datastore: query"],
+                "tags": ["Datastore"],
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/datastoreDistributionUuid"
@@ -416,7 +416,7 @@
                 "operationId": "datastore-datasetindex-query-download-get",
                 "summary": "Query a single datastore resource for file download",
                 "description": "Like the other datastore query GET endpoints, additional parameters may be added by serializing a query JSON object (documented in the POST endpoints) into a query string.",
-                "tags": ["Datastore: query"],
+                "tags": ["Datastore"],
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/datastoreDatasetUuid"
@@ -448,7 +448,7 @@
                 "operationId": "datastore-sql",
                 "summary": "Query resources in datastore",
                 "description": "Interact with resources in the datastore using an SQL-like syntax.\n",
-                "tags": ["Datastore: SQL Query"],
+                "tags": ["Datastore"],
                 "parameters": [
                     {
                         "name": "query",

--- a/modules/datastore/docs/query.json
+++ b/modules/datastore/docs/query.json
@@ -205,6 +205,8 @@
                         "between",
                         "in",
                         "not in",
+                        "is_empty",
+                        "not_empty",
                         "contains",
                         "starts with",
                         "match"

--- a/modules/datastore/src/Plugin/DkanApiDocs/DatastoreApiDocs.php
+++ b/modules/datastore/src/Plugin/DkanApiDocs/DatastoreApiDocs.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @DkanApiDocs(
  *  id = "datastore_api_docs",
+ *  weight = 1,
  *  description = "Datastore docs"
  * )
  */

--- a/modules/harvest/src/DashboardController.php
+++ b/modules/harvest/src/DashboardController.php
@@ -68,11 +68,7 @@ class DashboardController {
    * Private.
    */
   private function buildHarvestRow(string $harvestId, string $runId, $info) {
-    // PDC: make harvest dashboard accessible without authentication.
-    $queryParams = [
-      'harvest_id' => $harvestId,
-    ];
-    $url = Url::fromUri('base:provider-data/dashboard/datastore', ['query' => $queryParams]);
+    $url = Url::fromRoute('datastore.datasets_import_status_dashboard', ['harvest_id' => $harvestId]);
 
     return [
       'harvest_link' => Link::fromTextAndUrl($harvestId, $url),

--- a/modules/harvest/src/DashboardController.php
+++ b/modules/harvest/src/DashboardController.php
@@ -68,13 +68,11 @@ class DashboardController {
    * Private.
    */
   private function buildHarvestRow(string $harvestId, string $runId, $info) {
-    // PDC-specific change: make harvest dashboard accessible without authentication.
-    // $url = Url::fromRoute('datastore.datasets_import_status_dashboard', ['harvest_id' => $harvestId]);
+    // PDC: make harvest dashboard accessible without authentication.
     $queryParams = [
       'harvest_id' => $harvestId,
     ];
     $url = Url::fromUri('base:provider-data/dashboard/datastore', ['query' => $queryParams]);
-    // End PDC-specific change
 
     return [
       'harvest_link' => Link::fromTextAndUrl($harvestId, $url),

--- a/modules/harvest/src/DashboardController.php
+++ b/modules/harvest/src/DashboardController.php
@@ -68,7 +68,13 @@ class DashboardController {
    * Private.
    */
   private function buildHarvestRow(string $harvestId, string $runId, $info) {
-    $url = Url::fromRoute('datastore.datasets_import_status_dashboard', ['harvest_id' => $harvestId]);
+    // PDC-specific change: make harvest dashboard accessible without authentication.
+    // $url = Url::fromRoute('datastore.datasets_import_status_dashboard', ['harvest_id' => $harvestId]);
+    $queryParams = [
+      'harvest_id' => $harvestId,
+    ];
+    $url = Url::fromUri('base:provider-data/dashboard/datastore', ['query' => $queryParams]);
+    // End PDC-specific change
 
     return [
       'harvest_link' => Link::fromTextAndUrl($harvestId, $url),

--- a/modules/harvest/src/Plugin/DkanApiDocs/HarvestApiDocs.php
+++ b/modules/harvest/src/Plugin/DkanApiDocs/HarvestApiDocs.php
@@ -13,6 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @DkanApiDocs(
  *  id = "harvest_api_docs",
+ *  weight = 5,
  *  description = "Harvest docs"
  * )
  */

--- a/modules/metastore/docs/openapi_spec.json
+++ b/modules/metastore/docs/openapi_spec.json
@@ -195,6 +195,30 @@
                 }
             }
         },
+        "/api/1/metastore/schemas/dataset/items/{identifier}/docs": {
+            "get": {
+                "operationId": "docs-get-dataset-specific",
+                "summary": "Dataset-specific json documentation",
+                "tags": [
+                    "Documentation"
+                ],
+                "parameters": [
+                    { "$ref": "#/components/parameters/exampleUuid" }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/1/metastore/schemas/{schema_id}/items/{identifier}/revisions": {
             "get": {
                 "operationId": "metastore-get-all-revisions",

--- a/modules/metastore/modules/metastore_search/src/Plugin/DkanApiDocs/MetastoreSearchApiDocs.php
+++ b/modules/metastore/modules/metastore_search/src/Plugin/DkanApiDocs/MetastoreSearchApiDocs.php
@@ -13,6 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @DkanApiDocs(
  *  id = "metastore_search_api_docs",
+ *  weight = 4,
  *  description = "Search docs"
  * )
  *

--- a/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
+++ b/modules/metastore/modules/metastore_search/src/Plugin/search_api/datasource/DkanDataset.php
@@ -69,6 +69,7 @@ class DkanDataset extends DatasourcePluginBase {
    */
   public function getItemIds($page = NULL) {
     $ids_query = $this->nodeQueryService
+      ->addTag('search_api_datasource_dkan')
       ->accessCheck(FALSE)
       ->condition('type', 'data')
       ->condition('field_data_type', 'dataset');

--- a/modules/metastore/modules/metastore_search/tests/src/Unit/Plugin/search_api/datasource/DkanDatasetTest.php
+++ b/modules/metastore/modules/metastore_search/tests/src/Unit/Plugin/search_api/datasource/DkanDatasetTest.php
@@ -51,6 +51,7 @@ class DkanDatasetTest extends TestCase {
       ->add(EntityTypeManager::class, 'getStorage', EntityStorageInterface::class)
       ->add(EntityStorageInterface::class, 'getQuery', QueryInterface::class)
       ->add(EntityStorageInterface::class, 'loadMultiple', [$nodeMock, $nodeMock])
+      ->add(QueryInterface::class, 'addTag', QueryInterface::class)
       ->add(QueryInterface::class, 'accessCheck', QueryInterface::class)
       ->add(QueryInterface::class, 'condition', QueryInterface::class)
       ->add(QueryInterface::class, 'count', QueryInterface::class)

--- a/modules/metastore/src/Plugin/DkanApiDocs/MetastoreApiDocs.php
+++ b/modules/metastore/src/Plugin/DkanApiDocs/MetastoreApiDocs.php
@@ -13,6 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @DkanApiDocs(
  *  id = "metastore_api_docs",
+ *  weight = 2,
  *  description = "Metastore docs"
  * )
  */
@@ -107,7 +108,7 @@ class MetastoreApiDocs extends DkanApiDocsBase {
 
       $tSchema = [':schemaId' => $schemaId];
       $spec['tags'][] = [
-        'name' => $this->t("Metastore: :schemaId", $tSchema),
+        'name' => $this->t("Metastore"),
         'description' => $this->t(
           'CRUD operations for :schemaId metastore items. Substitute any other schema name for ":schemaId" to modify other items.',
           $tSchema
@@ -282,7 +283,7 @@ class MetastoreApiDocs extends DkanApiDocsBase {
     return [
       "operationId" => "$schemaId-post",
       "summary" => $this->t("Create a new :schemaId.", $tSchema),
-      "tags" => [$this->t("Metastore: :schemaId", $tSchema)],
+      "tags" => [$this->t("Metastore")],
       "security" => [['basic_auth' => []]],
       "requestBody" => [
         "required" => TRUE,
@@ -319,7 +320,7 @@ class MetastoreApiDocs extends DkanApiDocsBase {
     return [
       "operationId" => "$schemaId-get-item",
       "summary" => $this->t("Get a single :schemaId.", $tSchema),
-      "tags" => [$this->t("Metastore: :schemaId", $tSchema)],
+      "tags" => [$this->t("Metastore")],
       "parameters" => [
         ['$ref' => "#/components/parameters/{$schemaId}Uuid"],
         ['$ref' => "#/components/parameters/showReferenceIds"],
@@ -353,7 +354,7 @@ class MetastoreApiDocs extends DkanApiDocsBase {
       "operationId" => "$schemaId-put",
       "summary" => $this->t("Replace a :schemaId", $tSchema),
       "description" => $this->t("Object will be completely replaced; optional properties not included in the request will be deleted.\n\nAutomatic example not yet available; try retrieving a :schemaId via GET, changing values, and pasting to test.", $tSchema),
-      "tags" => [$this->t("Metastore: :schemaId", $tSchema)],
+      "tags" => [$this->t("Metastore")],
       "security" => [
         ['basic_auth' => []],
       ],
@@ -392,7 +393,7 @@ class MetastoreApiDocs extends DkanApiDocsBase {
       "operationId" => "$schemaId-patch",
       "summary" => $this->t("Modify an existing :schemaId", $tSchema),
       "description" => $this->t("Values provided will replace existing values, but required values may be omitted.\n\nAutomatic example not yet available; try retrieving a :schemaId via GET, changing values, removing unchanged properties, and pasting to test.", $tSchema),
-      "tags" => [$this->t("Metastore: :schemaId", $tSchema)],
+      "tags" => [$this->t("Metastore")],
       "security" => [
         ['basic_auth' => []],
       ],


### PR DESCRIPTION
This is not for review or committing to DKAN proper but just for reference. These PDC changes include the following:

- Unify datastore and metastore tags for Swagger UI's Open API spec. (might be removed in WCMS-16863 )
- Add the complete API documentation path to DKAN Common's spec.
- Add the dataset-specific API documentation path to DKAN Metastore's spec.
- Add weight to and sort the ApiDocs plugins (might be removed in WCMS-16863 )
- Tag Search API's DKAN datasource plugin's query to later modify - Could be more broadly useful
- Add datastore filter conditions is_empty and not_empty - Could be more broadly useful; should not have underscores to match other filter conditions.

