### PR TITLE
Fix passing null to parameter #3 on handleStringElement

### DIFF
--- a/modules/json_form_widget/src/StringHelper.php
+++ b/modules/json_form_widget/src/StringHelper.php
@@ -82,7 +82,7 @@ class StringHelper implements ContainerInjectionInterface {
     // Add extra validate if element type is email.
     if ($element['#type'] === 'email') {
       $element['#element_validate'][] = [$this, 'validateEmail'];
-      $element['#default_value'] = str_replace('mailto:', '', $element['#default_value']);
+      $element['#default_value'] = str_replace('mailto:', '', $element['#default_value'] ?? '');
     }
 
     return $element;


### PR DESCRIPTION
fix for 
```
Deprecated function: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in Drupal\json_form_widget\StringHelper->handleStringElement() (line 85 of /var/www/html/dkan/modules/json_form_widget/src/StringHelper.php). 
```

**QA:**

1. Spin up a dkan build
2. Go to /node/add/data
3. Confirm you do not see the error above