### PR TITLE
Re-reference distributions on presave

### DIFF
--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -75,9 +75,7 @@ class Referencer {
         $data->{$property_id} = $this->referenceProperty($property_id, $data->{$property_id});
 
         // Remove de-referenced info from metadata.
-        if (isset($data->{'%Ref:' . $property_id})) {
-          unset($data->{'%Ref:' . $property_id});
-        }
+        unset($data->{'%Ref:' . $property_id});
       }
     }
     return $data;

--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -73,6 +73,11 @@ class Referencer {
     foreach ($this->getPropertyList() as $property_id) {
       if (isset($data->{$property_id})) {
         $data->{$property_id} = $this->referenceProperty($property_id, $data->{$property_id});
+
+        // Remove de-referenced info from metadata.
+        if (isset($data->{'%Ref:' . $property_id})) {
+          unset($data->{'%Ref:' . $property_id});
+        }
       }
     }
     return $data;


### PR DESCRIPTION
fixes [org/repo/issue#]

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Create a vanilla DKAN site with the sample content.
- [ ] Disable the default data dictionary if present. 
- [ ] Check the resource settings. ( admin/dkan/resources ) Resource download display should be 'source'
- [ ] Set the default dkan moderation state to draft. ( admin/config/workflow/workflows/manage/dkan_publishing )
- [ ] Create a dataset that has a distribution. (Can use a link to a dkan demo site CSV). Save as draft.
- [ ] Take node of the node IDs for the draft dataset and the draft distribution.
- [ ] Run cron: ddev drush cron
- [ ] View the contents of the node__field_json_metadata field for both the dataset and the distribution nodes. e.g. "SELECT field_json_metadata_value FROM node__field_json_metadata where entity_id = [nid]" for each
- [ ] No "%Ref:" arrays should be present in the json in the DB. All referenced entities should simply have a value of the uuids of the nodes they are referencing. The distribution downloadURL value should be the reference to the resource. (resourceID__version__perspective)
- [ ] On the dataset admin view (/admin/dkan/datasets), check the draft dataset and publish the latest revision.
- [ ] View the contents of the node__field_json_metadata field for both the dataset and the distribution nodes again. 
- [ ] No "%Ref:" arrays should be present in the json in the DB. All referenced entities should simply have a value of the uuids of the nodes they are referencing. The distribution downloadURL value should be the reference to the resource. (resourceID__version__perspective)
- [ ] Confirm that the dataset published and displays correctly.
