### PR TITLE
enum values in schema.json vs schema.ui.json (#4041)

### DIFF
--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -174,7 +174,9 @@ class WidgetRouter implements ContainerInjectionInterface {
    */
   public function getDropdownElement($element, $spec, $titleProperty = FALSE) {
     $element['#type'] = $this->getSelectType($spec);
-    $element['#options'] = $this->getDropdownOptions($spec->source, $titleProperty);
+    if ($spec->source) {
+      $element['#options'] = $this->getDropdownOptions($spec->source, $titleProperty);
+    }
     if ($element['#type'] === 'select_or_other_select') {
       $element = $this->handleSelectOtherDefaultValue($element, $element['#options']);
       $element['#input_type'] = isset($spec->other_type) ? $spec->other_type : 'textfield';

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -174,7 +174,7 @@ class WidgetRouter implements ContainerInjectionInterface {
    */
   public function getDropdownElement($element, $spec, $titleProperty = FALSE) {
     $element['#type'] = $this->getSelectType($spec);
-    if ($spec->source) {
+    if (isset($spec->source)) {
       $element['#options'] = $this->getDropdownOptions($spec->source, $titleProperty);
     }
     if ($element['#type'] === 'select_or_other_select') {


### PR DESCRIPTION
fixes #4041

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Add the following to dataset.ui.json at "accessLevel" -> "ui:options"
```
      "widget": "list",
      "type": "select_other"
```
see that access level will now generate a "select other" widget with the options from the enum from dataset.json

