### PR TITLE
Use the latest published dataset revision when returning results for the datastore query endpoint

### DIFF
--- a/modules/common/src/DatasetInfo.php
+++ b/modules/common/src/DatasetInfo.php
@@ -136,7 +136,8 @@ class DatasetInfo implements ContainerInjectionInterface {
   }
 
   /**
-   * Get the distribution UUID for the most recent published revision of a dataset.
+   * Get the distribution UUID for the most recent published revision
+   * of a dataset.
    *
    * @param string $dataset_uuid
    *   The uuid of a dataset.

--- a/modules/common/src/DatasetInfo.php
+++ b/modules/common/src/DatasetInfo.php
@@ -136,9 +136,9 @@ class DatasetInfo implements ContainerInjectionInterface {
   }
 
   /**
-   * Get the current distribution UUID for a dataset.
+   * Get the distribution UUID for the most recent published revision of a dataset.
    *
-   * @param string $uuid
+   * @param string $dataset_uuid
    *   The uuid of a dataset.
    * @param string $index
    *   The index of the resource in the dataset array. Defaults to first.
@@ -146,19 +146,19 @@ class DatasetInfo implements ContainerInjectionInterface {
    * @return string
    *   The distribution UUID
    */
-  public function getDistributionUuid(string $uuid, string $index = '0'): string {
-    $metadata = $this->gather($uuid);
+  public function getDistributionUuid(string $dataset_uuid, string $index = '0'): string {
+    $dataset_info = $this->gather($dataset_uuid);
 
-    if (!isset($metadata['latest_revision'])) {
+    if (!isset($dataset_info['latest_revision'])) {
       return '';
     }
 
     // Default to latest dataset revision.
-    $datasetRevision = $metadata['latest_revision'];
+    $datasetRevision = $dataset_info['latest_revision'];
 
     // Use the published dataset revision instead if present.
-    if (isset($metadata['published_revision'])) {
-      $datasetRevision = $metadata['published_revision'];
+    if (isset($dataset_info['published_revision'])) {
+      $datasetRevision = $dataset_info['published_revision'];
     }
     return $datasetRevision['distributions'][$index]['distribution_uuid'] ?? '';
   }

--- a/modules/common/src/DatasetInfo.php
+++ b/modules/common/src/DatasetInfo.php
@@ -136,6 +136,35 @@ class DatasetInfo implements ContainerInjectionInterface {
   }
 
   /**
+   * Get the current distribution UUID for a dataset.
+   *
+   * @param string $uuid
+   *   The uuid of a dataset.
+   *
+   * @param string $index
+   *   The index of the resource in the dataset array. Defaults to first.
+   *
+   * @return string
+   *   The distribution UUID
+   */
+  public function getDistributionUuid(string $uuid, string $index = '0'): string {
+    $metadata = $this->gather($uuid);
+
+    if (!isset($metadata['latest_revision'])) {
+      return '';
+    }
+
+    // Default to latest dataset revision.
+    $datasetRevision = $metadata['latest_revision'];
+
+    // Use the published dataset revision instead if present.
+    if (isset($metadata['published_revision'])) {
+      $datasetRevision = $metadata['published_revision'];
+    }
+    return $datasetRevision['distributions'][$index]['distribution_uuid'] ?? '';
+  }
+
+  /**
    * Get various information from a dataset node's specific revision.
    *
    * @param \Drupal\node\Entity\Node $node

--- a/modules/common/src/DatasetInfo.php
+++ b/modules/common/src/DatasetInfo.php
@@ -140,7 +140,6 @@ class DatasetInfo implements ContainerInjectionInterface {
    *
    * @param string $uuid
    *   The uuid of a dataset.
-   *
    * @param string $index
    *   The index of the resource in the dataset array. Defaults to first.
    *

--- a/modules/common/src/DatasetInfo.php
+++ b/modules/common/src/DatasetInfo.php
@@ -136,7 +136,9 @@ class DatasetInfo implements ContainerInjectionInterface {
   }
 
   /**
-   * Get the distribution UUID for the most recent published revision
+   * Get the distribution UUID for a dataset.
+   *
+   * Return the distribution UUID for the most recent published revision
    * of a dataset.
    *
    * @param string $dataset_uuid

--- a/modules/common/tests/src/Unit/DatasetInfoTest.php
+++ b/modules/common/tests/src/Unit/DatasetInfoTest.php
@@ -344,6 +344,40 @@ class DatasetInfoTest extends TestCase {
   }
 
   /**
+   * @covers ::getDistributionUuid
+   */
+  public function testGetDistributionUuid() {
+    // Only latest revision present.
+    $info['latest_revision']['distributions'][0]['distribution_uuid'] = '123';
+    $datasetInfo = $this->getGatherMock($info);
+
+    // Check that when only have latest revision, that distribution_uuid returned.
+    $result = $datasetInfo->getDistributionUuid('dataset1');
+    $this->assertEquals('123', $result);
+
+    // Add a published revision
+    $info['published_revision']['distributions'][0]['distribution_uuid'] = '456';
+    $datasetInfo = $this->getGatherMock($info);
+
+    // Check that when published revision present, that distribution_uuid returned.
+    $result = $datasetInfo->getDistributionUuid('dataset1');
+    $this->assertEquals('456', $result);
+  }
+
+  /**
+   *
+   */
+  private function getGatherMock($info = []) {
+    $datasetInfo = $this->getMockBuilder(DatasetInfo::class)
+      ->onlyMethods(['gather'])
+      ->getMock();
+    $datasetInfo->method('gather')
+      ->willReturn($info);
+
+    return $datasetInfo;
+  }
+
+  /**
    *
    */
   private function getCommonChain() {

--- a/modules/datastore/src/Controller/AbstractQueryController.php
+++ b/modules/datastore/src/Controller/AbstractQueryController.php
@@ -156,15 +156,13 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
    *   The json response.
    */
   public function queryDatasetResource(string $dataset, string $index, Request $request) {
-    $metadata = $this->datasetInfo->gather($dataset);
-    if (!isset($metadata['latest_revision'])) {
-      return $this->getResponse((object) ['message' => "No dataset found with the identifier $dataset"], 404);
+    $distribution_uuid = $this->datasetInfo->getDistributionUuid($dataset, $index);
+
+    if (empty($distribution_uuid)) {
+      return $this->getResponse((object) ['message' => "No resource found for dataset $dataset at index $index"], 404);
     }
-    if (!isset($metadata['latest_revision']['distributions'][$index]['distribution_uuid'])) {
-      return $this->getResponse((object) ['message' => "No resource found at index $index"], 404);
-    }
-    $identifier = $metadata['latest_revision']['distributions'][$index]['distribution_uuid'];
-    return $this->queryResource($identifier, $request);
+
+    return $this->queryResource($distribution_uuid, $request);
   }
 
   /**
@@ -266,8 +264,8 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
       $hasProperty = $hasProperty ?: (isset($property->property) && $property->property == 'record_number');
       if ($hasProperty) {
         throw new \Exception('The record_number property is for internal use and cannot be requested ' .
-        'directly. Set rowIds to true and remove properties from your query to see the full table ' .
-        'with row IDs.');
+          'directly. Set rowIds to true and remove properties from your query to see the full table ' .
+          'with row IDs.');
       }
     }
   }


### PR DESCRIPTION
Use the latest published dataset revision when returning results for the datastore query endpoint. 
Also does some slight cleanup of the DatasetBTB test.

To recreate the error in a vanilla DKAN site:

- Create a published dataset with a distribution.
- Set the default moderation state to "draft".
- Edit the dataset and replace the distribution file with data that is recognizably different than the published version. Save as a draft.
- Run cron to do the imports
- Visit the dataset page in the site and confirm that the published version of the dataset is still displayed.
- Use the datastore query endpoint {domain}/api/1/datastore/query/{dataset}/{index} and observe that the data returned is from the unpublished draft, not the published version.

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Create a published dataset with a distribution.
- [ ] Set the default moderation state to "draft".
- [ ] Edit the dataset and replace the distribution file with data that is recognizably different than the published version. Save as a draft.
- [ ] Run cron to do the imports
- [ ] Verify that the draft revision exists by running ddev drush dkan:dataset-info {datasetID}
- [ ] Visit the dataset page in the site and confirm that the published version of the dataset is still displayed.
- [ ] Use the datastore query endpoint {domain}/api/1/datastore/query/{dataset}/{index} and observe that the data returned is still from the published version.
