### PR TITLE
ResourceLocalizer constructor arg should be an interface

### DIFF
--- a/modules/datastore/src/Service/ResourceLocalizer.php
+++ b/modules/datastore/src/Service/ResourceLocalizer.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\datastore\Service;
 
-use Drupal\common\FileFetcher\FileFetcherFactory;
+use Contracts\FactoryInterface;
 use Drupal\common\LoggerTrait;
 use Drupal\common\DataResource;
 use Drupal\common\Storage\JobStoreFactory;
@@ -48,9 +48,11 @@ class ResourceLocalizer {
   /**
    * DKAN resource file fetcher factory.
    *
-   * @var \Drupal\common\FileFetcher\FileFetcherFactory
+   * @see \Drupal\common\FileFetcher\FileFetcherFactory
+   *
+   * @var \Contracts\FactoryInterface
    */
-  private FileFetcherFactory $fileFetcherFactory;
+  private FactoryInterface $fileFetcherFactory;
 
   /**
    * Drupal files utility service.
@@ -71,7 +73,7 @@ class ResourceLocalizer {
    */
   public function __construct(
     ResourceMapper $fileMapper,
-    FileFetcherFactory $fileFetcherFactory,
+    FactoryInterface $fileFetcherFactory,
     DrupalFiles $drupalFiles,
     JobStoreFactory $jobStoreFactory
   ) {

--- a/modules/datastore/src/Service/ResourceLocalizer.php
+++ b/modules/datastore/src/Service/ResourceLocalizer.php
@@ -48,9 +48,9 @@ class ResourceLocalizer {
   /**
    * DKAN resource file fetcher factory.
    *
-   * @see \Drupal\common\FileFetcher\FileFetcherFactory
-   *
    * @var \Contracts\FactoryInterface
+   *
+   * @see \Drupal\common\FileFetcher\FileFetcherFactory
    */
   private FactoryInterface $fileFetcherFactory;
 


### PR DESCRIPTION
One DKAN site uses a bespoke file fetcher for S3 localization.

Changes in https://github.com/GetDKAN/dkan/pull/3996 broke this functionality, since we changed the signature of `ResourceLocalizer::__construct()`.

This PR changes the signature back so it's `\Contracts\FactoryInterface`.