### PR TITLE
Add a test for the cleanup of orphan draft distributions with the orphan reference processor

### DIFF
--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -334,13 +334,11 @@ class DatasetBTBTest extends BrowserTestBase {
    *   Dataset title.
    * @param array $downloadUrls
    *   Array of resource files URLs for this dataset.
-   * @param string $modified
-   *   Optional modified date
    *
    * @return \RootedData\RootedJsonData
    *   Json encoded string of this dataset's metadata, or FALSE if error.
    */
-  private function getData(string $identifier, string $title, array $downloadUrls, string $modified = '06-04-2020'): RootedJsonData {
+  private function getData(string $identifier, string $title, array $downloadUrls): RootedJsonData {
     /** @var \Drupal\metastore\ValidMetadataFactory $valid_metadata_factory */
     $valid_metadata_factory = $this->container->get('dkan.metastore.valid_metadata');
 
@@ -349,7 +347,7 @@ class DatasetBTBTest extends BrowserTestBase {
     $data->description = 'Some description.';
     $data->identifier = $identifier;
     $data->accessLevel = 'public';
-    $data->modified = $modified;
+    $data->modified = '06-04-2020';
     $data->keyword = ['some keyword'];
     $data->distribution = [];
     $data->publisher = (object) [

--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -133,12 +133,9 @@ class DatasetBTBTest extends BrowserTestBase {
    */
   public function testOrphanDraftDistributionCleanup() {
     // Get the original configuration settings.
-    $config = \Drupal::service('config.factory');
+    $config = $this->container->get('config.factory');
     $datastoreSettings = $config->getEditable('datastore.settings');
-    $deleteLocalResourceOriginal = $datastoreSettings->get('delete_local_resource');
-    $triggeringOriginal = $datastoreSettings->get('triggering_properties');
     $defaultModerationState = $config->getEditable('workflows.workflow.dkan_publishing');
-    $defaultModerationStateOriginal = $defaultModerationState->get('type_settings.default_moderation_state');
 
     // Set delete local resource files = false.
     $datastoreSettings->set('delete_local_resource', 0);
@@ -182,12 +179,6 @@ class DatasetBTBTest extends BrowserTestBase {
 
     // Confirm original distribution local directory removed.
     $this->assertDirectoryDoesNotExist('public://resources/' . $resourceDirectory);
-
-    // Restore the original config values.
-    $datastoreSettings->set('delete_local_resource', $deleteLocalResourceOriginal);
-    $datastoreSettings->set('triggering_properties', $triggeringOriginal);
-    $datastoreSettings->save();
-    $defaultModerationState->set('type_settings.default_moderation_state', $defaultModerationStateOriginal)->save();
   }
 
   /**
@@ -224,9 +215,8 @@ class DatasetBTBTest extends BrowserTestBase {
     $id_1 = uniqid(__FUNCTION__ . '1');
     $id_2 = uniqid(__FUNCTION__ . '2');
 
-    // Get the original config value.
-    $datastoreSettings = \Drupal::service('config.factory')->getEditable('datastore.settings');
-    $deleteLocalResourceOriginal = $datastoreSettings->get('delete_local_resource');
+    // Get the datastore configuration.
+    $datastoreSettings = $this->container->get('config.factory')->getEditable('datastore.settings');
 
     // delete_local_resource is on.
     $datastoreSettings->set('delete_local_resource', 1)->save();
@@ -258,9 +248,6 @@ class DatasetBTBTest extends BrowserTestBase {
 
     // Assert the local resource folder exists.
     $this->assertDirectoryExists('public://resources/' . $refUuid);
-
-    // Restore the original config value.
-    $datastoreSettings->set('delete_local_resource', $deleteLocalResourceOriginal)->save();
   }
 
   private function datasetPostAndRetrieve(): object {
@@ -300,7 +287,7 @@ class DatasetBTBTest extends BrowserTestBase {
   }
 
   private function changeDatasetsResourceOutputPerspective(string $perspective = DataResource::DEFAULT_SOURCE_PERSPECTIVE) {
-    $configFactory = \Drupal::service('config.factory');
+    $configFactory = $this->container->get('config.factory');
     $config = $configFactory->getEditable('metastore.settings');
     $config->set('resource_perspective_display', $perspective);
     $config->save();

--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -140,34 +140,53 @@ class DatasetBTBTest extends BrowserTestBase {
     $defaultModerationState = $config->getEditable('workflows.workflow.dkan_publishing');
     $defaultModerationStateOriginal = $defaultModerationState->get('type_settings.default_moderation_state');
 
-    // Do not delete local resource files.
+    // Set delete local resource files = false.
     $datastoreSettings->set('delete_local_resource', 0)->save();
 
-    // Set draft as the default moderation state.
-    $defaultModerationState->set('workflows.workflow.dkan_publishing', 'draft')->save();
+    // Set default moderation state = draft.
+    $defaultModerationState->set('type_settings.default_moderation_state', 'draft')->save();
 
     // Post dataset 1 and run the 'datastore_import' queue.
     $id_1 = uniqid(__FUNCTION__ . '1');
     $this->storeDatasetRunQueues($id_1, '1', ['1.csv']);
 
-    // Get distribution local file + table
-    $dataset = $this->getMetastore()->get('dataset', $id_1);
-    $datasetMetadata = $dataset->{'$'};
-    $resourceId = explode('__', $datasetMetadata['%Ref:distribution'][0]['data']['%Ref:downloadURL'][0]['identifier']);
+    // Get dataset.
+    $datasetRootedJsonData = $this->getMetastore()->get('dataset', $id_1, FALSE);
+    $dataset = json_decode($datasetRootedJsonData);
+
+    // Get the associated distribution's table.
+    $distribution = $this->getResourceFromDataset($dataset);
+    $distributionTable = $this->getResourceDatastoreTable($distribution);
+
+    // Confirm distribution table exists.
+    $databaseSchema = $this->container->get('database')->schema();
+    $distributionTableExists = $databaseSchema->tableExists($distributionTable);
+    $this->assertTrue($distributionTableExists, $distributionTable . ' exists.');
+
+    // Get the associated distribution's resource directory
+    $resourceId = explode('__', $distribution->identifier);
     $refUuid = $resourceId[0] . '_' . $resourceId[1];
 
-    // Confirm local directory exists.
+    // Confirm distribution local directory exists.
     $this->assertDirectoryExists('public://resources/' . $refUuid);
 
-    // Update the modified date and run the 'datastore_import' queue again, same dataset.
-    $this->storeDatasetRunQueues($id_1, '1', ['1.csv'], 'put', '06-05-2020');
+    // Update the modified date for the dataset.
+    $updatedJson = $this->getData($id_1, '1', ['1.csv'], '06-05-2020');
+    $this->getMetastore()->put('dataset', $id_1, $updatedJson);
+
+    // Simulate datastore_import and cleanup queues post update.
+    $this->runQueues(['datastore_import', 'orphan_reference_processor']);
+
+    // Confirm original distribution table removed.
+    $distributionTableExists = $databaseSchema->tableExists($distributionTable);
+    $this->assertFalse($distributionTableExists, $distributionTable . ' removed.');
 
     // Confirm original distribution local directory removed.
     $this->assertDirectoryDoesNotExist('public://resources/' . $refUuid);
 
     // Restore the original config values.
     $datastoreSettings->set('delete_local_resource', $deleteLocalResourceOriginal)->save();
-    $defaultModerationState->set('workflows.workflow.dkan_publishing', $defaultModerationStateOriginal)->save();
+    $defaultModerationState->set('type_settings.default_moderation_state', $defaultModerationStateOriginal)->save();
   }
 
   /**
@@ -391,8 +410,8 @@ class DatasetBTBTest extends BrowserTestBase {
   /**
    * Store or update a dataset,run datastore_import and resource_purger queues.
    */
-  private function storeDatasetRunQueues(string $identifier, string $title, array $filenames, string $method = 'post', string $modified = '06-04-2020') {
-    $datasetRootedJsonData = $this->getData($identifier, $title, $filenames, $modified);
+  private function storeDatasetRunQueues(string $identifier, string $title, array $filenames, string $method = 'post') {
+    $datasetRootedJsonData = $this->getData($identifier, $title, $filenames);
     $this->httpVerbHandler($method, $datasetRootedJsonData, json_decode($datasetRootedJsonData));
 
     // Simulate a cron on queues relevant to this scenario.
@@ -462,14 +481,6 @@ class DatasetBTBTest extends BrowserTestBase {
     return $identifier;
   }
 
-  private function setDefaultModerationState($state = 'published') {
-    /** @var \Drupal\Core\Config\ConfigFactory $config */
-    $config = \Drupal::service('config.factory');
-    $defaultModerationState = $config->getEditable('workflows.workflow.dkan_publishing');
-    $defaultModerationState->set('type_settings.default_moderation_state', $state);
-    $defaultModerationState->save();
-  }
-
   private function getQueueService() : QueueFactory {
     return \Drupal::service('queue');
   }
@@ -480,13 +491,6 @@ class DatasetBTBTest extends BrowserTestBase {
 
   private function getNodeStorage(): NodeStorage {
     return \Drupal::service('entity_type.manager')->getStorage('node');
-  }
-
-  /**
-   * @return \Drupal\metastore_search\Search
-   */
-  private function getMetastoreSearch() : Search {
-    return \Drupal::service('dkan.metastore_search.service');
   }
 
   /**


### PR DESCRIPTION
This is a test associated with the change in https://github.com/GetDKAN/dkan/pull/3979

- [ ] Test coverage exists
- [ ] Documentation exists


