### PR TITLE
Issue #3956: Harvest deregister message

### DIFF
--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -190,7 +190,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    */
   public function remove(string $id) {
     $tableName = $this->getTableName();
-    $this->connection->delete($tableName)
+    return $this->connection->delete($tableName)
       ->condition($this->primaryKey(), $id)
       ->execute();
   }

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -130,6 +130,9 @@ class HarvestCommands extends DrushCommands {
       if ($this->harvestService->deregisterHarvest($id)) {
         $message = "Successfully deregistered the {$id} harvest.";
       }
+      else {
+        $message = "No harvest {$id} deregistered. Check if it exists.";
+      }
     }
     catch (\Exception $e) {
       $message = $e->getMessage();


### PR DESCRIPTION
fixes [GetDKAN/dkan/#3956]

## QA Steps

- Register a harvest using a local json file: ddev drush dkan:harvest:register --identifier=h1 --extract-uri=https://mylocal.ddev.site/sites/default/files/h1.json
- Confirm harvest exists:  ddev drush dkan:harvest:list 
- -- Returns output that includes h1 as a plan id
- Deregister harvest: ddev drush dkan:harvest:deregister h1
- -- Returns "Successfully deregistered the h1 harvest."
- Confirm harvest no longer exists: ddev drush dkan:harvest:list
- -- Returns no h1 under plan id
- Run deregister again when harvest no longer exists: ddev drush dkan:harvest:deregister h1
- -- Returns "No harvest h1 deregistered. Check if it exists."
