### PR TITLE
Try removing install-docker-tools in circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,6 @@ jobs:
         default: false
         type: boolean
     steps:
-      - docker/install-docker-tools
       - prepare_build:
           php_version: << parameters.php_version >>
           dkan_recommended_branch: << parameters.dkan_recommended_branch >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,6 @@ jobs:
         default: false
         type: boolean
     steps:
-      - docker/install-docker-tools
       - prepare_build:
           php_version: << parameters.php_version >>
           dkan_recommended_branch: << parameters.dkan_recommended_branch >>


### PR DESCRIPTION
The install-docker-tools command was failing - I'm not sure if we need it though, because docker-compose is already present? This PR removes it which gets the cypress pipelines passing again.