### PR TITLE
Add justinrainbow/json-schema to composer.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ commands:
         type: string
     steps:
       - run:
+          # TODO: We might not need to do this.
           name: Set up composer config
           command: |
             mkdir ~/.composer
@@ -50,6 +51,7 @@ commands:
             ddev --version
             ddev config --project-name test-$CIRCLE_WORKFLOW_JOB_ID --project-type drupal9 --docroot docroot --create-docroot
             ddev get https://github.com/GetDKAN/dkan-ddev-addon/archive/refs/heads/<< parameters.addon_branch >>.tar.gz
+            bash -c 'echo GITHUB_TOKEN=$GITHUB_TOKEN' > .ddev/.env
             # Modify config to use our PHP version.
             sed -i 's/^php_version.*$/php_version: "<< parameters.php_version >>"/' .ddev/config.dkan.yaml
             ddev restart

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
             ddev --version
             ddev config --project-name test-$CIRCLE_WORKFLOW_JOB_ID --project-type drupal9 --docroot docroot --create-docroot
             ddev get https://github.com/GetDKAN/dkan-ddev-addon/archive/refs/heads/<< parameters.addon_branch >>.tar.gz
-            bash -c 'echo GITHUB_TOKEN=$GITHUB_TOKEN' > .ddev/.env
+            bash -c 'echo COMPOSER_AUTH=$COMPOSER_AUTH' > .ddev/.env
             # Modify config to use our PHP version.
             sed -i 's/^php_version.*$/php_version: "<< parameters.php_version >>"/' .ddev/config.dkan.yaml
             ddev restart
@@ -137,7 +137,6 @@ jobs:
       - prepare_build:
           php_version: << parameters.php_version >>
           dkan_recommended_branch: << parameters.dkan_recommended_branch >>
-          addon_branch: composer-verbose
       - prepare_site:
           upgrade: << parameters.upgrade >>
           needs_cypress: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ jobs:
       - prepare_build:
           php_version: << parameters.php_version >>
           dkan_recommended_branch: << parameters.dkan_recommended_branch >>
+          addon_branch: composer-verbose
       - prepare_site:
           upgrade: << parameters.upgrade >>
           needs_cypress: false

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "getdkan/rooted-json-data": "^0.1",
         "guzzlehttp/guzzle" : "^6.5.8 || ^7.4.5",
         "ilbee/csv-response": "^1.1.1",
+        "justinrainbow/json-schema": "^5.2",
         "m1x0n/opis-json-schema-error-presenter": "^0.5.3",
         "fylax/forceutf8": "~3.0",
         "npm-asset/select2": "^4.0",


### PR DESCRIPTION
In the 2.16.10 release, _getdkan/json-schema-provider_ was removed. If you upgraded and were not building with dev dependencies including _drupal/core-dev_, you may have run into:

```
Uncaught PHP Exception Error: "Class "JsonSchema\Validator" not found" at /mnt/www/html/datamedicaidstg/docroot/modules/contrib/dkan/modules/datastore/src/Controller/AbstractQueryController.php line 344 request_id="v-b70ba20c-6395-11ee-a3c1-0bb257c19d59" 
```
