### PR TITLE
16918: Correct configuration schema errors

### DIFF
--- a/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
+++ b/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
@@ -1,4 +1,3 @@
-uuid: c0964d9a-bd75-400f-9c1f-e894ad143951
 langcode: en
 status: true
 dependencies:
@@ -9,8 +8,6 @@ dependencies:
     - content_moderation
     - node
     - user
-_core:
-  default_config_hash: HCA18uEyP4cck_d6itshxQD0dlQHcZZ0ZAC6HGZEM8E
 id: dkan_dataset_content
 label: 'DKAN Datasets'
 module: node

--- a/modules/metastore/modules/metastore_admin/config/schema/metastore_admin.schema.yml
+++ b/modules/metastore/modules/metastore_admin/config/schema/metastore_admin.schema.yml
@@ -1,3 +1,3 @@
-action.configuration.hide_latest_revision_action:
+action.configuration.hide_current_revision_action:
   type: action_configuration_default
   label: 'Remove latest revision from search index'

--- a/modules/metastore/modules/metastore_search/config/schema/metastore_search.schema.yml
+++ b/modules/metastore/modules/metastore_search/config/schema/metastore_search.schema.yml
@@ -1,0 +1,2 @@
+plugin.plugin_configuration.search_api_datasource.dkan_dataset:
+  type: config_dependencies


### PR DESCRIPTION
Currently both search_api.index.dkan and system.action.hide_current return schema errors when running the following check:

drush config:inspect --strict-validation

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [x] Temporarily install the config_inspector contributed module
- [x] Run drush config:inspect --strict-validation and confirm no schema errors for DKAN-related configuration files.
