### PR TITLE
Issue #3959: dkan:harvest:status - undefined array key

### DIFF
--- a/modules/harvest/src/Commands/Helper.php
+++ b/modules/harvest/src/Commands/Helper.php
@@ -104,7 +104,7 @@ trait Helper {
       $table->setHeaders(["item_id", "extract", "transform", "load"]);
 
       foreach ($run['status']['extracted_items_ids'] as $item_id) {
-        $row = $this->generateItemStatusRow($item_id, $run['status'], $run['errors']);
+        $row = $this->generateItemStatusRow($item_id, $run['status'], $run['errors'] ?? []);
         $table->addRow($row);
       }
 


### PR DESCRIPTION
fixes [GetDKAN/dkan/#3959]

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- Register a harvest using a local json file: ddev drush dkan:harvest:register --identifier=h1 --extract-uri=https://mylocal.ddev.site/sites/default/files/h1.json
- Run the harvest: ddev drush dkan:harvest:run h1
- -- Returns output showing it processed successfully
- Get the status with drush: ddev drush dkan:harvest:status h1
- -- Returns status without "Undefined array key" error
