### PR TITLE
Allow orphan cleanup of draft distributions.

### DIFF
--- a/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
+++ b/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
@@ -75,7 +75,7 @@ class MetastoreSubscriber implements EventSubscriberInterface {
   public function cleanResourceMapperTable(Event $event) {
     $distribution_id = $event->getData();
     // Use the metastore service to build a distribution object.
-    $distribution = $this->service->get('distribution', $distribution_id);
+    $distribution = $this->service->get('distribution', $distribution_id, FALSE);
     // Attempt to extract all resources for the given distribution.
     $resources = $distribution->{'$.data["%Ref:downloadURL"]..data'} ?? [];
 

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -233,12 +233,14 @@ class MetastoreService implements ContainerInjectionInterface {
    *   The {schema_id} slug from the HTTP request.
    * @param string $identifier
    *   Identifier.
+   * @param bool $published
+   *   If true, retrieve only published revision.
    *
    * @return \RootedData\RootedJsonData
    *   The json data.
    */
-  public function get(string $schema_id, string $identifier): RootedJsonData {
-    $json_string = $this->getStorage($schema_id)->retrieve($identifier, TRUE);
+  public function get(string $schema_id, string $identifier, bool $published = TRUE): RootedJsonData {
+    $json_string = $this->getStorage($schema_id)->retrieve($identifier, $published);
     $data = $this->validMetadataFactory->get($json_string, $schema_id);
 
     $data = $this->dispatchEvent(self::EVENT_DATA_GET, $data);


### PR DESCRIPTION
In sites where datasets and their referenced distributions are all created as draft nodes (like PDC), we've seen a build up of orphan_reference_processor queue items. 

This is because prior to this PR, the MetastoreService would only ever retrieve published node revisions - even when getting an orphaned distribution for cleanup. 

Since many of the distribution nodes were never published (due to initially being created as a draft) this results in "Error retrieving metadata: distribution {$uuid} not found." being thrown for all distributions being cleaned up that were never published.

This PR adds an optional boolean parameter to MetastoreService::get() to allow it to retrieve unpublished distributions when it is called by cleanResourceMapperTable().

### To recreate in a vanilla DKAN site:

1. Change the default moderation state to "draft" on /admin/config/workflow/workflows/manage/dkan_publishing
2. Create a new draft dataset. 
3. ddev drush cron to import the datastore
4. Confirm that a new datastore table was created and there is a draft dataset with a corresponding draft distribution.
5. Delete the dataset
6. ddev drush cron to run the orphan_reference_processor
7. Will get the following error "[error]  Drupal\metastore\Exception\MissingObjectException: Error retrieving metadata: distribution [distribution uuid] not found. in Drupal\metastore\Storage\Data->retrieve() (line 190 of /var/www/html/docroot/modules/contrib/dkan/modules/metastore/src/Storage/Data.php)."

To confirm this patch fixes the error, apply the patch, follow the steps above, and do not receive an error. The resource file directory and datastore table are also deleted successfully.


