### PR TITLE
Replace ltrim with str_replace in json_form_widget

### DIFF
--- a/modules/json_form_widget/src/StringHelper.php
+++ b/modules/json_form_widget/src/StringHelper.php
@@ -82,7 +82,7 @@ class StringHelper implements ContainerInjectionInterface {
     // Add extra validate if element type is email.
     if ($element['#type'] === 'email') {
       $element['#element_validate'][] = [$this, 'validateEmail'];
-      $element['#default_value'] = ltrim($element['#default_value'] ?? '', 'mailto:');
+      $element['#default_value'] = str_replace('mailto:', '', $element['#default_value']);
     }
 
     return $element;

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -19,7 +19,7 @@ class ValueHandler {
       case 'string':
         $data = $this->handleStringValues($formValues, $property);
         if ($property === 'hasEmail' && is_string($data)) {
-          $data = 'mailto:' . ltrim($data, 'mailto:');
+          $data = 'mailto:' . str_replace('mailto:', '', $data);
         }
         break;
 


### PR DESCRIPTION
An `ltrim` followed by a second parameter will trim any matching contiguous character(s) from the left side of the email address. e.g. matildafoo@test.com will become dafoo@test.com

Switching to `str_replace` will result in only removing an exact match on "mailto:"

## QA Steps

- [ ] Create a dataset, fill in the ContactPoint email field with "matildafoo@test.com", and save
- [ ] view or edit the dataset to confirm the value was saved correctly
