### PR TITLE
Update docs to reflect that api authorization must be base64 encoded

### DIFF
--- a/docs/source/user-guide/guide_api.rst
+++ b/docs/source/user-guide/guide_api.rst
@@ -24,7 +24,7 @@ Learn more about :term:`Moderation State` here.
 
        POST https://[site-domain]/api/1/metastore/schemas/dataset/items/[identifier]/revisions HTTP/1.1
 
-       Authorization: Basic user:password
+       Authorization: Basic [base64 encoded 'user:password' string]
 
        {
            "state": "hidden",

--- a/docs/source/user-guide/guide_dataset.rst
+++ b/docs/source/user-guide/guide_dataset.rst
@@ -9,6 +9,19 @@ API
 ---
 You will need to authenticate with a user account possessing the 'api user' role. Use *Basic Auth*.
 
+Note that the username:password string submitted as the Authorization must be base 64 encoded.
+
+You can obtain the base 64 encoded string from the command line by running the following (replace admin:admin with username:password):
+
+.. code-block::
+    echo -n 'admin:admin' | base64
+    // Result
+    YWRtaW46YWRtaW4=
+
+    // When using basic auth via REST API
+    content-type: application/json
+    Authorization: Basic YWRtaW46YWRtaW4=
+
 Run a POST command to ``/api/1/metastore/schemas/dataset/items`` with a json formatted request body, the minimal elements are:
 
 


### PR DESCRIPTION
The user:password string for basic authentication must be base 64 encoded. This updates the documentation.
