### PR TITLE
Remove getdkan/locker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "getdkan/file-fetcher" : "^4.2.1",
         "getdkan/harvest": "^1.0.0",
         "getdkan/json-schema-provider": "^0.1.2",
-        "getdkan/locker": "^1.1.0",
         "getdkan/procrastinator": "^4.0.0",
         "getdkan/rooted-json-data": "^0.1",
         "getdkan/sql-parser": "^2.1.0",


### PR DESCRIPTION
As part of a move to integrate all the getdkan-named external packages into the module, here we investigate removing  [getdkan/locker](https://github.com/GetDKAN/locker).

As it turns out, we can just remove the dependency and all the tests pass locally.