### PR TITLE
Use stable version of select_or_other (4.1.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "drupal/moderated_content_bulk_publish": "~2.0.20",
         "drupal/search_api": "^1.15",
-        "drupal/select_or_other": "dev-4.x#ae0585ff8c",
+        "drupal/select_or_other": "^4.1.0",
         "drupal/select2": "^1.13",
         "drupal/views_bulk_operations": "^4.0",
         "ext-json": "*",


### PR DESCRIPTION
Select_or_other has released 4.1.0 which is compatible with Drupal 10.

We should use that as our constraint instead of a commit SHA.