### PR TITLE
Add dkan_js_frontend library attributes config

### DIFF
--- a/modules/dkan_js_frontend/config/install/dkan_js_frontend.config.yml
+++ b/modules/dkan_js_frontend/config/install/dkan_js_frontend.config.yml
@@ -8,3 +8,5 @@ routes:
   - datasetapi,/dataset/{id}/api
   - search,/search
   - publishers,/publishers
+minified: true
+preprocess: true

--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -41,7 +41,10 @@ function dkan_js_frontend_library_info_build() {
   }
   foreach(glob(\Drupal::root() . $css_path . '*.css') as $full_path) {
     $basename = basename($full_path);
-    $libraries['dkan_js_frontend']['css']['theme'][$css_path . $basename] = [];
+    $libraries['dkan_js_frontend']['css']['theme'][$css_path . $basename] = [
+      "minified" => $minified ? $minified : true,
+      "preprocess" => $preprocess ? $preprocess : false,
+    ];
   }
   $libraries['dkan_js_frontend']['dependencies'] = [
     'core/drupal',

--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -26,7 +26,7 @@ const DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK = [
  */
 function dkan_js_frontend_library_info_build() {
   $libraries = [];
-  $frontend_config = \Drupal::config('dkan_js_frontend.config')
+  $frontend_config = \Drupal::config('dkan_js_frontend.config');
   $minified = $frontend_config->get('minified');
   $preprocess = $frontend_config->get('preprocess');
   $js_path = $frontend_config->get('js_folder');

--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -26,11 +26,18 @@ const DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK = [
  */
 function dkan_js_frontend_library_info_build() {
   $libraries = [];
-  $js_path = \Drupal::config('dkan_js_frontend.config')->get('js_folder');
-  $css_path = \Drupal::config('dkan_js_frontend.config')->get('css_folder');
+  $frontend_config = \Drupal::config('dkan_js_frontend.config')
+  $minified = $frontend_config->get('minified');
+  $preprocess = $frontend_config->get('preprocess');
+  $js_path = $frontend_config->get('js_folder');
+  $css_path = $frontend_config->get('css_folder');
+
   foreach(glob(\Drupal::root() . $js_path . '*.js') as $full_path) {
     $basename = basename($full_path);
-    $libraries['dkan_js_frontend']['js'][$js_path . $basename] = [];
+    $libraries['dkan_js_frontend']['js'][$js_path . $basename] = [
+      "minified" => $minified ? $minified : true,
+      "preprocess" => $preprocess ? $preprocess : false,
+    ];
   }
   foreach(glob(\Drupal::root() . $css_path . '*.css') as $full_path) {
     $basename = basename($full_path);

--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -26,24 +26,23 @@ const DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK = [
  */
 function dkan_js_frontend_library_info_build() {
   $libraries = [];
-  $frontend_config = \Drupal::config('dkan_js_frontend.config');
-  $minified = $frontend_config->get('minified');
-  $preprocess = $frontend_config->get('preprocess');
-  $js_path = $frontend_config->get('js_folder');
-  $css_path = $frontend_config->get('css_folder');
+  $minified = \Drupal::config('dkan_js_frontend.config')->get('minified');
+  $preprocess = \Drupal::config('dkan_js_frontend.config')->get('preprocess');
+  $js_path = \Drupal::config('dkan_js_frontend.config')->get('js_folder');
+  $css_path = \Drupal::config('dkan_js_frontend.config')->get('css_folder');
 
   foreach(glob(\Drupal::root() . $js_path . '*.js') as $full_path) {
     $basename = basename($full_path);
     $libraries['dkan_js_frontend']['js'][$js_path . $basename] = [
-      "minified" => $minified ? $minified : true,
-      "preprocess" => $preprocess ? $preprocess : false,
+      "minified" => isset($minified) ? $minified : false,
+      "preprocess" => isset($preprocess) ? $preprocess : true,
     ];
   }
   foreach(glob(\Drupal::root() . $css_path . '*.css') as $full_path) {
     $basename = basename($full_path);
     $libraries['dkan_js_frontend']['css']['theme'][$css_path . $basename] = [
-      "minified" => $minified ? $minified : true,
-      "preprocess" => $preprocess ? $preprocess : false,
+      "minified" => isset($minified) ? $minified : false,
+      "preprocess" => isset($preprocess) ? $preprocess : true,
     ];
   }
   $libraries['dkan_js_frontend']['dependencies'] = [


### PR DESCRIPTION
Fixes issue with Drupal 10.1 where compiled JS apps would break because of the extra minification Drupal applied to the files. 


## QA Steps

- [ ] Test against a 10.1+ Drupal site
- [ ] This should work with no config change on an existing site by telling Drupal the code is already minified and it should be added to the rest of the JS on the site. 
