### PR TITLE
MySQL import jobs should not try again if the table exists already

### DIFF
--- a/modules/common/src/LoggerTrait.php
+++ b/modules/common/src/LoggerTrait.php
@@ -57,7 +57,7 @@ trait LoggerTrait {
   /**
    * Private.
    */
-  private function log($loggerName, $message, $variables = [], $level = LogLevel::ERROR) {
+  protected function log($loggerName, $message, $variables = [], $level = LogLevel::ERROR) {
     if ($this->loggerService) {
       $this->loggerService->get($loggerName)->log($level, $message, $variables);
     }
@@ -66,7 +66,7 @@ trait LoggerTrait {
   /**
    * Private.
    */
-  private function error(string $message, array $context = []) {
+  protected function error(string $message, array $context = []) {
 
     if ($this->loggerService) {
       $this->loggerService->get($this->loggerName)->error($message, $context);
@@ -76,7 +76,7 @@ trait LoggerTrait {
   /**
    * Private.
    */
-  private function warning(string $message, array $context = []) {
+  protected function warning(string $message, array $context = []) {
 
     if ($this->loggerService) {
       $this->loggerService->get($this->loggerName)->warning($message, $context);
@@ -86,7 +86,7 @@ trait LoggerTrait {
   /**
    * Private.
    */
-  private function notice(string $message, array $context = []) {
+  protected function notice(string $message, array $context = []) {
 
     if ($this->loggerService) {
       $this->loggerService->get($this->loggerName)->notice($message, $context);

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -282,14 +282,13 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    * Check for existence of a table name.
    */
   protected function tableExist($table_name) {
-    $exists = $this->connection->schema()->tableExists($table_name);
-    return $exists;
+    return $this->connection->schema()->tableExists($table_name);
   }
 
   /**
    * Create a table given a name and schema.
    */
-  private function tableCreate($table_name, $schema) {
+  protected function tableCreate($table_name, $schema) {
     // Opportunity to further alter the schema before table creation.
     $schema = $this->dispatchEvent(self::EVENT_TABLE_CREATE, $schema);
 

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -5,6 +5,7 @@ namespace Drupal\common\Storage;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\DatabaseExceptionWrapper;
 use Drupal\common\EventDispatcherTrait;
+use Drupal\Core\Database\SchemaObjectExistsException;
 
 /**
  * Base class for database storage methods.
@@ -299,7 +300,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    * Set the schema using the existing database table.
    */
   protected function setSchemaFromTable() {
-    $fields_info = $this->connection->query("DESCRIBE `{$this->getTableName()}`")->fetchAll();
+    $fields_info = $this->connection->query('DESCRIBE {' . $this->getTableName() . '}')->fetchAll();
     if (empty($fields_info)) {
       return;
     }

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -5,7 +5,6 @@ namespace Drupal\common\Storage;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\DatabaseExceptionWrapper;
 use Drupal\common\EventDispatcherTrait;
-use Drupal\Core\Database\SchemaObjectExistsException;
 
 /**
  * Base class for database storage methods.

--- a/modules/common/src/Storage/JobStore.php
+++ b/modules/common/src/Storage/JobStore.php
@@ -18,6 +18,8 @@ class JobStore extends AbstractDatabaseTable {
   private $jobClass;
 
   /**
+   * Store the name of the table so we do not have to recompute.
+   *
    * @var string
    */
   private $tableName;

--- a/modules/common/src/Storage/JobStore.php
+++ b/modules/common/src/Storage/JobStore.php
@@ -18,6 +18,11 @@ class JobStore extends AbstractDatabaseTable {
   private $jobClass;
 
   /**
+   * @var string
+   */
+  private $tableName;
+
+  /**
    * Constructor.
    */
   public function __construct(string $jobClass, Connection $connection) {
@@ -44,8 +49,16 @@ class JobStore extends AbstractDatabaseTable {
    * Protected.
    */
   protected function getTableName() {
-    $safeClassName = strtolower(preg_replace('/\\\\/', '_', $this->jobClass));
-    return 'jobstore_' . $safeClassName;
+    if (empty($this->tableName)) {
+      // Avoid table-name-too-long errors by hashing the FQN of the class.
+      $exploded_class = explode("\\", $this->jobClass);
+      $this->tableName = strtolower(implode('_', [
+        'jobstore',
+        crc32($this->jobClass),
+        array_pop($exploded_class),
+      ]));
+    }
+    return $this->tableName;
   }
 
   /**

--- a/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.services.yml
+++ b/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.services.yml
@@ -3,4 +3,9 @@ services:
     class: \Drupal\datastore_mysql_import\Factory\MysqlImportFactory
     arguments:
       - '@dkan.common.job_store'
-      - '@dkan.datastore.database_table_factory'
+      - '@dkan.datastore_mysql_import.database_table_factory'
+
+  dkan.datastore_mysql_import.database_table_factory:
+    class: \Drupal\datastore_mysql_import\Storage\MySqlDatabaseTableFactory
+    arguments:
+      - '@dkan.datastore.database'

--- a/modules/datastore/modules/datastore_mysql_import/src/Factory/MysqlImportFactory.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Factory/MysqlImportFactory.php
@@ -7,6 +7,7 @@ use Drupal\datastore\Service\Factory\ImportFactoryInterface;
 use Drupal\datastore\Service\ImportService;
 use Drupal\datastore\Storage\DatabaseTableFactory;
 use Drupal\datastore_mysql_import\Service\MysqlImport;
+use Drupal\datastore_mysql_import\Storage\MySqlDatabaseTableFactory;
 
 /**
  * Importer factory.

--- a/modules/datastore/modules/datastore_mysql_import/src/Factory/MysqlImportFactory.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Factory/MysqlImportFactory.php
@@ -5,7 +5,6 @@ namespace Drupal\datastore_mysql_import\Factory;
 use Drupal\common\Storage\JobStoreFactory;
 use Drupal\datastore\Service\Factory\ImportFactoryInterface;
 use Drupal\datastore\Service\ImportService;
-use Drupal\datastore\Storage\DatabaseTableFactory;
 use Drupal\datastore_mysql_import\Service\MysqlImport;
 use Drupal\datastore_mysql_import\Storage\MySqlDatabaseTableFactory;
 
@@ -26,7 +25,7 @@ class MysqlImportFactory implements ImportFactoryInterface {
   /**
    * Database table factory service.
    *
-   * @var \Drupal\datastore\Storage\MySqlDatabaseTableFactory
+   * @var \Drupal\datastore_mysql_import\Storage\MySqlDatabaseTableFactory
    */
   private $databaseTableFactory;
 

--- a/modules/datastore/modules/datastore_mysql_import/src/Factory/MysqlImportFactory.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Factory/MysqlImportFactory.php
@@ -26,7 +26,7 @@ class MysqlImportFactory implements ImportFactoryInterface {
   /**
    * Database table factory service.
    *
-   * @var \Drupal\datastore\Storage\DatabaseTableFactory
+   * @var \Drupal\datastore\Storage\MySqlDatabaseTableFactory
    */
   private $databaseTableFactory;
 
@@ -40,7 +40,7 @@ class MysqlImportFactory implements ImportFactoryInterface {
   /**
    * Constructor.
    */
-  public function __construct(JobStoreFactory $jobStoreFactory, DatabaseTableFactory $databaseTableFactory) {
+  public function __construct(JobStoreFactory $jobStoreFactory, MySqlDatabaseTableFactory $databaseTableFactory) {
     $this->jobStoreFactory = $jobStoreFactory;
     $this->databaseTableFactory = $databaseTableFactory;
   }

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -2,14 +2,16 @@
 
 namespace Drupal\datastore_mysql_import\Service;
 
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Database;
+use Drupal\Core\Database\SchemaObjectExistsException;
 use Drupal\datastore\Plugin\QueueWorker\ImportJob;
 use Procrastinator\Result;
 
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
 
 /**
- * Expiremental MySQL LOAD DATA importer.
+ * MySQL LOAD DATA importer.
  */
 class MysqlImport extends ImportJob {
 
@@ -25,16 +27,21 @@ class MysqlImport extends ImportJob {
   ];
 
   /**
-   * Override.
+   * Perform the import job.
    *
-   * {@inheritdoc}
+   * @return mixed
+   *   The data to be placed in the Result object. This class does not use the
+   *   result data, so it returns void.
+   *
+   * @throws \Exception
+   *   Any exception thrown will be turned into an error in the Result object.
    */
   protected function runIt() {
     // Attempt to resolve resource file name from file path.
     $file_path = \Drupal::service('file_system')->realpath($this->resource->getFilePath());
 
     $mimeType = $this->resource->getMimeType();
-    $delimiter = $mimeType == 'text/tab-separated-values' ? "\t" : ",";
+    $delimiter = $mimeType == 'text/tab-separated-values' ? "\t" : ',';
 
     if ($file_path === FALSE) {
       return $this->setResultError(sprintf('Unable to resolve file name "%s" for resource with identifier "%s".', $this->resource->getFilePath(), $this->resource->getId()));
@@ -58,7 +65,13 @@ class MysqlImport extends ImportJob {
     $spec = $this->generateTableSpec($columns);
     $this->dataStorage->setSchema(['fields' => $spec]);
 
-    $this->dataStorage->count();
+    try {
+      $this->dataStorage->count();
+    }
+    catch (SchemaObjectExistsException $e) {
+      $this->setError($e->getMessage());
+      throw $e;
+    }
     // Construct and execute a SQL import statement using the information
     // gathered from the CSV file being imported.
     $this->getDatabaseConnectionCapableOfDataLoad()->query(
@@ -67,8 +80,7 @@ class MysqlImport extends ImportJob {
     Database::setActiveConnection();
 
     $this->getResult()->setStatus(Result::DONE);
-
-    return $this->getResult();
+    return NULL;
   }
 
   /**
@@ -83,7 +95,7 @@ class MysqlImport extends ImportJob {
    *   An array containing only two elements; the CSV columns and the column
    *   lines.
    *
-   * @throws Symfony\Component\HttpFoundation\File\Exception\FileException
+   * @throws \Symfony\Component\HttpFoundation\File\Exception\FileException
    *   On failure to open the file;
    *   on failure to read the first line from the file.
    */
@@ -180,7 +192,7 @@ class MysqlImport extends ImportJob {
       }
 
       $spec[$name] = [
-        'type' => "text",
+        'type' => 'text',
         'description' => ImportJob::sanitizeDescription($column ?? ''),
       ];
     }
@@ -193,7 +205,7 @@ class MysqlImport extends ImportJob {
    *
    * @param string $file_path
    *   File path to the CSV file being imported.
-   * @param string $tablename
+   * @param string $table_name
    *   Name of the datastore table the file is being imported into.
    * @param string[] $headers
    *   List of CSV headers.
@@ -207,10 +219,10 @@ class MysqlImport extends ImportJob {
    * @return string
    *   Generated SQL file import statement.
    */
-  protected function getSqlStatement(string $file_path, string $tablename, array $headers, string $eol, int $header_line_count, string $delimiter): string {
+  protected function getSqlStatement(string $file_path, string $table_name, array $headers, string $eol, int $header_line_count, string $delimiter): string {
     return implode(' ', [
       'LOAD DATA LOCAL INFILE \'' . $file_path . '\'',
-      'INTO TABLE {' . $tablename . '}',
+      'INTO TABLE {' . $table_name . '}',
       'FIELDS TERMINATED BY \'' . $delimiter . '\'',
       'OPTIONALLY ENCLOSED BY \'"\'',
       'ESCAPED BY \'\'',

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -210,7 +210,7 @@ class MysqlImport extends ImportJob {
   protected function getSqlStatement(string $file_path, string $tablename, array $headers, string $eol, int $header_line_count, string $delimiter): string {
     return implode(' ', [
       'LOAD DATA LOCAL INFILE \'' . $file_path . '\'',
-      'INTO TABLE ' . $tablename,
+      'INTO TABLE {' . $tablename . '}',
       'FIELDS TERMINATED BY \'' . $delimiter . '\'',
       'OPTIONALLY ENCLOSED BY \'"\'',
       'ESCAPED BY \'\'',

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -34,7 +34,8 @@ class MysqlImport extends ImportJob {
    *   result data, so it returns void.
    *
    * @throws \Exception
-   *   Any exception thrown will be turned into an error in the Result object.
+   *   Any exception thrown will be turned into an error in the Result object
+   *   in the run() method.
    */
   protected function runIt() {
     // Attempt to resolve resource file name from file path.
@@ -65,13 +66,10 @@ class MysqlImport extends ImportJob {
     $spec = $this->generateTableSpec($columns);
     $this->dataStorage->setSchema(['fields' => $spec]);
 
-    try {
-      $this->dataStorage->count();
-    }
-    catch (SchemaObjectExistsException $e) {
-      $this->setError($e->getMessage());
-      throw $e;
-    }
+    // Count() will attempt to create the database table by side-effect of
+    // calling setTable().
+    $this->dataStorage->count();
+
     // Construct and execute a SQL import statement using the information
     // gathered from the CSV file being imported.
     $this->getDatabaseConnectionCapableOfDataLoad()->query(

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -2,9 +2,7 @@
 
 namespace Drupal\datastore_mysql_import\Service;
 
-use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Database;
-use Drupal\Core\Database\SchemaObjectExistsException;
 use Drupal\datastore\Plugin\QueueWorker\ImportJob;
 use Procrastinator\Result;
 

--- a/modules/datastore/modules/datastore_mysql_import/src/Storage/MySqlDatabaseTable.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Storage/MySqlDatabaseTable.php
@@ -11,6 +11,11 @@ class MySqlDatabaseTable extends DatabaseTable {
 
   /**
    * Create the table in the db if it does not yet exist.
+   *
+   * @throws \Exception
+   *   Can throw any DB-related exception. Notably, can throw
+   *   \Drupal\Core\Database\SchemaObjectExistsException if the table already
+   *   exists when we try to create it.
    */
   protected function setTable() {
     // Never check for pre-existing table, never catch exceptions.

--- a/modules/datastore/modules/datastore_mysql_import/src/Storage/MySqlDatabaseTable.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Storage/MySqlDatabaseTable.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\datastore_mysql_import\Storage;
+
+use Drupal\datastore\Storage\DatabaseTable;
+
+/**
+ * MySQL import database table.
+ */
+class MySqlDatabaseTable extends DatabaseTable {
+
+  /**
+   * Create the table in the db if it does not yet exist.
+   */
+  protected function setTable() {
+    // Never check for pre-existing table, never catch exceptions.
+    if ($this->schema) {
+      $this->tableCreate($this->getTableName(), $this->schema);
+    }
+    else {
+      throw new \Exception("Could not instantiate the table due to a lack of schema.");
+    }
+  }
+
+}

--- a/modules/datastore/modules/datastore_mysql_import/src/Storage/MySqlDatabaseTableFactory.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Storage/MySqlDatabaseTableFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\datastore_mysql_import\Storage;
+
+use Drupal\datastore\Storage\DatabaseTableFactory;
+
+/**
+ * MySQL import database table.
+ */
+class MySqlDatabaseTableFactory extends DatabaseTableFactory {
+
+  protected function getDatabaseTable($resource) {
+    return new MySqlDatabaseTable($this->connection, $resource);
+  }
+
+}

--- a/modules/datastore/modules/datastore_mysql_import/src/Storage/MySqlDatabaseTableFactory.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Storage/MySqlDatabaseTableFactory.php
@@ -9,6 +9,9 @@ use Drupal\datastore\Storage\DatabaseTableFactory;
  */
 class MySqlDatabaseTableFactory extends DatabaseTableFactory {
 
+  /**
+   * {@inheritDoc}
+   */
   protected function getDatabaseTable($resource) {
     return new MySqlDatabaseTable($this->connection, $resource);
   }

--- a/modules/datastore/modules/datastore_mysql_import/tests/data/columnspaces.csv
+++ b/modules/datastore/modules/datastore_mysql_import/tests/data/columnspaces.csv
@@ -1,0 +1,3 @@
+"id","name","columnname"
+1,"Yessenia",67.1
+2,"Roberto",2.2

--- a/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Service/MysqlImportTest.php
+++ b/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Service/MysqlImportTest.php
@@ -53,6 +53,7 @@ class MysqlImportTest extends KernelTestBase {
     // The import job aggressively keeps track of what's already done, so we
     // have to reset that.
     $import_job->getResult()->setStatus(Result::IN_PROGRESS);
+    // Try to import again.
     $result = $import_job->run();
     $this->assertEquals(Result::ERROR, $result->getStatus(), $result->getError());
     $this->assertStringContainsString('already exists', $result->getError());

--- a/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Service/MysqlImportTest.php
+++ b/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Service/MysqlImportTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\Tests\datastore_mysql_import\Kernel\Service;
+
+use Drupal\common\DataResource;
+use Drupal\datastore_mysql_import\Factory\MysqlImportFactory;
+use Drupal\datastore_mysql_import\Storage\MySqlDatabaseTable;
+use Drupal\KernelTests\KernelTestBase;
+use Procrastinator\Result;
+
+/**
+ * @covers \Drupal\datastore_mysql_import\Service\MysqlImport
+ * @coversDefaultClass \Drupal\datastore_mysql_import\Service\MysqlImport
+ *
+ * @group datastore_mysql_import
+ */
+class MysqlImportKernelTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'common',
+    'datastore',
+    'datastore_mysql_import',
+    'metastore',
+  ];
+
+  public function testTableDuplicateException() {
+    $identifier = 'my_id';
+    $file_path = dirname(__FILE__, 4) . '/data/columnspaces.csv';
+    $data_resource = new DataResource($file_path, 'text/csv');
+
+    $import_factory = $this->container->get('dkan.datastore.service.factory.import');
+    $this->assertInstanceOf(MysqlImportFactory::class, $import_factory);
+
+    /** @var \Drupal\datastore\Plugin\QueueWorker\ImportJob $import_job */
+    $import_job = $import_factory->getInstance($identifier, ['resource' => $data_resource])
+      ->getImporter();
+    $this->assertInstanceOf(MySqlDatabaseTable::class, $db_table = $import_job->getStorage());
+
+    // Store the table.
+    $result = $import_job->run();
+    $this->assertEquals(Result::DONE, $result->getStatus(), $result->getError());
+
+    // Do it again...
+    $import_job = $import_factory->getInstance(
+      $identifier,
+      ['resource' => $data_resource]
+    )->getImporter();
+    // The import job aggressively keeps track of what's already done, so we
+    // have to reset that.
+    $import_job->getResult()->setStatus(Result::IN_PROGRESS);
+    $result = $import_job->run();
+    $this->assertEquals(Result::ERROR, $result->getStatus(), $result->getError());
+    $this->assertStringContainsString('already exists', $result->getError());
+  }
+
+}

--- a/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Service/MysqlImportTest.php
+++ b/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Service/MysqlImportTest.php
@@ -14,7 +14,7 @@ use Procrastinator\Result;
  *
  * @group datastore_mysql_import
  */
-class MysqlImportKernelTest extends KernelTestBase {
+class MysqlImportTest extends KernelTestBase {
 
   /**
    * {@inheritdoc}
@@ -35,9 +35,11 @@ class MysqlImportKernelTest extends KernelTestBase {
     $this->assertInstanceOf(MysqlImportFactory::class, $import_factory);
 
     /** @var \Drupal\datastore\Plugin\QueueWorker\ImportJob $import_job */
-    $import_job = $import_factory->getInstance($identifier, ['resource' => $data_resource])
-      ->getImporter();
-    $this->assertInstanceOf(MySqlDatabaseTable::class, $db_table = $import_job->getStorage());
+    $import_job = $import_factory->getInstance(
+      $identifier,
+      ['resource' => $data_resource]
+    )->getImporter();
+    $this->assertInstanceOf(MySqlDatabaseTable::class, $import_job->getStorage());
 
     // Store the table.
     $result = $import_job->run();

--- a/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Storage/MySqlDatabaseTableFactoryTest.php
+++ b/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Storage/MySqlDatabaseTableFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\Tests\datastore_mysql_import\Kernel\Storage;
+
+use Drupal\datastore\DatastoreResource;
+use Drupal\datastore_mysql_import\Storage\MySqlDatabaseTable;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * @covers \Drupal\datastore_mysql_import\Storage\MySqlDatabaseTableFactory
+ * @coversDefaultClass \Drupal\datastore_mysql_import\Storage\MySqlDatabaseTableFactory
+ *
+ * @group datastore_mysql_import
+ */
+class MySqlDatabaseTableFactoryKernelTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'common',
+    'datastore',
+    'datastore_mysql_import',
+    'metastore',
+  ];
+
+  public function testFactoryServiceResourceException() {
+    /** @var \Drupal\datastore_mysql_import\Storage\MySqlDatabaseTableFactory $factory */
+    $factory = $this->container->get('dkan.datastore_mysql_import.database_table_factory');
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage("config['resource'] is required");
+    $table = $factory->getInstance('id', []);
+  }
+
+  public function testFactoryService() {
+    $identifier = 'identifier';
+    $file_path = dirname(__FILE__, 4) . '/data/columnspaces.csv';
+    $datastore_resource = new DatastoreResource(
+      $identifier,
+      $file_path,
+      'text/csv'
+    );
+
+    /** @var \Drupal\datastore_mysql_import\Storage\MySqlDatabaseTableFactory $factory */
+    $factory = $this->container->get('dkan.datastore_mysql_import.database_table_factory');
+    $table = $factory->getInstance('id', ['resource' => $datastore_resource]);
+    $this->assertInstanceOf(MySqlDatabaseTable::class, $table);
+  }
+
+}

--- a/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Storage/MySqlDatabaseTableFactoryTest.php
+++ b/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Storage/MySqlDatabaseTableFactoryTest.php
@@ -12,7 +12,7 @@ use Drupal\KernelTests\KernelTestBase;
  *
  * @group datastore_mysql_import
  */
-class MySqlDatabaseTableFactoryKernelTest extends KernelTestBase {
+class MySqlDatabaseTableFactoryTest extends KernelTestBase {
 
   /**
    * {@inheritdoc}

--- a/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Storage/MySqlDatabaseTableTest.php
+++ b/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Storage/MySqlDatabaseTableTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\Tests\datastore_mysql_import\Kernel\Storage;
+
+use Drupal\common\DataResource;
+use Drupal\datastore\DatastoreResource;
+use Drupal\datastore_mysql_import\Factory\MysqlImportFactory;
+use Drupal\datastore_mysql_import\Storage\MySqlDatabaseTable;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\datastore\Service\ImportService;
+use Drupal\datastore\Plugin\QueueWorker\ImportJob;
+use Procrastinator\Result;
+
+/**
+ * @covers \Drupal\datastore_mysql_import\Storage\MySqlDatabaseTable
+ * @coversDefaultClass \Drupal\datastore_mysql_import\Storage\MySqlDatabaseTable
+ *
+ * @group datastore_mysql_import
+ */
+class MySqlDatabaseTableKernelTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'common',
+    'datastore',
+    'datastore_mysql_import',
+    'metastore',
+  ];
+
+  public function testTable() {
+    $identifier = 'id';
+    $file_path = dirname(__FILE__, 4) . '/data/columnspaces.csv';
+
+    $data_resource = new DataResource($file_path, 'text/csv');
+
+    $import_factory = $this->container->get('dkan.datastore.service.factory.import');
+    $this->assertInstanceOf(MysqlImportFactory::class, $import_factory);
+
+    /** @var \Drupal\datastore\Plugin\QueueWorker\ImportJob $import_job */
+    $import_job = $import_factory->getInstance($identifier, ['resource' => $data_resource])
+      ->getImporter();
+    $result = $import_job->run();
+    $this->assertEquals(Result::DONE, $result->getStatus(), $result->getError());
+  }
+
+  public function testTableDuplicateException() {
+    $identifier = 'id';
+    $file_path = dirname(__FILE__, 4) . '/data/columnspaces.csv';
+    $data_resource = new DataResource($file_path, 'text/csv');
+
+    $import_factory = $this->container->get('dkan.datastore.service.factory.import');
+    $this->assertInstanceOf(MysqlImportFactory::class, $import_factory);
+
+    /** @var \Drupal\datastore\Plugin\QueueWorker\ImportJob $import_job */
+    $import_job = $import_factory->getInstance($identifier, ['resource' => $data_resource])
+      ->getImporter();
+    $result = $import_job->run();
+    $this->assertEquals(Result::DONE, $result->getStatus(), $result->getError());
+
+    // Perform the import again.
+    $thingie = $import_factory->getInstance($identifier, ['resource' => $data_resource]);
+    /** @var \Drupal\datastore\Plugin\QueueWorker\ImportJob $import_job */
+//    $import_job = $thingie->getImporter();
+//    $result = $import_job->run();
+//    $this->assertEquals(Result::DONE, $result->getStatus(), $result->getError());
+  }
+
+}

--- a/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Storage/MySqlDatabaseTableTest.php
+++ b/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Storage/MySqlDatabaseTableTest.php
@@ -4,12 +4,9 @@ namespace Drupal\Tests\datastore_mysql_import\Kernel\Storage;
 
 use Drupal\common\DataResource;
 use Drupal\Core\Database\SchemaObjectExistsException;
-use Drupal\datastore\DatastoreResource;
 use Drupal\datastore_mysql_import\Factory\MysqlImportFactory;
 use Drupal\datastore_mysql_import\Storage\MySqlDatabaseTable;
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\datastore\Service\ImportService;
-use Drupal\datastore\Plugin\QueueWorker\ImportJob;
 use Procrastinator\Result;
 
 /**
@@ -17,8 +14,9 @@ use Procrastinator\Result;
  * @coversDefaultClass \Drupal\datastore_mysql_import\Storage\MySqlDatabaseTable
  *
  * @group datastore_mysql_import
+ * @group kernel
  */
-class MySqlDatabaseTableKernelTest extends KernelTestBase {
+class MySqlDatabaseTableTest extends KernelTestBase {
 
   /**
    * {@inheritdoc}
@@ -57,7 +55,10 @@ class MySqlDatabaseTableKernelTest extends KernelTestBase {
     /** @var \Drupal\datastore\Plugin\QueueWorker\ImportJob $import_job */
     $import_job = $import_factory->getInstance($identifier, ['resource' => $data_resource])
       ->getImporter();
-    $this->assertInstanceOf(MySqlDatabaseTable::class, $db_table = $import_job->getStorage());
+    $this->assertInstanceOf(
+      MySqlDatabaseTable::class,
+      $db_table = $import_job->getStorage()
+    );
 
     // Store the table.
     $result = $import_job->run();
@@ -69,8 +70,27 @@ class MySqlDatabaseTableKernelTest extends KernelTestBase {
     $db_table->count();
   }
 
-  public function testTableDuplicateExceptionNewImporter() {
-    $this->markTestIncomplete('add the same test as above to test handling by import job.');
+  public function testTableNoSchema() {
+    $identifier = 'my_id';
+    $file_path = dirname(__FILE__, 4) . '/data/columnspaces.csv';
+    $data_resource = new DataResource($file_path, 'text/csv');
+
+    $import_factory = $this->container->get('dkan.datastore.service.factory.import');
+    $this->assertInstanceOf(MysqlImportFactory::class, $import_factory);
+
+    /** @var \Drupal\datastore\Plugin\QueueWorker\ImportJob $import_job */
+    $import_job = $import_factory->getInstance($identifier, ['resource' => $data_resource])
+      ->getImporter();
+    $this->assertInstanceOf(
+      MySqlDatabaseTable::class,
+      $db_table = $import_job->getStorage()
+    );
+
+    // Count() will trigger setTable(), which will throw an exception because
+    // the table object does not have a schema set up yet.
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('Could not instantiate the table due to a lack of schema.');
+    $db_table->count();
   }
 
 }

--- a/modules/datastore/modules/datastore_mysql_import/tests/src/Unit/Service/MysqlImportTest.php
+++ b/modules/datastore/modules/datastore_mysql_import/tests/src/Unit/Service/MysqlImportTest.php
@@ -151,8 +151,8 @@ class MysqlImportTest extends TestCase {
         };
       }
 
-      protected function getSqlStatement(string $file_path, string $tablename, array $headers, string $eol, int $header_line_count, string $delimiter): string {
-        $this->sqlStatement = parent::getSqlStatement($file_path, $tablename, $headers, $eol, $header_line_count, $delimiter);
+      protected function getSqlStatement(string $file_path, string $table_name, array $headers, string $eol, int $header_line_count, string $delimiter): string {
+        $this->sqlStatement = parent::getSqlStatement($file_path, $table_name, $headers, $eol, $header_line_count, $delimiter);
         return $this->sqlStatement;
       }
 

--- a/modules/datastore/modules/datastore_mysql_import/tests/src/Unit/Service/MysqlImportTest.php
+++ b/modules/datastore/modules/datastore_mysql_import/tests/src/Unit/Service/MysqlImportTest.php
@@ -113,7 +113,7 @@ class MysqlImportTest extends TestCase {
 
     $this->assertEquals($mysqlImporter->sqlStatement, implode(' ', [
       'LOAD DATA LOCAL INFILE \'' . $file_path . '\'',
-      'INTO TABLE ' . self::TABLE_NAME,
+      'INTO TABLE {' . self::TABLE_NAME . '}',
       'FIELDS TERMINATED BY \',\'',
       'OPTIONALLY ENCLOSED BY \'"\'',
       'ESCAPED BY \'\'',

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -78,7 +78,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    */
   public function getTableName() {
     if ($this->resource) {
-      return "datastore_{$this->resource->getId()}";
+      return 'datastore_' . $this->resource->getId();
     }
     return "datastore_does_not_exist";
   }
@@ -131,7 +131,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    */
   protected function setSchemaFromTable() {
     $tableName = $this->getTableName();
-    $fieldsInfo = $this->connection->query("DESCRIBE `{$tableName}`")->fetchAll();
+    $fieldsInfo = $this->connection->query('DESCRIBE `{' . $tableName . '}`')->fetchAll();
 
     $schema = $this->buildTableSchema($tableName, $fieldsInfo);
     $this->setSchema($schema);

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -131,7 +131,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    */
   protected function setSchemaFromTable() {
     $tableName = $this->getTableName();
-    $fieldsInfo = $this->connection->query('DESCRIBE `{' . $tableName . '}`')->fetchAll();
+    $fieldsInfo = $this->connection->query('DESCRIBE {' . $tableName . '}')->fetchAll();
 
     $schema = $this->buildTableSchema($tableName, $fieldsInfo);
     $this->setSchema($schema);
@@ -199,7 +199,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
       return;
     }
 
-    $indexInfo = $this->connection->query("SHOW INDEXES FROM  `{$this->getTableName()}`")->fetchAll();
+    $indexInfo = $this->connection->query('SHOW INDEXES FROM  {' . $this->getTableName() . '}')->fetchAll();
     foreach ($indexInfo as $info) {
       // Primary key is handled elsewhere.
       if ($info->Key_name == 'PRIMARY') {

--- a/modules/datastore/src/Storage/DatabaseTableFactory.php
+++ b/modules/datastore/src/Storage/DatabaseTableFactory.php
@@ -15,7 +15,7 @@ class DatabaseTableFactory implements FactoryInterface {
    *
    * @var \Drupal\Core\Database\Connection
    */
-  private $connection;
+  protected $connection;
 
   /**
    * Constructor.

--- a/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/ImportQueueWorkerTest.php
+++ b/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/ImportQueueWorkerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\Tests\datastore\Kernel\Plugin\QueueWorker;
+
+use Drupal\datastore\DatastoreService;
+use Drupal\datastore\Plugin\QueueWorker\ImportQueueWorker;
+use Drupal\KernelTests\KernelTestBase;
+use Procrastinator\Result;
+
+/**
+ * @covers \Drupal\datastore\Plugin\QueueWorker\ImportQueueWorker
+ * @coversDefaultClass \Drupal\datastore\Plugin\QueueWorker\ImportQueueWorker
+ *
+ * @group datastore
+ * @group kernel
+ */
+class ImportQueueWorkerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'common',
+    'datastore',
+    'metastore',
+  ];
+
+  public function testErrorPath() {
+    // The result we'll mock to come from the datastore service.
+    $result = new Result();
+    $result->setStatus(Result::ERROR);
+    $result->setError('Oops');
+
+    // Mock the datastore service. All the services are real, we only want to
+    // mock import().
+    $datastore_service = $this->getMockBuilder(DatastoreService::class)
+      ->setConstructorArgs([
+        $this->container->get('dkan.datastore.service.resource_localizer'),
+        $this->container->get('dkan.datastore.service.factory.import'),
+        $this->container->get('queue'),
+        $this->container->get('dkan.common.job_store'),
+        $this->container->get('dkan.datastore.import_info_list'),
+        $this->container->get('dkan.datastore.service.resource_processor.dictionary_enforcer'),
+      ])
+      ->onlyMethods(['import'])
+      ->getMock();
+    $datastore_service->method('import')
+      ->willReturn([$result]);
+
+    // Add our mock to the container.
+    $this->container->set('dkan.datastore.service', $datastore_service);
+
+    // Make a partial mock of ImportQueueWorker so that we can tell the test
+    // to expect never to call notice() and only to call error() once.
+    $queue_worker = $this->createPartialMock(
+      ImportQueueWorker::class,
+      ['error', 'notice']
+    );
+    $queue_worker->expects($this->once())
+      ->method('error');
+    $queue_worker->expects($this->never())
+      ->method('notice');
+    // Set the state of the mock via constructor.
+    $queue_worker->__construct(
+      [],
+      'id',
+      ['cron' => ['lease_time' => 10]],
+      $this->container->get('config.factory'),
+      $this->container->get('dkan.datastore.service'),
+      $this->container->get('logger.factory'),
+      $this->container->get('dkan.metastore.reference_lookup'),
+      $this->container->get('dkan.common.database_connection_factory'),
+      $this->container->get('dkan.datastore.database_connection_factory')
+    );
+
+    // Some random data to process.
+    $data = ['data' => ['identifier' => '12345', 'version' => '23456']];
+    $queue_worker->processItem((object) $data);
+  }
+
+}

--- a/modules/datastore/tests/src/Unit/Plugin/QueueWorker/ImportQueueWorkerTest.php
+++ b/modules/datastore/tests/src/Unit/Plugin/QueueWorker/ImportQueueWorkerTest.php
@@ -21,9 +21,9 @@ use PHPUnit\Framework\TestCase;
 use Procrastinator\Result;
 
 /**
- * Test.
+ * @coversDefaultClass \Drupal\datastore\Plugin\QueueWorker\ImportQueueWorker
  */
-class ImportTest extends TestCase {
+class ImportQueueWorkerTest extends TestCase {
 
   private $data = [
     'data' => [


### PR DESCRIPTION
This PR:
- Any items in the queue which perform CSV whole-file importing thru MySQL will error out if they try to create a table with a name that already exists.
- Error will be logged.
- Errored queue item has default behavior, which is to be re-queued. They should error out again, but it's mitigated by the fact that they won't try to perform the MySQL import again.
- More sophisticated error-handling strategies will occur in further work.

Changes:
- Modifies references to DB table names to include `{braces}` so that we can test using `KernelTestBase`.
- Modifies some table name generators so they aren't too long when used in the test framework.
- Adds `Drupal\datastore_mysql_import\Storage\MySqlDatabaseTable::setTable()` which does not check for a pre-existing table. This causes Drupal's `schema()->createTable()` to throw `Drupal\Core\Database\SchemaObjectExistsException`, which in turn is processed into a `Result::ERROR`. (TODO: Make this the default behavior in `AbstractDatabaseTable::setTable()`. Out of scope here.)
- Changes `datastore_mysql_import` module's service definition to support the new database table type.
- Adds tests to prove that the changes do the thing they say they'll do. See especially `Drupal\Tests\datastore_mysql_import\Kernel\Service\MysqlImportTest`.