### PR TITLE
Issue #4036: Allow for an empty option in select fields via schema pr…

### DIFF
--- a/modules/json_form_widget/src/StringHelper.php
+++ b/modules/json_form_widget/src/StringHelper.php
@@ -77,6 +77,9 @@ class StringHelper implements ContainerInjectionInterface {
     // Add options if element type is select.
     if ($element['#type'] === 'select') {
       $element['#options'] = $this->getSelectOptions($property);
+      if ($property->empty_value) {
+        $element['#empty_value'] = '';
+      }
     }
 
     // Add extra validate if element type is email.

--- a/modules/json_form_widget/src/StringHelper.php
+++ b/modules/json_form_widget/src/StringHelper.php
@@ -77,7 +77,7 @@ class StringHelper implements ContainerInjectionInterface {
     // Add options if element type is select.
     if ($element['#type'] === 'select') {
       $element['#options'] = $this->getSelectOptions($property);
-      if ($property->empty_value) {
+      if (!$this->checkIfRequired($field_name, $element_schema)) {
         $element['#empty_value'] = '';
       }
     }

--- a/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
+++ b/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
@@ -162,6 +162,7 @@ class JsonFormBuilderTest extends TestCase {
           "R/P10Y" => "Decennial",
           "R/P4Y" => "Quadrennial",
         ],
+        "#empty_value" => ''
       ],
     ];
     $default_data = new stdClass();

--- a/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
+++ b/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
@@ -162,7 +162,7 @@ class JsonFormBuilderTest extends TestCase {
           "R/P10Y" => "Decennial",
           "R/P4Y" => "Quadrennial",
         ],
-        "#empty_value" => ''
+        "#empty_value" => '',
       ],
     ];
     $default_data = new stdClass();


### PR DESCRIPTION
fixes #4036 

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] create or edit a dataset with an optional list (enum) field (like accrualPeriodicity) and note that there will be an empty option beside the real values in the select dialog
- [ ] if you save with the empty option the value should not exist in the json stored
