### PR TITLE
CSV downloads display 'default' rather than expected values

### DIFF
--- a/modules/common/src/Storage/SelectFactory.php
+++ b/modules/common/src/Storage/SelectFactory.php
@@ -104,7 +104,7 @@ class SelectFactory {
   private function addDateExpressions($db_query, $fields, $meta_data) {
     foreach ($meta_data as $definition) {
       // Confirm definition name is in the fields list.
-      if ($fields[$definition['name']]['field'] ?? FALSE && $definition['type'] == 'date') {
+      if ($fields[$definition['name']]['field'] && $definition['type'] == 'date') {
         $db_query->addExpression("DATE_FORMAT(" . $definition['name'] . ", '" . $definition['format'] . "')", $definition['name']);
       }
     }


### PR DESCRIPTION
fixes [org/repo/issue#]

- [x ] Test coverage exists
- [ x] Documentation exists

## QA Steps

- [ ] Filter an NADAC dataset and confirm the date fields are formatted as mm/dd/yyyy
- [ ] Next go to a State Drug Utilization Dataset and filter the data. Confirm that the data is exported as expected.
