### PR TITLE
Clean up leftover harvest data tables

### DIFF
--- a/modules/harvest/drush.services.yml
+++ b/modules/harvest/drush.services.yml
@@ -4,5 +4,6 @@ services:
     arguments:
       - '@dkan.harvest.service'
       - '@dkan.harvest.logger_channel'
+      - '@dkan.harvest.utility'
     tags:
       - { name: drush.command }

--- a/modules/harvest/harvest.install
+++ b/modules/harvest/harvest.install
@@ -4,6 +4,30 @@
  * @file
  */
 
+function harvest_requirements($phase): array {
+  $requirements = [];
+  if ($phase == 'runtime') {
+    /** @var \Drupal\harvest\HarvestUtility $harvest_utility */
+    if ($harvest_utility = \Drupal::service('dkan.harvest.utility')) {
+      if ($leftover_harvest_data_ids = $harvest_utility->findOrphanedHarvestDataIds()) {
+        $requirements['dkan harvest leftover data'] = [
+          'title' => t('DKAN Harvest Leftover Plan Data'),
+          'value' => t('Leftover harvest data for plans: @plans', [
+            '@plans' => implode(', ', $leftover_harvest_data_ids)
+            ]),
+          'description' => t(
+            'DKAN\'s harvest module has detected extra unneeded data tables.
+            You can remove them using this Drush command from the CLI:
+            <code>drush dkan:harvest:cleanup</code>'
+          ),
+          'severity' => REQUIREMENT_WARNING,
+        ];
+      }
+    }
+  }
+  return $requirements;
+}
+
 /**
  * Uninstall obsolete submodule harvest_dashboard.
  */

--- a/modules/harvest/harvest.services.yml
+++ b/modules/harvest/harvest.services.yml
@@ -7,6 +7,12 @@ services:
       - '@entity_type.manager'
     calls:
       - [ setLoggerFactory, [ '@logger.factory' ] ]
+  dkan.harvest.utility:
+    class: Drupal\harvest\HarvestUtility
+    arguments:
+      - '@dkan.harvest.service'
+      - '@dkan.harvest.storage.database_table'
+      - '@database'
   dkan.harvest.storage.database_table:
     class: Drupal\harvest\Storage\DatabaseTableFactory
     arguments:

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -369,6 +369,7 @@ class HarvestCommands extends DrushCommands {
    * @command dkan:harvest:cleanup
    *
    * @return int
+   *   Bash status code.
    *
    * @option cleanup Clean up the extra tables.
    * @bootstrap full

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -363,27 +363,23 @@ class HarvestCommands extends DrushCommands {
   /**
    * Report and cleanup harvest data which may be cluttering your database.
    *
-   * Will print a report, unless the --cleanup argument is added, in which case
-   * the clutter will be removed.
+   * Will print a report. Add -y or --no-interaction to automatically perform
+   * this cleanup.
    *
    * @command dkan:harvest:cleanup
    *
    * @return int
    *   Bash status code.
    *
-   * @option cleanup Clean up the extra tables.
    * @bootstrap full
    */
-  public function harvestCleanup(array $options = ['cleanup' => FALSE]): int {
+  public function harvestCleanup(): int {
     $logger = $this->logger();
     $orphaned = $this->harvestUtility->findOrphanedHarvestDataIds();
     if ($orphaned) {
       $logger->notice('Detected leftover harvest data for these plans: ' . implode(', ', $orphaned));
-      if ($options['cleanup'] ?? FALSE) {
+      if ($this->io()->confirm(t('Do you want to remove this data?'), FALSE)) {
         $this->cleanupHarvestDataTables($orphaned);
-      }
-      else {
-        $logger->notice('Run this command again with the --cleanup flag to remove leftover data.');
       }
     }
     else {

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -380,10 +380,7 @@ class HarvestCommands extends DrushCommands {
     if ($orphaned) {
       $logger->notice('Detected leftover harvest data for these plans: ' . implode(', ', $orphaned));
       if ($options['cleanup'] ?? FALSE) {
-        foreach ($orphaned as $orphan) {
-          $logger->notice('Cleaning up: ' . $orphan);
-          $this->harvestUtility->destructOrphanTables($orphan);
-        }
+        $this->cleanupHarvestDataTables($orphaned);
       }
       else {
         $logger->notice('Run this command again with the --cleanup flag to remove leftover data.');
@@ -393,6 +390,19 @@ class HarvestCommands extends DrushCommands {
       $logger->notice('No leftover harvest data detected.');
     }
     return DrushCommands::EXIT_SUCCESS;
+  }
+
+  /**
+   * Perform the harvest data table cleanup.
+   *
+   * @param array $plan_ids
+   *   An array of plan identifiers to clean up.
+   */
+  protected function cleanupHarvestDataTables(array $plan_ids) : void {
+    foreach ($plan_ids as $plan_id) {
+      $this->logger()->notice('Cleaning up: ' . $plan_id);
+      $this->harvestUtility->destructOrphanTables($plan_id);
+    }
   }
 
   /**

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -365,10 +365,11 @@ class HarvestCommands extends DrushCommands {
    * @command dkan:harvest:cleanup
    *
    * @return int
+   *
    * @option cleanup Clean up the extra tables.
    * @bootstrap full
    */
-  public function harvestCleanup(array $options = ['cleanup' => false]): int {
+  public function harvestCleanup(array $options = ['cleanup' => FALSE]): int {
     $logger = $this->logger();
     $orphaned = $this->harvestUtility->findOrphanedHarvestDataIds();
     if ($orphaned) {

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -7,6 +7,7 @@ use Drupal\harvest\HarvestUtility;
 use Drupal\harvest\Load\Dataset;
 use Drupal\harvest\HarvestService;
 use Drush\Commands\DrushCommands;
+use Drush\Exceptions\UserAbortException;
 use Harvest\ETL\Extract\DataJson;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -140,13 +141,16 @@ class HarvestCommands extends DrushCommands {
    */
   public function deregister($id) {
     $message = 'Could not deregister the ' . $id . ' harvest.';
-    try {
+    $this->logger->warning(
+      'If you deregister a harvest with published datasets, you will
+       not be able to bulk revert the datasets connected to this harvest.');
+    if ($this->io()->confirm("Deregister harvest {$id}")) {
       if ($this->harvestService->deregisterHarvest($id)) {
         $message = 'Successfully deregistered the ' . $id . ' harvest.';
       }
     }
-    catch (\Exception $e) {
-      $message = $e->getMessage();
+    else {
+      throw new UserAbortException();
     }
 
     $this->logger->notice($message);

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -378,7 +378,7 @@ class HarvestCommands extends DrushCommands {
     $orphaned = $this->harvestUtility->findOrphanedHarvestDataIds();
     if ($orphaned) {
       $logger->notice('Detected leftover harvest data for these plans: ' . implode(', ', $orphaned));
-      if ($this->io()->confirm(t('Do you want to remove this data?'), FALSE)) {
+      if ($this->io()->confirm('Do you want to remove this data?', FALSE)) {
         $this->cleanupHarvestDataTables($orphaned);
       }
     }

--- a/modules/harvest/src/HarvestService.php
+++ b/modules/harvest/src/HarvestService.php
@@ -129,17 +129,26 @@ class HarvestService implements ContainerInjectionInterface {
   /**
    * Deregister harvest.
    *
-   * @param string $id
-   *   Id.
+   * @param string $plan_id
+   *   Plan identifier.
    *
    * @return bool
-   *   Boolean.
+   *   Whether this happened successfully.
    */
-  public function deregisterHarvest(string $id) {
-
+  public function deregisterHarvest(string $plan_id) {
+    // Remove all the support tables for this plan id.
+    foreach ([
+      'harvest_' . $plan_id . '_items',
+      'harvest_' . $plan_id . '_hashes',
+      'harvest_' . $plan_id . '_runs',
+    ] as $table_name) {
+      /** @var \Drupal\common\Storage\DatabaseTableInterface $store */
+      $store = $this->storeFactory->getInstance($table_name);
+      $store->destruct();
+    }
+    // Remove the plan id from the harvest_plans table.
     $plan_store = $this->storeFactory->getInstance("harvest_plans");
-
-    return $plan_store->remove($id);
+    return $plan_store->remove($plan_id);
   }
 
   /**

--- a/modules/harvest/src/HarvestService.php
+++ b/modules/harvest/src/HarvestService.php
@@ -52,7 +52,7 @@ class HarvestService implements ContainerInjectionInterface {
    */
   public static function create(ContainerInterface $container) {
     return new self(
-      $container->get("dkan.harvest.storage.database_table"),
+      $container->get('dkan.harvest.storage.database_table'),
       $container->get('dkan.metastore.service'),
       $container->get('entity_type.manager')
     );
@@ -147,7 +147,7 @@ class HarvestService implements ContainerInjectionInterface {
       $store->destruct();
     }
     // Remove the plan id from the harvest_plans table.
-    $plan_store = $this->storeFactory->getInstance("harvest_plans");
+    $plan_store = $this->storeFactory->getInstance('harvest_plans');
     return $plan_store->remove($plan_id);
   }
 

--- a/modules/harvest/src/HarvestUtility.php
+++ b/modules/harvest/src/HarvestUtility.php
@@ -69,14 +69,14 @@ class HarvestUtility implements ContainerInjectionInterface {
    * harvest_ID_that_might_have_underscores_[something]. For example:
    * 'harvest_id_here_run'.
    *
-   * @param $table_name
+   * @param string $table_name
    *   The table name.
    *
    * @return string
    *   The ID gleaned from the table name. If no ID could be gleaned, returns
    *   an empty string.
    */
-  public static function planIdFromTableName($table_name): string {
+  public static function planIdFromTableName(string $table_name): string {
     $name_explode = explode('_', $table_name);
     if (count($name_explode) < 3) {
       return '';
@@ -126,12 +126,10 @@ class HarvestUtility implements ContainerInjectionInterface {
    *
    * Will not remove data tables for existing plans.
    *
-   * @param $plan_id
+   * @param string $plan_id
    *   Plan identifier to work with.
-   *
-   * @return void
    */
-  public function destructOrphanTables($plan_id): void {
+  public function destructOrphanTables(string $plan_id): void {
     if (!in_array($plan_id, $this->harvestService->getAllHarvestIds())) {
       foreach ([
         'harvest_' . $plan_id . '_runs',

--- a/modules/harvest/src/HarvestUtility.php
+++ b/modules/harvest/src/HarvestUtility.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Drupal\harvest;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\harvest\Storage\DatabaseTableFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * DKAN Harvest utility service for maintenance tasks.
+ *
+ * These methods generally exist to support a thin Drush layer. These are
+ * methods that we don't need in the HarvestService object.
+ */
+class HarvestUtility implements ContainerInjectionInterface {
+
+  /**
+   * Harvest service.
+   *
+   * @var \Drupal\harvest\HarvestService
+   */
+  private HarvestService $harvestService;
+
+  /**
+   * Service to instantiate storage objects for Harvest plan storage.
+   *
+   * @var DatabaseTableFactory
+   */
+  private DatabaseTableFactory $storeFactory;
+
+  /**
+   * Database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  private Connection $connection;
+
+  /**
+   * Create.
+   *
+   * @inheritdoc
+   */
+  public static function create(ContainerInterface $container) {
+    return new self(
+      $container->get('dkan.harvest.service'),
+      $container->get("dkan.harvest.storage.database_table"),
+      $container->get('database'),
+    );
+  }
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    HarvestService $harvestService,
+    DatabaseTableFactory $storeFactory,
+    Connection $connection
+  ) {
+    $this->harvestService = $harvestService;
+    $this->storeFactory = $storeFactory;
+    $this->connection = $connection;
+  }
+
+  /**
+   * Get the plan ID from a given harvest table name.
+   *
+   * Harvest table names are assumed to look like this:
+   * harvest_ID_that_might_have_underscores_[something]. For example:
+   * 'harvest_id_here_run'.
+   *
+   * @param $table_name
+   *   The table name.
+   *
+   * @return string
+   *   The ID gleaned from the table name. If no ID could be gleaned, returns
+   *   an empty string.
+   */
+  public static function planIdFromTableName($table_name): string {
+    $name_explode = explode('_', $table_name);
+    if (count($name_explode) < 3) {
+      return '';
+    }
+    // Remove first and last item.
+    array_shift($name_explode);
+    array_pop($name_explode);
+    return implode('_', $name_explode);
+  }
+
+  /**
+   * Find harvest IDs with data tables that aren't in the harvest_plans table.
+   *
+   * @return array
+   *   Array of orphan plan ids, as both key and value. Empty if there are no
+   *   orphaned plan ids.
+   */
+  public function findOrphanedHarvestDataIds(): array {
+    $existing_plans = $this->harvestService->getAllHarvestIds();
+
+    $tables = [];
+    foreach ([
+      // @todo Figure out an expression for harvest_%_thing, since underscore
+      //   is a special character.
+      'harvest%runs',
+      'harvest%items',
+      'harvest%hashes',
+    ] as $table_expression) {
+      if ($found_tables = $this->connection->schema()->findTables($table_expression)) {
+        $tables = array_merge($tables, $found_tables);
+      }
+    }
+
+    $orphan_ids = [];
+    // Find IDs that are not in the existing plans.
+    foreach ($tables as $table_name) {
+      $plan_id = static::planIdFromTableName($table_name);
+      if (!in_array($plan_id, $existing_plans)) {
+        $orphan_ids[$plan_id] = $plan_id;
+      }
+    }
+    return $orphan_ids;
+  }
+
+  /**
+   * Remove existing harvest data tables for the given plan identifier.
+   *
+   * Will not remove data tables for existing plans.
+   *
+   * @param $plan_id
+   *   Plan identifier to work with.
+   *
+   * @return void
+   */
+  public function destructOrphanTables($plan_id): void {
+    if (!in_array($plan_id, $this->harvestService->getAllHarvestIds())) {
+      foreach ([
+        'harvest_' . $plan_id . '_runs',
+        'harvest_' . $plan_id . '_items',
+        'harvest_' . $plan_id . '_hashes',
+      ] as $table) {
+        $this->storeFactory->getInstance($table)->destruct();
+      }
+    }
+  }
+
+}

--- a/modules/harvest/src/HarvestUtility.php
+++ b/modules/harvest/src/HarvestUtility.php
@@ -25,7 +25,7 @@ class HarvestUtility implements ContainerInjectionInterface {
   /**
    * Service to instantiate storage objects for Harvest plan storage.
    *
-   * @var DatabaseTableFactory
+   * @var \Drupal\harvest\Storage\DatabaseTableFactory
    */
   private DatabaseTableFactory $storeFactory;
 
@@ -44,7 +44,7 @@ class HarvestUtility implements ContainerInjectionInterface {
   public static function create(ContainerInterface $container) {
     return new self(
       $container->get('dkan.harvest.service'),
-      $container->get("dkan.harvest.storage.database_table"),
+      $container->get('dkan.harvest.storage.database_table'),
       $container->get('database'),
     );
   }

--- a/modules/harvest/src/Storage/DatabaseTable.php
+++ b/modules/harvest/src/Storage/DatabaseTable.php
@@ -38,6 +38,7 @@ class DatabaseTable extends AbstractDatabaseTable {
    */
   public function retrieve(string $id) {
     $result = parent::retrieve($id);
+    if ($result)
     return ($result === NULL) ? NULL : $result->data;
   }
 

--- a/modules/harvest/src/Storage/DatabaseTable.php
+++ b/modules/harvest/src/Storage/DatabaseTable.php
@@ -38,7 +38,6 @@ class DatabaseTable extends AbstractDatabaseTable {
    */
   public function retrieve(string $id) {
     $result = parent::retrieve($id);
-    if ($result)
     return ($result === NULL) ? NULL : $result->data;
   }
 

--- a/modules/harvest/tests/src/Kernel/HarvestServiceTest.php
+++ b/modules/harvest/tests/src/Kernel/HarvestServiceTest.php
@@ -31,12 +31,12 @@ class HarvestServiceTest extends KernelTestBase {
     $plan = (object) [
       'identifier' => 'test_plan',
       'extract' => (object) [
-        "type" => DataJson::class,
-        "uri" => "file://" . __DIR__ . '/../../files/data.json',
+        'type' => DataJson::class,
+        'uri' => 'file://' . __DIR__ . '/../../files/data.json',
       ],
       'transforms' => [],
       'load' => (object) [
-        "type" => Simple::class,
+        'type' => Simple::class,
       ],
     ];
 
@@ -51,11 +51,11 @@ class HarvestServiceTest extends KernelTestBase {
     // Run a harvest.
     $result = $harvest_service->runHarvest('test_plan');
 
-    $this->assertEquals("SUCCESS", $result['status']['extract']);
+    $this->assertEquals('SUCCESS', $result['status']['extract']);
     $this->assertEquals(2, count($result['status']['extracted_items_ids']));
-    $this->assertEquals(json_encode(["NEW", "NEW"]), json_encode(array_values($result['status']['load'])));
+    $this->assertEquals(json_encode(['NEW', 'NEW']), json_encode(array_values($result['status']['load'])));
 
-    $storedObject = $storage_factory->getInstance('harvest_test_plan_items')->retrieve("cedcd327-4e5d-43f9-8eb1-c11850fa7c55");
+    $storedObject = $storage_factory->getInstance('harvest_test_plan_items')->retrieve('cedcd327-4e5d-43f9-8eb1-c11850fa7c55');
     $this->assertTrue(is_string($storedObject));
     $storedObject = json_decode($storedObject);
     $this->assertTrue(is_object($storedObject));
@@ -63,25 +63,25 @@ class HarvestServiceTest extends KernelTestBase {
     // Run harvest again, no changes.
     $result = $harvest_service->runHarvest('test_plan');
 
-    $this->assertEquals("SUCCESS", $result['status']['extract']);
+    $this->assertEquals('SUCCESS', $result['status']['extract']);
     $this->assertEquals(2, count($result['status']['extracted_items_ids']));
-    $this->assertEquals(json_encode(["UNCHANGED", "UNCHANGED"]), json_encode(array_values($result['status']['load'])));
+    $this->assertEquals(json_encode(['UNCHANGED', 'UNCHANGED']), json_encode(array_values($result['status']['load'])));
 
     // Run harvest with changes.
     $plan2 = clone $plan;
-    $plan2->extract->uri = "file://" . __DIR__ . '/../../files/data2.json';
+    $plan2->extract->uri = 'file://' . __DIR__ . '/../../files/data2.json';
     $harvest_service->registerHarvest($plan2);
     $result = $harvest_service->runHarvest('test_plan');
 
-    $this->assertEquals("SUCCESS", $result['status']['extract']);
+    $this->assertEquals('SUCCESS', $result['status']['extract']);
     $this->assertEquals(2, count($result['status']['extracted_items_ids']));
-    $this->assertEquals(json_encode(["UPDATED", "UNCHANGED"]), json_encode(array_values($result['status']['load'])));
+    $this->assertEquals(json_encode(['UPDATED', 'UNCHANGED']), json_encode(array_values($result['status']['load'])));
 
-    $storedObject = $storage_factory->getInstance('harvest_test_plan_items')->retrieve("cedcd327-4e5d-43f9-8eb1-c11850fa7c55");
+    $storedObject = $storage_factory->getInstance('harvest_test_plan_items')->retrieve('cedcd327-4e5d-43f9-8eb1-c11850fa7c55');
     $this->assertTrue(is_string($storedObject));
     $storedObject = json_decode($storedObject);
     $this->assertTrue(is_object($storedObject));
-    $this->assertEquals("Florida Bike Lanes 2", $storedObject->title);
+    $this->assertEquals('Florida Bike Lanes 2', $storedObject->title);
 
     /** @var \Drupal\Core\Database\Schema $schema */
     $schema = $this->container->get('database')->schema();

--- a/modules/harvest/tests/src/Kernel/HarvestServiceTest.php
+++ b/modules/harvest/tests/src/Kernel/HarvestServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Drupal\Tests\harvest\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Harvest\ETL\Extract\DataJson;
+use Harvest\ETL\Load\Simple;
+
+/**
+ * @covers \Drupal\harvest\HarvestService
+ * @coversDefaultClass \Drupal\harvest\HarvestService
+ *
+ * @group dkan
+ * @group harvest
+ * @group kernel
+ */
+class HarvestServiceTest extends KernelTestBase {
+
+  protected static $modules = [
+    'common',
+    'harvest',
+    'metastore',
+    'node',
+  ];
+
+  public function testPlan() {
+    /** @var \Drupal\harvest\HarvestService $harvest_service */
+    $harvest_service = $this->container->get('dkan.harvest.service');
+    $storage_factory = $this->container->get('dkan.harvest.storage.database_table');
+
+    $plan = (object) [
+      'identifier' => 'test_plan',
+      'extract' => (object) [
+        "type" => DataJson::class,
+        "uri" => "file://" . __DIR__ . '/../../files/data.json',
+      ],
+      'transforms' => [],
+      'load' => (object) [
+        "type" => Simple::class,
+      ],
+    ];
+
+    // Register a harvest.
+    $result = $harvest_service->registerHarvest($plan);
+
+    $this->assertEquals('test_plan', $result);
+
+    $storedTestPlan = json_decode($storage_factory->getInstance('harvest_plans')->retrieve('test_plan'));
+    $this->assertEquals('test_plan', $storedTestPlan->identifier);
+
+    // Run a harvest.
+    $result = $harvest_service->runHarvest('test_plan');
+
+    $this->assertEquals("SUCCESS", $result['status']['extract']);
+    $this->assertEquals(2, count($result['status']['extracted_items_ids']));
+    $this->assertEquals(json_encode(["NEW", "NEW"]), json_encode(array_values($result['status']['load'])));
+
+    $storedObject = $storage_factory->getInstance('harvest_test_plan_items')->retrieve("cedcd327-4e5d-43f9-8eb1-c11850fa7c55");
+    $this->assertTrue(is_string($storedObject));
+    $storedObject = json_decode($storedObject);
+    $this->assertTrue(is_object($storedObject));
+
+    // Run harvest again, no changes.
+    $result = $harvest_service->runHarvest('test_plan');
+
+    $this->assertEquals("SUCCESS", $result['status']['extract']);
+    $this->assertEquals(2, count($result['status']['extracted_items_ids']));
+    $this->assertEquals(json_encode(["UNCHANGED", "UNCHANGED"]), json_encode(array_values($result['status']['load'])));
+
+    // Run harvest with changes.
+    $plan2 = clone $plan;
+    $plan2->extract->uri = "file://" . __DIR__ . '/../../files/data2.json';
+    $harvest_service->registerHarvest($plan2);
+    $result = $harvest_service->runHarvest('test_plan');
+
+    $this->assertEquals("SUCCESS", $result['status']['extract']);
+    $this->assertEquals(2, count($result['status']['extracted_items_ids']));
+    $this->assertEquals(json_encode(["UPDATED", "UNCHANGED"]), json_encode(array_values($result['status']['load'])));
+
+    $storedObject = $storage_factory->getInstance('harvest_test_plan_items')->retrieve("cedcd327-4e5d-43f9-8eb1-c11850fa7c55");
+    $this->assertTrue(is_string($storedObject));
+    $storedObject = json_decode($storedObject);
+    $this->assertTrue(is_object($storedObject));
+    $this->assertEquals("Florida Bike Lanes 2", $storedObject->title);
+
+    /** @var \Drupal\Core\Database\Schema $schema */
+    $schema = $this->container->get('database')->schema();
+
+    // Reverting the harvest should leave behind the items and hashes tables,
+    // but remove the runs table.
+    $harvest_service->revertHarvest('test_plan');
+    foreach ([
+      'harvest_test_plan_items',
+      'harvest_test_plan_hashes',
+    ] as $storageId) {
+      $this->assertTrue($schema->tableExists($storageId), $storageId . ' does not exist.');
+    }
+    $this->assertFalse($schema->tableExists('harvest_test_plan_runs', 'harvest_test_plan_runs exists.'));
+
+    // All these tables should be empty. The runs table will be re-created
+    // as a side effect of calling retrieveAll() on it.
+    $storageTables = [
+      'harvest_test_plan_items',
+      'harvest_test_plan_hashes',
+      'harvest_test_plan_runs',
+    ];
+    foreach ($storageTables as $storageId) {
+      $this->assertCount(0, $storage_factory->getInstance($storageId)->retrieveAll());
+    }
+
+    // Deregister harvest.
+    $harvest_service->deregisterHarvest('test_plan');
+    $this->assertNull($harvest_service->getHarvestPlan('test_plan'));
+    $this->assertNotContains('test_plan', $harvest_service->getAllHarvestIds());
+    // Check the data tables. They should have been removed.
+    foreach ($storageTables as $storageId) {
+      $this->assertFalse($schema->tableExists($storageId), $storageId . ' exists.');
+    }
+  }
+
+}

--- a/modules/harvest/tests/src/Kernel/HarvestUtilityTest.php
+++ b/modules/harvest/tests/src/Kernel/HarvestUtilityTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\Tests\harvest\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\harvest\HarvestService;
+use Drupal\harvest\Storage\DatabaseTableFactory;
+
+/**
+ * @covers \Drupal\harvest\HarvestUtility
+ * @coversDefaultClass \Drupal\harvest\HarvestUtility
+ *
+ * @group dkan
+ * @group harvest
+ * @group kernel
+ */
+class HarvestUtilityTest extends KernelTestBase {
+
+  protected static $modules = [
+    'common',
+    'harvest',
+    'metastore',
+  ];
+
+  public function test() {
+    $existing_plan_id = 'testplanid';
+    $orphan_plan_id = 'orphanplanid';
+
+    /** @var HarvestService $harvest_service */
+    $harvest_service = $this->container->get('dkan.harvest.service');
+
+    // Use a database table to store a fake plan so we don't have to actually
+    // store a plan.
+    /** @var DatabaseTableFactory $table_factory */
+    $table_factory = $this->container->get('dkan.harvest.storage.database_table');
+    /** @var \Drupal\harvest\Storage\DatabaseTable $plan_storage */
+    $plan_storage = $table_factory->getInstance('harvest_plans');
+    $plan_storage->store('{we do not have a plan}', $existing_plan_id);
+
+    // Getting all harvest run info for a non-existent plan results in a run
+    // table being created.
+    // @todo This is probably something that needs fixing.
+    $harvest_service->getAllHarvestRunInfo($orphan_plan_id);
+
+    /** @var \Drupal\harvest\HarvestUtility $harvest_utility */
+    $harvest_utility = $this->container->get('dkan.harvest.utility');
+    $orphaned = $harvest_utility->findOrphanedHarvestDataIds();
+    $this->assertNotContains($existing_plan_id, $orphaned);
+    $this->assertEquals([$orphan_plan_id => $orphan_plan_id], $orphaned);
+
+    // Remove the orphans.
+    foreach($orphaned as $orphan) {
+      $harvest_utility->destructOrphanTables($orphan);
+    }
+    $this->assertEmpty(
+      $this->container->get('database')->schema()
+        ->findTables('harvest_' . $orphan_plan_id . '%')
+    );
+  }
+
+}

--- a/modules/harvest/tests/src/Kernel/HarvestUtilityTest.php
+++ b/modules/harvest/tests/src/Kernel/HarvestUtilityTest.php
@@ -3,8 +3,6 @@
 namespace Drupal\Tests\harvest\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\harvest\HarvestService;
-use Drupal\harvest\Storage\DatabaseTableFactory;
 
 /**
  * @covers \Drupal\harvest\HarvestUtility
@@ -26,12 +24,12 @@ class HarvestUtilityTest extends KernelTestBase {
     $existing_plan_id = 'testplanid';
     $orphan_plan_id = 'orphanplanid';
 
-    /** @var HarvestService $harvest_service */
+    /** @var \Drupal\harvest\HarvestService $harvest_service */
     $harvest_service = $this->container->get('dkan.harvest.service');
 
     // Use a database table to store a fake plan so we don't have to actually
     // store a plan.
-    /** @var DatabaseTableFactory $table_factory */
+    /** @var \Drupal\harvest\Storage\DatabaseTableFactory $table_factory */
     $table_factory = $this->container->get('dkan.harvest.storage.database_table');
     /** @var \Drupal\harvest\Storage\DatabaseTable $plan_storage */
     $plan_storage = $table_factory->getInstance('harvest_plans');
@@ -49,7 +47,7 @@ class HarvestUtilityTest extends KernelTestBase {
     $this->assertEquals([$orphan_plan_id => $orphan_plan_id], $orphaned);
 
     // Remove the orphans.
-    foreach($orphaned as $orphan) {
+    foreach ($orphaned as $orphan) {
       $harvest_utility->destructOrphanTables($orphan);
     }
     $this->assertEmpty(

--- a/modules/harvest/tests/src/Unit/HarvestServiceTest.php
+++ b/modules/harvest/tests/src/Unit/HarvestServiceTest.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\Tests\harvest\Unit;
 
-use Contracts\FactoryInterface;
-use Contracts\Mock\Storage\Memory;
 use Drupal\Component\DependencyInjection\Container;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Logger\LoggerChannelFactory;
@@ -14,111 +12,20 @@ use Drupal\harvest\HarvestService;
 use Drupal\harvest\Storage\DatabaseTableFactory;
 use Drupal\metastore\MetastoreService;
 use Drupal\node\NodeStorage;
-use Harvest\ETL\Extract\DataJson;
-use Harvest\ETL\Load\Simple;
 use MockChain\Chain;
 use MockChain\Options;
 use MockChain\Sequence;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * @covers \Drupal\harvest\HarvestService
  * @coversDefaultClass \Drupal\harvest\HarvestService
+ *
+ * @group dkan
  * @group harvest
  */
-class ServiceTest extends TestCase {
+class HarvestServiceTest extends TestCase {
   use ServiceCheckTrait;
-
-  private $storageFactory;
-
-  /**
-   *
-   */
-  public function test() {
-    $options = (new Options())
-      ->add('dkan.harvest.storage.database_table', $this->getStorageFactory())
-      ->add('dkan.metastore.service', $this->getMetastoreMockChain())
-      ->add('entity_type.manager', $this->getEntityTypeManagerMockChain())
-      ->index(0);
-
-    $this->checkService('dkan.harvest.storage.database_table', 'harvest');
-
-    $container = (new Chain($this))
-      ->add(ContainerInterface::class, 'get', $options)
-      ->getMock();
-
-    $service = HarvestService::create($container);
-
-    $plan = (object) [
-      'identifier' => 'test_plan',
-      'extract' => (object) [
-        "type" => DataJson::class,
-        "uri" => "file://" . __DIR__ . '/../../files/data.json',
-      ],
-      'transforms' => [],
-      'load' => (object) [
-        "type" => Simple::class,
-      ],
-    ];
-
-    // Register a harvest.
-    $result = $service->registerHarvest($plan);
-
-    $this->assertEquals('test_plan', $result);
-
-    $storedTestPlan = json_decode($this->getStorageFactory()->getInstance('harvest_plans')->retrieve('test_plan'));
-    $this->assertEquals('test_plan', $storedTestPlan->identifier);
-
-    // Run a harvest.
-    $result = $service->runHarvest('test_plan');
-
-    $this->assertEquals("SUCCESS", $result['status']['extract']);
-    $this->assertEquals(2, count($result['status']['extracted_items_ids']));
-    $this->assertEquals(json_encode(["NEW", "NEW"]), json_encode(array_values($result['status']['load'])));
-
-    $storedObject = $this->getStorageFactory()->getInstance('harvest_test_plan_items')->retrieve("cedcd327-4e5d-43f9-8eb1-c11850fa7c55");
-    $this->assertTrue(is_string($storedObject));
-    $storedObject = json_decode($storedObject);
-    $this->assertTrue(is_object($storedObject));
-
-    // Run harvest again, no changes.
-    $result = $service->runHarvest('test_plan');
-
-    $this->assertEquals("SUCCESS", $result['status']['extract']);
-    $this->assertEquals(2, count($result['status']['extracted_items_ids']));
-    $this->assertEquals(json_encode(["UNCHANGED", "UNCHANGED"]), json_encode(array_values($result['status']['load'])));
-
-    // Run harvest with changes.
-    $plan2 = clone $plan;
-    $plan2->extract->uri = "file://" . __DIR__ . '/../../files/data2.json';
-    $service->registerHarvest($plan2);
-    $result = $service->runHarvest('test_plan');
-
-    $this->assertEquals("SUCCESS", $result['status']['extract']);
-    $this->assertEquals(2, count($result['status']['extracted_items_ids']));
-    $this->assertEquals(json_encode(["UPDATED", "UNCHANGED"]), json_encode(array_values($result['status']['load'])));
-
-    $storedObject = $this->getStorageFactory()->getInstance('harvest_test_plan_items')->retrieve("cedcd327-4e5d-43f9-8eb1-c11850fa7c55");
-    $this->assertTrue(is_string($storedObject));
-    $storedObject = json_decode($storedObject);
-    $this->assertTrue(is_object($storedObject));
-    $this->assertEquals("Florida Bike Lanes 2", $storedObject->title);
-
-    // Revert harvest.
-    $service->revertHarvest('test_plan');
-    $storageTypes = [
-      'harvest_test_plan_items',
-      'harvest_test_plan_hashes',
-      'harvest_test_plan_runs',
-    ];
-    foreach ($storageTypes as $storageId) {
-      $this->assertEquals(0, count($this->getStorageFactory()->getInstance($storageId)->retrieveAll()));
-    }
-
-    // Deregister harvest.
-    $service->deregisterHarvest('test_plan');
-    $this->assertEquals(0, count($this->getStorageFactory()->getInstance('harvest_plans')->retrieveAll()));
-  }
 
   /**
    *
@@ -158,46 +65,6 @@ class ServiceTest extends TestCase {
 
     $result = $service->getHarvestRunInfo("test", "1");
     $this->assertFalse($result);
-  }
-
-  /**
-   * Private.
-   */
-  private function getStorageFactory() {
-    if (!isset($this->storageFactory)) {
-      $this->storageFactory = new class() implements FactoryInterface {
-        private $stores = [];
-
-        /**
-         * Getter.
-         */
-        public function getInstance(string $identifier, array $config = []) {
-          if (!isset($this->stores[$identifier])) {
-            $this->stores[$identifier] = new class() extends Memory {
-
-              /**
-               *
-               */
-              public function retrieveAll(): array {
-                return array_keys(parent::retrieveAll());
-              }
-
-              /**
-               *
-               */
-              public function destruct() {
-                $this->storage = [];
-              }
-
-            };
-          }
-          return $this->stores[$identifier];
-        }
-
-      };
-    }
-
-    return $this->storageFactory;
   }
 
   /**


### PR DESCRIPTION
- `HarvestService` now removes support tables when the harvest plan is deregistered.
- Adds a service called `HarvestUtility`.
- `HarvestUtility` supports a Drush command called `dkan:harvest:cleanup` which reports on leftover data tables for harvest.
- The `--cleanup` flag on the Drush command will cause the leftover tables to be removed.
- Adds `harvest_requirements()` to show leftover info on the Drupal status page.
- Adds/updates tests to prove that the support tables are removed on deregister.

## To QA:

### That harvest data is removed:

Register a harvest. Here's a sample command: `drush dkan:harvest:register --identifier=2016 --extract-uri=https://openpaymentsdata.cms.gov/modules/custom/op_harvest/JUNE2023/2016.json`

Run the harvest: `drush dkan:harvest:run 2016`

Verify that there are support tables:
```
 % drush sql:query "show tables like 'harvest_%';"
harvest_2016_hashes
harvest_2016_runs
harvest_plans
```

Deregister:
```
% drush dkan:harvest:deregister 2016
 [warning] If you deregister a harvest with published datasets, you will
       not be able to bulk revert the datasets connected to this harvest.

 Deregister harvest 2016 (yes/no) [yes]:
 > yes

 [notice] Successfully deregistered the 2016 harvest.
```

Verify that the tables are gone:
```
% drush sql:query "show tables like 'harvest_%';"
harvest_plans
```

### Drush cleanup command:

Register a harvest. Here's a sample command: `drush dkan:harvest:register --identifier=2016 --extract-uri=https://openpaymentsdata.cms.gov/modules/custom/op_harvest/JUNE2023/2016.json`

Run the harvest: `drush dkan:harvest:run 2016`

Verify that there are support tables:
```
 % drush sql:query "show tables like 'harvest_%';"
harvest_2016_hashes
harvest_2016_runs
harvest_plans
```

Remove the harvest from the `harvest_plans` table:
```
% drush sql:query "delete from harvest_plans where id = 2016;"  
```

Since the plan ID is missing, we should see a report of 2016 in the cleanup command:
```
 % drush dkan:harvest:cleanup
 [notice] Detected leftover harvest data for these plans: 2016
 [notice] Run this command again with the --cleanup flag to remove leftover data.
```

Run again with `--cleanup` to perform the cleanup:
```
% ddev drush dkan:harvest:cleanup --cleanup
 [notice] Detected leftover harvest data for these plans: 2016
 [notice] Cleaning up: 2016
```

Verify the tables are gone:
```
% ddev drush sql:query "show tables like 'harvest_%';"
harvest_plans
```