### PR TITLE
Validation added to data-dictionary settings page

### DIFF
--- a/modules/metastore/src/Form/DataDictionarySettingsForm.php
+++ b/modules/metastore/src/Form/DataDictionarySettingsForm.php
@@ -121,14 +121,16 @@ class DataDictionarySettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
-    try {
-      // Search for existing data-dictionary id.
-      if (!$this->metastore->get('data-dictionary', $form_state->getValue('sitewide_dictionary_id'))) {
-        throw new \Exception('Data not found.');
+    if ($form_state->getValue('dictionary_mode') === 'sitewide') {
+      try {
+        // Search for existing data-dictionary id.
+        if (!$this->metastore->get('data-dictionary', $form_state->getValue('sitewide_dictionary_id'))) {
+          throw new \Exception('Data not found.');
+        }
       }
-    }
-    catch (\Exception $e) {
-      $form_state->setErrorByName('sitewide_dictionary_id', $e->getMessage());
+      catch (\Exception $e) {
+        $form_state->setErrorByName('sitewide_dictionary_id', $e->getMessage());
+      }
     }
 
     parent::validateForm($form, $form_state);

--- a/modules/metastore/src/Form/DataDictionarySettingsForm.php
+++ b/modules/metastore/src/Form/DataDictionarySettingsForm.php
@@ -3,13 +3,63 @@
 namespace Drupal\metastore\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\metastore\MetastoreService;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscoveryInterface;
 
 /**
  * Data-Dictionary settings form.
  */
 class DataDictionarySettingsForm extends ConfigFormBase {
+
+  /**
+   * The metastore service.
+   *
+   * @var \Drupal\metastore\MetastoreService
+   */
+  protected $metastore;
+
+  /**
+   * The messenger interface.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * Constructs a \Drupal\Core\Form\ConfigFormBase object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger.
+   * @param \Drupal\metastore\MetastoreService $metastore
+   *   The metastore service.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, MessengerInterface $messenger, MetastoreService $metastore) {
+    $this->setConfigFactory($config_factory);
+    $this->messenger = $messenger;
+    $this->metastore = $metastore;
+  }
+
+  /**
+   * Instantiates a new instance of this class.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   Interface implemented by service container classes.
+   *
+   * @return static
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('messenger'),
+      $container->get('dkan.metastore.service')
+    );
+  }
 
   /**
    * Config ID.
@@ -65,6 +115,23 @@ class DataDictionarySettingsForm extends ConfigFormBase {
     ];
 
     return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    try {
+      // Search for existing data-dictionary id.
+      if (!$this->metastore->get('data-dictionary', $form_state->getValue('sitewide_dictionary_id'))) {
+        throw new \Exception('Data not found.');
+      }
+    }
+    catch (\Exception $e) {
+      $form_state->setErrorByName('sitewide_dictionary_id', $e->getMessage());
+    }
+
+    parent::validateForm($form, $form_state);
   }
 
   /**

--- a/modules/metastore/tests/src/Kernel/DataDictionarySettingsFormTest.php
+++ b/modules/metastore/tests/src/Kernel/DataDictionarySettingsFormTest.php
@@ -21,7 +21,7 @@ class DataDictionarySettingsFormTest extends ConfigFormTestBase {
    *
    * @var string[]
    */
-  public static $modules = ['system', 'node', 'user', 'field', 'field_ui', 'filter', 'text', 'metastore', 'common', 'datastore', 'dkan', 'menu_ui', 'menu_link_content', 'basic_auth', 'content_moderation', 'workflows'];
+  public static $modules = ['system', 'node', 'user', 'field', 'field_ui', 'filter', 'text', 'metastore', 'common', 'datastore', 'dkan', 'menu_link_content', 'basic_auth', 'content_moderation', 'workflows'];
 
   /**
    * Metastore service.
@@ -153,7 +153,6 @@ class DataDictionarySettingsFormTest extends ConfigFormTestBase {
     $this->installConfig('node');
     $this->installConfig('metastore');
     $this->installConfig('common');
-    $this->installConfig('menu_ui');
     $this->installConfig('basic_auth');
     $this->installConfig('content_moderation');
     $this->installConfig('workflows');

--- a/modules/metastore/tests/src/Kernel/DataDictionarySettingsFormTest.php
+++ b/modules/metastore/tests/src/Kernel/DataDictionarySettingsFormTest.php
@@ -5,6 +5,9 @@ namespace Drupal\Tests\metastore\Kernel;
 use Drupal\Tests\common\Kernel\ConfigFormTestBase;
 use Drupal\metastore\Form\DataDictionarySettingsForm;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscoveryInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\Tests\metastore\Unit\MetastoreServiceTest;
+use Drupal\Component\Render\FormattableMarkup;
 
 /**
  * Data Dictionary Settings Form class test.
@@ -18,7 +21,28 @@ class DataDictionarySettingsFormTest extends ConfigFormTestBase {
    *
    * @var string[]
    */
-  public static $modules = ['metastore', 'common'];
+  public static $modules = ['system', 'node', 'user', 'field', 'field_ui', 'filter', 'text', 'metastore', 'common', 'datastore', 'dkan', 'menu_ui', 'menu_link_content', 'basic_auth', 'content_moderation', 'workflows'];
+
+  /**
+   * Metastore service.
+   *
+   * @var \Drupal\metastore\MetastoreService
+   */
+  protected $metastore;
+
+  /**
+   * The ValidMetadataFactory class used for testing.
+   *
+   * @var \Drupal\metastore\ValidMetadataFactory|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected $validMetadataFactory;
+
+  /**
+   * Node data storage.
+   *
+   * @var \Drupal\metastore\Storage\NodeData
+   */
+  protected $datasetStorage;
 
   /**
    * {@inheritdoc}
@@ -33,7 +57,21 @@ class DataDictionarySettingsFormTest extends ConfigFormTestBase {
             '#config_key' => 'data_dictionary_mode',
           ],
           'sitewide_dictionary_id' => [
-            '#value' => $this->randomString(),
+            '#value' => 'data-dictionary-true',
+            '#config_name' => DataDictionarySettingsForm::SETTINGS,
+            '#config_key' => 'data_dictionary_sitewide',
+          ],
+        ],
+      ],
+      [
+        [
+          'dictionary_mode' => [
+            '#value' => DataDictionaryDiscoveryInterface::MODE_SITEWIDE,
+            '#config_name' => DataDictionarySettingsForm::SETTINGS,
+            '#config_key' => 'data_dictionary_mode',
+          ],
+          'sitewide_dictionary_id' => [
+            '#value' => 'data-dictionary-false',
             '#config_name' => DataDictionarySettingsForm::SETTINGS,
             '#config_key' => 'data_dictionary_sitewide',
           ],
@@ -46,6 +84,11 @@ class DataDictionarySettingsFormTest extends ConfigFormTestBase {
             '#config_name' => DataDictionarySettingsForm::SETTINGS,
             '#config_key' => 'data_dictionary_mode',
           ],
+          'sitewide_dictionary_id' => [
+            '#value' => '',
+            '#config_name' => DataDictionarySettingsForm::SETTINGS,
+            '#config_key' => 'data_dictionary_sitewide',
+          ],
         ],
       ],
     ];
@@ -54,10 +97,133 @@ class DataDictionarySettingsFormTest extends ConfigFormTestBase {
   /**
    * {@inheritdoc}
    */
+  private function getDataDictionary(array $fields, array $indexes, string $identifier, string $title = 'Test DataDict') {
+    return json_encode([
+      'identifier' => $identifier,
+      'title' => $title,
+      'data' => [
+        'fields' => $fields,
+        'indexes' => $indexes,
+      ],
+    ], JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES);
+  }
+
+  /**
+   * Test submitting config form.
+   *
+   * @param array $form_values
+   *   Form values to test.
+   *
+   * @dataProvider provideFormData
+   */
+  public function testConfigForm(array $form_values) {
+    // Programmatically submit the given values.
+    foreach ($form_values as $form_key => $data) {
+      $values[$form_key] = $data['#value'];
+    }
+    $form_state = (new FormState())->setValues($values);
+    \Drupal::formBuilder()->submitForm($this->form, $form_state);
+
+    // Check that the form returns an error when expected, and vice versa.
+    $errors = $form_state->getErrors();
+    $valid_form = empty($errors);
+    $args = [
+      '%values' => print_r($values, TRUE),
+      '%errors' => $valid_form ? t('None') : implode(' ', $errors),
+    ];
+
+    // Confirm data-dictionary settings form validates.
+    if ($valid_form) {
+      $this->assertTrue($valid_form, new FormattableMarkup('Input values: %values<br/>Validation handler errors: %errors', $args));
+    }
+
+    // Confirm data-dictionary settings form does not validate.
+    if ($errors) {
+      $this->assertTrue(!empty($errors), new FormattableMarkup('Input values: %values<br/>Validation handler errors: %errors', $args));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   protected function setUp(): void {
     parent::setUp();
+    $this->installConfig('system');
+    $this->installConfig('datastore');
+    $this->installConfig('node');
+    $this->installConfig('metastore');
+    $this->installConfig('common');
+    $this->installConfig('menu_ui');
+    $this->installConfig('basic_auth');
+    $this->installConfig('content_moderation');
+    $this->installConfig('workflows');
+    $this->installSchema('system', ['sequences']);
+    $this->installSchema('node', ['node_access']);
+    $this->installSchema('user', ['users_data']);
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('workflow');
+    $this->installEntitySchema('content_moderation_state');
+    $this->installConfig('field');
+    $this->installConfig('field_ui');
+    $this->installEntitySchema('user');
+    $this->installConfig('field');
 
-    $this->form = new DataDictionarySettingsForm($this->container->get('config.factory'));
+    $this->metastore = \Drupal::service('dkan.metastore.service');
+    $this->validMetadataFactory = MetastoreServiceTest::getValidMetadataFactory($this);
+
+    $dict_id = 'data-dictionary-pass';
+    $fields = [
+      [
+        'name' => 'a',
+        'type' => 'integer',
+        'format' => 'default',
+      ],
+      [
+        'name' => 'b',
+        'title' => 'B',
+        'type' => 'date',
+        'format' => '%m/%d/%Y',
+      ],
+      [
+        'name' => 'c',
+        'title' => 'C',
+        'type' => 'number',
+      ],
+      [
+        'name' => 'd',
+        'title' => 'D',
+        'type' => 'string',
+      ],
+      [
+        'name' => 'e',
+        'title' => 'E',
+        'type' => 'boolean',
+      ],
+    ];
+    $indexes = [
+      [
+        'name' => 'index_a',
+        'fields' => [
+          ['name' => 'a'],
+          ['name' => 'd', 'length' => 6],
+        ],
+        'type' => 'index',
+      ],
+      [
+        'name' => 'fulltext_index_a',
+        'fields' => [
+          ['name' => 'd', 'length' => 3],
+        ],
+        'type' => 'fulltext',
+      ],
+    ];
+    $data_dict = $this->validMetadataFactory->get($this->getDataDictionary($fields, $indexes, $dict_id), 'data-dictionary');
+
+    // Create data-dictionary.
+    $this->metastore->post('data-dictionary', $data_dict);
+    $this->metastore->publish('data-dictionary', $dict_id);
+
+    $this->form = new DataDictionarySettingsForm($this->container->get('config.factory'), $this->container->get('messenger'), $this->container->get('dkan.metastore.service'));
   }
 
 }


### PR DESCRIPTION
Validation added to data-dictionary settings page to check for existing data dictionary.

fixes [org/repo/issue#]

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

Add manual QA steps in checklist format for a reviewer to perform to confirm that the feature or fix is working. Include as much details as possible so that the reviewer doesn't lose time figuring out how to perform steps.

- [ ] log in as an admin
- [ ] create a data dictionary at /node/add/data?schema=data-dictionary
- [ ] remember the identification you used on the data dictionary page
- [ ] navigate to the DKAN > Data-dictionary settings page
- [ ] enter an invalid ID and click save
- [ ] confirm you get an error message
- [ ] enter a valid ID from step 2 and click save
- [ ] confirm you get a success message
