### PR TITLE
Factor out drupal_static for resource display

### DIFF
--- a/modules/datastore/src/Form/ResourceSettingsForm.php
+++ b/modules/datastore/src/Form/ResourceSettingsForm.php
@@ -25,7 +25,7 @@ class ResourceSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   protected function getEditableConfigNames() {
-    return ['datastore.settings'];
+    return ['datastore.settings', 'metastore.settings'];
   }
 
   /**

--- a/modules/datastore/src/Form/ResourceSettingsForm.php
+++ b/modules/datastore/src/Form/ResourceSettingsForm.php
@@ -63,7 +63,7 @@ class ResourceSettingsForm extends ConfigFormBase {
         'local_url' => $this->t('Local URL'),
       ],
       '#default_value' => $this->config('metastore.settings')->get('resource_perspective_display')
-        ?: DataResource::DEFAULT_SOURCE_PERSPECTIVE,
+      ?: DataResource::DEFAULT_SOURCE_PERSPECTIVE,
     ];
     return parent::buildForm($form, $form_state);
   }

--- a/modules/datastore/src/Form/ResourceSettingsForm.php
+++ b/modules/datastore/src/Form/ResourceSettingsForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\datastore\Form;
 
+use Drupal\common\DataResource;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 
@@ -52,6 +53,17 @@ class ResourceSettingsForm extends ConfigFormBase {
       '#default_value' => $this->config('datastore.settings')->get('delete_local_resource'),
       '#description' => $this->t('Delete local copy of remote files after the datastore import is complete'),
     ];
+    $form['resource_perspective_display'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Resource download url display'),
+      '#description' => $this->t('Choose to display either the source or local path to a resource file in the metadata.'),
+      '#options' => [
+        DataResource::DEFAULT_SOURCE_PERSPECTIVE => $this->t('Source'),
+        'local_url' => $this->t('Local URL'),
+      ],
+      '#default_value' => $this->config('metastore.settings')->get('resource_perspective_display')
+        ?: DataResource::DEFAULT_SOURCE_PERSPECTIVE,
+    ];
     return parent::buildForm($form, $form_state);
   }
 
@@ -63,6 +75,9 @@ class ResourceSettingsForm extends ConfigFormBase {
       ->set('purge_table', $form_state->getValue('purge_table'))
       ->set('purge_file', $form_state->getValue('purge_file'))
       ->set('delete_local_resource', $form_state->getValue('delete_local_resource'))
+      ->save();
+    $this->config('metastore.settings')
+      ->set('resource_perspective_display', $form_state->getValue('resource_perspective_display'))
       ->save();
     parent::submitForm($form, $form_state);
   }

--- a/modules/datastore/src/Form/ResourceSettingsForm.php
+++ b/modules/datastore/src/Form/ResourceSettingsForm.php
@@ -56,7 +56,8 @@ class ResourceSettingsForm extends ConfigFormBase {
     $form['resource_perspective_display'] = [
       '#type' => 'select',
       '#title' => $this->t('Resource download url display'),
-      '#description' => $this->t('Choose to display either the source or local path to a resource file in the metadata.'),
+      '#description' => $this->t('Choose to display either the source or local path to a resource file in the 
+        metadata. Note that "Local URL" display only makes sense if "Delete local resource" is unchecked.'),
       '#options' => [
         DataResource::DEFAULT_SOURCE_PERSPECTIVE => $this->t('Source'),
         'local_url' => $this->t('Local URL'),

--- a/modules/metastore/config/install/metastore.settings.yml
+++ b/modules/metastore/config/install/metastore.settings.yml
@@ -19,3 +19,4 @@ property_list:
   'spatial': 0
   'temporal': 0
   'isPartOf': 0
+resource_perspective_display: source

--- a/modules/metastore/config/schema/metastore.schema.yml
+++ b/modules/metastore/config/schema/metastore.schema.yml
@@ -14,3 +14,6 @@ metastore.settings:
       sequence:
         type: string
         label: 'Property'
+    resource_perspective_display:
+      type: string
+      label: 'Resource download url display'

--- a/modules/metastore/metastore.module
+++ b/modules/metastore/metastore.module
@@ -4,7 +4,6 @@
  * @file
  */
 
-use Drupal\common\DataResource;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
@@ -51,13 +50,6 @@ function metastore_entity_bundle_field_info_alter(&$fields, EntityTypeInterface 
       $fields['field_json_metadata']->addConstraint('ProperJson', []);
     }
   }
-}
-
-/**
- * Helper method to retrieve the static value for a resource's display.
- */
-function resource_mapper_display() {
-  return drupal_static('metastore_resource_mapper_display', DataResource::DEFAULT_SOURCE_PERSPECTIVE);
 }
 
 /**

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -16,6 +16,7 @@ services:
       - '@date.formatter'
       - '@dkan.metastore.storage'
       - '@queue'
+      - '@config.factory'
   dkan.metastore.schema_retriever:
     class: \Drupal\metastore\SchemaRetriever
     arguments:

--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -5,6 +5,7 @@ namespace Drupal\metastore\LifeCycle;
 use Drupal\common\EventDispatcherTrait;
 use Drupal\common\DataResource;
 use Drupal\common\UrlHostTokenResolver;
+use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\metastore\MetastoreItemInterface;
@@ -73,6 +74,13 @@ class LifeCycle {
   protected $queueFactory;
 
   /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
    * Constructor.
    */
   public function __construct(
@@ -82,7 +90,8 @@ class LifeCycle {
     ResourceMapper $resourceMapper,
     DateFormatter $dateFormatter,
     DataFactory $dataFactory,
-    QueueFactory $queueFactory
+    QueueFactory $queueFactory,
+    ConfigFactory $configFactory
   ) {
     $this->referencer = $referencer;
     $this->dereferencer = $dereferencer;
@@ -91,6 +100,7 @@ class LifeCycle {
     $this->dateFormatter = $dateFormatter;
     $this->dataFactory = $dataFactory;
     $this->queueFactory = $queueFactory;
+    $this->configFactory = $configFactory;
   }
 
   /**
@@ -227,7 +237,8 @@ class LifeCycle {
     }
 
     $reference[] = $this->createResourceReference($sourceResource);
-    $perspective = \resource_mapper_display();
+    $perspective = $this->configFactory->get('metastore.settings')->get('resource_perspective_display')
+      ?: DataResource::DEFAULT_SOURCE_PERSPECTIVE;
     $resource = $sourceResource;
 
     if (

--- a/tests/src/Functional/DatasetTest.php
+++ b/tests/src/Functional/DatasetTest.php
@@ -307,8 +307,10 @@ class DatasetTest extends ExistingSiteBase {
   }
 
   private function changeDatasetsResourceOutputPerspective(string $perspective = DataResource::DEFAULT_SOURCE_PERSPECTIVE) {
-    $display = &drupal_static('metastore_resource_mapper_display');
-    $display = $perspective;
+    $configFactory = \Drupal::service('config.factory');
+    $config = $configFactory->getEditable('metastore.settings');
+    $config->set('resource_perspective_display', $perspective);
+    $config->save();
   }
 
   private function getResourceDatastoreTable(object $resource) {


### PR DESCRIPTION
Drupal has had a meta issue to remove all drupal_static calls in core and deprecate the functionality. With that in mind, we're working to move the configuration of the resource download url in the metadata to configuration (that can be edited through the UI) instead of using drupal_static.

This change will need to be reflected in the release notes so that sites who are currently calling &drupal_static('metastore_resource_mapper_display')
know that they will need to update their code.

Included changes:
- metastore_resource_mapper_display static variable fully removed
- new configuration setting in metastore.settings called 'resource_perspective_display' with two options: source (default) and local_url
- retrieveDownloadUrlFromResourceMapper() uses the new config setting to determine how to display the download url
- The new config setting can be modified on the Resources form.

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- Install a demo vanilla DKAN site
- Visit /admin/dkan/resources and confirm the new 'Resource download url display' select defaults to 'source'. Don't save anything.
- Create a new published dataset with a remote distribution download url like http://demo.getdkan.org/sites/default/files/distribution/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/Bike_Lane.csv
- Check the metastore api path for the dataset e.g. https://dkan10.ddev.site/api/1/metastore/schemas/dataset/items/[uuid]
- Confirm that the distribution -> downloadURL shows the remote source url (e.g. http://demo.getdkan.org....)
- Go back to /admin/dkan/resources and change 'Resource download url display' to local url and save
- Clear the drupal cache (ddev drush cr)
- Re-visit the metastore api path for the dataset and confirm that the distribution -> downloadURL now shows the local file path to the resource.
