### PR TITLE
Issue #3512: Create special form widget for vCard email field

### DIFF
--- a/modules/json_form_widget/src/StringHelper.php
+++ b/modules/json_form_widget/src/StringHelper.php
@@ -82,6 +82,7 @@ class StringHelper implements ContainerInjectionInterface {
     // Add extra validate if element type is email.
     if ($element['#type'] === 'email') {
       $element['#element_validate'][] = [$this, 'validateEmail'];
+      $element['#default_value'] = ltrim($element['#default_value'], 'mailto:');
     }
 
     return $element;

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -18,6 +18,9 @@ class ValueHandler {
     switch ($schema->type) {
       case 'string':
         $data = $this->handleStringValues($formValues, $property);
+        if ($property === 'hasEmail') {
+          $data = 'mailto:' . ltrim($data, 'mailto:');
+        }
         break;
 
       case 'object':


### PR DESCRIPTION
possible fix to #3512 

This only addresses the issue with editing the email field through the UI for a vCard with the hasEmail property that was imported via the API.

## Steps to Recreate

- Create a dataset through the API / via a harvest that has a contactPoint with the hasEmail property

`"contactPoint": {
        "@type": "vcard:Contact",
        "fn": "First Name",
        "hasEmail": "mailto:email@example.com"
      },`

- Attempt to edit the dataset through the UI. The validation of the email field fails.

## QA Steps

- Create a dataset through the API / via a harvest that has a contactPoint with the hasEmail property
- Only the email appears in the email form field (no mailto:)
- Edit and save the dataset through the UI without an error.
- When visiting the API path for the metastore ( /api/1/metastore/schemas/dataset/items/{identifier} ) the hasEmail still shows the mailto: prefix.
