### PR TITLE
Revert Cypress tests to match latest version of admin_toolbar

### DIFF
--- a/cypress/integration/09_admin_links.spec.js
+++ b/cypress/integration/09_admin_links.spec.js
@@ -7,45 +7,45 @@ context('Administration pages', () => {
   })
 
   it('I should see a link for the dataset properties configuration', () => {
-    cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-handle').then($el=>{
-        cy.wrap($el).click()
-        cy.get('.toolbar-menu').contains('Metastore referencer')
+    cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=>{
+        cy.wrap($el).invoke('show')
+        cy.wrap($el).contains('Metastore referencer')
     })
     cy.visit(baseurl + "/admin/dkan/properties")
     cy.get('.option').should('contain.text', 'Distribution (distribution)')
   })
 
   it('I should see a link for the datastore configuration', () => {
-    cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-handle').then($el=>{
-        cy.wrap($el).click()
-        cy.get('.toolbar-menu').contains('Datastore settings')
+    cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=>{
+        cy.wrap($el).invoke('show')
+        cy.wrap($el).contains('Datastore settings')
     })
     cy.visit(baseurl + "/admin/dkan/datastore")
     cy.get('label[for="edit-rows-limit"]').should('have.text', 'Rows limit')
   })
 
   it('I should see a link for the datastore status', () => {
-    cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-handle').then($el=>{
-        cy.wrap($el).click()
-        cy.get('.toolbar-menu').contains('Datastore Import Status')
+    cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=>{
+        cy.wrap($el).invoke('show')
+        cy.wrap($el).contains('Datastore Import Status')
     })
     cy.visit(baseurl + "/admin/dkan/datastore/status")
     cy.contains('h1', 'Datastore Import Status');
   })
 
   it('I should see a link for the harvest status', () => {
-    cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-handle').then($el=>{
-        cy.wrap($el).click()
-        cy.get('.toolbar-menu').contains('Harvests')
+    cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=>{
+        cy.wrap($el).invoke('show')
+        cy.wrap($el).contains('Harvests')
     })
     cy.visit(baseurl + "/admin/dkan/harvest")
     cy.contains('h1', 'Harvests');
   })
 
   it('There is a link in the admin menu to the datasets admin screen.', () => {
-    cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-handle').then($el=> {
-        cy.wrap($el).click()
-        cy.get('.toolbar-menu').contains('Datasets')
+    cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=> {
+        cy.wrap($el).invoke('show')
+        cy.wrap($el).contains('Datasets')
     })
   })
 


### PR DESCRIPTION
We were seeing errors with the most recent builds having failing Cypress tests.

admin_toolbar put out a new 3.4 release that reverted a number of earlier commits over the past 2 months including removing the expand/collapse buttons. https://git.drupalcode.org/project/admin_toolbar/-/commit/ed4b6816274525cb1866402812ce0b261b7421b3 (reverted in the 3.4 release)

We had updated the Cypress tests to match the version of admin_toolbar with those buttons in https://github.com/GetDKAN/dkan/pull/3951 but since the changes in admin_toolbar were reverted, we need to revert our Cypress test changes.

- [ ] Test coverage exists

