### PR TITLE
Allow empty distribution and email in UI form if schema allows

### DIFF
--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -18,8 +18,8 @@ class ValueHandler {
     switch ($schema->type) {
       case 'string':
         $data = $this->handleStringValues($formValues, $property);
-        if ($property === 'hasEmail' && !(empty($data))) {
-          $data = 'mailto:' . ltrim($data ?? '', 'mailto:');
+        if ($property === 'hasEmail' && is_string($data)) {
+          $data = 'mailto:' . ltrim($data, 'mailto:');
         }
         break;
 

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -180,10 +180,12 @@ class ValueHandler {
    */
   private function getObjectInArrayData($formValues, $property, $schema) {
     $data = [];
-    foreach ($formValues[$property][$property] as $key => $item) {
-      $value = $this->handleObjectValues($formValues[$property][$property][$key][$property], $property, $schema);
-      if ($value) {
-        $data[$key] = $value;
+    if (isset($formValues[$property][$property])) {
+      foreach ($formValues[$property][$property] as $key => $item) {
+        $value = $this->handleObjectValues($formValues[$property][$property][$key][$property], $property, $schema);
+        if ($value) {
+          $data[$key] = $value;
+        }
       }
     }
     return $data;

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -18,7 +18,7 @@ class ValueHandler {
     switch ($schema->type) {
       case 'string':
         $data = $this->handleStringValues($formValues, $property);
-        if ($property === 'hasEmail') {
+        if ($property === 'hasEmail' && !(empty($data))) {
           $data = 'mailto:' . ltrim($data ?? '', 'mailto:');
         }
         break;


### PR DESCRIPTION
I ran into errors when creating a dataset through the UI if I did not add at least one distribution. PDC also has the situation where we require either an email or a url for contacts, and when email wasn't used, the value for that field was being set to simply "mailto"

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] In a vanilla DKAN site, customize schema so that hasEmail is not required for contactPoint and minItems not defined for distribution (copy the schema directory from dkan into docroot and edit dataset.json to remove "minItems": 1 from "distribution" and "hasEmail" from the required "contactPoint" properties.) 
- [ ] Create a dataset through the UI with no distributions and no contact email address.
- [ ] Successfully save.
