### PR TITLE
API functional test refactor to BrowserTestBase

### DIFF
--- a/modules/common/tests/src/Functional/Api1TestBase.php
+++ b/modules/common/tests/src/Functional/Api1TestBase.php
@@ -66,7 +66,6 @@ abstract class Api1TestBase extends BrowserTestBase {
       RequestOptions::JSON => $data,
       RequestOptions::AUTH => $this->auth,
       RequestOptions::HTTP_ERRORS => $httpErrors,
-      RequestOptions::TIMEOUT => 10000,
     ]);
   }
 

--- a/modules/common/tests/src/Functional/Api1TestBase.php
+++ b/modules/common/tests/src/Functional/Api1TestBase.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\common\Functional;
 
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\user\Entity\Role;
 use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
 use Opis\JsonSchema\Schema;
@@ -32,13 +33,26 @@ abstract class Api1TestBase extends BrowserTestBase {
     'harvest',
     'metastore',
     'node',
+    'user',
   ];
 
+  /**
+   * Set up test client, role and user, initialize spec.
+   */
   public function setUp(): void {
     parent::setUp();
+
+    $role = Role::create([
+      'id' => 'api_user',
+      'label' => "API User",
+    ]);
+    if ($role->save() === SAVED_NEW) {
+      $permissions = ["post put delete datasets through the api"];
+      $this->grantPermissions($role, $permissions);
+    }
+
     $user = $this->createUser([], "testapiuser", FALSE, [
       'roles' => ['api_user'],
-      'permissions' => ["post put delete datasets through the api"],
       'mail' => 'testapiuser@test.com',
     ]);
 

--- a/modules/common/tests/src/Functional/Api1TestBase.php
+++ b/modules/common/tests/src/Functional/Api1TestBase.php
@@ -4,7 +4,6 @@ namespace Drupal\Tests\common\Functional;
 
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
-use Drupal\user\Entity\Role;
 use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
 use Opis\JsonSchema\Schema;
@@ -25,15 +24,13 @@ abstract class Api1TestBase extends BrowserTestBase {
   protected $endpoint;
 
   protected $defaultTheme = 'stark';
+  protected $strictConfigSchema = FALSE;
 
   protected static $modules = [
     'common',
     'datastore',
-    'dynamic_page_cache',
-    'harvest',
     'metastore',
     'node',
-    'user',
   ];
 
   /**
@@ -41,21 +38,7 @@ abstract class Api1TestBase extends BrowserTestBase {
    */
   public function setUp(): void {
     parent::setUp();
-
-    $role = Role::create([
-      'id' => 'api_user',
-      'label' => "API User",
-    ]);
-    if ($role->save() === SAVED_NEW) {
-      $permissions = ["post put delete datasets through the api"];
-      $this->grantPermissions($role, $permissions);
-    }
-
-    $user = $this->createUser([], "testapiuser", FALSE, [
-      'roles' => ['api_user'],
-      'mail' => 'testapiuser@test.com',
-    ]);
-
+    $user = $this->createUser(["post put delete datasets through the api"], "testapiuser", FALSE);
     $this->httpClient = $this->container->get('http_client_factory')
       ->fromOptions([
         'base_uri' => $this->baseUrl,

--- a/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
@@ -11,8 +11,12 @@ class DatasetItemTest extends Api1TestBase {
     return 'api/1/metastore/schemas/dataset/items';
   }
 
-  public function testList() {
-    $response = $this->post($this->getSampleDataset(0), FALSE);
+  public function testGet() {
+    $dataset = $this->getSampleDataset();
+
+    $response = $this->post($dataset, FALSE);
+    $this->assertDatasetGet($dataset);
+
     $this->post($this->getSampleDataset(1));
 
     $responseSchema = $this->spec->paths->{'/api/1/metastore/schemas/{schema_id}/items'}
@@ -22,12 +26,7 @@ class DatasetItemTest extends Api1TestBase {
     $this->assertEquals(2, count($responseBody));
     $this->assertTrue(is_object($responseBody[1]));
     $this->assertJsonIsValid($responseSchema, $responseBody);
-  }
 
-  public function testGetItem() {
-    $dataset = $this->getSampleDataset();
-    $this->post($dataset);
-    $this->assertDatasetGet($dataset);
     $datasetId = 'abc-123';
     $response = $this->httpClient->get("$this->endpoint/$datasetId", [
       RequestOptions::HTTP_ERRORS => FALSE,

--- a/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
@@ -12,12 +12,12 @@ class DatasetItemTest extends Api1TestBase {
   }
 
   public function testList() {
-    $this->post($this->getSampleDataset(0));
+    $response = $this->post($this->getSampleDataset(0), FALSE);
     $this->post($this->getSampleDataset(1));
 
     $responseSchema = $this->spec->paths->{'/api/1/metastore/schemas/{schema_id}/items'}
       ->get->responses->{"200"}->content->{"application/json"}->schema;
-    $response = $this->http->request('GET', $this->endpoint);
+    $response = $this->httpClient->request('GET', $this->endpoint);
     $responseBody = json_decode($response->getBody());
     $this->assertEquals(2, count($responseBody));
     $this->assertTrue(is_object($responseBody[1]));
@@ -29,7 +29,7 @@ class DatasetItemTest extends Api1TestBase {
     $this->post($dataset);
     $this->assertDatasetGet($dataset);
     $datasetId = 'abc-123';
-    $response = $this->http->get("$this->endpoint/$datasetId", [
+    $response = $this->httpClient->get("$this->endpoint/$datasetId", [
       RequestOptions::HTTP_ERRORS => FALSE,
     ]);
     $this->assertEquals(404, $response->getStatusCode());
@@ -62,7 +62,7 @@ class DatasetItemTest extends Api1TestBase {
     $datasetId = $dataset->identifier;
 
     $newTitle = (object) ['title' => 'Modified Title'];
-    $response = $this->http->patch("$this->endpoint/$datasetId", [
+    $response = $this->httpClient->patch("$this->endpoint/$datasetId", [
       RequestOptions::JSON => $newTitle,
       RequestOptions::AUTH => $this->auth,
     ]);
@@ -80,7 +80,7 @@ class DatasetItemTest extends Api1TestBase {
     $datasetId = "abc-123";
     $newTitle = (object) ['title' => 'Modified Title'];
 
-    $response = $this->http->patch("$this->endpoint/$datasetId", [
+    $response = $this->httpClient->patch("$this->endpoint/$datasetId", [
       RequestOptions::HTTP_ERRORS => FALSE,
       RequestOptions::JSON => $newTitle,
       RequestOptions::AUTH => $this->auth,
@@ -101,7 +101,7 @@ class DatasetItemTest extends Api1TestBase {
     $newDataset = $this->getSampleDataset(1);
     $newDataset->identifier = $datasetId;
 
-    $response = $this->http->put("$this->endpoint/$datasetId", [
+    $response = $this->httpClient->put("$this->endpoint/$datasetId", [
       RequestOptions::JSON => $newDataset,
       RequestOptions::AUTH => $this->auth,
     ]);
@@ -113,7 +113,7 @@ class DatasetItemTest extends Api1TestBase {
 
     // Now try with mismatched identifiers.
     $datasetId = 'abc-123';
-    $response = $this->http->put("$this->endpoint/$datasetId", [
+    $response = $this->httpClient->put("$this->endpoint/$datasetId", [
       RequestOptions::JSON => $newDataset,
       RequestOptions::AUTH => $this->auth,
       RequestOptions::HTTP_ERRORS => FALSE,
@@ -124,7 +124,7 @@ class DatasetItemTest extends Api1TestBase {
   private function assertDatasetGet($dataset) {
     $id = $dataset->identifier;
     $responseSchema = $this->spec->components->schemas->dataset;
-    $response = $this->http->get("$this->endpoint/$id");
+    $response = $this->httpClient->get("$this->endpoint/$id");
     $responseBody = json_decode($response->getBody());
     $this->assertEquals(200, $response->getStatusCode());
     $this->assertJsonIsValid($responseSchema, $responseBody);

--- a/modules/metastore/tests/src/Functional/Api1/DatasetRevisionTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetRevisionTest.php
@@ -14,16 +14,16 @@ class DatasetRevisionTest extends Api1TestBase {
 
   public function testList() {
     $data = $this->getSampleDataset(0);
-    $this->http->post('/api/1/metastore/schemas/dataset/items', [
+    $this->httpClient->post('/api/1/metastore/schemas/dataset/items', [
       RequestOptions::JSON => $data,
       RequestOptions::AUTH => $this->auth,
     ]);
-    $this->http->patch("/api/1/metastore/schemas/dataset/items/{$data->identifier}", [
+    $this->httpClient->patch("/api/1/metastore/schemas/dataset/items/{$data->identifier}", [
       RequestOptions::JSON => ['title' => "Changing title"],
       RequestOptions::AUTH => $this->auth,
     ]);
 
-    $response = $this->http->get($this->endpoint, [
+    $response = $this->httpClient->get($this->endpoint, [
       RequestOptions::AUTH => $this->auth,
     ]);
     $responseBody = json_decode($response->getBody());
@@ -34,7 +34,7 @@ class DatasetRevisionTest extends Api1TestBase {
 
     // Test a bad dataset ID.
     $badDatasetUrl = "/api/1/metastore/schemas/dataset/items/abc-123/revisions";
-    $response = $this->http->get($badDatasetUrl, [
+    $response = $this->httpClient->get($badDatasetUrl, [
       RequestOptions::HTTP_ERRORS => FALSE,
       RequestOptions::AUTH => $this->auth,
     ]);
@@ -45,7 +45,7 @@ class DatasetRevisionTest extends Api1TestBase {
 
   public function testGetItem() {
     $data = $this->getSampleDataset(0);
-    $response = $this->http->post('/api/1/metastore/schemas/dataset/items', [
+    $response = $this->httpClient->post('/api/1/metastore/schemas/dataset/items', [
       RequestOptions::JSON => $data,
       RequestOptions::AUTH => $this->auth,
     ]);
@@ -54,14 +54,14 @@ class DatasetRevisionTest extends Api1TestBase {
     $responseBody = json_decode($response->getBody());
     $this->assertJsonIsValid($responseSchema, $responseBody);
 
-    $response = $this->http->get($this->endpoint, [
+    $response = $this->httpClient->get($this->endpoint, [
       RequestOptions::AUTH => $this->auth,
     ]);
     $responseBody = json_decode($response->getBody());
     $listRevision = $responseBody[0];
 
     // Confirm we get the same object from the item get as the list.
-    $response = $this->http->get($this->endpoint . "/$listRevision->identifier", [
+    $response = $this->httpClient->get($this->endpoint . "/$listRevision->identifier", [
       RequestOptions::AUTH => $this->auth,
     ]);
     $this->assertEquals(200, $response->getStatusCode());
@@ -70,7 +70,7 @@ class DatasetRevisionTest extends Api1TestBase {
 
     // Confirm error if we have a non-existant dataset ID.
     $badDatasetUrl = "/api/1/metastore/schemas/dataset/items/abc-123/revisions/$listRevision->identifier";
-    $response = $this->http->get($badDatasetUrl, [
+    $response = $this->httpClient->get($badDatasetUrl, [
       RequestOptions::HTTP_ERRORS => FALSE,
       RequestOptions::AUTH => $this->auth,
     ]);
@@ -80,12 +80,12 @@ class DatasetRevisionTest extends Api1TestBase {
 
     // Confirm error if we have real but mismatched revision and dataset IDs.
     $secondData = $this->getSampleDataset(1);
-    $this->http->post('/api/1/metastore/schemas/dataset/items', [
+    $this->httpClient->post('/api/1/metastore/schemas/dataset/items', [
       RequestOptions::JSON => $secondData,
       RequestOptions::AUTH => $this->auth,
     ]);
     $badDatasetUrl = "/api/1/metastore/schemas/dataset/items/$secondData->identifier/revisions/$listRevision->identifier";
-    $response = $this->http->get($badDatasetUrl, [
+    $response = $this->httpClient->get($badDatasetUrl, [
       RequestOptions::HTTP_ERRORS => FALSE,
       RequestOptions::AUTH => $this->auth,
     ]);
@@ -94,7 +94,7 @@ class DatasetRevisionTest extends Api1TestBase {
     $this->assertStringContainsString("has no revision", $responseBody->message);
 
     // Confirm we get an error if we have a non-existant revision ID.
-    $response = $this->http->get($this->endpoint . "/123456789", [
+    $response = $this->httpClient->get($this->endpoint . "/123456789", [
       RequestOptions::HTTP_ERRORS => FALSE,
       RequestOptions::AUTH => $this->auth,
     ]);
@@ -106,7 +106,7 @@ class DatasetRevisionTest extends Api1TestBase {
   public function testPost() {
     $this->setDefaultModerationState('draft');
     $data = $this->getSampleDataset(0);
-    $this->http->post('/api/1/metastore/schemas/dataset/items', [
+    $this->httpClient->post('/api/1/metastore/schemas/dataset/items', [
       RequestOptions::JSON => $data,
       RequestOptions::AUTH => $this->auth,
     ]);
@@ -133,7 +133,7 @@ class DatasetRevisionTest extends Api1TestBase {
       $this->assertJsonIsValid($responseSchema, $responseBody);
 
       // Validate URL and contents of response object.
-      $response = $this->http->get($responseBody->endpoint, [
+      $response = $this->httpClient->get($responseBody->endpoint, [
         RequestOptions::AUTH => $this->auth,
       ]);
       $responseBody = json_decode($response->getBody());
@@ -142,7 +142,7 @@ class DatasetRevisionTest extends Api1TestBase {
       $this->assertEquals($state, $responseBody->state);
 
       // Confirm revisions list has increased by one item.
-      $response = $this->http->get($this->endpoint, [
+      $response = $this->httpClient->get($this->endpoint, [
         RequestOptions::AUTH => $this->auth,
       ]);
       $responseBody = json_decode($response->getBody());
@@ -151,7 +151,7 @@ class DatasetRevisionTest extends Api1TestBase {
       // Confirm dataset visibility matches expected.
       $expectedCode = $public ? 200 : 404;
       $datasetUrl = "/api/1/metastore/schemas/dataset/items/{$data->identifier}";
-      $response = $this->http->get($datasetUrl, [
+      $response = $this->httpClient->get($datasetUrl, [
         RequestOptions::HTTP_ERRORS => FALSE,
       ]);
       $this->assertEquals($expectedCode, $response->getStatusCode());
@@ -162,7 +162,7 @@ class DatasetRevisionTest extends Api1TestBase {
     $this->assertEquals(400, $response->getStatusCode());
     $responseBody = json_decode($response->getBody());
     $this->assertStringContainsString('does not exist in workflow', $responseBody->message);
-    $response = $this->http->get($this->endpoint, [
+    $response = $this->httpClient->get($this->endpoint, [
       RequestOptions::AUTH => $this->auth,
     ]);
     $responseBody = json_decode($response->getBody());
@@ -173,7 +173,7 @@ class DatasetRevisionTest extends Api1TestBase {
       'message' => "New published revision.",
       'state' => 'published',
     ];
-    $response = $this->http->post('/api/1/metastore/schemas/dataset/items/abc-123/revisions', [
+    $response = $this->httpClient->post('/api/1/metastore/schemas/dataset/items/abc-123/revisions', [
       RequestOptions::JSON => $newRevision,
       RequestOptions::AUTH => $this->auth,
       RequestOptions::HTTP_ERRORS => FALSE,
@@ -181,7 +181,7 @@ class DatasetRevisionTest extends Api1TestBase {
     $this->assertEquals(400, $response->getStatusCode());
     $responseBody = json_decode($response->getBody());
     $this->assertStringContainsString('No dataset found', $responseBody->message);
-    $response = $this->http->get($this->endpoint, [
+    $response = $this->httpClient->get($this->endpoint, [
       RequestOptions::AUTH => $this->auth,
     ]);
     $responseBody = json_decode($response->getBody());
@@ -194,7 +194,7 @@ class DatasetRevisionTest extends Api1TestBase {
       'message' => "New $state revision.",
       'state' => $state,
     ];
-    return $this->http->post($this->endpoint, [
+    return $this->httpClient->post($this->endpoint, [
       RequestOptions::JSON => $newRevision,
       RequestOptions::AUTH => $this->auth,
       RequestOptions::HTTP_ERRORS => FALSE,

--- a/modules/metastore/tests/src/Functional/Api1/SchemaTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/SchemaTest.php
@@ -11,13 +11,13 @@ class SchemaTest extends Api1TestBase {
   }
 
   public function testList() {
-    $response = $this->http->request('GET', $this->endpoint);
+    $response = $this->httpClient->request('GET', $this->endpoint);
     $responseBody = json_decode($response->getBody());
     $this->assertEquals("http://dkan/api/v1/schema/dataset", $responseBody->dataset->id);
   }
 
   public function testGetItem() {
-    $response = $this->http->request('GET', "$this->endpoint/dataset");
+    $response = $this->httpClient->request('GET', "$this->endpoint/dataset");
     $responseBody = json_decode($response->getBody());
     $this->assertEquals("http://dkan/api/v1/schema/dataset", $responseBody->id);
   }


### PR DESCRIPTION
Following lead of #4008, converting the API functional tests to use BrowserTestBase instead of ExistingSiteBase. Test logic unchanged.

Functional test run time is significantly higher now. We may want to consider using parallelism on CircleCI if it starts to take longer than the Cypress tests.