### PR TITLE
Replace deprecated/removed form alter hook with D10 version

### DIFF
--- a/modules/json_form_widget/json_form_widget.module
+++ b/modules/json_form_widget/json_form_widget.module
@@ -70,11 +70,11 @@ function _json_form_widget_build_count_property(array $button_element): array {
 }
 
 /**
- * Implements hook_field_widget_multivalue_form_alter().
+ * Implements hook_field_widget_complete_form_alter().
  *
  * Set json_form_widget flag for later.
  */
-function json_form_widget_field_widget_multivalue_form_alter(array $elements, FormStateInterface $form_state, array $context) {
+function json_form_widget_field_widget_complete_form_alter(&$field_widget_complete_form, FormStateInterface $form_state, $context) {
   if ($context['widget'] instanceof JsonFormWidget) {
     $form_state->has_json_form_widget = TRUE;
   }


### PR DESCRIPTION
hook_field_widget_multivalue_form_alter was deprecated in Drupal 9.2 and removed in Drupal 10. 

https://api.drupal.org/api/drupal/core%21modules%21field%21field.api.php/function/hook_field_widget_multivalue_form_alter/9

This hook was used to identify json form widget forms and in its absence, json_form_widget_file_submit() is not run on node form submission. The result is that the files uploaded through the node form are left in temporary status and the file usage table also not updated. This can result in data loss when temporary files are cleaned up.

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Create a dataset through the node form UI and make sure to upload a distribution file.
- [ ] After submitting the form, visit admin/content/files and confirm that the file has a status of "Permanent"
