### PR TITLE
Miscellaneous error fixing in json_form_widget and metastore.theme.inc

### DIFF
--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -69,7 +69,7 @@ class UploadOrLink extends ManagedFile {
     $element = static::unsetFilesWhenRemoving($form_state->getTriggeringElement(), $element);
 
     $file_url_remote = isset($element['#value']['file_url_remote']) ? $element['#value']['file_url_remote'] : $element['#uri'];
-    $file_url_remote_is_valid = UrlHelper::isValid($file_url_remote, TRUE);
+    $file_url_remote_is_valid = isset($file_url_remote) && UrlHelper::isValid($file_url_remote, TRUE);
     $is_remote = $file_url_remote_is_valid && $file_url_type == static::TYPE_REMOTE;
     if ($is_remote) {
       $element = static::loadRemoteFile($element, $file_url_remote);

--- a/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidget.php
+++ b/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidget.php
@@ -114,7 +114,9 @@ class JsonFormWidget extends WidgetBase {
     $default_data = [];
     // Get default data.
     foreach ($items as $item) {
-      $default_data = json_decode($item->value);
+      if ($item->value) {
+        $default_data = json_decode($item->value);
+      }
     }
     $type = $this->getSchemaId($form_state);
     // Copy the item type to the entity.

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -48,7 +48,7 @@ class ValueHandler {
     if (isset($formValues[$property]['select'])) {
       return isset($formValues[$property][0]) ? $formValues[$property][0] : NULL;
     }
-    return !empty($formValues[$property]) ? $this->cleanSelectId($formValues[$property]) : FALSE;
+    return !empty($formValues[$property]) && is_string($formValues[$property]) ? $this->cleanSelectId($formValues[$property]) : FALSE;
   }
 
   /**

--- a/modules/metastore/metastore.theme.inc
+++ b/modules/metastore/metastore.theme.inc
@@ -97,13 +97,11 @@ function metastore_preprocess_node__data(&$variables) {
           ];
         }
       }
+      // Fallback to display file path for link title.
+      if ($rows['downloadURL'] && !property_exists($d, 'title')) {
+        $rows['title'] = $rows['downloadURL'];
+      }
       $variables['dataset']['distributions'][] = $rows;
-      $variables['dataset']['distributions_tables'][] = [
-        '#type' => 'table',
-        '#caption' => $d->title,
-        '#header' => [t("Key"), t("Value")],
-        '#rows' => $rows,
-      ];
     }
   }
 }


### PR DESCRIPTION
Fixes the following errors:

- Unable to use add buttons for distribution/related documents when adding a dataset node through the UI
- PHP error when viewing dataset node page (not in React) when distribution does not have a title: Warning: Undefined property: stdClass::$title in metastore_preprocess_node__data() (line 103 of /var/www/html/docroot/modules/contrib/dkan/modules/metastore/metastore.theme.inc)
- PHP errors when creating a new dataset through the UI: Deprecated function: json_decode(): Passing null to parameter 1 ($json) of type string is deprecated in Drupal\json_form_widget\Plugin\Field\FieldWidget\JsonFormWidget->formElement() (line 117 of /var/www/html/docroot/modules/contrib/dkan/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidget.php) and Deprecated function: preg_match(): Passing null to parameter 2 ($subject) of type string is deprecated in Drupal\Component\Utility\UrlHelper::isValid() (line 396 of /var/www/html/docroot/core/lib/Drupal/Component/Utility/UrlHelper.php)

## QA Steps

In a vanilla installation of DKAN:

1. Enable the Database Logging module if not already enabled.
3. Visit /node/add/data and create a dataset through the UI that has a distribution with an empty title field. 
4. Click the 'add one' button to add another distribution. It succeeds.
5. Save the dataset node.
6. Visit the node path (e.g. node/[id]) for the newly created dataset node. 
7. Check the recent log messages (/admin/reports/dblog) and confirm there are no PHP errors.
