### PR TITLE
WCMS-16115: Apply HTML filtering to only properties that are configured to allow HTML.

### DIFF
--- a/cypress/integration/09_admin_links.spec.js
+++ b/cypress/integration/09_admin_links.spec.js
@@ -9,7 +9,7 @@ context('Administration pages', () => {
   it('I should see a link for the dataset properties configuration', () => {
     cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=>{
         cy.wrap($el).invoke('show')
-        cy.wrap($el).contains('Metastore referencer')
+        cy.wrap($el).contains('Metastore configuration')
     })
     cy.visit(baseurl + "/admin/dkan/properties")
     cy.get('.option').should('contain.text', 'Distribution (distribution)')

--- a/modules/metastore/config/install/metastore.settings.yml
+++ b/modules/metastore/config/install/metastore.settings.yml
@@ -19,4 +19,7 @@ property_list:
   'spatial': '0'
   'temporal': '0'
   'isPartOf': '0'
+html_allowed_properties:
+  'dataset.description': 'dataset.description'
+  'distribution.description': 'distribution.description'
 resource_perspective_display: source

--- a/modules/metastore/config/install/metastore.settings.yml
+++ b/modules/metastore/config/install/metastore.settings.yml
@@ -19,7 +19,5 @@ property_list:
   'spatial': '0'
   'temporal': '0'
   'isPartOf': '0'
-html_allowed_properties:
-  'dataset.description': 'dataset.description'
-  'distribution.description': 'distribution.description'
+html_allowed_properties: []
 resource_perspective_display: source

--- a/modules/metastore/config/schema/metastore.schema.yml
+++ b/modules/metastore/config/schema/metastore.schema.yml
@@ -14,6 +14,12 @@ metastore.settings:
       sequence:
         type: string
         label: 'Property'
+    html_allowed_properties:
+      type: sequence
+      label: 'HTML Allowed Properties'
+      sequence:
+        type: string
+        label: 'Property'
     resource_perspective_display:
       type: string
       label: 'Resource download url display'

--- a/modules/metastore/metastore.links.menu.yml
+++ b/modules/metastore/metastore.links.menu.yml
@@ -1,7 +1,7 @@
 dkan.metastore.config_properties:
-  title: Metastore referencer
+  title: Metastore configuration
   route_name: dkan.metastore.config_properties
-  description: Configure dataset properties for referencing an API endpoint.
+  description: Configure dataset properties for referencing sub-schemas and for HTML sanitization.
   parent: system.admin_dkan
   weight: 14
 

--- a/modules/metastore/metastore.post_update.php
+++ b/modules/metastore/metastore.post_update.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for Metastore module.
+ */
+
+/**
+ * Trigger clear cache to pick up admin menu update.
+ */
+function metastore_post_update_menu_clear_cache(&$sandbox = NULL) {
+}

--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -153,7 +153,7 @@ dkan.metastore.config_properties:
   path: '/admin/dkan/properties'
   defaults:
     _form: '\Drupal\metastore\Form\DkanDataSettingsForm'
-    _title: 'Metastore referencer configuration'
+    _title: 'Metastore configuration'
   requirements:
     _permission: 'access administration pages'
   options:

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -33,6 +33,7 @@ services:
     class: \Drupal\metastore\Storage\DataFactory
     arguments:
       - '@entity_type.manager'
+      - '@config.factory'
 
   dkan.metastore.referencer:
     class: \Drupal\metastore\Reference\Referencer

--- a/modules/metastore/src/Form/DkanDataSettingsForm.php
+++ b/modules/metastore/src/Form/DkanDataSettingsForm.php
@@ -93,7 +93,7 @@ class DkanDataSettingsForm extends ConfigFormBase {
       '#description' => $this->t('Metadata properties that may contain HTML elements.'),
       '#options' => $this->schemaHelper->retrieveStringSchemaProperties(),
       '#default_value' => $config->get('html_allowed_properties') ?:
-        ['dataset.description', 'distribution.description'],
+        ['dataset_description', 'distribution_description'],
     ];
 
     $form['property_list'] = [

--- a/modules/metastore/src/Form/DkanDataSettingsForm.php
+++ b/modules/metastore/src/Form/DkanDataSettingsForm.php
@@ -80,20 +80,30 @@ class DkanDataSettingsForm extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('metastore.settings');
-    $options = $this->schemaHelper->retrieveSchemaProperties('dataset');
-    $default_values = $config->get('property_list');
+
     $form['description'] = [
       '#markup' => $this->t(
-        'Select properties from the dataset schema to be available as individual objects.
-        Each property will be assigned a unique identifier in addition to its original schema value.'
+        'Configure the metastore settings.'
       ),
     ];
+
+    $form['html_allowed_properties'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Properties that allow HTML'),
+      '#description' => $this->t('Metadata properties that may contain HTML elements.'),
+      '#options' => $this->schemaHelper->retrieveStringSchemaProperties(),
+      '#default_value' => $config->get('html_allowed_properties') ?: ['dataset.description', 'distribution.description'],
+    ];
+
     $form['property_list'] = [
       '#type' => 'checkboxes',
-      '#title' => $this->t('Dataset properties'),
-      '#options' => $options,
-      '#default_value' => $default_values,
+      '#title' => $this->t('Dataset properties to be stored as separate entities; use caution'),
+      '#description' => $this->t('Select properties from the dataset schema to be available as individual objects.
+        Each property will be assigned a unique identifier in addition to its original schema value.'),
+      '#options' => $this->schemaHelper->retrieveSchemaProperties(),
+      '#default_value' => $config->get('property_list'),
     ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -107,6 +117,7 @@ class DkanDataSettingsForm extends ConfigFormBase {
 
     $this->config('metastore.settings')
       ->set('property_list', $form_state->getValue('property_list'))
+      ->set('html_allowed_properties', $form_state->getValue('html_allowed_properties'))
       ->save();
 
     // Rebuild routes, without clearing all caches.

--- a/modules/metastore/src/Form/DkanDataSettingsForm.php
+++ b/modules/metastore/src/Form/DkanDataSettingsForm.php
@@ -92,7 +92,8 @@ class DkanDataSettingsForm extends ConfigFormBase {
       '#title' => $this->t('Properties that allow HTML'),
       '#description' => $this->t('Metadata properties that may contain HTML elements.'),
       '#options' => $this->schemaHelper->retrieveStringSchemaProperties(),
-      '#default_value' => $config->get('html_allowed_properties') ?: ['dataset.description', 'distribution.description'],
+      '#default_value' => $config->get('html_allowed_properties') ?:
+        ['dataset.description', 'distribution.description'],
     ];
 
     $form['property_list'] = [

--- a/modules/metastore/src/SchemaPropertiesHelper.php
+++ b/modules/metastore/src/SchemaPropertiesHelper.php
@@ -82,7 +82,7 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
    * @param mixed $input
    *   Object we're parsing.
    * @param string $parent
-   *   Schema for this object
+   *   Parent object.
    * @param array $property_list
    *   Array we're building of schema properties.
    *
@@ -95,8 +95,7 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
       if (substr($id, 0, 1) == '@' || gettype($object) != 'object' || !isset($object->type)) {
         continue;
       }
-      $type = $object->type;
-      if ($type == 'string') {
+      if ($object->type == 'string') {
         if (isset($object->title)) {
           $property_list[$parent . '.' . $id] = ucfirst($parent) . ': ' . "{$object->title} ({$id})";
         }
@@ -105,13 +104,11 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
         }
       }
       // Find nested properties.
-      elseif (in_array($type, ['array', 'object'])) {
-        if (isset($object->properties) && gettype($object->properties == 'object')) {
-          $property_list = $this->buildPropertyList($object->properties, $id, $property_list);
-        }
-        elseif (isset($object->items) && gettype($object->items) == 'object' && isset($object->items->properties)) {
-          $property_list = $this->buildPropertyList($object->items->properties, $id, $property_list);
-        }
+      elseif (isset($object->properties) && gettype($object->properties == 'object')) {
+        $property_list = $this->buildPropertyList($object->properties, $id, $property_list);
+      }
+      elseif (isset($object->items) && gettype($object->items) == 'object' && isset($object->items->properties)) {
+        $property_list = $this->buildPropertyList($object->items->properties, $id, $property_list);
       }
     }
 

--- a/modules/metastore/src/SchemaPropertiesHelper.php
+++ b/modules/metastore/src/SchemaPropertiesHelper.php
@@ -79,7 +79,7 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
   /**
    * Build a list of schema properties.
    *
-   * @param mixed $input
+   * @param object $input
    *   Object we're parsing.
    * @param string $parent
    *   Parent object.
@@ -89,7 +89,7 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
    * @return array
    *   List of schema properties' title and description.
    */
-  private function buildPropertyList(mixed $input, string $parent = 'dataset', array &$property_list = []): array {
+  private function buildPropertyList($input, string $parent = 'dataset', array &$property_list = []): array {
     foreach ($input as $id => $object) {
       // Exclude properties starting with @.
       if (substr($id, 0, 1) == '@' || gettype($object) != 'object' || !isset($object->type)) {

--- a/modules/metastore/src/SchemaPropertiesHelper.php
+++ b/modules/metastore/src/SchemaPropertiesHelper.php
@@ -95,22 +95,39 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
       if (substr($id, 0, 1) == '@' || gettype($object) != 'object' || !isset($object->type)) {
         continue;
       }
-      if ($object->type == 'string' && isset($object->title)) {
+      $type = $object->type;
+      if ($type == 'string' && isset($object->title)) {
         $property_list[$parent . '_' . $id] = ucfirst($parent) . ': ' . "{$object->title} ({$id})";
       }
-      elseif ($object->type == 'string') {
+      elseif($type == 'string') {
         $property_list[$parent . '_' . $id] = ucfirst($parent) . ': ' . ucfirst($id);
       }
       // Find nested properties.
-      elseif (isset($object->properties) && gettype($object->properties == 'object')) {
-        $property_list = $this->buildPropertyList($object->properties, $id, $property_list);
-      }
-      elseif (isset($object->items) && gettype($object->items) == 'object' && isset($object->items->properties)) {
-        $property_list = $this->buildPropertyList($object->items->properties, $id, $property_list);
+      else {
+        $this->parseNestedProperties($id, $object, $property_list);
       }
     }
 
     return $property_list;
+  }
+
+  /**
+   * Parse nested string schema properties.
+   *
+   * @param string $id
+   *   Property ID.
+   * @param object $object
+   *   Object we're parsing.
+   * @param array $property_list
+   *   Array we're building of schema properties.
+   */
+  private function parseNestedProperties(string $id, $object, array &$property_list = []) {
+    if (isset($object->properties) && gettype($object->properties == 'object')) {
+      $property_list = $this->buildPropertyList($object->properties, $id, $property_list);
+    }
+    elseif (isset($object->items) && gettype($object->items) == 'object' && isset($object->items->properties)) {
+      $property_list = $this->buildPropertyList($object->items->properties, $id, $property_list);
+    }
   }
 
 }

--- a/modules/metastore/src/SchemaPropertiesHelper.php
+++ b/modules/metastore/src/SchemaPropertiesHelper.php
@@ -96,10 +96,10 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
         continue;
       }
       if ($object->type == 'string' && isset($object->title)) {
-        $property_list[$parent . '.' . $id] = ucfirst($parent) . ': ' . "{$object->title} ({$id})";
+        $property_list[$parent . '_' . $id] = ucfirst($parent) . ': ' . "{$object->title} ({$id})";
       }
       elseif ($object->type == 'string') {
-        $property_list[$parent . '.' . $id] = ucfirst($parent) . ': ' . ucfirst($id);
+        $property_list[$parent . '_' . $id] = ucfirst($parent) . ': ' . ucfirst($id);
       }
       // Find nested properties.
       elseif (isset($object->properties) && gettype($object->properties == 'object')) {

--- a/modules/metastore/src/SchemaPropertiesHelper.php
+++ b/modules/metastore/src/SchemaPropertiesHelper.php
@@ -95,12 +95,10 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
       if (substr($id, 0, 1) == '@' || gettype($object) != 'object' || !isset($object->type)) {
         continue;
       }
-      $type = $object->type;
-      if ($type == 'string' && isset($object->title)) {
-        $property_list[$parent . '_' . $id] = ucfirst($parent) . ': ' . "{$object->title} ({$id})";
-      }
-      elseif($type == 'string') {
-        $property_list[$parent . '_' . $id] = ucfirst($parent) . ': ' . ucfirst($id);
+
+      if ($object->type == 'string') {
+        $title = $object->title ? $object->title . ' (' . $id . ')' : ucfirst($id);
+        $property_list[$parent . '_' . $id] = ucfirst($parent) . ': ' . $title;
       }
       // Find nested properties.
       else {

--- a/modules/metastore/src/SchemaPropertiesHelper.php
+++ b/modules/metastore/src/SchemaPropertiesHelper.php
@@ -97,7 +97,7 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
       }
 
       if ($object->type == 'string') {
-        $title = $object->title ? $object->title . ' (' . $id . ')' : ucfirst($id);
+        $title = isset($object->title) ? $object->title . ' (' . $id . ')' : ucfirst($id);
         $property_list[$parent . '_' . $id] = ucfirst($parent) . ': ' . $title;
       }
       // Find nested properties.

--- a/modules/metastore/src/SchemaPropertiesHelper.php
+++ b/modules/metastore/src/SchemaPropertiesHelper.php
@@ -80,7 +80,7 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
    * Build a list of JSON schema properties.
    *
    * @param object $input
-   *   Object we're parsing.
+   *   JSON Schema object we're parsing.
    * @param string $parent
    *   Parent object.
    * @param array $property_list
@@ -99,14 +99,14 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
   }
 
   /**
-   * Parse a single property from a JSON schema
+   * Parse a single property from a JSON schema.
    *
    * @param string $name
    *   Property name.
    * @param mixed $property
-   *   JSON schema property object.
+   *   JSON schema "property" object.
    * @param string $parent
-   *   The parent propety of the current property.
+   *   The parent JSON Schema propety of the current property.
    * @param array $property_list
    *   Array we're building of schema properties.
    */
@@ -124,16 +124,16 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
     // Non-strings (arrays and objects) can be parsed for nested properties.
     else {
       $this->parseNestedProperties($name, $property, $property_list);
-    }    
+    }
   }
 
   /**
    * Parse nested schema properties.
    *
-   * @param string $id
+   * @param string $name
    *   Property ID.
-   * @param object $object
-   *   Object we're parsing.
+   * @param object $property
+   *   JSON Schema "property" object we're parsing.
    * @param array $property_list
    *   Array we're building of schema properties.
    */

--- a/modules/metastore/src/SchemaPropertiesHelper.php
+++ b/modules/metastore/src/SchemaPropertiesHelper.php
@@ -38,7 +38,7 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
   }
 
   /**
-   * Retrieve schema properties.
+   * Retrieve dataset schema properties.
    *
    * @return array
    *   List of schema properties' title and description.
@@ -56,6 +56,62 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
       }
       else {
         $property_list[$property_id] = ucfirst($property_id);
+      }
+    }
+
+    return $property_list;
+  }
+
+  /**
+   * Retrieve all string schema properties.
+   *
+   * @return array
+   *   List of schema properties' title and description.
+   */
+  public function retrieveStringSchemaProperties(): array {
+    // Create a json object from our schema.
+    $schema = $this->schemaRetriever->retrieve('dataset');
+    $schema_object = json_decode($schema);
+
+    return $this->buildPropertyList($schema_object->properties);
+  }
+
+  /**
+   * Build a list of schema properties.
+   *
+   * @param mixed $input
+   *   Object we're parsing.
+   * @param string $parent
+   *   Schema for this object
+   * @param array $property_list
+   *   Array we're building of schema properties.
+   *
+   * @return array
+   *   List of schema properties' title and description.
+   */
+  private function buildPropertyList(mixed $input, string $parent = 'dataset', array &$property_list = []): array {
+    foreach ($input as $id => $object) {
+      // Exclude properties starting with @.
+      if (substr($id, 0, 1) == '@' || gettype($object) != 'object' || !isset($object->type)) {
+        continue;
+      }
+      $type = $object->type;
+      if ($type == 'string') {
+        if (isset($object->title)) {
+          $property_list[$parent . '.' . $id] = ucfirst($parent) . ': ' . "{$object->title} ({$id})";
+        }
+        else {
+          $property_list[$parent . '.' . $id] = ucfirst($parent) . ': ' . ucfirst($id);
+        }
+      }
+      // Find nested properties.
+      elseif (in_array($type, ['array', 'object'])) {
+        if (isset($object->properties) && gettype($object->properties == 'object')) {
+          $property_list = $this->buildPropertyList($object->properties, $id, $property_list);
+        }
+        elseif (isset($object->items) && gettype($object->items) == 'object' && isset($object->items->properties)) {
+          $property_list = $this->buildPropertyList($object->items->properties, $id, $property_list);
+        }
       }
     }
 

--- a/modules/metastore/src/SchemaPropertiesHelper.php
+++ b/modules/metastore/src/SchemaPropertiesHelper.php
@@ -95,13 +95,11 @@ class SchemaPropertiesHelper implements ContainerInjectionInterface {
       if (substr($id, 0, 1) == '@' || gettype($object) != 'object' || !isset($object->type)) {
         continue;
       }
-      if ($object->type == 'string') {
-        if (isset($object->title)) {
-          $property_list[$parent . '.' . $id] = ucfirst($parent) . ': ' . "{$object->title} ({$id})";
-        }
-        else {
-          $property_list[$parent . '.' . $id] = ucfirst($parent) . ': ' . ucfirst($id);
-        }
+      if ($object->type == 'string' && isset($object->title)) {
+        $property_list[$parent . '.' . $id] = ucfirst($parent) . ': ' . "{$object->title} ({$id})";
+      }
+      elseif ($object->type == 'string') {
+        $property_list[$parent . '.' . $id] = ucfirst($parent) . ': ' . ucfirst($id);
       }
       // Find nested properties.
       elseif (isset($object->properties) && gettype($object->properties == 'object')) {

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -374,7 +374,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
   private function createNewEntity(string $uuid, $data) {
     $title = '';
     if ($this->schemaId === 'dataset') {
-      $title = isset($data->title) ? $data->title : $data->name;
+      $title = $data->title ?? $data->name;
     }
     else {
       $title = MetastoreService::metadataHash($data->data);

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -88,7 +88,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
   /**
    * The config factory.
    *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
   protected $configFactory;
 

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -410,7 +410,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
    */
   private function filterHtml($input, string $parent = 'dataset') {
     $html_allowed = $this->configFactory->get('metastore.settings')->get('html_allowed_properties')
-      ?: ['dataset.description', 'distribution.description'];
+      ?: ['dataset_description', 'distribution_description'];
     switch (gettype($input)) {
       case "string":
         return $this->htmlPurifier($input);
@@ -419,7 +419,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
       case "object":
         foreach ($input as $name => &$value) {
           // Only apply filtering to properties that allow HTML.
-          if (in_array($parent . '.' . $name, $html_allowed)) {
+          if (in_array($parent . '_' . $name, $html_allowed)) {
             $value = $this->filterHtml($value, $name);
           }
           // Nested properties; check using parent.

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -3,6 +3,7 @@
 namespace Drupal\metastore\Storage;
 
 use Drupal\common\LoggerTrait;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -85,12 +86,20 @@ abstract class Data implements MetastoreEntityStorageInterface {
   protected $schemaIdField;
 
   /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   */
+  protected $configFactory;
+
+  /**
    * Constructor.
    */
-  public function __construct(string $schemaId, EntityTypeManagerInterface $entityTypeManager) {
+  public function __construct(string $schemaId, EntityTypeManagerInterface $entityTypeManager, ConfigFactoryInterface $config_factory) {
     $this->entityTypeManager = $entityTypeManager;
     $this->entityStorage = $this->entityTypeManager->getStorage($this->entityType);
     $this->schemaId = $schemaId;
+    $this->configFactory = $config_factory;
   }
 
   /**
@@ -400,8 +409,8 @@ abstract class Data implements MetastoreEntityStorageInterface {
    *   Filtered output.
    */
   private function filterHtml($input, string $parent = 'dataset') {
-    // Temporarily hard code allowed properties.
-    $html_allowed = ['dataset.description', 'distribution.description'];
+    $html_allowed = $this->configFactory->get('metastore.settings')->get('html_allowed_properties')
+      ?: ['dataset.description', 'distribution.description'];
     switch (gettype($input)) {
       case "string":
         return $this->htmlPurifier($input);

--- a/modules/metastore/src/Storage/DataFactory.php
+++ b/modules/metastore/src/Storage/DataFactory.php
@@ -3,6 +3,7 @@
 namespace Drupal\metastore\Storage;
 
 use Contracts\FactoryInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 
 /**
@@ -25,10 +26,18 @@ class DataFactory implements FactoryInterface {
   private $entityTypeManager;
 
   /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * Constructor.
    */
-  public function __construct(EntityTypeManager $entityTypeManager) {
+  public function __construct(EntityTypeManager $entityTypeManager, ConfigFactoryInterface $config_factory) {
     $this->entityTypeManager = $entityTypeManager;
+    $this->configFactory = $config_factory;
   }
 
   /**
@@ -79,7 +88,7 @@ class DataFactory implements FactoryInterface {
    *   Storage object.
    */
   protected function createNodeInstance(string $identifier) {
-    return new NodeData($identifier, $this->entityTypeManager);
+    return new NodeData($identifier, $this->entityTypeManager, $this->configFactory);
   }
 
   /**

--- a/modules/metastore/src/Storage/NodeData.php
+++ b/modules/metastore/src/Storage/NodeData.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\metastore\Storage;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 
 /**
@@ -12,14 +13,14 @@ class NodeData extends Data {
   /**
    * NodeData constructor.
    */
-  public function __construct(string $schemaId, EntityTypeManagerInterface $entityTypeManager) {
+  public function __construct(string $schemaId, EntityTypeManagerInterface $entityTypeManager, ConfigFactoryInterface $config_factory) {
     $this->entityType = 'node';
     $this->bundle = 'data';
     $this->bundleKey = "type";
     $this->labelKey = "title";
     $this->schemaIdField = "field_data_type";
     $this->metadataField = "field_json_metadata";
-    parent::__construct($schemaId, $entityTypeManager);
+    parent::__construct($schemaId, $entityTypeManager, $config_factory);
   }
 
   /**

--- a/modules/metastore/tests/src/Unit/MetastoreControllerTest.php
+++ b/modules/metastore/tests/src/Unit/MetastoreControllerTest.php
@@ -47,10 +47,10 @@ class MetastoreControllerTest extends TestCase {
    * @var string[]
    */
   public const HTML_ALLOWED_PROPERTIES = [
-    'dataset.description' => 'dataset.description',
-    'distribution.description' => 'distribution.description',
-    'dataset.title' => 0,
-    'dataset.identifier' => 0,
+    'dataset_description' => 'dataset_description',
+    'distribution_description' => 'distribution_description',
+    'dataset_title' => 0,
+    'dataset_identifier' => 0,
   ];
 
   protected function setUp(): void {

--- a/modules/metastore/tests/src/Unit/MetastoreControllerTest.php
+++ b/modules/metastore/tests/src/Unit/MetastoreControllerTest.php
@@ -3,6 +3,8 @@
 namespace Drupal\Tests\metastore\Unit;
 
 use Drupal\Core\Cache\Context\CacheContextsManager;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\metastore\DatasetApiDocs;
 use Drupal\metastore\Exception\ExistingObjectException;
 use Drupal\metastore\Exception\MissingObjectException;
@@ -38,6 +40,18 @@ class MetastoreControllerTest extends TestCase {
    * @var \Drupal\metastore\ValidMetadataFactory|\PHPUnit\Framework\MockObject\MockObject
    */
   protected $validMetadataFactory;
+
+  /**
+   * List html allowed schema properties properties.
+   *
+   * @var string[]
+   */
+  public const HTML_ALLOWED_PROPERTIES = [
+    'dataset.description' => 'dataset.description',
+    'distribution.description' => 'distribution.description',
+    'dataset.title' => 0,
+    'dataset.identifier' => 0,
+  ];
 
   protected function setUp(): void {
     parent::setUp();
@@ -111,7 +125,13 @@ class MetastoreControllerTest extends TestCase {
       ->add(QueryInterface::class, 'condition', QueryInterface::class)
       ->add(QueryInterface::class, 'execute', NULL)
       ->getMock();
-    $nodeDataMock = new NodeData($schema_id, $entityTypeManagerMock);
+    $immutableConfig = (new Chain($this))
+      ->add(ImmutableConfig::class, 'get', self::HTML_ALLOWED_PROPERTIES)
+      ->getMock();
+    $configFactoryMock = (new Chain($this))
+      ->add(ConfigFactoryInterface::class, 'get', $immutableConfig)
+      ->getMock();
+    $nodeDataMock = new NodeData($schema_id, $entityTypeManagerMock, $configFactoryMock);
     $container = $this->getCommonMockChain()
       ->add(MetastoreService::class, 'getStorage', $nodeDataMock)
       ->getMock();

--- a/modules/metastore/tests/src/Unit/SchemaPropertiesHelperTest.php
+++ b/modules/metastore/tests/src/Unit/SchemaPropertiesHelperTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 class SchemaPropertiesHelperTest extends TestCase {
 
   /**
-   * Test.
+   * Test to retrieve dataset schema properties.
    */
   public function test() {
     $schema = '{
@@ -43,4 +43,67 @@ class SchemaPropertiesHelperTest extends TestCase {
     $this->assertEquals($expected, $schemaPropertiesHelper->retrieveSchemaProperties());
   }
 
+  /**
+   * Test to retrieve string schema properties.
+   */
+  public function testRetrieveStringSchemaProperties() {
+    $schema = '{
+      "type":"object",
+      "properties":{
+        "@type":{
+          "type":"string",
+          "title":"Metadata Context"
+        },
+        "title":{
+          "type":"string",
+          "title":"Title"
+        },
+        "test":{
+          "type":"string"
+        },
+        "theme": {
+          "type":"array",
+          "items": {
+            "type": "string",
+            "title": "Category"
+          }
+        },
+        "contactPoint":{
+          "type":"object",
+          "properties": {
+            "fn":{
+              "type":"string",
+              "title":"Contact Name"
+            }
+          }
+        },
+        "distribution": {
+          "type":"array",
+          "items": {
+            "type": "object",
+            "title": "Data File",
+            "properties": {
+              "title":{
+                "type":"string",
+                "title":"Title"
+              }
+            }
+          }
+        }
+      }
+    }';
+    $expected = [
+      'dataset.title' => 'Dataset: Title (title)',
+      'dataset.test' => 'Dataset: Test',
+      'contactPoint.fn' => 'ContactPoint: Contact Name (fn)',
+      'distribution.title' => 'Distribution: Title (title)'
+    ];
+
+    $chain = (new Chain($this))
+      ->add(Container::class, 'get', SchemaRetriever::class)
+      ->add(SchemaRetriever::class, 'retrieve', $schema);
+
+    $schemaPropertiesHelper = SchemaPropertiesHelper::create($chain->getMock());
+    $this->assertEquals($expected, $schemaPropertiesHelper->retrieveStringSchemaProperties());
+  }
 }

--- a/modules/metastore/tests/src/Unit/SchemaPropertiesHelperTest.php
+++ b/modules/metastore/tests/src/Unit/SchemaPropertiesHelperTest.php
@@ -93,10 +93,10 @@ class SchemaPropertiesHelperTest extends TestCase {
       }
     }';
     $expected = [
-      'dataset.title' => 'Dataset: Title (title)',
-      'dataset.test' => 'Dataset: Test',
-      'contactPoint.fn' => 'ContactPoint: Contact Name (fn)',
-      'distribution.title' => 'Distribution: Title (title)'
+      'dataset_title' => 'Dataset: Title (title)',
+      'dataset_test' => 'Dataset: Test',
+      'contactPoint_fn' => 'ContactPoint: Contact Name (fn)',
+      'distribution_title' => 'Distribution: Title (title)'
     ];
 
     $chain = (new Chain($this))

--- a/modules/metastore/tests/src/Unit/Storage/DataTest.php
+++ b/modules/metastore/tests/src/Unit/Storage/DataTest.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\Tests\metastore\Unit\Storage;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Field\FieldItemListInterface;
@@ -18,9 +20,27 @@ use PHPUnit\Framework\TestCase;
  */
 class DataTest extends TestCase {
 
-  public function testGetStorageNode() {
+  /**
+   * List html allowed schema properties properties.
+   *
+   * @var string[]
+   */
+  public const HTML_ALLOWED_PROPERTIES = [
+    'dataset.description' => 'dataset.description',
+    'distribution.description' => 'distribution.description',
+    'dataset.title' => 0,
+    'dataset.identifier' => 0,
+  ];
 
-    $data = new NodeData('dataset', $this->getEtmChain()->getMock());
+  public function testGetStorageNode() {
+    $immutableConfig = (new Chain($this))
+      ->add(ImmutableConfig::class, 'get', self::HTML_ALLOWED_PROPERTIES)
+      ->getMock();
+    $configFactoryMock = (new Chain($this))
+      ->add(ConfigFactoryInterface::class, 'get', $immutableConfig)
+      ->getMock();
+
+    $data = new NodeData('dataset', $this->getEtmChain()->getMock(), $configFactoryMock);
     $this->assertInstanceOf(NodeStorage::class, $data->getEntityStorage());
   }
 
@@ -29,9 +49,15 @@ class DataTest extends TestCase {
     $etmMock = $this->getEtmChain()
       ->add(QueryInterface::class, 'execute', [])
       ->getMock();
+    $immutableConfig = (new Chain($this))
+      ->add(ImmutableConfig::class, 'get', self::HTML_ALLOWED_PROPERTIES)
+      ->getMock();
+    $configFactoryMock = (new Chain($this))
+      ->add(ConfigFactoryInterface::class, 'get', $immutableConfig)
+      ->getMock();
 
     $this->expectExceptionMessage('Error: 1 not found.');
-    $nodeData = new NodeData('dataset', $etmMock);
+    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock);
     $nodeData->publish('1');
   }
 
@@ -43,8 +69,14 @@ class DataTest extends TestCase {
       ->add(Node::class, 'set')
       ->add(Node::class, 'save')
       ->getMock();
+    $immutableConfig = (new Chain($this))
+      ->add(ImmutableConfig::class, 'get', self::HTML_ALLOWED_PROPERTIES)
+      ->getMock();
+    $configFactoryMock = (new Chain($this))
+      ->add(ConfigFactoryInterface::class, 'get', $immutableConfig)
+      ->getMock();
 
-    $nodeData = new NodeData('dataset', $etmMock);
+    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock);
     $result = $nodeData->publish('1');
     $this->assertEquals(TRUE, $result);
   }
@@ -55,8 +87,14 @@ class DataTest extends TestCase {
       ->add(Node::class, 'get', FieldItemListInterface::class)
       ->add(FieldItemListInterface::class, 'getString', 'published')
       ->getMock();
+    $immutableConfig = (new Chain($this))
+      ->add(ImmutableConfig::class, 'get', self::HTML_ALLOWED_PROPERTIES)
+      ->getMock();
+    $configFactoryMock = (new Chain($this))
+      ->add(ConfigFactoryInterface::class, 'get', $immutableConfig)
+      ->getMock();
 
-    $nodeData = new NodeData('dataset', $etmMock);
+    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock);
     $result = $nodeData->publish('1');
     $this->assertEquals(FALSE, $result);
   }
@@ -86,9 +124,15 @@ class DataTest extends TestCase {
     $etmMock = $this->getEtmChain()
       ->add(QueryInterface::class, 'execute', $count)
       ->getMock();
+    $immutableConfig = (new Chain($this))
+      ->add(ImmutableConfig::class, 'get', self::HTML_ALLOWED_PROPERTIES)
+      ->getMock();
+    $configFactoryMock = (new Chain($this))
+      ->add(ConfigFactoryInterface::class, 'get', $immutableConfig)
+      ->getMock();
 
     // Create Data object.
-    $nodeData = new NodeData('dataset', $etmMock);
+    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock);
     // Ensure count matches return value.
     $this->assertEquals($count, $nodeData->count());
   }
@@ -115,9 +159,15 @@ class DataTest extends TestCase {
     $etmMock = $this->getEtmChain()
       ->add(NodeStorage::class, 'loadMultiple', $nodes)
       ->getMock();
+    $immutableConfig = (new Chain($this))
+      ->add(ImmutableConfig::class, 'get', self::HTML_ALLOWED_PROPERTIES)
+      ->getMock();
+    $configFactoryMock = (new Chain($this))
+      ->add(ConfigFactoryInterface::class, 'get', $immutableConfig)
+      ->getMock();
 
     // Create Data object.
-    $nodeData = new NodeData('dataset', $etmMock);
+    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock);
     // Ensure the returned uuids match those belonging to the generated nodes.
     $this->assertEquals($uuids, $nodeData->retrieveIds(1, 5));
   }

--- a/modules/metastore/tests/src/Unit/Storage/DataTest.php
+++ b/modules/metastore/tests/src/Unit/Storage/DataTest.php
@@ -26,10 +26,10 @@ class DataTest extends TestCase {
    * @var string[]
    */
   public const HTML_ALLOWED_PROPERTIES = [
-    'dataset.description' => 'dataset.description',
-    'distribution.description' => 'distribution.description',
-    'dataset.title' => 0,
-    'dataset.identifier' => 0,
+    'dataset_description' => 'dataset_description',
+    'distribution_description' => 'distribution_description',
+    'dataset_title' => 0,
+    'dataset_identifier' => 0,
   ];
 
   public function testGetStorageNode() {


### PR DESCRIPTION
Adds a new configuration setting for properties that can contain HTML and then limits HTML filtering (via the API) to those fields. If the config setting is not set, the allowed properties default to dataset and distribution description fields.

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Set (check) dataset and distribution descriptions as HTML allowed on the /admin/dkan/properties configuration form and save.
- [ ] Create a harvest file called data2.json with the contents of the data2.pdf file attached to WCMS-16115 and put it in docroot/sites/default/files
- [ ] Register the harvest: ddev drush dkan:harvest:register --identifier=h1 --extract-uri=https://yourdomain.ddev.site/sites/default/files/data2.json
- [ ] Run the harvest: ddev drush dkan:harvest:run h1
- [ ] Visit the dataset link ( /dataset/069d-826b ). Confirm that the dangerous HTML (and ampersand) are displayed as plain text in the dataset title and that the ampersand is displayed correctly in the keyword. Confirm that the onauxclick link was stripped from the dataset description
- [ ] Visit the node link for the dataset ( /node/[nid] ). Confirm that the dangerous HTML (and ampersand) are displayed as plain text in the dataset title and that the ampersand is displayed correctly in the keyword. Confirm that the onauxclick link was stripped from the dataset description
