### PR TITLE
Adjust edit workflow to be compatible with a default moderation state of draft.

### DIFF
--- a/modules/datastore/src/EventSubscriber/DatastoreSubscriber.php
+++ b/modules/datastore/src/EventSubscriber/DatastoreSubscriber.php
@@ -187,6 +187,10 @@ class DatastoreSubscriber implements EventSubscriberInterface {
       $rev = &drupal_static('metastore_resource_mapper_new_revision');
       $rev = 1;
     }
+    else {
+      $rev = &drupal_static('metastore_resource_mapper_new_revision');
+      $rev = 0;
+    }
   }
 
   /**

--- a/modules/datastore/src/EventSubscriber/DatastoreSubscriber.php
+++ b/modules/datastore/src/EventSubscriber/DatastoreSubscriber.php
@@ -171,7 +171,7 @@ class DatastoreSubscriber implements EventSubscriberInterface {
   public function onPreReference(Event $event) {
     // Attempt to retrieve new and original revisions of metadata object.
     $data = $event->getData();
-    $original = $data->getOriginal();
+    $original = $data->getLatestRevision();
     // Retrieve a list of metadata properties which, when changed, should
     // trigger a new metadata resource revision.
     $datastore_settings = $this->configFactory->get('datastore.settings');
@@ -182,7 +182,7 @@ class DatastoreSubscriber implements EventSubscriberInterface {
     // If a change was found in one of the triggering elements, change the
     // "new revision" flag to true in order to trigger a datastore update.
     if (!empty($triggers) && $original instanceof MetastoreItemInterface &&
-        $this->lazyDiffObject($original->getMetadata(), $data->getMetadata(), $triggers)) {
+      $this->lazyDiffObject($original->getMetadata(), $data->getMetadata(), $triggers)) {
       // Assign value to static variable.
       $rev = &drupal_static('metastore_resource_mapper_new_revision');
       $rev = 1;

--- a/modules/datastore/src/EventSubscriber/DatastoreSubscriber.php
+++ b/modules/datastore/src/EventSubscriber/DatastoreSubscriber.php
@@ -181,14 +181,14 @@ class DatastoreSubscriber implements EventSubscriberInterface {
     // of the wrapped node.
     // If a change was found in one of the triggering elements, change the
     // "new revision" flag to true in order to trigger a datastore update.
+    $rev = &drupal_static('metastore_resource_mapper_new_revision');
     if (!empty($triggers) && $original instanceof MetastoreItemInterface &&
       $this->lazyDiffObject($original->getMetadata(), $data->getMetadata(), $triggers)) {
-      // Assign value to static variable.
-      $rev = &drupal_static('metastore_resource_mapper_new_revision');
+      // Update static to reflect that a new resource is needed.
       $rev = 1;
     }
     else {
-      $rev = &drupal_static('metastore_resource_mapper_new_revision');
+      // Set static back to default value of false.
       $rev = 0;
     }
   }

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -87,6 +87,7 @@ services:
     class: \Drupal\metastore\NodeWrapper\NodeDataFactory
     arguments:
       - '@entity.repository'
+      - '@entity_type.manager'
 
   dkan.metastore.dataset_api_docs:
     class: \Drupal\metastore\DatasetApiDocs

--- a/modules/metastore/modules/metastore_search/metastore_search.module
+++ b/modules/metastore/modules/metastore_search/metastore_search.module
@@ -10,23 +10,14 @@ use Drupal\metastore\NodeWrapper\Data;
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   The entity in question.
- * @param string $op
- *   The operation calling this function.
  *
  * @return bool
  *   Whether the entity is a dataset.
  */
-function _metastore_search_is_dataset(EntityInterface $entity, string $op = 'update'): bool {
+function _metastore_search_is_dataset(EntityInterface $entity): bool {
   try {
-    $data = new Data($entity, \Drupal::entityTypeManager());
-
-    $config = \Drupal::configFactory();
-    $processors = $config->get('search_api.index.dkan')->get('processor_settings');
-    if ($op == 'update' && isset($processors['dkan_dataset_filter_unpublished'])) {
-      // Only index published datasets.
-      return ($data->getDataType() === 'dataset' && $data->getModerationState() === 'published');
-    }
-    return $data->getDataType() === 'dataset';
+    // Attempt to check this entity's data type.
+    return (new Data($entity, \Drupal::entityTypeManager()))->getDataType() === 'dataset';
   }
   catch (DataNodeLifeCycleEntityValidationException $e) {
     // If the data object fails validation, the given entity is not a dataset.
@@ -40,8 +31,8 @@ function _metastore_search_is_dataset(EntityInterface $entity, string $op = 'upd
  * Track created datasets in the DKAN search api index.
  */
 function metastore_search_entity_insert(EntityInterface $entity): void {
-  // Ensure the entity in question is a dataset and is not hidden or
-  // unpublished.
+  // Ensure the entity in question is a dataset.
+  // @todo Ensure it is not hidden or unpublished.
   if (!_metastore_search_is_dataset($entity)) {
     return;
   }
@@ -74,7 +65,7 @@ function metastore_search_entity_update(EntityInterface $entity): void {
  */
 function metastore_search_entity_delete(EntityInterface $entity): void {
   // Ensure the entity in question is a dataset.
-  if (!_metastore_search_is_dataset($entity, 'delete')) {
+  if (!_metastore_search_is_dataset($entity)) {
     return;
   }
 

--- a/modules/metastore/modules/metastore_search/metastore_search.module
+++ b/modules/metastore/modules/metastore_search/metastore_search.module
@@ -18,8 +18,15 @@ function _metastore_search_is_dataset(EntityInterface $entity): bool {
   try {
     $data = new Data($entity, \Drupal::entityTypeManager());
 
-    // Is this a published dataset?
-    return ($data->getDataType() === 'dataset' && $data->getModerationState() === 'published');
+    $config = \Drupal::configFactory();
+    $processors = $config->get('search_api.index.dkan')->get('processor_settings');
+    if (isset($processors['dkan_dataset_filter_unpublished'])) {
+      // Only index published datasets.
+      return ($data->getDataType() === 'dataset' && $data->getModerationState() === 'published');
+    }
+    else {
+      return $data->getDataType() === 'dataset';
+    }
   }
   catch (DataNodeLifeCycleEntityValidationException $e) {
     // If the data object fails validation, the given entity is not a dataset.

--- a/modules/metastore/modules/metastore_search/metastore_search.module
+++ b/modules/metastore/modules/metastore_search/metastore_search.module
@@ -10,23 +10,23 @@ use Drupal\metastore\NodeWrapper\Data;
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   The entity in question.
+ * @param string $op
+ *   The operation calling this function.
  *
  * @return bool
  *   Whether the entity is a dataset.
  */
-function _metastore_search_is_dataset(EntityInterface $entity): bool {
+function _metastore_search_is_dataset(EntityInterface $entity, string $op = 'update'): bool {
   try {
     $data = new Data($entity, \Drupal::entityTypeManager());
 
     $config = \Drupal::configFactory();
     $processors = $config->get('search_api.index.dkan')->get('processor_settings');
-    if (isset($processors['dkan_dataset_filter_unpublished'])) {
+    if ($op == 'update' && isset($processors['dkan_dataset_filter_unpublished'])) {
       // Only index published datasets.
       return ($data->getDataType() === 'dataset' && $data->getModerationState() === 'published');
     }
-    else {
-      return $data->getDataType() === 'dataset';
-    }
+    return $data->getDataType() === 'dataset';
   }
   catch (DataNodeLifeCycleEntityValidationException $e) {
     // If the data object fails validation, the given entity is not a dataset.
@@ -74,7 +74,7 @@ function metastore_search_entity_update(EntityInterface $entity): void {
  */
 function metastore_search_entity_delete(EntityInterface $entity): void {
   // Ensure the entity in question is a dataset.
-  if (!_metastore_search_is_dataset($entity)) {
+  if (!_metastore_search_is_dataset($entity, 'delete')) {
     return;
   }
 

--- a/modules/metastore/modules/metastore_search/metastore_search.module
+++ b/modules/metastore/modules/metastore_search/metastore_search.module
@@ -16,8 +16,10 @@ use Drupal\metastore\NodeWrapper\Data;
  */
 function _metastore_search_is_dataset(EntityInterface $entity): bool {
   try {
-    // Attempt to check this entity's data type.
-    return (new Data($entity, \Drupal::entityTypeManager()))->getDataType() === 'dataset';
+    $data = new Data($entity, \Drupal::entityTypeManager());
+
+    // Is this a published dataset?
+    return ($data->getDataType() === 'dataset' && $data->getModerationState() === 'published');
   }
   catch (DataNodeLifeCycleEntityValidationException $e) {
     // If the data object fails validation, the given entity is not a dataset.

--- a/modules/metastore/modules/metastore_search/metastore_search.module
+++ b/modules/metastore/modules/metastore_search/metastore_search.module
@@ -17,7 +17,7 @@ use Drupal\metastore\NodeWrapper\Data;
 function _metastore_search_is_dataset(EntityInterface $entity): bool {
   try {
     // Attempt to check this entity's data type.
-    return (new Data($entity))->getDataType() === 'dataset';
+    return (new Data($entity, \Drupal::entityTypeManager()))->getDataType() === 'dataset';
   }
   catch (DataNodeLifeCycleEntityValidationException $e) {
     // If the data object fails validation, the given entity is not a dataset.

--- a/modules/metastore/src/Factory/MetastoreItemFactoryInterface.php
+++ b/modules/metastore/src/Factory/MetastoreItemFactoryInterface.php
@@ -4,6 +4,7 @@ namespace Drupal\metastore\Factory;
 
 use Contracts\FactoryInterface;
 use Drupal\Core\Entity\EntityRepository;
+use Drupal\Core\Entity\EntityTypeManager;
 
 /**
  * Interface MetastoreItemFactoryInterface.
@@ -19,8 +20,10 @@ interface MetastoreItemFactoryInterface extends FactoryInterface {
    *
    * @param \Drupal\Core\Entity\EntityRepository $entityRepository
    *   Entity Repository service.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   Entity Type Manager service.
    */
-  public function __construct(EntityRepository $entityRepository);
+  public function __construct(EntityRepository $entityRepository, EntityTypeManager $entityTypeManager);
 
   /**
    * Return a metastore item.

--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -312,6 +312,7 @@ class LifeCycle {
 
     // Check for possible orphan property references when updating a dataset.
     if (!$data->isNew()) {
+      // Compare with the latest revision (saved as raw metadata).
       $raw = $data->getRawMetadata();
       $this->orphanChecker->processReferencesInUpdatedDataset($raw, $metadata);
     }

--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -4,7 +4,10 @@ namespace Drupal\metastore\LifeCycle;
 
 use Drupal\common\EventDispatcherTrait;
 use Drupal\common\DataResource;
+use Drupal\common\Exception\DataNodeLifeCycleEntityValidationException;
 use Drupal\common\UrlHostTokenResolver;
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Queue\QueueFactory;
@@ -120,7 +123,7 @@ class LifeCycle {
    * @param \Drupal\metastore\MetastoreItemInterface $data
    *   Metastore item object.
    */
-  public function go($stage, MetastoreItemInterface $data) {
+  public function go(string $stage, MetastoreItemInterface $data): void {
     // Removed dashes from schema ID since function names can't include dashes.
     $schema_id = str_replace('-', '', $data->getSchemaId());
     $stage = ucwords($stage);
@@ -288,33 +291,80 @@ class LifeCycle {
    *
    * @param \Drupal\metastore\MetastoreItemInterface $data
    *   Dataset metastore item.
+   * @throws \Exception
    */
   protected function datasetPresave(MetastoreItemInterface $data): void {
     $this->setNodeValuesFromMetadata($data);
     $this->referenceMetadata($data);
+
+    if (!$data->isNew()) {
+      try {
+        $this->triggerOrphanReferences($data);
+      }
+      catch (InvalidPluginDefinitionException|PluginNotFoundException|DataNodeLifeCycleEntityValidationException $e) {
+        throw new \Exception($e->getMessage());
+      }
+    }
   }
 
   /**
-   * Reference metadata and trigger datastore_import/orphan_reference_processor.
+   * Trigger datastore import and reference metadata with uuids.
    *
    * @param \Drupal\metastore\MetastoreItemInterface $data
    *   Metastore item.
+   * @throws \Exception
    */
   protected function referenceMetadata(MetastoreItemInterface $data): void {
+    $metadata = $data->getMetadata();
+
+    // Trigger datastore import if applicable.
+    // Needs to happen before updating references.
     $this->dispatchEvent(self::EVENT_PRE_REFERENCE, $data, function ($data) {
       return $data instanceof MetastoreItemInterface;
     });
 
-    $metadata = $data->getMetaData();
+    // Convert references in metadata to uuids.
+    // Create new reference entities if they do not exist.
     $metadata = $this->referencer->reference($metadata);
 
+    // Re-add metadata to data object with uuids
     $data->setMetadata($metadata);
+  }
+
+  /**
+   * Orphan removed references if applicable.
+   *
+   * @param MetastoreItemInterface $data
+   * @return void
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\common\Exception\DataNodeLifeCycleEntityValidationException
+   */
+  protected function triggerOrphanReferences(MetastoreItemInterface $data): void {
+    $metadata = $data->getMetadata();
 
     // Check for possible orphan property references when updating a dataset.
-    if (!$data->isNew()) {
-      // Compare with the latest revision (saved as raw metadata).
-      $raw = $data->getRawMetadata();
-      $this->orphanChecker->processReferencesInUpdatedDataset($raw, $metadata);
+    // Compare with the latest revision (saved as raw metadata).
+    $raw = $data->getRawMetadata();
+    $this->orphanChecker->processReferencesInUpdatedDataset($raw, $metadata);
+
+    // Are we publishing this new revision?
+    $state = $data->getModerationState();
+
+    // If publishing a previous draft, check for orphans from last published version.
+    if ($state == 'published') {
+      // Get last published version.
+      $published = $data->getPublishedRevision();
+
+      // Get latest revision ID.
+      $latestVid = $data->getLoadedRevisionId();
+
+      // Only proceed if latest revision was NOT the published revision.
+      if ($published && $published->getRevisionId() <> $latestVid) {
+        $published_metadata = $published->getMetaData();
+        $published_metadata = $this->referencer->reference($published_metadata);
+        $this->orphanChecker->processReferencesInUpdatedDataset($published_metadata, $metadata);
+      }
     }
   }
 

--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -291,6 +291,7 @@ class LifeCycle {
    *
    * @param \Drupal\metastore\MetastoreItemInterface $data
    *   Dataset metastore item.
+   *
    * @throws \Exception
    */
   protected function datasetPresave(MetastoreItemInterface $data): void {
@@ -301,7 +302,7 @@ class LifeCycle {
       try {
         $this->triggerOrphanReferences($data);
       }
-      catch (InvalidPluginDefinitionException|PluginNotFoundException|DataNodeLifeCycleEntityValidationException $e) {
+      catch (InvalidPluginDefinitionException | PluginNotFoundException | DataNodeLifeCycleEntityValidationException $e) {
         throw new \Exception($e->getMessage());
       }
     }
@@ -312,6 +313,7 @@ class LifeCycle {
    *
    * @param \Drupal\metastore\MetastoreItemInterface $data
    *   Metastore item.
+   *
    * @throws \Exception
    */
   protected function referenceMetadata(MetastoreItemInterface $data): void {
@@ -327,15 +329,16 @@ class LifeCycle {
     // Create new reference entities if they do not exist.
     $metadata = $this->referencer->reference($metadata);
 
-    // Re-add metadata to data object with uuids
+    // Re-add metadata to data object with uuids.
     $data->setMetadata($metadata);
   }
 
   /**
    * Orphan removed references if applicable.
    *
-   * @param MetastoreItemInterface $data
-   * @return void
+   * @param \Drupal\metastore\MetastoreItemInterface $data
+   *   Metastore item.
+   *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    * @throws \Drupal\common\Exception\DataNodeLifeCycleEntityValidationException
@@ -351,7 +354,8 @@ class LifeCycle {
     // Are we publishing this new revision?
     $state = $data->getModerationState();
 
-    // If publishing a previous draft, check for orphans from last published version.
+    // If publishing a previous draft, check for orphans
+    // from last published version.
     if ($state == 'published') {
       // Get last published version.
       $published = $data->getPublishedRevision();

--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -300,7 +300,7 @@ class LifeCycle {
 
     if (!$data->isNew()) {
       try {
-        $this->triggerOrphanReferences($data);
+        $this->queueOrphanReferenceCleanup($data);
       }
       catch (InvalidPluginDefinitionException | PluginNotFoundException | DataNodeLifeCycleEntityValidationException $e) {
         throw new \Exception($e->getMessage());
@@ -343,7 +343,7 @@ class LifeCycle {
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    * @throws \Drupal\common\Exception\DataNodeLifeCycleEntityValidationException
    */
-  protected function triggerOrphanReferences(MetastoreItemInterface $data): void {
+  protected function queueOrphanReferenceCleanup(MetastoreItemInterface $data): void {
     $metadata = $data->getMetadata();
 
     // Check for possible orphan property references when updating a dataset.

--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -329,19 +329,6 @@ class LifeCycle {
     // Create new reference entities if they do not exist.
     $metadata = $this->referencer->reference($metadata);
 
-    // Remove dereferenced data from the metadata to save.
-    if (isset($metadata->{'%Ref:distribution'})) {
-      unset($metadata->{'%Ref:distribution'});
-    }
-    if (isset($metadata->{'%Ref:keyword'})) {
-      unset($metadata->{'%Ref:keyword'});
-    }
-    if (isset($metadata->{'%Ref:theme'})) {
-      unset($metadata->{'%Ref:theme'});
-    }
-    if (isset($metadata->{'%Ref:publisher'})) {
-      unset($metadata->{'%Ref:publisher'});
-    }
     // Re-add metadata to data object with uuids.
     $data->setMetadata($metadata);
   }

--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -365,8 +365,8 @@ class LifeCycle {
 
       // Only proceed if latest revision was NOT the published revision.
       if ($published && $published->getRevisionId() <> $latestVid) {
-        $published_metadata = $published->getMetaData();
-        $published_metadata = $this->referencer->reference($published_metadata);
+        // Get the raw referenced metadata.
+        $published_metadata = $published->getRawMetadata();
         $this->orphanChecker->processReferencesInUpdatedDataset($published_metadata, $metadata);
       }
     }

--- a/modules/metastore/src/NodeWrapper/Data.php
+++ b/modules/metastore/src/NodeWrapper/Data.php
@@ -246,7 +246,7 @@ class Data implements MetastoreItemInterface {
    * Get published revision.
    *
    * @return Data|void
-   *    Data object containing the latest revision or null
+   *   Data object containing the latest revision or null
    *
    * @throws \Drupal\common\Exception\DataNodeLifeCycleEntityValidationException
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException

--- a/modules/metastore/src/NodeWrapper/Data.php
+++ b/modules/metastore/src/NodeWrapper/Data.php
@@ -201,6 +201,24 @@ class Data implements MetastoreItemInterface {
   }
 
   /**
+   * Get the latest revision ID.
+   *
+   * @return int|string|null
+   */
+  public function getLoadedRevisionId() {
+    return $this->node->getLoadedRevisionId();
+  }
+
+  /**
+   * Get the current revision ID.
+   *
+   * @return int|mixed|string|null
+   */
+  public function getRevisionId() {
+    return $this->node->getRevisionId();
+  }
+
+  /**
    * Get latest revision.
    *
    * @return Data|void
@@ -213,11 +231,38 @@ class Data implements MetastoreItemInterface {
       // See https://www.drupal.org/project/drupal/issues/3201209
       // node->original is set to the published revision, not the latest.
       // Compare to the latest revision of the node instead.
+      $latest_revision_id = $this->getLoadedRevisionId();
       $node_storage = $this->entityTypeManager->getStorage('node');
-      $latest_revision_id = $node_storage->getLatestRevisionId($this->node->id());
       $original = $node_storage->loadRevision($latest_revision_id);
       return new Data($original, $this->entityTypeManager);
     }
+  }
+
+  /**
+   * Get published revision.
+   *
+   * @return Data|void
+   * @throws DataNodeLifeCycleEntityValidationException
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function getPublishedRevision() {
+    if (!$this->isNew()) {
+      $node_storage = $this->entityTypeManager->getStorage('node');
+      $node = $node_storage->load($this->node->id());
+      if ($node->isPublished()) {
+        return new Data($node, $this->entityTypeManager);
+      }
+    }
+  }
+
+  /**
+   * Get moderation state.
+   *
+   * @return string
+   */
+  public function getModerationState() {
+    return $this->node->get('moderation_state')->getString();
   }
 
 }

--- a/modules/metastore/src/NodeWrapper/Data.php
+++ b/modules/metastore/src/NodeWrapper/Data.php
@@ -30,7 +30,7 @@ class Data implements MetastoreItemInterface {
   protected $rawMetadata;
 
   /**
-   * Entity Type Manager
+   * Entity Type Manager.
    *
    * @var Drupal\Core\Entity\EntityTypeManager
    */
@@ -207,7 +207,7 @@ class Data implements MetastoreItemInterface {
     if (!$this->isNew()) {
       // See https://www.drupal.org/project/drupal/issues/3201209
       // node->original is set to the published revision, not the latest.
-      // We want to compare to the version of the node directly prior to this one.
+      // Compare to the latest revision of the node instead.
       $node_storage = $this->entityTypeManager->getStorage('node');
       $latest_revision_id = $node_storage->getLatestRevisionId($this->node->id());
       $original = $node_storage->loadRevision($latest_revision_id);

--- a/modules/metastore/src/NodeWrapper/Data.php
+++ b/modules/metastore/src/NodeWrapper/Data.php
@@ -37,6 +37,13 @@ class Data implements MetastoreItemInterface {
   private $entityTypeManager;
 
   /**
+   * Entity Node Storage.
+   *
+   * @var Drupal\Core\Entity\EntityStorageInterface
+   */
+  private $nodeStorage;
+
+  /**
    * Constructor.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
@@ -50,6 +57,7 @@ class Data implements MetastoreItemInterface {
     $this->validate($entity);
     $this->node = $entity;
     $this->entityTypeManager = $entityTypeManager;
+    $this->nodeStorage = $this->entityTypeManager->getStorage('node');
   }
 
   /**
@@ -236,8 +244,7 @@ class Data implements MetastoreItemInterface {
       // node->original is set to the published revision, not the latest.
       // Compare to the latest revision of the node instead.
       $latest_revision_id = $this->getLoadedRevisionId();
-      $node_storage = $this->entityTypeManager->getStorage('node');
-      $original = $node_storage->loadRevision($latest_revision_id);
+      $original = $this->nodeStorage->loadRevision($latest_revision_id);
       return new Data($original, $this->entityTypeManager);
     }
   }
@@ -254,8 +261,7 @@ class Data implements MetastoreItemInterface {
    */
   public function getPublishedRevision() {
     if (!$this->isNew()) {
-      $node_storage = $this->entityTypeManager->getStorage('node');
-      $node = $node_storage->load($this->node->id());
+      $node = $this->nodeStorage->load($this->node->id());
       if ($node->isPublished()) {
         return new Data($node, $this->entityTypeManager);
       }

--- a/modules/metastore/src/NodeWrapper/Data.php
+++ b/modules/metastore/src/NodeWrapper/Data.php
@@ -278,4 +278,17 @@ class Data implements MetastoreItemInterface {
     return $this->node->get('moderation_state')->getString();
   }
 
+  /**
+   * Getter.
+   *
+   * @deprecated Use getLatestRevision() instead.
+   *
+   * @see https://www.drupal.org/project/drupal/issues/3346430
+   */
+  public function getOriginal() {
+    if (isset($this->node->original)) {
+      return new Data($this->node->original);
+    }
+  }
+
 }

--- a/modules/metastore/src/NodeWrapper/Data.php
+++ b/modules/metastore/src/NodeWrapper/Data.php
@@ -201,9 +201,14 @@ class Data implements MetastoreItemInterface {
   }
 
   /**
-   * Getter.
+   * Get latest revision.
+   *
+   * @return Data|void
+   * @throws DataNodeLifeCycleEntityValidationException
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function getOriginal() {
+  public function getLatestRevision() {
     if (!$this->isNew()) {
       // See https://www.drupal.org/project/drupal/issues/3201209
       // node->original is set to the published revision, not the latest.

--- a/modules/metastore/src/NodeWrapper/Data.php
+++ b/modules/metastore/src/NodeWrapper/Data.php
@@ -204,6 +204,7 @@ class Data implements MetastoreItemInterface {
    * Get the latest revision ID.
    *
    * @return int|string|null
+   *   Latest revision ID or null
    */
   public function getLoadedRevisionId() {
     return $this->node->getLoadedRevisionId();
@@ -213,6 +214,7 @@ class Data implements MetastoreItemInterface {
    * Get the current revision ID.
    *
    * @return int|mixed|string|null
+   *   Revision ID or null
    */
   public function getRevisionId() {
     return $this->node->getRevisionId();
@@ -222,7 +224,9 @@ class Data implements MetastoreItemInterface {
    * Get latest revision.
    *
    * @return Data|void
-   * @throws DataNodeLifeCycleEntityValidationException
+   *  Data object containing the latest revision or null
+   *
+   * @throws \Drupal\common\Exception\DataNodeLifeCycleEntityValidationException
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
@@ -260,6 +264,7 @@ class Data implements MetastoreItemInterface {
    * Get moderation state.
    *
    * @return string
+   *   Node moderation state
    */
   public function getModerationState() {
     return $this->node->get('moderation_state')->getString();

--- a/modules/metastore/src/NodeWrapper/Data.php
+++ b/modules/metastore/src/NodeWrapper/Data.php
@@ -224,7 +224,7 @@ class Data implements MetastoreItemInterface {
    * Get latest revision.
    *
    * @return Data|void
-   *  Data object containing the latest revision or null
+   *   Data object containing the latest revision or null
    *
    * @throws \Drupal\common\Exception\DataNodeLifeCycleEntityValidationException
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
@@ -246,7 +246,9 @@ class Data implements MetastoreItemInterface {
    * Get published revision.
    *
    * @return Data|void
-   * @throws DataNodeLifeCycleEntityValidationException
+   *    Data object containing the latest revision or null
+   *
+   * @throws \Drupal\common\Exception\DataNodeLifeCycleEntityValidationException
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */

--- a/modules/metastore/src/NodeWrapper/NodeDataFactory.php
+++ b/modules/metastore/src/NodeWrapper/NodeDataFactory.php
@@ -21,7 +21,7 @@ class NodeDataFactory implements MetastoreEntityItemFactoryInterface {
   private $entityRepository;
 
   /**
-   * Entity Type Manager
+   * Entity Type Manager.
    *
    * @var Drupal\Core\Entity\EntityTypeManager
    */

--- a/modules/metastore/src/NodeWrapper/NodeDataFactory.php
+++ b/modules/metastore/src/NodeWrapper/NodeDataFactory.php
@@ -3,6 +3,7 @@
 namespace Drupal\metastore\NodeWrapper;
 
 use Drupal\Core\Entity\EntityRepository;
+use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\metastore\Factory\MetastoreEntityItemFactoryInterface;
 
 /**
@@ -20,13 +21,23 @@ class NodeDataFactory implements MetastoreEntityItemFactoryInterface {
   private $entityRepository;
 
   /**
+   * Entity Type Manager
+   *
+   * @var Drupal\Core\Entity\EntityTypeManager
+   */
+  private $entityTypeManager;
+
+  /**
    * Constructor.
    *
    * @param \Drupal\Core\Entity\EntityRepository $entityRepository
    *   The entity repository service.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   Entity Type Manager service.
    */
-  public function __construct(EntityRepository $entityRepository) {
+  public function __construct(EntityRepository $entityRepository, EntityTypeManager $entityTypeManager) {
     $this->entityRepository = $entityRepository;
+    $this->entityTypeManager = $entityTypeManager;
   }
 
   /**
@@ -42,7 +53,7 @@ class NodeDataFactory implements MetastoreEntityItemFactoryInterface {
    */
   public function getInstance(string $identifier, array $config = []) {
     $dataNode = $this->entityRepository->loadEntityByUuid("node", $identifier);
-    return new Data($dataNode);
+    return new Data($dataNode, $this->entityTypeManager);
   }
 
   /**
@@ -55,7 +66,7 @@ class NodeDataFactory implements MetastoreEntityItemFactoryInterface {
    *   Metastore data node object.
    */
   public function wrap($dataNode) {
-    return new Data($dataNode);
+    return new Data($dataNode, $this->entityTypeManager);
   }
 
   /**

--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -75,9 +75,7 @@ class Referencer {
         $data->{$property_id} = $this->referenceProperty($property_id, $data->{$property_id});
 
         // Remove de-referenced info from metadata.
-        if (isset($data->{'%Ref:' . $property_id})) {
-          unset($data->{'%Ref:' . $property_id});
-        }
+        unset($data->{'%Ref:' . $property_id});
       }
     }
     return $data;

--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -249,7 +249,7 @@ class Referencer {
       if (isset($info[0]->identifier)) {
         /** @var \Drupal\common\DataResource $stored */
         $stored = $this->getFileMapper()->get($info[0]->identifier, DataResource::DEFAULT_SOURCE_PERSPECTIVE);
-        $downloadUrl = $this->handleExistingResource($info, $stored, $mimeType);
+        $downloadUrl = $this->handleExistingResource($stored, $mimeType);
       }
     }
 
@@ -259,8 +259,6 @@ class Referencer {
   /**
    * Get download URL for existing resource.
    *
-   * @param array $info
-   *   Info.
    * @param \Drupal\common\DataResource $stored
    *   Stored data resource object.
    * @param string $mimeType
@@ -269,8 +267,8 @@ class Referencer {
    * @return string
    *   The download URL.
    */
-  private function handleExistingResource(array $info, DataResource $stored, string $mimeType): string {
-    if ($info[0]->perspective == DataResource::DEFAULT_SOURCE_PERSPECTIVE &&
+  private function handleExistingResource(DataResource $stored, string $mimeType): string {
+    if ($stored->getPerspective() == DataResource::DEFAULT_SOURCE_PERSPECTIVE &&
       (ResourceMapper::newRevision() == 1 || $stored->getMimeType() != $mimeType)) {
       $new = $stored->createNewVersion();
       // Update the MIME type, since this may be updated by the user.

--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -73,6 +73,11 @@ class Referencer {
     foreach ($this->getPropertyList() as $property_id) {
       if (isset($data->{$property_id})) {
         $data->{$property_id} = $this->referenceProperty($property_id, $data->{$property_id});
+
+        // Remove de-referenced info from metadata.
+        if (isset($data->{'%Ref:' . $property_id})) {
+          unset($data->{'%Ref:' . $property_id});
+        }
       }
     }
     return $data;

--- a/modules/metastore/tests/src/Unit/NodeWrapper/DataTest.php
+++ b/modules/metastore/tests/src/Unit/NodeWrapper/DataTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\Container;
  * Testing the NodeWrapper.
  */
 class DataTest extends TestCase {
-  public function testGetOriginalGetUsAWrapper() {
+  public function testGetLatestRevisionGetUsAWrapper() {
     $node = (new Chain($this))
       ->add(Node::class, 'bundle', 'data')
       ->addd('__isset', true)
@@ -48,11 +48,11 @@ class DataTest extends TestCase {
 
     $wrapper = new Data($node, $entityTypeManager);
     $this->assertTrue(
-      $wrapper->getOriginal() instanceof Data
+      $wrapper->getLatestRevision() instanceof Data
     );
   }
 
-  public function testGetOriginalGiveUsNull() {
+  public function testGetLatestRevisionGiveUsNull() {
     $node = (new Chain($this))
       ->add(Node::class, 'bundle', 'data')
       ->addd('__isset', true)
@@ -72,7 +72,7 @@ class DataTest extends TestCase {
 
     $wrapper = new Data($node, $entityTypeManager);
     $this->assertNull(
-      $wrapper->getOriginal()
+      $wrapper->getLatestRevision()
     );
   }
 

--- a/modules/metastore/tests/src/Unit/NodeWrapper/DataTest.php
+++ b/modules/metastore/tests/src/Unit/NodeWrapper/DataTest.php
@@ -12,14 +12,14 @@ use Drupal\metastore\NodeWrapper\Data;
 use Drupal\metastore\NodeWrapper\NodeDataFactory;
 use Drupal\node\Entity\Node;
 use MockChain\Chain;
+use MockChain\Options;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 
 /**
  * Testing the NodeWrapper.
  */
-class DataTest extends TestCase
-{
+class DataTest extends TestCase {
   public function testGetOriginalGetUsAWrapper() {
     $node = (new Chain($this))
       ->add(Node::class, 'bundle', 'data')
@@ -31,12 +31,16 @@ class DataTest extends TestCase
 
     $entityTypeManager = (new Chain($this))
       ->add(EntityTypeManager::class, 'getStorage', RevisionableStorageInterface::class)
+      ->add(EntityTypeManager::class, 'findDefinitions', ['node'])
       ->add(RevisionableStorageInterface::class, 'getLatestRevisionId', 123)
-      ->addd('loadRevision', Node::class)
+      ->addd('loadRevision', $node)
       ->getMock();
 
     $container = (new Chain($this))
-      ->add(Container::class)
+      ->add(Container::class, 'get', (new Options())
+        ->add('entity_type.manager', $entityTypeManager)
+        ->index(0)
+      )
       ->add(EntityTypeManager::class, 'getStorage', RevisionableStorageInterface::class)
       ->getMock();
 

--- a/modules/metastore/tests/src/Unit/NodeWrapper/DataTest.php
+++ b/modules/metastore/tests/src/Unit/NodeWrapper/DataTest.php
@@ -27,6 +27,7 @@ class DataTest extends TestCase {
       ->addd('__get', Node::class)
       ->addd('isNew', false)
       ->addd('id', 123)
+      ->addd('getLoadedRevisionId', 111)
       ->getMock();
 
     $entityTypeManager = (new Chain($this))
@@ -73,6 +74,62 @@ class DataTest extends TestCase {
     $wrapper = new Data($node, $entityTypeManager);
     $this->assertNull(
       $wrapper->getLatestRevision()
+    );
+  }
+
+  public function testGetPublishedRevisionGetUsAWrapper() {
+    $node = (new Chain($this))
+      ->add(Node::class, 'bundle', 'data')
+      ->addd('__isset', true)
+      ->addd('__get', Node::class)
+      ->addd('isNew', false)
+      ->addd('id', 123)
+      ->addd('isPublished', true)
+      ->getMock();
+
+    $entityTypeManager = (new Chain($this))
+      ->add(EntityTypeManager::class, 'getStorage', RevisionableStorageInterface::class)
+      ->add(EntityTypeManager::class, 'findDefinitions', ['node'])
+      ->add(RevisionableStorageInterface::class, 'load', $node)
+      ->getMock();
+
+    $container = (new Chain($this))
+      ->add(Container::class, 'get', (new Options())
+        ->add('entity_type.manager', $entityTypeManager)
+        ->index(0)
+      )
+      ->add(EntityTypeManager::class, 'getStorage', RevisionableStorageInterface::class)
+      ->getMock();
+
+    \Drupal::setContainer($container);
+
+    $wrapper = new Data($node, $entityTypeManager);
+    $this->assertTrue(
+      $wrapper->getPublishedRevision() instanceof Data
+    );
+  }
+
+  public function testGetPublishedRevisionGiveUsNull() {
+    $node = (new Chain($this))
+      ->add(Node::class, 'bundle', 'data')
+      ->addd('__isset', true)
+      ->addd('__get', Node::class)
+      ->addd('isNew', true)
+      ->getMock();
+
+    $entityTypeManager = (new Chain($this))
+      ->add(EntityTypeManager::class, 'getStorage', RevisionableStorageInterface::class)
+      ->getMock();
+
+    $container = (new Chain($this))
+      ->add(Container::class)
+      ->getMock();
+
+    \Drupal::setContainer($container);
+
+    $wrapper = new Data($node, $entityTypeManager);
+    $this->assertNull(
+      $wrapper->getPublishedRevision()
     );
   }
 

--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\dkan\Functional;
 
+use Drupal\common\DataResource;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\datastore\Service\ResourceLocalizer;
 use Drupal\harvest\Load\Dataset;
@@ -195,105 +196,39 @@ class DatasetBTBTest extends BrowserTestBase {
   }
 
   /**
-   * Test draft moderation workflow with local resource perspective.
+   * Test draft moderation workflow with modified trigger and default source resource perspective.
    */
-  public function testDraftWorkflowWithLocalPerspective() {
-    // Set delete local resource files = false and modified as a triggering property.
-    $this->config('datastore.settings')
-      ->set('delete_local_resource', 0)
-      ->set('triggering_properties', ['modified'])
+  public function testDraftWorkflowModifiedTriggerSourcePerspective() {
+    // Set resource perspective to source.
+    $this->config('metastore.settings')
+      ->set('resource_perspective_display', DataResource::DEFAULT_SOURCE_PERSPECTIVE)
       ->save();
 
-    // Set default moderation state = draft.
-    $this->config('workflows.workflow.dkan_publishing')
-      ->set('type_settings.default_moderation_state', 'draft')
-      ->save();
+    $this->runDraftWorkflowModifiedTrigger();
+  }
 
+  /**
+   * Test draft moderation workflow with modified trigger and local_url resource perspective.
+   */
+  public function testDraftWorkflowModifiedTriggerLocalPerspective() {
     // Set resource perspective to local_url.
     $this->config('metastore.settings')
       ->set('resource_perspective_display', ResourceLocalizer::LOCAL_URL_PERSPECTIVE)
       ->save();
 
-    // Post dataset 1 and run the 'datastore_import' queue.
-    $id_1 = uniqid(__FUNCTION__ . '1');
-    $this->storeDatasetRunQueues($id_1, '1', ['1.csv']);
+    $this->runDraftWorkflowModifiedTrigger();
+  }
 
-    // Publish the draft dataset
-    $this->getMetastore()->publish('dataset', $id_1);
+  /**
+   * Test draft moderation workflow with distribution title update and source resource perspective.
+   */
+  public function testDraftWorkflowUpdateDistributionTitleSourcePerspective() {
+    // Set resource perspective to local_url.
+    $this->config('metastore.settings')
+      ->set('resource_perspective_display', DataResource::DEFAULT_SOURCE_PERSPECTIVE)
+      ->save();
 
-    // Simulate all possible queues post publish.
-    // Should only include post_import (not included earlier) and resource_purger.
-    $this->runQueues([
-      'datastore_import',
-      'resource_purger',
-      'orphan_reference_processor',
-      'orphan_resource_remover',
-      'post_import',
-    ]);
-
-    // Create a new draft with an updated modified date.
-    $this->getMetastore()->patch('dataset', $id_1, json_encode(['modified' => '06-05-2222']));
-
-    // Simulate all possible queues post update.
-    // Should include datastore_import, orphan_reference_processor and resource_purger
-    $this->runQueues([
-      'datastore_import',
-      'resource_purger',
-      'orphan_reference_processor',
-      'orphan_resource_remover',
-      'post_import',
-    ]);
-
-    // Get dataset info.
-    $datasetInfoService = $this->container->get('dkan.common.dataset_info');
-    $metadata = $datasetInfoService->gather($id_1);
-    $distributionTableLatest = $metadata['latest_revision']['distributions'][0]['table_name'];
-    $distributionTablePublished = $metadata['published_revision']['distributions'][0]['table_name'] ?? '';
-
-    // Make sure there are both latest and published versions with different tables.
-    $this->assertNotEmpty($distributionTablePublished, 'Draft revision exists.');
-    $this->assertNotEquals($distributionTableLatest, $distributionTablePublished, 'Separate distribution tables exist for latest and published revisions.');
-
-    // Confirm latest and published distribution tables exist.
-    $databaseSchema = $this->container->get('database')->schema();
-    $distributionTableLatestExists = $databaseSchema->tableExists($distributionTableLatest);
-    $this->assertTrue($distributionTableLatestExists, $distributionTableLatest . ' exists.');
-    $distributionTablePublishedExists = $databaseSchema->tableExists($distributionTablePublished);
-    $this->assertTrue($distributionTablePublishedExists, $distributionTablePublished . ' exists.');
-
-    // Publish the draft dataset revision.
-    $this->getMetastore()->publish('dataset', $id_1);
-
-    // Simulate all possible queues post update.
-    $this->runQueues([
-      'datastore_import',
-      'resource_purger',
-      'orphan_reference_processor',
-      'orphan_resource_remover',
-    ]);
-
-    $metadata = $datasetInfoService->gather($id_1);
-    $distributionTableLatestUpdated = $metadata['latest_revision']['distributions'][0]['table_name'];
-    $distributionTablePublishedUpdated = $metadata['published_revision']['distributions'][0]['table_name'] ?? '';
-
-    // Make sure there is only a single latest revision.
-    $this->assertEmpty($distributionTablePublishedUpdated, 'Only published revision listed.');
-    $this->assertEquals($distributionTableLatestUpdated, $distributionTableLatest, 'Latest draft distribution table now published version.');
-
-    $distributionTableLatestExists = $databaseSchema->tableExists($distributionTableLatest);
-    $this->assertTrue($distributionTableLatestExists, $distributionTableLatest . ' exists.');
-
-    // Confirm new latest revision table exists.
-    $this->assertTrue(
-      $databaseSchema->tableExists($distributionTableLatest),
-      'Distribution table exists: ' . $distributionTableLatest
-    );
-
-    // Confirm original published distribution table removed.
-    $this->assertFalse(
-      $databaseSchema->tableExists($distributionTablePublished),
-      'Distribution table exists: ' . $distributionTablePublished
-    );
+    $this->runDraftWorkflowUpdateDistributionTitle();
   }
 
   /**
@@ -676,4 +611,223 @@ class DatasetBTBTest extends BrowserTestBase {
     return \Drupal::service('dkan.metastore.service');
   }
 
+  /**
+   * Run a typical draft workflow using modified trigger.
+   */
+  private function runDraftWorkflowModifiedTrigger(): void {
+    // Set delete local resource files = false and modified as a triggering property.
+    $this->config('datastore.settings')
+      ->set('delete_local_resource', 0)
+      ->set('triggering_properties', ['modified'])
+      ->save();
+
+    // Set default moderation state = draft.
+    $this->config('workflows.workflow.dkan_publishing')
+      ->set('type_settings.default_moderation_state', 'draft')
+      ->save();
+
+    // Post dataset 1 and run the 'datastore_import' queue.
+    $id_1 = uniqid(__FUNCTION__ . '1');
+    $this->storeDatasetRunQueues($id_1, '1', ['1.csv']);
+
+    // Publish the draft dataset
+    $this->getMetastore()->publish('dataset', $id_1);
+
+    // Simulate all possible queues post publish.
+    // Should only include post_import (not included earlier) and resource_purger.
+    $this->runQueues([
+      'datastore_import',
+      'resource_purger',
+      'orphan_reference_processor',
+      'orphan_resource_remover',
+      'post_import',
+    ]);
+
+    // Create a new draft with an updated modified date.
+    $this->getMetastore()->patch('dataset', $id_1, json_encode(['modified' => '06-05-2222']));
+
+    // Simulate all possible queues post update.
+    // Should include datastore_import, orphan_reference_processor and resource_purger
+    $this->runQueues([
+      'datastore_import',
+      'resource_purger',
+      'orphan_reference_processor',
+      'orphan_resource_remover',
+      'post_import',
+    ]);
+
+    // Get dataset info.
+    $datasetInfoService = $this->container->get('dkan.common.dataset_info');
+    $metadata = $datasetInfoService->gather($id_1);
+    $distributionTableLatest = $metadata['latest_revision']['distributions'][0]['table_name'];
+    $distributionTablePublished = $metadata['published_revision']['distributions'][0]['table_name'] ?? '';
+    $distributionUuidOld = $metadata['published_revision']['distributions'][0]['distribution_uuid'] ?? '';
+
+    // Make sure there are both latest and published versions with different tables.
+    $this->assertNotEmpty($distributionTablePublished, 'Draft revision exists.');
+    $this->assertNotEquals($distributionTableLatest, $distributionTablePublished, 'Separate distribution tables exist for latest and published revisions.');
+
+    // Confirm latest and published distribution tables exist.
+    $databaseSchema = $this->container->get('database')->schema();
+    $distributionTableLatestExists = $databaseSchema->tableExists($distributionTableLatest);
+    $this->assertTrue($distributionTableLatestExists, $distributionTableLatest . ' exists.');
+    $distributionTablePublishedExists = $databaseSchema->tableExists($distributionTablePublished);
+    $this->assertTrue($distributionTablePublishedExists, $distributionTablePublished . ' exists.');
+
+    // Publish the draft dataset revision.
+    $this->getMetastore()->publish('dataset', $id_1);
+
+    // Simulate all possible queues post update.
+    $this->runQueues([
+      'datastore_import',
+      'resource_purger',
+      'orphan_reference_processor',
+      'orphan_resource_remover',
+    ]);
+
+    $metadata = $datasetInfoService->gather($id_1);
+    $distributionTableLatestNew = $metadata['latest_revision']['distributions'][0]['table_name'];
+    $distributionUuidLatestNew = $metadata['latest_revision']['distributions'][0]['distribution_uuid'];
+    $distributionTablePublishedUpdated = $metadata['published_revision']['distributions'][0]['table_name'] ?? '';
+
+    // Load previous distribution node and its moderation state.
+    $entityManager = \Drupal::entityTypeManager()->getStorage('node');
+    $distributionNodeOld = $entityManager->loadByProperties(['uuid' => $distributionUuidOld]);
+    $distributionNodeOld = reset($distributionNodeOld);
+    $distributionStateOld = $distributionNodeOld->get('moderation_state')->getString();
+    $this->assertEquals('orphaned', $distributionStateOld, 'Old distribution orphaned.');
+
+    // Load new distribution node and its moderation state.
+    $distributionNodeNew = $entityManager->loadByProperties(['uuid' => $distributionUuidLatestNew]);
+    $distributionNodeNew = reset($distributionNodeNew);
+    $distributionStateNew = $distributionNodeNew->get('moderation_state')->getString();
+    $this->assertEquals('published', $distributionStateNew, 'New distribution published.');
+
+    // Make sure there is only a single latest revision.
+    $this->assertEmpty($distributionTablePublishedUpdated, 'Only published revision listed.');
+    $this->assertEquals($distributionTableLatestNew, $distributionTableLatest, 'Latest draft distribution table now published version.');
+
+    // Confirm new latest revision table exists.
+    $this->assertTrue(
+      $databaseSchema->tableExists($distributionTableLatest),
+      'Distribution table exists: ' . $distributionTableLatest
+    );
+
+    // Confirm original published distribution table removed.
+    $this->assertFalse(
+      $databaseSchema->tableExists($distributionTablePublished),
+      'Distribution table exists: ' . $distributionTablePublished
+    );
+  }
+
+  /**
+   * Run a typical draft workflow with distribution title update.
+   */
+  private function runDraftWorkflowUpdateDistributionTitle(): void {
+    // Set delete local resource files = false and modified as a triggering property.
+    $this->config('datastore.settings')
+      ->set('delete_local_resource', 0)
+      ->set('triggering_properties', ['modified'])
+      ->save();
+
+    // Set default moderation state = draft.
+    $this->config('workflows.workflow.dkan_publishing')
+      ->set('type_settings.default_moderation_state', 'draft')
+      ->save();
+
+    // Post dataset 1 and run the 'datastore_import' queue.
+    $id_1 = uniqid(__FUNCTION__ . '1');
+    $this->storeDatasetRunQueues($id_1, '1', ['1.csv']);
+
+    // Publish the draft dataset
+    $this->getMetastore()->publish('dataset', $id_1);
+
+    // Simulate all possible queues post publish.
+    // Should only include post_import (not included earlier) and resource_purger.
+    $this->runQueues([
+      'datastore_import',
+      'resource_purger',
+      'orphan_reference_processor',
+      'orphan_resource_remover',
+      'post_import',
+    ]);
+
+    // Use same values for distribution as original getData() with updated title.
+    $distribution = new \stdClass();
+    $distribution->title = 'Updated Distribution #0 for ' . $id_1;
+    $distribution->downloadURL = $this->getDownloadUrl('1.csv');
+    $distribution->format = 'csv';
+    $distribution->mediaType = 'text/csv';
+
+    // Create a new draft with the new distribution title.
+    $this->getMetastore()->patch('dataset', $id_1, json_encode(
+      ['distribution' => [$distribution]]
+    ));
+
+    // Simulate all possible queues post update.
+    // Should NOT include datastore_import.
+    $this->runQueues([
+      'datastore_import',
+      'resource_purger',
+      'orphan_reference_processor',
+      'orphan_resource_remover',
+      'post_import',
+    ]);
+
+    // Get dataset info.
+    $datasetInfoService = $this->container->get('dkan.common.dataset_info');
+    $metadata = $datasetInfoService->gather($id_1);
+    $distributionTableLatest = $metadata['latest_revision']['distributions'][0]['table_name'];
+    $distributionTablePublished = $metadata['published_revision']['distributions'][0]['table_name'] ?? '';
+    $distributionUuidOld = $metadata['published_revision']['distributions'][0]['distribution_uuid'] ?? '';
+
+    // Make sure there are both latest and published versions that share the same table.
+    $this->assertNotEmpty($distributionTablePublished, 'Draft revision exists.');
+    $this->assertEquals($distributionTableLatest, $distributionTablePublished, 'Same distribution used for latest and published revisions.');
+
+    // Confirm latest/published distribution table exists.
+    $databaseSchema = $this->container->get('database')->schema();
+    $distributionTableLatestExists = $databaseSchema->tableExists($distributionTableLatest);
+    $this->assertTrue($distributionTableLatestExists, $distributionTableLatest . ' exists.');
+
+    // Publish the draft dataset revision.
+    $this->getMetastore()->publish('dataset', $id_1);
+
+    // Simulate all possible queues post update.
+    // Should NOT include datastore_import.
+    $this->runQueues([
+      'datastore_import',
+      'resource_purger',
+      'orphan_reference_processor',
+      'orphan_resource_remover',
+    ]);
+
+    $metadata = $datasetInfoService->gather($id_1);
+    $distributionTableLatestNew = $metadata['latest_revision']['distributions'][0]['table_name'];
+    $distributionUuidLatestNew = $metadata['latest_revision']['distributions'][0]['distribution_uuid'];
+    $distributionTablePublishedUpdated = $metadata['published_revision']['distributions'][0]['table_name'] ?? '';
+
+    // Load previous distribution node and its moderation state.
+    $entityManager = \Drupal::entityTypeManager()->getStorage('node');
+    $distributionNodeOld = $entityManager->loadByProperties(['uuid' => $distributionUuidOld]);
+    $distributionNodeOld = reset($distributionNodeOld);
+    $distributionStateOld = $distributionNodeOld->get('moderation_state')->getString();
+    $this->assertEquals('orphaned', $distributionStateOld, 'Old distribution orphaned.');
+
+    // Load new distribution node and its moderation state.
+    $distributionNodeNew = $entityManager->loadByProperties(['uuid' => $distributionUuidLatestNew]);
+    $distributionNodeNew = reset($distributionNodeNew);
+    $distributionStateNew = $distributionNodeNew->get('moderation_state')->getString();
+    $this->assertEquals('published', $distributionStateNew, 'New distribution published.');
+
+    // Make sure there is only a single latest revision.
+    $this->assertEmpty($distributionTablePublishedUpdated, 'Only published revision listed.');
+    $this->assertEquals($distributionTableLatestNew, $distributionTableLatest, 'Latest draft distribution table now published version.');
+
+    // Confirm latest revision table exists.
+    $this->assertTrue(
+      $databaseSchema->tableExists($distributionTableLatest),
+      'Distribution table exists: ' . $distributionTableLatest
+    );
+  }
 }

--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -232,6 +232,21 @@ class DatasetBTBTest extends BrowserTestBase {
   }
 
   /**
+   * Test draft moderation workflow with distribution title update and local_url resource perspective.
+   * Current fails due to faulty logic in MetastoreSubscriber::resourceInUseElsewhere.
+   * Should use ReferenceLookup similar to ResourcePurger::resourceNotShared.
+
+  public function testDraftWorkflowUpdateDistributionTitleLocalPerspective() {
+    // Set resource perspective to local_url.
+    $this->config('metastore.settings')
+      ->set('resource_perspective_display', ResourceLocalizer::LOCAL_URL_PERSPECTIVE)
+      ->save();
+
+    $this->runDraftWorkflowUpdateDistributionTitle();
+  }
+   */
+
+  /**
    * Test cleanup of orphaned draft distributions.
    */
   public function testOrphanDraftDistributionCleanup() {


### PR DESCRIPTION
DatastoreSubscriber::onPreReference compares the old version of the metadata to the new version of the metadata during dataset preSave and then queues a datastore_import and orphan_reference_processor queue items if there is a change.

However, it's using the node->original property which is incorrectly set to the last PUBLISHED revision of the node, not the LATEST revision. When using a publication workflow with draft datasets that are later published, this results in the datastore_import being queued incorrectly when the dataset draft is published.

In addition, this PR removes a bunch of logic related to triggering datastore imports and orphan reference processing from the presave hook on data dictionaries.

Lastly, this PR checks for orphans from the last published revision when publishing a new revision of a dataset if the latest revision was not published. (e.g. if this was a draft revision being published)

This adds 5 new functional tests to cover the workflows that were not previously covered.

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Create a vanilla DKAN site with the sample content.
- [ ] Check the resource settings. ( admin/dkan/resources ) Purge tables and purge files should both checked and delete local resource should be unchecked.
- [ ] Disable the default data dictionary if present. Create a new data dictionary entry setting "price" to numeric and make sure the dictionary node is published. Set it as the new sitewide data dictionary. ( admin/dkan/data-dictionary/settings )
- [ ] Enable last modified as the only triggering property ( admin/dkan/datastore )
- [ ] Set the default moderation state to draft. ( admin/config/workflow/workflows/manage/dkan_publishing )
- [ ] Using the dataset "Gold Prices in London 1950-2008 (Monthly)" with identifier 5dc1cfcf-8028-476c-a020-f58ec6dd621c
- [ ] Make sure the original resource file is present in sites/default/files/distribution/5dc1cfcf-8028-476c-a020-f58ec6dd621c/data.csv (source path) and also in the original resource directory e.g. sites/default/files/resources/0821c20012819a030c6fc33f6b329643_1687525521/data.csv
- [ ] Make sure the queue table is empty using ddev drush queue:list (all zeros)
- [ ] ddev drush dkan:dataset-info 5dc1cfcf-8028-476c-a020-f58ec6dd621c and make a note of the existing datastore table name and file_path. Should only have "latest revision".
- [ ] Edit the dataset through the node form UI. Append a "2" to the dataset title and the distribution title for easy tracking. Change the last modified date. Save the dataset as a draft revision.
- [ ] Confirm that a single draft distribution node was created: admin/dkan/datasets?title=&data-type=distribution&status=All&moderation_state=All
- [ ] Confirm that a single draft revision was added on the dataset node.
- [ ] ddev drush queue:list should return a single item in each of the following queues: datastore_import, orphan_reference_processor, and resource_purger
- [ ] ddev drush cron to run all the queues
- [ ] ddev drush queue:list to confirm all queues are complete (all zeros). If necessary run cron again for post_import queue.
- [ ] ddev drush dkan:dataset-info 5dc1cfcf-8028-476c-a020-f58ec6dd621c and make a note of the datastore table name and file_path for both latest_revision (should be draft) and published_revision. 
- [ ] Confirm that both datastore tables and both file_path directories are still present.
- [ ] Confirm that the new datastore table has a decimal type on the price column.
- [ ] Publish the latest draft revision of the dataset using the content admin form ( admin/content ), check the box next to the dataset, and choose "publish latest revision".
- [ ] ddev drush queue:list to confirm queue items for only orphan_reference_processor and resource_purger.
- [ ] ddev drush dkan:dataset-info 5dc1cfcf-8028-476c-a020-f58ec6dd621c and confirm latest_revision is published with a datastore table and still importer_status of done, 100%
- [ ] ddev drush cron to run all the queues
- [ ] Confirm that there are only 2 distribution nodes associated with the dataset and that the one with the "2" appended to the title is now published and the old one is orphaned.
- [ ] Visit the dataset page and confirm that the updates were applied to the live version with data still present.
- [ ] Confirm that the original datastore table and the original file in the original file_path were dropped/removed.
