### PR TITLE
Use consistent naming conventions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ commands:
                   ddev composer update getdkan/dkan -W
                   ddev composer show getdkan/dkan
                   ddev drush updb -y
+                  ddev drush cr
                   ddev drush rq
       - unless:
           condition: << parameters.upgrade >>

--- a/cypress/integration/09_admin_links.spec.js
+++ b/cypress/integration/09_admin_links.spec.js
@@ -9,7 +9,7 @@ context('Administration pages', () => {
   it('I should see a link for the dataset properties configuration', () => {
     cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=>{
         cy.wrap($el).invoke('show')
-        cy.wrap($el).contains('Metastore configuration')
+        cy.wrap($el).contains('Metastore settings')
     })
     cy.visit(baseurl + "/admin/dkan/properties")
     cy.get('.option').should('contain.text', 'Distribution (distribution)')

--- a/modules/metastore/metastore.links.menu.yml
+++ b/modules/metastore/metastore.links.menu.yml
@@ -1,5 +1,5 @@
 dkan.metastore.config_properties:
-  title: Metastore configuration
+  title: Metastore settings
   route_name: dkan.metastore.config_properties
   description: Configure dataset properties for referencing sub-schemas and for HTML sanitization.
   parent: system.admin_dkan

--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -153,7 +153,7 @@ dkan.metastore.config_properties:
   path: '/admin/dkan/properties'
   defaults:
     _form: '\Drupal\metastore\Form\DkanDataSettingsForm'
-    _title: 'Metastore configuration'
+    _title: 'Metastore settings'
   requirements:
     _permission: 'access administration pages'
   options:

--- a/modules/metastore/src/Form/DkanDataSettingsForm.php
+++ b/modules/metastore/src/Form/DkanDataSettingsForm.php
@@ -89,7 +89,7 @@ class DkanDataSettingsForm extends ConfigFormBase {
 
     $form['html_allowed_properties'] = [
       '#type' => 'checkboxes',
-      '#title' => $this->t('Properties that allow HTML'),
+      '#title' => $this->t('Dataset properties that allow HTML'),
       '#description' => $this->t('Metadata properties that may contain HTML elements.'),
       '#options' => $this->schemaHelper->retrieveStringSchemaProperties(),
       '#default_value' => $config->get('html_allowed_properties') ?:


### PR DESCRIPTION
## QA Steps

- [ ] Visit the dkan menu
- [ ] Confirm the link to metastore config is "Metastore settings" to be consistent with Datastore settings, and Data Dictionary settings.
