### PR TITLE
16181 Chunk Imports Are Marked Done Before They're Done

### DIFF
--- a/modules/datastore/modules/datastore_mysql_import/src/Storage/MySqlDatabaseTable.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Storage/MySqlDatabaseTable.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\datastore_mysql_import\Storage;
 
+use Drupal\common\Storage\ImportedItemInterface;
 use Drupal\Core\Database\Database;
 use Drupal\datastore\Storage\DatabaseTable;
 
@@ -14,7 +15,7 @@ use Drupal\datastore\Storage\DatabaseTable;
  *
  * @see https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_strict_mode
  */
-class MySqlDatabaseTable extends DatabaseTable {
+class MySqlDatabaseTable extends DatabaseTable implements ImportedItemInterface {
 
   /**
    * {@inheritDoc}
@@ -51,6 +52,22 @@ class MySqlDatabaseTable extends DatabaseTable {
       Database::setActiveConnection($active_db);
       $this->connection = $active_connection;
     }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * For datastore_mysql_import, at this point we only check if the table exists
+   * in the database and has more than 0 rows. This is because the importer is
+   * assumed to have used LOAD DATA LOCAL INFILE to import the data in one step.
+   *
+   * @see \Drupal\datastore_mysql_import\Service\MysqlImport::getSqlStatement
+   */
+  public function hasBeenImported(): bool {
+    if ($this->tableExist($this->getTableName())) {
+      return $this->count() > 0;
+    }
+    return FALSE;
   }
 
 }

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -4,7 +4,6 @@ namespace Drupal\datastore\Storage;
 
 use Drupal\common\LoggerTrait;
 use Drupal\common\Storage\AbstractDatabaseTable;
-use Drupal\common\Storage\ImportedItemInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\datastore\DatastoreResource;
 
@@ -13,7 +12,7 @@ use Drupal\datastore\DatastoreResource;
  *
  * @see \Drupal\common\Storage\DatabaseTableInterface
  */
-class DatabaseTable extends AbstractDatabaseTable implements ImportedItemInterface, \JsonSerializable {
+class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
 
   use LoggerTrait;
 
@@ -253,19 +252,6 @@ class DatabaseTable extends AbstractDatabaseTable implements ImportedItemInterfa
       'not null' => $notNull,
       $driver . '_type' => $db_type,
     ];
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * For datastore (and datastore_mysql_import by inheritance), at this point
-   * we only check if the table exists in the database and has more than 0 rows.
-   */
-  public function hasBeenImported(): bool {
-    if ($this->tableExist($this->getTableName())) {
-      return $this->count() > 0;
-    }
-    return FALSE;
   }
 
 }

--- a/modules/datastore/tests/src/Kernel/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Kernel/Storage/DatabaseTableTest.php
@@ -31,10 +31,13 @@ class DatabaseTableTest extends KernelTestBase {
   /**
    * Ensure that non-mysql-import tables do not implement hasBeenImported().
    *
+   * We don't want DatabaseTable to be able to report that the table has already
+   * been imported.
+   *
    * We exercise the whole import service factory pattern here to make sure we
    * get the DatabaseTable object we expect.
    */
-  public function testNoHasBeenImported() {
+  public function testIsNotImportedItemInterface() {
     // Do an import.
     $identifier = 'my_id';
     $file_path = dirname(__FILE__, 4) . '/data/columnspaces.csv';


### PR DESCRIPTION
Chunked imports (using the datastore module, without datastore_mysql_import) were discovered to be quitting after partial imports on multiple queue instances.

Investigation by @jastraat revealed this was due to the DB import short-circuit which was intended to allow graceful recovery from DB import timeouts in datastore_mysql_import imports.

Solution:

Limit the short-circuit behavior to datastore_mysql_imports imports by only implementing `ImportedItemInterface` on `MySqlDatabaseTable` and not `DatabaseTable`.