### PR TITLE
Make PHP 8.1 + Drupal 10.1 the default in CI matrix tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,7 @@ workflows:
           matrix:
             parameters:
               dkan_recommended_branch: [ '10.1.x-dev' ]
-              php_version: [ '8.1' ]
+              php_version: [ '8.2' ]
   upgrade_and_test:
     jobs:
       - cypress:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
     parameters:
       php_version:
         description: 'PHP major.minor for DDev to use.'
-        default: '8.0'
+        default: '8.1'
         type: string
       addon_branch:
         description: 'Repo branch name for the dkan-ddev-addon you want to test against.'
@@ -34,7 +34,7 @@ commands:
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'
-        default: '9.5.x-dev'
+        default: '10.1.x-dev'
         type: string
     steps:
       - run:
@@ -117,11 +117,11 @@ jobs:
     parameters:
       php_version:
         description: 'PHP major.minor for DDev to use.'
-        default: '8.0'
+        default: '8.1'
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'
-        default: '9.5.x-dev'
+        default: '10.1.x-dev'
         type: string
       report_coverage:
         description: 'Generate coverage report and send it to CodeClimate'
@@ -184,11 +184,11 @@ jobs:
     parameters:
       php_version:
         description: 'PHP major.minor for DDev to use.'
-        default: '8.0'
+        default: '8.1'
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'
-        default: '9.5.x-dev'
+        default: '10.1.x-dev'
         type: string
       upgrade:
         description: 'If true, will install the latest stable DKAN version and test upgrade'
@@ -227,7 +227,7 @@ workflows:
     jobs:
       - cypress:
           name: install_test_cypress
-          dkan_recommended_branch: '9.5.x-dev'
+          dkan_recommended_branch: '10.1.x-dev'
       - phpunit:
           matrix:
             parameters:
@@ -237,14 +237,14 @@ workflows:
           matrix:
             parameters:
               dkan_recommended_branch: [ '9.5.x-dev']
-              php_version: [ '7.4', '8.1' ]
+              php_version: [ '7.4', '8.0' ]
       - phpunit:
-          name: 'Install target (Drupal 9.5, PHP 8.0)'
+          name: 'Install target (Drupal 10.1, PHP 8.1)'
           report_coverage: true
           matrix:
             parameters:
-              dkan_recommended_branch: [ '9.5.x-dev']
-              php_version: [ '8.0' ]
+              dkan_recommended_branch: [ '10.1.x-dev']
+              php_version: [ '8.1' ]
       - phpunit:
          matrix:
            parameters:
@@ -260,11 +260,11 @@ workflows:
       - cypress:
           name: upgrade_test_cypress
           upgrade: true
-          dkan_recommended_branch: '9.5.x-dev'
+          dkan_recommended_branch: '10.1.x-dev'
       - phpunit:
-          name: 'Upgrade target (Drupal 9.5, PHP 8.0)'
+          name: 'Upgrade target (Drupal 10.1, PHP 8.1)'
           upgrade: true
           matrix:
             parameters:
-              dkan_recommended_branch: [ '9.5.x-dev']
-              php_version: [ '8.0' ]
+              dkan_recommended_branch: [ '10.1.x-dev']
+              php_version: [ '8.1' ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ workflows:
           matrix:
             parameters:
               dkan_recommended_branch: [ '9.5.x-dev']
-              php_version: [ '7.4', '8.0' ]
+              php_version: [ '7.4', '8.0', '8.1' ]
       - phpunit:
           name: 'Install target (Drupal 10.1, PHP 8.1)'
           report_coverage: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,11 +250,6 @@ workflows:
            parameters:
              dkan_recommended_branch: [ '10.0.x-dev']
              php_version: [ '8.1' ]
-      - phpunit:
-          matrix:
-            parameters:
-              dkan_recommended_branch: [ '10.1.x-dev' ]
-              php_version: [ '8.2' ]
   upgrade_and_test:
     jobs:
       - cypress:

--- a/cypress/integration/07_admin_dataset_json_form.spec.js
+++ b/cypress/integration/07_admin_dataset_json_form.spec.js
@@ -80,10 +80,9 @@ context('Admin dataset json form', () => {
         // Delete dataset.
         cy.visit(baseurl + "/admin/dkan/datasets")
         cy.wait(2000)
-        cy.get('#edit-action').select('Delete content',{ force: true }).should('have.value', 'node_delete_action')
         cy.get('#edit-node-bulk-form-0').check({ force:true })
-        cy.get('#edit-submit--2').click({ force:true })
-        cy.get('.button').contains('Yes').click({ force:true });
+        cy.get('#edit-action').select('Delete content',{ force: true }).should('have.value', 'node_delete_action')
+        cy.get('#edit-submit').click({ force:true })
         cy.get('input[value="Delete"]').click({ force:true })
         cy.get('.messages__content').should('contain','Deleted 1 content item.')
     })

--- a/cypress/integration/08_admin_views.spec.js
+++ b/cypress/integration/08_admin_views.spec.js
@@ -61,30 +61,26 @@ context('Admin content and dataset views', () => {
         // Change the state of the first dataset from published to published hidden.
         cy.get('#edit-node-bulk-form-0').click({force:true})
         cy.get('#edit-action').select('Hide current revision',{ force: true }).should('have.value', 'hide_current')
-        cy.get('#edit-submit--2').click({ force:true })
-        cy.get('.button').contains('Yes').click({ force:true })
+        cy.get('#edit-submit').click({ force:true })
         cy.get('tbody > :nth-child(1) > .views-field-status').should('contain', 'Published')
         cy.get('tbody > :nth-child(1) > .views-field-moderation-state', {timeout: 2000}).should('contain', 'Published (hidden)')
          // Change the state of the first dataset from hidden to archived.
         cy.get('#edit-node-bulk-form-0').click({force:true})
         cy.get('#edit-action').select('Archive current revision',{ force: true }).should('have.value', 'archive_current')
-        cy.get('#edit-submit--2').click({ force:true })
-        cy.get('.button').contains('Yes').click({ force:true });
+        cy.get('#edit-submit').click({ force:true })
         cy.get('tbody > :nth-child(1) > .views-field-status', {timeout: 2000}).should('contain', 'Unpublished')
         cy.get('tbody > :nth-child(1) > .views-field-moderation-state', {timeout: 2000}).should('contain', 'Archived')
          // Change the state of the first dataset from archived to published.
         cy.get('#edit-node-bulk-form-0').click({force:true})
         cy.get('#edit-action').select('Publish latest revision',{ force: true }).should('have.value', 'publish_latest')
-        cy.get('#edit-submit--2').click({ force:true })
-        cy.get('.button').contains('Yes').click({ force:true })
+        cy.get('#edit-submit').click({ force:true })
         cy.get('tbody > :nth-child(1) > .views-field-status', {timeout: 2000}).should('contain', 'Published')
         cy.get('tbody > :nth-child(1) > .views-field-moderation-state', {timeout: 2000}).should('contain', 'Published')
          // Delete the dataset.
         cy.get('#edit-node-bulk-form-0').click({force:true})
         cy.get('#edit-action').select('Delete content',{ force: true }).should('have.value', 'node_delete_action')
-        cy.get('#edit-submit--2').click({ force:true })
-        cy.get('.button').contains('Yes').click({ force:true })
         cy.get('#edit-submit').click({ force:true })
+        cy.get('.button').contains('Delete').click({ force:true })
         cy.get('.messages--status').should('contain','Deleted 1 content item.')
     })
 


### PR DESCRIPTION
This updates the matrix tests to make PHP 8.1 and Drupal 10.1 the default configuration to test. This means the install and upgrade tests as well as the Cypress tests running now on that configuration. 

Also updated the Cypress tests to reflect a change (likely in VBO) where bulk view operations no longer trigger confirmation popups.