### PR TITLE
Use literal identifier for FileFetcherJobStoreFactory

### DIFF
--- a/modules/common/common.services.yml
+++ b/modules/common/common.services.yml
@@ -27,8 +27,13 @@ services:
   dkan.common.file_fetcher:
     class: \Drupal\common\FileFetcher\FileFetcherFactory
     arguments:
-      - '@dkan.common.job_store'
+      - '@dkan.common.filefetcher_job_store_factory'
       - '@config.factory'
+
+  dkan.common.filefetcher_job_store_factory:
+    class: \Drupal\common\Storage\FileFetcherJobStoreFactory
+    arguments:
+      - '@database'
 
   dkan.common.dataset_info:
     class: \Drupal\common\DatasetInfo

--- a/modules/common/src/FileFetcher/FileFetcherFactory.php
+++ b/modules/common/src/FileFetcher/FileFetcherFactory.php
@@ -3,7 +3,7 @@
 namespace Drupal\common\FileFetcher;
 
 use Contracts\FactoryInterface;
-use Drupal\common\Storage\JobStoreFactory;
+use Drupal\common\Storage\FileFetcherJobStoreFactory;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
 use FileFetcher\FileFetcher;
@@ -14,11 +14,11 @@ use FileFetcher\FileFetcher;
 class FileFetcherFactory implements FactoryInterface {
 
   /**
-   * Job store factory service.
+   * File fetcher job store factory.
    *
-   * @var \Drupal\common\Storage\JobStoreFactory
+   * @var \Drupal\common\Storage\FileFetcherJobStoreFactory
    */
-  private JobStoreFactory $jobStoreFactory;
+  private FileFetcherJobStoreFactory $fileFetcherJobStoreFactory;
 
   /**
    * The common.settings config.
@@ -39,8 +39,8 @@ class FileFetcherFactory implements FactoryInterface {
   /**
    * Constructor.
    */
-  public function __construct(JobStoreFactory $jobStoreFactory, ConfigFactoryInterface $configFactory) {
-    $this->jobStoreFactory = $jobStoreFactory;
+  public function __construct(FileFetcherJobStoreFactory $fileFetcherJobStoreFactory, ConfigFactoryInterface $configFactory) {
+    $this->fileFetcherJobStoreFactory = $fileFetcherJobStoreFactory;
     $this->dkanConfig = $configFactory->get('common.settings');
   }
 
@@ -50,7 +50,7 @@ class FileFetcherFactory implements FactoryInterface {
   public function getInstance(string $identifier, array $config = []) {
     return FileFetcher::get(
       $identifier,
-      $this->jobStoreFactory->getInstance(FileFetcher::class),
+      $this->fileFetcherJobStoreFactory->getInstance(),
       $this->getFileFetcherConfig($config)
     );
   }

--- a/modules/common/src/Storage/FileFetcherJobStoreFactory.php
+++ b/modules/common/src/Storage/FileFetcherJobStoreFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\common\Storage;
+
+/**
+ * Create a job store object for the import process.
+ */
+class FileFetcherJobStoreFactory extends AbstractJobStoreFactory {
+
+  /**
+   * {@inheritDoc}
+   *
+   * This string contains an ugly hash for historical reasons.
+   */
+  protected string $tableName = 'jobstore_524493904_filefetcher';
+
+}

--- a/modules/common/tests/src/Traits/CleanUp.php
+++ b/modules/common/tests/src/Traits/CleanUp.php
@@ -46,13 +46,12 @@ trait CleanUp {
    *
    */
   private function removeAllFileFetchingJobs() {
-    /** @var \Drupal\common\Storage\JobStoreFactory $jobStoreFactory */
-    $jobStoreFactory = \Drupal::service('dkan.common.job_store');
+    /** @var \Drupal\common\Storage\FileFetcherJobStoreFactory $jobStoreFactory */
+    $jobStoreFactory = \Drupal::service('dkan.common.filefetcher_job_store_factory');
 
-    /** @var \Drupal\common\Storage\JobStore $jobStore */
-    $jobStore = $jobStoreFactory->getInstance(FileFetcher::class);
-    foreach ($jobStore->retrieveAll() as $id) {
-      $jobStore->remove($id);
+    $fileFetcherJob = $jobStoreFactory->getInstance();
+    foreach ($fileFetcherJob->retrieveAll() as $id) {
+      $fileFetcherJob->remove($id);
     }
   }
 

--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -26,7 +26,7 @@ services:
       - '@dkan.metastore.resource_mapper'
       - '@dkan.common.file_fetcher'
       - '@dkan.common.drupal_files'
-      - '@dkan.common.job_store'
+      - '@dkan.common.filefetcher_job_store_factory'
       - '@queue'
 
   dkan.datastore.service.resource_processor_collector:
@@ -110,7 +110,7 @@ services:
   dkan.datastore.import_info_list:
     class: \Drupal\datastore\Service\Info\ImportInfoList
     arguments:
-      - '@dkan.common.job_store'
+      - '@dkan.common.filefetcher_job_store_factory'
       - '@dkan.datastore.import_info'
 
   dkan.datastore.import_job_store_factory:

--- a/modules/datastore/src/Service/Info/ImportInfoList.php
+++ b/modules/datastore/src/Service/Info/ImportInfoList.php
@@ -2,9 +2,8 @@
 
 namespace Drupal\datastore\Service\Info;
 
-use Drupal\common\Storage\JobStoreFactory;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use FileFetcher\FileFetcher;
+use Drupal\common\Storage\FileFetcherJobStoreFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -13,11 +12,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ImportInfoList implements ContainerInjectionInterface {
 
   /**
-   * A JobStore object.
+   * File fetcher job store factory.
    *
-   * @var \Drupal\common\Storage\JobStoreFactory
+   * @var \Drupal\common\Storage\FileFetcherJobStoreFactory
    */
-  private $jobStoreFactory;
+  private FileFetcherJobStoreFactory $fileFetcherJobStoreFactory;
 
   /**
    * Datastore import job info.
@@ -33,7 +32,7 @@ class ImportInfoList implements ContainerInjectionInterface {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('dkan.common.job_store'),
+      $container->get('dkan.common.filefetcher_job_store_factory'),
       $container->get('dkan.datastore.import_info')
     );
   }
@@ -41,8 +40,8 @@ class ImportInfoList implements ContainerInjectionInterface {
   /**
    * Constructor.
    */
-  public function __construct(JobStoreFactory $jobStoreFactory, ImportInfo $importInfo) {
-    $this->jobStoreFactory = $jobStoreFactory;
+  public function __construct(FileFetcherJobStoreFactory $fileFetcherJobStoreFactory, ImportInfo $importInfo) {
+    $this->fileFetcherJobStoreFactory = $fileFetcherJobStoreFactory;
     $this->importInfo = $importInfo;
   }
 
@@ -58,7 +57,7 @@ class ImportInfoList implements ContainerInjectionInterface {
   public function buildList() {
     $list = [];
 
-    $store = $this->jobStoreFactory->getInstance(FileFetcher::class);
+    $store = $this->fileFetcherJobStoreFactory->getInstance();
 
     foreach ($store->retrieveAll() as $id) {
       $pieces = explode('_', $id);

--- a/modules/datastore/src/Service/ResourceLocalizer.php
+++ b/modules/datastore/src/Service/ResourceLocalizer.php
@@ -6,7 +6,6 @@ use Contracts\FactoryInterface;
 use Drupal\common\DataResource;
 use Drupal\common\EventDispatcherTrait;
 use Drupal\common\LoggerTrait;
-use Drupal\common\Storage\JobStoreFactory;
 use Drupal\common\UrlHostTokenResolver;
 use Drupal\common\Util\DrupalFiles;
 use Drupal\Core\File\FileSystemInterface;

--- a/modules/datastore/src/Service/ResourceLocalizer.php
+++ b/modules/datastore/src/Service/ResourceLocalizer.php
@@ -11,6 +11,7 @@ use Drupal\common\UrlHostTokenResolver;
 use Drupal\common\Util\DrupalFiles;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Queue\QueueFactory;
+use Drupal\common\Storage\FileFetcherJobStoreFactory;
 use Drupal\metastore\Exception\AlreadyRegistered;
 use Drupal\metastore\ResourceMapper;
 use FileFetcher\FileFetcher;
@@ -69,11 +70,11 @@ class ResourceLocalizer {
   private DrupalFiles $drupalFiles;
 
   /**
-   * Job store factory.
+   * File fetcher job store factory.
    *
-   * @var \Drupal\common\Storage\JobStoreFactory
+   * @var \Drupal\common\Storage\FileFetcherJobStoreFactory
    */
-  private JobStoreFactory $jobStoreFactory;
+  private FileFetcherJobStoreFactory $fileFetcherJobStoreFactory;
 
   /**
    * Drupal queue.
@@ -89,13 +90,13 @@ class ResourceLocalizer {
     ResourceMapper $fileMapper,
     FactoryInterface $fileFetcherFactory,
     DrupalFiles $drupalFiles,
-    JobStoreFactory $jobStoreFactory,
+    FileFetcherJobStoreFactory $fileFetcherJobStoreFactory,
     QueueFactory $queueFactory
   ) {
     $this->resourceMapper = $fileMapper;
     $this->fileFetcherFactory = $fileFetcherFactory;
     $this->drupalFiles = $drupalFiles;
-    $this->jobStoreFactory = $jobStoreFactory;
+    $this->fileFetcherJobStoreFactory = $fileFetcherJobStoreFactory;
     $this->queueFactory = $queueFactory;
   }
 
@@ -242,7 +243,7 @@ class ResourceLocalizer {
    */
   private function removeJob($uuid) {
     if ($uuid) {
-      $this->jobStoreFactory->getInstance(FileFetcher::class)->remove($uuid);
+      $this->fileFetcherJobStoreFactory->getInstance()->remove($uuid);
     }
   }
 

--- a/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/LocalizeQueueWorkerTest.php
+++ b/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/LocalizeQueueWorkerTest.php
@@ -131,7 +131,7 @@ class LocalizeQueueWorkerTest extends KernelTestBase {
         $this->container->get('dkan.metastore.resource_mapper'),
         $this->container->get('dkan.common.file_fetcher'),
         $this->container->get('dkan.common.drupal_files'),
-        $this->container->get('dkan.common.job_store'),
+        $this->container->get('dkan.common.filefetcher_job_store_factory'),
         $this->container->get('queue'),
       ])
       ->onlyMethods(['localizeTask'])
@@ -165,7 +165,7 @@ class LocalizeQueueWorkerTest extends KernelTestBase {
         $this->container->get('dkan.metastore.resource_mapper'),
         $this->container->get('dkan.common.file_fetcher'),
         $this->container->get('dkan.common.drupal_files'),
-        $this->container->get('dkan.common.job_store'),
+        $this->container->get('dkan.common.filefetcher_job_store_factory'),
         $this->container->get('queue'),
       ])
       ->onlyMethods(['localizeTask'])

--- a/modules/datastore/tests/src/Kernel/Service/Info/ImportInfoListTest.php
+++ b/modules/datastore/tests/src/Kernel/Service/Info/ImportInfoListTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\datastore\Kernel\Service\Info;
 
 use Drupal\common\DataResource;
+use Drupal\common\Storage\FileFetcherJobStoreFactory;
 use Drupal\datastore\Plugin\QueueWorker\ImportJob;
 use Drupal\common\Storage\JobStore;
 use Drupal\common\Storage\JobStoreFactory;
@@ -63,10 +64,10 @@ class ImportInfoListTest extends KernelTestBase {
       ->getMock();
 
     $job_store_factory = (new Chain($this))
-      ->add(JobStoreFactory::class, 'getInstance', $job_store)
+      ->add(FileFetcherJobStoreFactory::class, 'getInstance', $job_store)
       ->getMock();
 
-    $this->container->set('dkan.common.job_store', $job_store_factory);
+    $this->container->set('dkan.common.filefetcher_job_store_factory', $job_store_factory);
 
     // Build the list.
     /** @var \Drupal\datastore\Service\Info\ImportInfoList $import_info_list */

--- a/modules/datastore/tests/src/Unit/Service/ResourceLocalizerTest.php
+++ b/modules/datastore/tests/src/Unit/Service/ResourceLocalizerTest.php
@@ -6,6 +6,7 @@ use Drupal\common\DataResource;
 use Drupal\common\FileFetcher\DkanFileFetcher;
 use Drupal\common\FileFetcher\FileFetcherFactory;
 use Drupal\common\Storage\DatabaseTableInterface;
+use Drupal\common\Storage\FileFetcherJobStoreFactory;
 use Drupal\common\Storage\JobStoreFactory;
 use Drupal\common\Util\DrupalFiles;
 use Drupal\Core\DependencyInjection\Container;
@@ -138,7 +139,7 @@ class ResourceLocalizerTest extends TestCase {
    */
   private function getJobStoreFactoryChain() {
     return (new Chain($this))
-      ->add(JobStoreFactory::class, 'getInstance', DatabaseTableInterface::class)
+      ->add(FileFetcherJobStoreFactory::class, 'getInstance', DatabaseTableInterface::class)
       ->add(DatabaseTableInterface::class, 'remove', NULL);
   }
 


### PR DESCRIPTION
Following the work of https://github.com/GetDKAN/dkan/pull/4083

Adds a `FileFetcherJobStoreFactory` class, which subclasses `AbstractJobStoreFactory`.

`FileFetcherJobStoreFactory` uses a literal table name of jobstore_524493904_filefetcher.

Adds this new class as a service: `dkan.common.filefetcher_job_store_factory`.

Changes service definitions which use `dkan.common.job_store` to use `dkan.common.filefetcher_job_store_factory`.

Changes all the services to accept `FileFetcherJobStoreFactory` instead of `JobStoreFactory`.

Modifies tests to use the new service.