### PR TITLE
If no time set after preview node set default time

### DIFF
--- a/modules/json_form_widget/src/Element/FlexibleDateTime.php
+++ b/modules/json_form_widget/src/Element/FlexibleDateTime.php
@@ -25,11 +25,8 @@ class FlexibleDateTime extends Datetime {
   /**
    * {@inheritdoc}
    */
-  public static function valueCallback(&$element, $input, FormStateInterface $form_state) {
-    if (empty($element['#default_value']) && !empty($input['date'])) {
-      $input['time'] = !empty($input['time']) ? $input['time'] : '00:00:00';
-    }
-    elseif (isset($element['#default_value']) && empty($input['time'])) {
+  public static function valueCallback(&$element, $input, FormStateInterface $form_state) {    
+    if (!empty($input["date"]) && empty($input['time'])) {
       $input['time'] = '00:00:00';
     }
     return parent::valueCallback($element, $input, $form_state);

--- a/modules/json_form_widget/src/Element/FlexibleDateTime.php
+++ b/modules/json_form_widget/src/Element/FlexibleDateTime.php
@@ -26,7 +26,7 @@ class FlexibleDateTime extends Datetime {
    * {@inheritdoc}
    */
   public static function valueCallback(&$element, $input, FormStateInterface $form_state) {
-    if (!empty($input["date"]) && empty($input['time'])) {
+    if (!empty($input['date']) && empty($input['time'])) {
       $input['time'] = '00:00:00';
     }
     return parent::valueCallback($element, $input, $form_state);

--- a/modules/json_form_widget/src/Element/FlexibleDateTime.php
+++ b/modules/json_form_widget/src/Element/FlexibleDateTime.php
@@ -29,6 +29,9 @@ class FlexibleDateTime extends Datetime {
     if (empty($element['#default_value']) && !empty($input['date'])) {
       $input['time'] = !empty($input['time']) ? $input['time'] : '00:00:00';
     }
+    elseif (isset($element['#default_value']) && empty($input['time'])) {
+      $input['time'] = '00:00:00';
+    }
     return parent::valueCallback($element, $input, $form_state);
   }
 

--- a/modules/json_form_widget/src/Element/FlexibleDateTime.php
+++ b/modules/json_form_widget/src/Element/FlexibleDateTime.php
@@ -25,7 +25,7 @@ class FlexibleDateTime extends Datetime {
   /**
    * {@inheritdoc}
    */
-  public static function valueCallback(&$element, $input, FormStateInterface $form_state) {    
+  public static function valueCallback(&$element, $input, FormStateInterface $form_state) { 
     if (!empty($input["date"]) && empty($input['time'])) {
       $input['time'] = '00:00:00';
     }

--- a/modules/json_form_widget/src/Element/FlexibleDateTime.php
+++ b/modules/json_form_widget/src/Element/FlexibleDateTime.php
@@ -25,7 +25,7 @@ class FlexibleDateTime extends Datetime {
   /**
    * {@inheritdoc}
    */
-  public static function valueCallback(&$element, $input, FormStateInterface $form_state) { 
+  public static function valueCallback(&$element, $input, FormStateInterface $form_state) {
     if (!empty($input["date"]) && empty($input['time'])) {
       $input['time'] = '00:00:00';
     }


### PR DESCRIPTION
fixes #4045

When using the Preview feature a `#default_value` is set when returning to the form. It seems like this is causing the error in the form. 

When saving the node or previewing the node, the `FlexibleDateTime:valueCallback` method correctly sets the time. When navigating back to the form, the default value for time was an empty string. I'm guessing this callback doesn't set form_state so checking to see if there is a default value and no time set, we can set the time the same as in the previous conditional. 
