### PR TITLE
#4051: Flexible DateTime widget: Small UX improvement when clearing date

### DIFF
--- a/modules/json_form_widget/src/Element/FlexibleDateTime.php
+++ b/modules/json_form_widget/src/Element/FlexibleDateTime.php
@@ -29,7 +29,7 @@ class FlexibleDateTime extends Datetime {
     if (!empty($input['date']) && empty($input['time'])) {
       $input['time'] = '00:00:00';
     }
-    if ($element['#date_date_element'] !== 'none' && empty($input['date'])) {
+    if (!empty($input['time']) && $element['#date_date_element'] !== 'none' && empty($input['date'])) {
       if ($input['time'] === '00:00:00') {
         unset($input['time']);
       }

--- a/modules/json_form_widget/src/Element/FlexibleDateTime.php
+++ b/modules/json_form_widget/src/Element/FlexibleDateTime.php
@@ -29,6 +29,11 @@ class FlexibleDateTime extends Datetime {
     if (!empty($input['date']) && empty($input['time'])) {
       $input['time'] = '00:00:00';
     }
+    if ($element['#date_date_element'] !== 'none' && empty($input['date'])) {
+      if ($input['time'] === '00:00:00') {
+        unset($input['time']);
+      }
+    }
     return parent::valueCallback($element, $input, $form_state);
   }
 

--- a/modules/json_form_widget/src/Element/FlexibleDateTime.php
+++ b/modules/json_form_widget/src/Element/FlexibleDateTime.php
@@ -29,10 +29,12 @@ class FlexibleDateTime extends Datetime {
     if (!empty($input['date']) && empty($input['time'])) {
       $input['time'] = '00:00:00';
     }
-    if (!empty($input['time']) && $element['#date_date_element'] !== 'none' && empty($input['date'])) {
-      if ($input['time'] === '00:00:00') {
-        unset($input['time']);
-      }
+    if (
+      ($input['time'] ?? NULL === '00:00:00')
+      && $element['#date_date_element'] !== 'none'
+      && empty($input['date'])
+    ) {
+      unset($input['time']);
     }
     return parent::valueCallback($element, $input, $form_state);
   }


### PR DESCRIPTION
fixes #4051 

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Clearing a date with time part "00:00:00" should allow to save and clear the time part while processing the value. Can use Release Date in dataset for example.