### PR TITLE
Use revision timestamp in datastore import status dashboard

### DIFF
--- a/modules/metastore/src/NodeWrapper/Data.php
+++ b/modules/metastore/src/NodeWrapper/Data.php
@@ -76,10 +76,8 @@ class Data implements MetastoreItemInterface {
    */
   public function getModifiedDate() {
     $this->fix();
-    /**
-     * The latest revision date does not match the changed value
-     * when there are multiple drafts.
-     */
+    // The latest revision date does not match the changed value
+    // when there are multiple drafts.
     if (!$this->node->isPublished()) {
       return $this->node->getRevisionCreationTime();
     }

--- a/modules/metastore/src/NodeWrapper/Data.php
+++ b/modules/metastore/src/NodeWrapper/Data.php
@@ -76,14 +76,9 @@ class Data implements MetastoreItemInterface {
    */
   public function getModifiedDate() {
     $this->fix();
-    // The latest revision date does not match the changed value
-    // when there are multiple drafts.
-    if (!$this->node->isPublished()) {
-      return $this->node->getRevisionCreationTime();
-    }
-    else {
-      return $this->node->getChangedTime();
-    }
+    // Use revision date because the latest revision date does not
+    // match the node changed value when there are multiple drafts.
+    return $this->node->getRevisionCreationTime();
   }
 
   /**

--- a/modules/metastore/src/NodeWrapper/Data.php
+++ b/modules/metastore/src/NodeWrapper/Data.php
@@ -76,7 +76,16 @@ class Data implements MetastoreItemInterface {
    */
   public function getModifiedDate() {
     $this->fix();
-    return $this->node->getChangedTime();
+    /**
+     * The latest revision date does not match the changed value
+     * when there are multiple drafts.
+     */
+    if (!$this->node->isPublished()) {
+      return $this->node->getRevisionCreationTime();
+    }
+    else {
+      return $this->node->getChangedTime();
+    }
   }
 
   /**


### PR DESCRIPTION
The datastore import status dashboard displays import statuses with dates for the current published revision of a dataset and (intended) the latest draft revision of that dataset if there is one. 

However, the date used for both of these is the "modified" date that is populated by calling getChangedTime() on the node. Unfortunately in the case of drafts, the "changed" value does not match the timestamp of the most recent draft. This can cause confusion when there have been multiple draft imports since the last published revision. The date in the dashboard will still show the date of the first draft revision.

To recreate, modify the DKAN publishing workflow (/admin/config/workflow/workflows/manage/dkan_publishing) and set the default moderation state to "draft". Then create multiple unpublished drafts of a dataset. The date displayed for the draft revision in the datastore import status dashboard will match the timestamp of the first draft, not the most recent.

## QA Steps

- [ ] Pull the PR branch into a vanilla DKAN site with sample content
- [ ] Modify the DKAN publishing workflow (/admin/config/workflow/workflows/manage/dkan_publishing) and set the default moderation state to "draft".
- [ ] Edit a dataset and save it as a draft revision
- [ ] Visit the datastore import status dashboard (/admin/dkan/datastore/status) and confirm that you see a draft row for that dataset in addition to the published row.
- [ ] Edit the same dataset a second time, again saving it as a draft revision.
- [ ] Visit the datastore import status dashboard (/admin/dkan/datastore/status) and confirm that the draft revision date matches the timestamp of the most recent revision.
