### PR TITLE
Prevent executing html from basic textarea on dataset node

### DIFF
--- a/modules/metastore/templates/node--data.html.twig
+++ b/modules/metastore/templates/node--data.html.twig
@@ -102,11 +102,11 @@
     <div{{ content_attributes }}>
         {% if not page %}
         <p>Last updated: {{ dataset.modified|date("m/d/Y") }}</p>
-        {{ dataset.description | raw }}
+        {{ dataset.description | drupal_escape }}
         {% endif %}
         {% if page %}
         <p>Last updated: {{ dataset.modified|date("m/d/Y") }}</p>
-        {{ dataset.description | raw }}
+        {{ dataset.description | drupal_escape }}
         {% if dataset.themes|length > 1 %}
             <h2>Themes</h2>
         {% elseif dataset.themes|length == 1 %}


### PR DESCRIPTION
This fixes an issue where HTML or JavaScript added to the Metadata form could be executed from the twig templates. Currently the template only shows the dataset description, but this would need to be added if distribution descriptions are ever shown. The spatial textarea seems to already escape so it isn't an issue. 

## QA Steps

- [ ] Create a new dataset
- [ ] In the description for the dataset add one of the following: `"><br><h1><a onauxclick=prompt(document.domain)>Right click me</h1>` or `"><img src=a onerror=prompt(document.domain)>`
- [ ] Save the dataset and view it. 
- [ ] You should see the string as entered, instead of the current result which would be a styled anchor with prompt on right click or an automatic prompt.
- [ ] The first line also fixes this if you visit the homepage on a base site and check for the dataset in the view list.
