### PR TITLE
Fix ltrim() deprecation message when null value

### DIFF
--- a/modules/json_form_widget/src/StringHelper.php
+++ b/modules/json_form_widget/src/StringHelper.php
@@ -82,7 +82,7 @@ class StringHelper implements ContainerInjectionInterface {
     // Add extra validate if element type is email.
     if ($element['#type'] === 'email') {
       $element['#element_validate'][] = [$this, 'validateEmail'];
-      $element['#default_value'] = ltrim($element['#default_value'], 'mailto:');
+      $element['#default_value'] = ltrim($element['#default_value'] ?? '', 'mailto:');
     }
 
     return $element;

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -19,7 +19,7 @@ class ValueHandler {
       case 'string':
         $data = $this->handleStringValues($formValues, $property);
         if ($property === 'hasEmail') {
-          $data = 'mailto:' . ltrim($data, 'mailto:');
+          $data = 'mailto:' . ltrim($data ?? '', 'mailto:');
         }
         break;
 


### PR DESCRIPTION
The new ltrim() calls from #3966 throw a deprecation warning in tests in php 8.1, because in some cases they receive a null argument:
![image](https://github.com/GetDKAN/dkan/assets/309671/83ae474d-7d8d-4cff-b690-ee2a0ce71a70)

See test output [here](https://app.circleci.com/pipelines/github/GetDKAN/dkan/4221/workflows/60f0b54d-ae0c-4422-9717-e618dcbc73c9/jobs/26353).