### PR TITLE
Fix a few typos in 'glossary' and 'how to add a dataset' documentation

### DIFF
--- a/docs/source/introduction/glossary.rst
+++ b/docs/source/introduction/glossary.rst
@@ -50,9 +50,9 @@ Glossary
      - **Draft**: Status is unpublished.
        This moderation state means the content is only visible to authenticated users with permission to view/edit unpublished content.
      - **Published**: Status is published.
-       This moderation state means the content is publicly availble, no authentication required to view.
+       This moderation state means the content is publicly available, no authentication required to view.
      - **Published (hidden)**: Status is published.
-       This moderation state means the content is publicly availble, but will not be indexed, meaning it will not be discoverable through the Dataset Search page. This 'hidden' state keeps the API endpoints public but the user must know the ID, and the dataset page is only visible if you know the URL.
+       This moderation state means the content is publicly available, but will not be indexed, meaning it will not be discoverable through the Dataset Search page. This 'hidden' state keeps the API endpoints public but the user must know the ID, and the dataset page is only visible if you know the URL.
      - **Archived**: Status is unpublished.
        This state is useful if you have published a dataset, but would like to remove it from public access but not delete it entirely.
      - **Orphaned**: Status is unpublished.

--- a/docs/source/user-guide/guide_dataset.rst
+++ b/docs/source/user-guide/guide_dataset.rst
@@ -170,7 +170,7 @@ Add demo site content
 
 Generate the same 10 datasets that are used on the demo site.
 Enable the sample content module. Run the create command to add the datasets.
-Running cron will run the queues that fetch the csv files and import them into datstore tables.
+Running cron will run the queues that fetch the csv files and import them into datastore tables.
 Remove the datasets with the remove command.
 
 .. prompt:: bash $


### PR DESCRIPTION
fixes [org/repo/issue#]

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Just a documentation typo fix so confirm the documentation page format is correct.
