### PR TITLE
Mark API-oriented Cypress tests with <api>

### DIFF
--- a/cypress/integration/01_metastore.spec.js
+++ b/cypress/integration/01_metastore.spec.js
@@ -5,7 +5,7 @@ const uuid_regex = new RegExp(Cypress.env('UUID_REGEX'))
 
 context('Metastore', () => {
   context('Catalog', () => {
-    it('Should contain newly created datasets', () => {
+    it('Should contain newly created datasets #api', () => {
       dkan.createMetastore('dataset').then((response) => {
         expect(response.status).eql(201)
         const identifier = response.body.identifier
@@ -20,7 +20,8 @@ context('Metastore', () => {
       })
     })
 
-    it('Corresponds to catalog shell', () => {
+    // Requires the data from 'Should contain newly created datasets'.
+    it('Corresponds to catalog shell #api', () => {
       cy.request('data.json').then((response) => {
         expect(response.status).eql(200)
         expect(response.body["@context"]).eql("https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld")
@@ -35,7 +36,7 @@ context('Metastore', () => {
   context('Dereference methods', () => {
     const schema_id = 'dataset'
 
-    it('bad query parameter', () => {
+    it('bad query parameter #api', () => {
       const item = dkan.generateMetastore(schema_id)
       dkan.createMetastore(schema_id, item).then((response) => {
         cy.request(dkan.getMetastoreGetEndpoint(schema_id, response.body.identifier) + '?view=foobar').then((response) => {
@@ -44,7 +45,7 @@ context('Metastore', () => {
       })
     })
 
-    it('data (default)', () => {
+    it('data (default) #api', () => {
       const item = dkan.generateMetastore(schema_id)
       dkan.createMetastore(schema_id, item).then((response) => {
         cy.request(dkan.getMetastoreGetEndpoint(schema_id, item.identifier)).then((response) => {
@@ -53,7 +54,7 @@ context('Metastore', () => {
       })
     })
 
-    it('data+identifier', () => {
+    it('data+identifier #api', () => {
       const item = dkan.generateMetastore(schema_id)
       dkan.createMetastore(schema_id, item).then((response) => {
         cy.request(dkan.getMetastoreGetEndpoint(schema_id, item.identifier) + '?show-reference-ids').then((response) => {
@@ -72,14 +73,14 @@ context('Metastore', () => {
 
   dkan.metastore_schemas.forEach((schema_id) => {
     context(`Metastore Item Creation (${schema_id})`, () => {
-      it(`Create a ${schema_id}`, () => {
+      it(`Create a ${schema_id} #api`, () => {
         dkan.createMetastore(schema_id).then((response) => {
           expect(response.status).eql(201)
           expect(response.body.identifier).to.match(uuid_regex)
         })
       })
 
-      it('Create request fails with an empty payload', () => {
+      it('Create request fails with an empty payload #api', () => {
         cy.request({
           method: 'POST',
           url: dkan.getMetastoreCreateEndpoint(schema_id),
@@ -91,7 +92,7 @@ context('Metastore', () => {
         })
       })
 
-      it('Create request fails with no payload', () => {
+      it('Create request fails with no payload #api', () => {
         cy.request({
           method: 'POST',
           url: dkan.getMetastoreCreateEndpoint(schema_id),
@@ -103,7 +104,7 @@ context('Metastore', () => {
       })
     })
 
-    context(`Metastore Item Retrieval (${schema_id})`, () => {
+    context(`Metastore Item Retrieval (${schema_id}) #api`, () => {
       it(`GET a non-existent ${schema_id}`, () => {
         cy.request({
           url: dkan.getMetastoreGetEndpoint(schema_id, dkan.generateRandomString()),
@@ -114,7 +115,7 @@ context('Metastore', () => {
       })
     })
 
-    context(`Metastore Item Replacement (${schema_id})`, () => {
+    context(`Metastore Item Replacement (${schema_id}) #api`, () => {
       it('PUT fails with an empty payload', () => {
         cy.request({
           method: 'PUT',
@@ -127,7 +128,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PUT fails with no payload', () => {
+      it('PUT fails with no payload #api', () => {
         cy.request({
           method: 'PUT',
           url: dkan.getMetastorePutEndpoint(schema_id, dkan.generateRandomString()),
@@ -138,7 +139,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PUT fails to modify the identifier', () => {
+      it('PUT fails to modify the identifier #api', () => {
         dkan.createMetastore(schema_id).then((response) => {
           expect(response.status).eql(201)
           cy.request({
@@ -153,7 +154,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PUT updates an existing dataset', () => {
+      it('PUT updates an existing dataset #api', () => {
         dkan.createMetastore(schema_id).then((response) => {
           expect(response.status).eql(201)
           const new_item = dkan.generateMetastore(schema_id, response.body.identifier)
@@ -175,7 +176,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PUT creates a dataset, if non-existent', () => {
+      it('PUT creates a dataset, if non-existent #api', () => {
         const item = dkan.generateMetastore(schema_id)
         const endpoint = dkan.getMetastorePutEndpoint(schema_id, item.identifier)
         cy.request({
@@ -194,7 +195,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PUT fails to modify if data is the same', () => {
+      it('PUT fails to modify if data is the same #api', () => {
         const item = dkan.generateMetastore(schema_id)
         dkan.createMetastore(schema_id, item).then((response) => {
           cy.request({
@@ -216,7 +217,7 @@ context('Metastore', () => {
     })
 
     context(`Metastore Item Replacement (${schema_id})`, () => {
-      it('PATCH fails for non-existent dataset', () => {
+      it('PATCH fails for non-existent dataset #api', () => {
         const identifier = dkan.generateRandomString(schema_id)
         cy.request({
           method: 'PATCH',
@@ -229,7 +230,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PATCH fails to modify the identifier', () => {
+      it('PATCH fails to modify the identifier #api', () => {
         dkan.createMetastore(schema_id).then((response) => {
           expect(response.status).eql(201)
           cy.request({
@@ -246,7 +247,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PATCH - empty payload', () => {
+      it('PATCH - empty payload #api', () => {
         const item = dkan.generateMetastore(schema_id)
         dkan.createMetastore(schema_id, item).then((response) => {
           expect(response.status).eql(201)
@@ -267,7 +268,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PATCH - basic case', () => {
+      it('PATCH - basic case #api', () => {
         dkan.createMetastore(schema_id).then((response) => {
           expect(response.status).eql(201)
           const item = dkan.generateMetastore(schema_id, response.body.identifier)
@@ -289,7 +290,7 @@ context('Metastore', () => {
     })
 
     context(`Metastore Item Deletion (${schema_id})`, () => {
-      it('Delete existing datasets', () => {
+      it('Delete existing datasets #api', () => {
         dkan.createMetastore(schema_id).then((response) => {
           const identifier = response.body.identifier
           cy.request({
@@ -312,7 +313,7 @@ context('Metastore', () => {
 
   context('Metastore Item Replacement (dataset; edge cases)', () => {
     const schema_id = 'dataset'
-    it('PATCH modifies array elements (add, remove, edit)', () => {
+    it('PATCH modifies array elements (add, remove, edit) #api', () => {
       const item = dkan.generateMetastore(schema_id)
       dkan.createMetastore(schema_id, item).then((response) => {
         expect(response.status).eql(201)
@@ -339,7 +340,7 @@ context('Metastore', () => {
       })
     })
 
-    it('PATCH modifies object properties (add, remove, edit)', () => {
+    it('PATCH modifies object properties (add, remove, edit) #api', () => {
       const item = dkan.generateMetastore(schema_id)
       dkan.createMetastore(schema_id, item).then((response) => {
         expect(response.status).eql(201)

--- a/cypress/integration/01_metastore.spec.js
+++ b/cypress/integration/01_metastore.spec.js
@@ -5,7 +5,7 @@ const uuid_regex = new RegExp(Cypress.env('UUID_REGEX'))
 
 context('Metastore', () => {
   context('Catalog', () => {
-    it('Should contain newly created datasets #api', () => {
+    it('Should contain newly created datasets <api>', () => {
       dkan.createMetastore('dataset').then((response) => {
         expect(response.status).eql(201)
         const identifier = response.body.identifier
@@ -21,7 +21,7 @@ context('Metastore', () => {
     })
 
     // Requires the data from 'Should contain newly created datasets'.
-    it('Corresponds to catalog shell #api', () => {
+    it('Corresponds to catalog shell <api>', () => {
       cy.request('data.json').then((response) => {
         expect(response.status).eql(200)
         expect(response.body["@context"]).eql("https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld")
@@ -36,7 +36,7 @@ context('Metastore', () => {
   context('Dereference methods', () => {
     const schema_id = 'dataset'
 
-    it('bad query parameter #api', () => {
+    it('bad query parameter <api>', () => {
       const item = dkan.generateMetastore(schema_id)
       dkan.createMetastore(schema_id, item).then((response) => {
         cy.request(dkan.getMetastoreGetEndpoint(schema_id, response.body.identifier) + '?view=foobar').then((response) => {
@@ -45,7 +45,7 @@ context('Metastore', () => {
       })
     })
 
-    it('data (default) #api', () => {
+    it('data (default) <api>', () => {
       const item = dkan.generateMetastore(schema_id)
       dkan.createMetastore(schema_id, item).then((response) => {
         cy.request(dkan.getMetastoreGetEndpoint(schema_id, item.identifier)).then((response) => {
@@ -54,7 +54,7 @@ context('Metastore', () => {
       })
     })
 
-    it('data+identifier #api', () => {
+    it('data+identifier <api>', () => {
       const item = dkan.generateMetastore(schema_id)
       dkan.createMetastore(schema_id, item).then((response) => {
         cy.request(dkan.getMetastoreGetEndpoint(schema_id, item.identifier) + '?show-reference-ids').then((response) => {
@@ -73,14 +73,14 @@ context('Metastore', () => {
 
   dkan.metastore_schemas.forEach((schema_id) => {
     context(`Metastore Item Creation (${schema_id})`, () => {
-      it(`Create a ${schema_id} #api`, () => {
+      it(`Create a ${schema_id} <api>`, () => {
         dkan.createMetastore(schema_id).then((response) => {
           expect(response.status).eql(201)
           expect(response.body.identifier).to.match(uuid_regex)
         })
       })
 
-      it('Create request fails with an empty payload #api', () => {
+      it('Create request fails with an empty payload <api>', () => {
         cy.request({
           method: 'POST',
           url: dkan.getMetastoreCreateEndpoint(schema_id),
@@ -92,7 +92,7 @@ context('Metastore', () => {
         })
       })
 
-      it('Create request fails with no payload #api', () => {
+      it('Create request fails with no payload <api>', () => {
         cy.request({
           method: 'POST',
           url: dkan.getMetastoreCreateEndpoint(schema_id),
@@ -104,7 +104,7 @@ context('Metastore', () => {
       })
     })
 
-    context(`Metastore Item Retrieval (${schema_id}) #api`, () => {
+    context(`Metastore Item Retrieval (${schema_id}) <api>`, () => {
       it(`GET a non-existent ${schema_id}`, () => {
         cy.request({
           url: dkan.getMetastoreGetEndpoint(schema_id, dkan.generateRandomString()),
@@ -115,7 +115,7 @@ context('Metastore', () => {
       })
     })
 
-    context(`Metastore Item Replacement (${schema_id}) #api`, () => {
+    context(`Metastore Item Replacement (${schema_id}) <api>`, () => {
       it('PUT fails with an empty payload', () => {
         cy.request({
           method: 'PUT',
@@ -128,7 +128,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PUT fails with no payload #api', () => {
+      it('PUT fails with no payload <api>', () => {
         cy.request({
           method: 'PUT',
           url: dkan.getMetastorePutEndpoint(schema_id, dkan.generateRandomString()),
@@ -139,7 +139,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PUT fails to modify the identifier #api', () => {
+      it('PUT fails to modify the identifier <api>', () => {
         dkan.createMetastore(schema_id).then((response) => {
           expect(response.status).eql(201)
           cy.request({
@@ -154,7 +154,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PUT updates an existing dataset #api', () => {
+      it('PUT updates an existing dataset <api>', () => {
         dkan.createMetastore(schema_id).then((response) => {
           expect(response.status).eql(201)
           const new_item = dkan.generateMetastore(schema_id, response.body.identifier)
@@ -176,7 +176,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PUT creates a dataset, if non-existent #api', () => {
+      it('PUT creates a dataset, if non-existent <api>', () => {
         const item = dkan.generateMetastore(schema_id)
         const endpoint = dkan.getMetastorePutEndpoint(schema_id, item.identifier)
         cy.request({
@@ -195,7 +195,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PUT fails to modify if data is the same #api', () => {
+      it('PUT fails to modify if data is the same <api>', () => {
         const item = dkan.generateMetastore(schema_id)
         dkan.createMetastore(schema_id, item).then((response) => {
           cy.request({
@@ -217,7 +217,7 @@ context('Metastore', () => {
     })
 
     context(`Metastore Item Replacement (${schema_id})`, () => {
-      it('PATCH fails for non-existent dataset #api', () => {
+      it('PATCH fails for non-existent dataset <api>', () => {
         const identifier = dkan.generateRandomString(schema_id)
         cy.request({
           method: 'PATCH',
@@ -230,7 +230,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PATCH fails to modify the identifier #api', () => {
+      it('PATCH fails to modify the identifier <api>', () => {
         dkan.createMetastore(schema_id).then((response) => {
           expect(response.status).eql(201)
           cy.request({
@@ -247,7 +247,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PATCH - empty payload #api', () => {
+      it('PATCH - empty payload <api>', () => {
         const item = dkan.generateMetastore(schema_id)
         dkan.createMetastore(schema_id, item).then((response) => {
           expect(response.status).eql(201)
@@ -268,7 +268,7 @@ context('Metastore', () => {
         })
       })
 
-      it('PATCH - basic case #api', () => {
+      it('PATCH - basic case <api>', () => {
         dkan.createMetastore(schema_id).then((response) => {
           expect(response.status).eql(201)
           const item = dkan.generateMetastore(schema_id, response.body.identifier)
@@ -290,7 +290,7 @@ context('Metastore', () => {
     })
 
     context(`Metastore Item Deletion (${schema_id})`, () => {
-      it('Delete existing datasets #api', () => {
+      it('Delete existing datasets <api>', () => {
         dkan.createMetastore(schema_id).then((response) => {
           const identifier = response.body.identifier
           cy.request({
@@ -313,7 +313,7 @@ context('Metastore', () => {
 
   context('Metastore Item Replacement (dataset; edge cases)', () => {
     const schema_id = 'dataset'
-    it('PATCH modifies array elements (add, remove, edit) #api', () => {
+    it('PATCH modifies array elements (add, remove, edit) <api>', () => {
       const item = dkan.generateMetastore(schema_id)
       dkan.createMetastore(schema_id, item).then((response) => {
         expect(response.status).eql(201)
@@ -340,7 +340,7 @@ context('Metastore', () => {
       })
     })
 
-    it('PATCH modifies object properties (add, remove, edit) #api', () => {
+    it('PATCH modifies object properties (add, remove, edit) <api>', () => {
       const item = dkan.generateMetastore(schema_id)
       dkan.createMetastore(schema_id, item).then((response) => {
         expect(response.status).eql(201)

--- a/cypress/integration/02_harvest_empty.spec.js
+++ b/cypress/integration/02_harvest_empty.spec.js
@@ -14,7 +14,7 @@ context('Harvest', () => {
   });
 
   context('GET harvest/plans', () => {
-    it('List harvest identifiers', () => {
+    it('List harvest identifiers #api', () => {
       cy.request({
         url: apiUri + '/harvest/plans',
         auth: user_credentials
@@ -24,7 +24,7 @@ context('Harvest', () => {
       })
     })
 
-    it('Requires authenticated user', () => {
+    it('Requires authenticated user #api', () => {
       cy.request({
         url: apiUri + '/harvest/plans',
         failOnStatusCode: false

--- a/cypress/integration/02_harvest_empty.spec.js
+++ b/cypress/integration/02_harvest_empty.spec.js
@@ -14,7 +14,7 @@ context('Harvest', () => {
   });
 
   context('GET harvest/plans', () => {
-    it('List harvest identifiers #api', () => {
+    it('List harvest identifiers <api>', () => {
       cy.request({
         url: apiUri + '/harvest/plans',
         auth: user_credentials
@@ -24,7 +24,7 @@ context('Harvest', () => {
       })
     })
 
-    it('Requires authenticated user #api', () => {
+    it('Requires authenticated user <api>', () => {
       cy.request({
         url: apiUri + '/harvest/plans',
         failOnStatusCode: false

--- a/cypress/integration/03_harvest.spec.js
+++ b/cypress/integration/03_harvest.spec.js
@@ -38,7 +38,7 @@ context('Harvest', () => {
   });
 
   context('GET harvest/plans', () => {
-    it('List harvest identifiers #api', () => {
+    it('List harvest identifiers <api>', () => {
       cy.request({
         url: apiUri + '/harvest/plans',
         auth: user_credentials
@@ -60,7 +60,7 @@ context('Harvest', () => {
       })
     })
 
-    it('Requires authenticated user #api', () => {
+    it('Requires authenticated user <api>', () => {
       cy.request({
         url: apiUri + '/harvest/plans',
         failOnStatusCode: false
@@ -71,7 +71,7 @@ context('Harvest', () => {
   });
 
   context('POST harvest/plans', () => {
-    it('Requires authenticated user #api', () => {
+    it('Requires authenticated user <api>', () => {
       cy.request({
         method: "POST",
         url: apiUri + '/harvest/plans',
@@ -83,7 +83,7 @@ context('Harvest', () => {
   });
 
   context('GET harvest/plans/PLAN_ID', () => {
-    it('Get a single harvest plan #api', () => {
+    it('Get a single harvest plan <api>', () => {
       cy.request({
         url: apiUri + '/harvest/plans/test',
         auth: user_credentials
@@ -93,7 +93,7 @@ context('Harvest', () => {
       })
     });
 
-    it('Requires authenticated user #api', () => {
+    it('Requires authenticated user <api>', () => {
       cy.request({
         url: apiUri + '/harvest/runs',
         failOnStatusCode: false
@@ -104,7 +104,7 @@ context('Harvest', () => {
   });
 
   context('GET harvest/runs?plan=PLAN_ID', () => {
-    it('Gives list of previous runs for a harvest id #api', () => {
+    it('Gives list of previous runs for a harvest id <api>', () => {
       cy.request({
         url: apiUri + '/harvest/runs?plan=test',
         auth: user_credentials
@@ -114,7 +114,7 @@ context('Harvest', () => {
       })
     });
 
-    it('Requires authenticated user #api', () => {
+    it('Requires authenticated user <api>', () => {
       cy.request({
         url: apiUri + '/harvest/runs?plan=PLAN_ID',
         failOnStatusCode: false
@@ -125,7 +125,7 @@ context('Harvest', () => {
   });
 
   context('POST harvest/runs', () => {
-    it('Requires authenticated user #api', () => {
+    it('Requires authenticated user <api>', () => {
       cy.request({
         method: "POST",
         url: apiUri + '/harvest/runs',
@@ -137,7 +137,7 @@ context('Harvest', () => {
   });
 
   context('GET harvest/runs/{identifier}', () => {
-    it('Gives information about a single previous harvest run #api', () => {
+    it('Gives information about a single previous harvest run <api>', () => {
       cy.request({
         url: apiUri + '/harvest/runs?plan=test',
         auth: user_credentials
@@ -154,7 +154,7 @@ context('Harvest', () => {
       })
     });
 
-    it('Requires authenticated user #api', () => {
+    it('Requires authenticated user <api>', () => {
       cy.request({
         url: apiUri + '/harvest/runs',
         failOnStatusCode: false

--- a/cypress/integration/03_harvest.spec.js
+++ b/cypress/integration/03_harvest.spec.js
@@ -4,6 +4,7 @@ context('Harvest', () => {
   let apiUri = Cypress.config().apiUri;
 
   // Set up.
+  // BTB conversion notes: Do not use API to test API.
   before(() => {
     cy.request({
       method: 'POST',
@@ -25,6 +26,7 @@ context('Harvest', () => {
   });
 
   // Clean up.
+  // BTB conversion notes: Do not use API to test API.
   after(() => {
     cy.request({
       method: 'DELETE',
@@ -36,7 +38,7 @@ context('Harvest', () => {
   });
 
   context('GET harvest/plans', () => {
-    it('List harvest identifiers', () => {
+    it('List harvest identifiers #api', () => {
       cy.request({
         url: apiUri + '/harvest/plans',
         auth: user_credentials
@@ -58,7 +60,7 @@ context('Harvest', () => {
       })
     })
 
-    it('Requires authenticated user', () => {
+    it('Requires authenticated user #api', () => {
       cy.request({
         url: apiUri + '/harvest/plans',
         failOnStatusCode: false
@@ -69,7 +71,7 @@ context('Harvest', () => {
   });
 
   context('POST harvest/plans', () => {
-    it('Requires authenticated user', () => {
+    it('Requires authenticated user #api', () => {
       cy.request({
         method: "POST",
         url: apiUri + '/harvest/plans',
@@ -81,7 +83,7 @@ context('Harvest', () => {
   });
 
   context('GET harvest/plans/PLAN_ID', () => {
-    it('Get a single harvest plan', () => {
+    it('Get a single harvest plan #api', () => {
       cy.request({
         url: apiUri + '/harvest/plans/test',
         auth: user_credentials
@@ -91,7 +93,7 @@ context('Harvest', () => {
       })
     });
 
-    it('Requires authenticated user', () => {
+    it('Requires authenticated user #api', () => {
       cy.request({
         url: apiUri + '/harvest/runs',
         failOnStatusCode: false
@@ -102,7 +104,7 @@ context('Harvest', () => {
   });
 
   context('GET harvest/runs?plan=PLAN_ID', () => {
-    it('Gives list of previous runs for a harvest id', () => {
+    it('Gives list of previous runs for a harvest id #api', () => {
       cy.request({
         url: apiUri + '/harvest/runs?plan=test',
         auth: user_credentials
@@ -112,7 +114,7 @@ context('Harvest', () => {
       })
     });
 
-    it('Requires authenticated user', () => {
+    it('Requires authenticated user #api', () => {
       cy.request({
         url: apiUri + '/harvest/runs?plan=PLAN_ID',
         failOnStatusCode: false
@@ -123,7 +125,7 @@ context('Harvest', () => {
   });
 
   context('POST harvest/runs', () => {
-    it('Requires authenticated user', () => {
+    it('Requires authenticated user #api', () => {
       cy.request({
         method: "POST",
         url: apiUri + '/harvest/runs',
@@ -135,7 +137,7 @@ context('Harvest', () => {
   });
 
   context('GET harvest/runs/{identifier}', () => {
-    it('Gives information about a single previous harvest run', () => {
+    it('Gives information about a single previous harvest run #api', () => {
       cy.request({
         url: apiUri + '/harvest/runs?plan=test',
         auth: user_credentials
@@ -152,7 +154,7 @@ context('Harvest', () => {
       })
     });
 
-    it('Requires authenticated user', () => {
+    it('Requires authenticated user #api', () => {
       cy.request({
         url: apiUri + '/harvest/runs',
         failOnStatusCode: false

--- a/cypress/integration/04_datastore_empty.spec.js
+++ b/cypress/integration/04_datastore_empty.spec.js
@@ -3,7 +3,7 @@ context('Datastore API - Empty', () => {
   let apiUri = Cypress.config().apiUri;
   let resource_identifier = "blah";
 
-  it('GET empty #api', () => {
+  it('GET empty <api>', () => {
     cy.request({
       url: apiUri + '/datastore/imports/' + resource_identifier,
       failOnStatusCode: false
@@ -12,7 +12,7 @@ context('Datastore API - Empty', () => {
     })
   });
 
-  it('GET openapi api spec #api', () => {
+  it('GET openapi api spec <api>', () => {
     cy.request(apiUri + '/datastore').then((response) => {
       expect(response.status).eql(200);
       expect(response.body.hasOwnProperty('openapi')).equals(true);

--- a/cypress/integration/04_datastore_empty.spec.js
+++ b/cypress/integration/04_datastore_empty.spec.js
@@ -3,7 +3,7 @@ context('Datastore API - Empty', () => {
   let apiUri = Cypress.config().apiUri;
   let resource_identifier = "blah";
 
-  it('GET empty', () => {
+  it('GET empty #api', () => {
     cy.request({
       url: apiUri + '/datastore/imports/' + resource_identifier,
       failOnStatusCode: false
@@ -12,7 +12,7 @@ context('Datastore API - Empty', () => {
     })
   });
 
-  it('GET openapi api spec', () => {
+  it('GET openapi api spec #api', () => {
     cy.request(apiUri + '/datastore').then((response) => {
       expect(response.status).eql(200);
       expect(response.body.hasOwnProperty('openapi')).equals(true);


### PR DESCRIPTION
Adds an <api> tag to Cypress tests which only touch the API, so they can be more easily identified as we do conversions to BTB.