### PR TITLE
Harvest adds unused DB schemas

### DIFF
--- a/modules/harvest/harvest.install
+++ b/modules/harvest/harvest.install
@@ -5,104 +5,17 @@
  */
 
 /**
- *
- */
-function harvest_schema() {
-
-  $schema['harvest_source'] = [
-    'description' => 'The table tracking harvest sources.',
-    'fields' => [
-      'source_id' => [
-        'description' => 'The primary identifier for an entity. Used to connect the harveset source to Drupal entity.',
-        'type' => 'varchar_ascii',
-        'length' => 32,
-        'not null' => TRUE,
-      ],
-      'config' => [
-        'description' => 'The id for the harvest run.',
-        'type' => 'text',
-        'not null' => TRUE,
-      ],
-    ],
-    'primary key' => [
-      'source_id',
-    ],
-  ];
-
-  $schema['harvest_run'] = [
-    'description' => 'The table tracking harvest sources.',
-    'fields' => [
-      'run_id' => [
-        'description' => 'The id for the harvest run.',
-        'type' => 'serial',
-        'not null' => TRUE,
-      ],
-      'source_id' => [
-        'description' => 'The primary identifier for an entity. Used to connect the harveset hash to Drupal entity.',
-        'type' => 'varchar_ascii',
-        'length' => 32,
-        'not null' => TRUE,
-        'default' => '',
-      ],
-      'timestamp' => [
-        'type' => 'int',
-        'not null' => TRUE,
-        'default' => 0,
-        'description' => 'Unix timestamp of when event occurred.',
-      ],
-      'results' => [
-        'description' => 'The id for the harvest run.',
-        'type' => 'text',
-        'not null' => TRUE,
-      ],
-    ],
-    'primary key' => [
-      'run_id',
-    ],
-  ];
-
-  $schema['harvest_hash'] = [
-    'description' => 'The table tracking harvest hashes.',
-    'fields' => [
-      'identifier' => [
-        'description' => 'The uuid for a dataset or open data entity.',
-        'type' => 'varchar_ascii',
-        'length' => 191,
-        'not null' => TRUE,
-        'default' => '',
-      ],
-      'source_id' => [
-        'description' => 'The primary identifier for an entity. Used to connect the harveset hash to Drupal entity.',
-        'type' => 'varchar_ascii',
-        'length' => 32,
-        'not null' => TRUE,
-        'default' => '',
-      ],
-      'hash' => [
-        'description' => 'The hash of the harvest.',
-        'type' => 'varchar_ascii',
-        'length' => 191,
-        'not null' => TRUE,
-        'default' => '',
-      ],
-      'timestamp' => [
-        'type' => 'int',
-        'not null' => TRUE,
-        'default' => 0,
-        'description' => 'Unix timestamp of when event occurred.',
-      ],
-    ],
-    'primary key' => [
-      'identifier',
-    ],
-  ];
-
-  return $schema;
-}
-
-/**
  * Uninstall obsolete submodule harvest_dashboard.
  */
 function harvest_update_8001(&$sandbox) {
   \Drupal::service('module_installer')->uninstall(['harvest_dashboard']);
+}
+
+/**
+ * Remove tables if they exist: harvest_source, harvest_run, harvest_hash.
+ */
+function harvest_update_8002(&$sandbox) {
+  foreach (['harvest_source', 'harvest_run', 'harvest_hash'] as $table) {
+    \Drupal::database()->schema()->dropTable($table);
+  }
 }


### PR DESCRIPTION
Poking around looking at other things I discovered `hook_schema()` in harvest module, `harvest_schema()`. This hook adds these tables: `harvest_source`, `harvest_run`, `harvest_hash`.

This was originally added in 2018, and then eventually made obsolete by the `AbstractDatabaseTable` model in common module. This is implemented in `Drupal\harvest\Storage\DatabaseTable`.

Nothing uses these database schemas, and tests pass locally if I remove them.

This PR adds an update hook which will remove the tables if they exist.