### PR TITLE
Allow select2 without entity reference (#4043)

### DIFF
--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -185,7 +185,7 @@ class WidgetRouter implements ContainerInjectionInterface {
       $element['#multiple'] = isset($spec->multiple) ? TRUE : FALSE;
       $element['#autocreate'] = isset($spec->allowCreate) ? TRUE : FALSE;
     }
-    if (isset($element['#autocreate'])) {
+    if (isset($element['#autocreate']) && $spec->type !== 'select2') {
       $element['#target_type'] = 'node';
     }
     return $element;
@@ -204,7 +204,7 @@ class WidgetRouter implements ContainerInjectionInterface {
     if (isset($spec->type) && $spec->type === 'select_other') {
       return 'select_or_other_select';
     }
-    elseif (isset($spec->type) && $spec->type === 'autocomplete') {
+    elseif (isset($spec->type) && ($spec->type === 'autocomplete' || $spec->type === 'select2')) {
       return 'select2';
     }
     return 'select';


### PR DESCRIPTION
fixes #4043

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Use select2 instead of select_other for license in dataset.ui.json
- [ ] see that the select widget changes to select2 (providing search in select widget)
