### PR TITLE
Use ReferenceLookup to determine if a resource is in use

### DIFF
--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -76,6 +76,7 @@ services:
       - '@logger.factory'
       - '@dkan.metastore.service'
       - '@dkan.metastore.resource_mapper'
+      - '@dkan.metastore.reference_lookup'
     tags:
       - { name: event_subscriber }
 

--- a/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
+++ b/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
@@ -145,6 +145,7 @@ class MetastoreSubscriber implements EventSubscriberInterface {
         return TRUE;
       }
     }
+    // No other distributions were found using this resource.
     return FALSE;
   }
 

--- a/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
+++ b/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
@@ -111,12 +111,12 @@ class MetastoreSubscriber implements EventSubscriberInterface {
       $resource_id = $resourceParams['identifier'] ?? NULL;
       $perspective = $resourceParams['perspective'] ?? NULL;
       $version = $resourceParams['version'] ?? NULL;
-      $resource_full_id = $resource_id . '__' . $version . '__' . $perspective;
+      $resource_id_wo_perspective = $resource_id . '__' . $version;
       $resource = $this->resourceMapper->get($resource_id, $perspective, $version);
 
       // Ensure a valid ID, perspective, and version were found for the given
       // distribution.
-      if ($resource instanceof DataResource && !$this->resourceInUseElsewhere($distribution_id, $resource_full_id)) {
+      if ($resource instanceof DataResource && !$this->resourceInUseElsewhere($distribution_id, $resource_id_wo_perspective)) {
         // Remove resource entry for metadata resource mapper.
         $this->resourceMapper->remove($resource);
       }

--- a/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
+++ b/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
@@ -108,15 +108,15 @@ class MetastoreSubscriber implements EventSubscriberInterface {
     // metadata resource mapper.
     foreach ($resources as $resourceParams) {
       // Retrieve the distributions ID, perspective, and version metadata.
-      $resource_identifier = $resourceParams['identifier'] ?? NULL;
+      $resource_id = $resourceParams['identifier'] ?? NULL;
       $perspective = $resourceParams['perspective'] ?? NULL;
       $version = $resourceParams['version'] ?? NULL;
-      $resource_id = $resource_identifier . '__' . $version . '__' . $perspective;
-      $resource = $this->resourceMapper->get($resource_identifier, $perspective, $version);
+      $resource_full_id = $resource_id . '__' . $version . '__' . $perspective;
+      $resource = $this->resourceMapper->get($resource_id, $perspective, $version);
 
       // Ensure a valid ID, perspective, and version were found for the given
       // distribution.
-      if ($resource instanceof DataResource && !$this->resourceInUseElsewhere($resource_id, $distribution_id)) {
+      if ($resource instanceof DataResource && !$this->resourceInUseElsewhere($distribution_id, $resource_full_id)) {
         // Remove resource entry for metadata resource mapper.
         $this->resourceMapper->remove($resource);
       }
@@ -126,26 +126,26 @@ class MetastoreSubscriber implements EventSubscriberInterface {
   /**
    * Determine if a resource is in use in another distribution.
    *
+   * @param string $dist_id
+   *   The uuid of the distribution where this resource is know to be in use.
    * @param string $resource_id
    *   The identifier of the resource.
-   * @param string $distribution_id
-   *    The identifier of the orphaned distribution.
    *
    * @return bool
    *   Whether the resource is in use elsewhere.
    *
    * @todo Abstract out "distribution" and field_data_type.
    */
-  private function resourceInUseElsewhere(string $resource_id, string $distribution_id): bool {
+  private function resourceInUseElsewhere(string $dist_id, string $resource_id): bool {
     $distributions = $this->referenceLookup->getReferencers('distribution', $resource_id, 'downloadURL');
 
     // Check if any other distributions reference it.
     foreach ($distributions as $distribution) {
-      if ($distribution != $distribution_id) {
-        return true;
+      if ($distribution != $dist_id) {
+        return TRUE;
       }
     }
-    return false;
+    return FALSE;
   }
 
 }

--- a/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
+++ b/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
@@ -4,7 +4,6 @@ namespace Drupal\metastore\EventSubscriber;
 
 use Drupal\common\DataResource;
 use Drupal\common\Events\Event;
-use Drupal\common\UrlHostTokenResolver;
 use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\metastore\MetastoreService;
 use Drupal\metastore\Plugin\QueueWorker\OrphanReferenceProcessor;
@@ -70,7 +69,7 @@ class MetastoreSubscriber implements EventSubscriberInterface {
    * @param \Drupal\metastore\ResourceMapper $resourceMapper
    *   The dkan.metastore.resource_mapper.
    * @param \Drupal\metastore\ReferenceLookupInterface $referenceLookup
-   *    The dkan.metastore.reference_lookup service.
+   *   The dkan.metastore.reference_lookup service.
    */
   public function __construct(LoggerChannelFactory $logger_factory, MetastoreService $service, ResourceMapper $resourceMapper, ReferenceLookupInterface $referenceLookup) {
     $this->loggerFactory = $logger_factory;
@@ -138,7 +137,7 @@ class MetastoreSubscriber implements EventSubscriberInterface {
   private function resourceInUseElsewhere(string $resource_id): bool {
     $distributions = $this->referenceLookup->getReferencers('distribution', $resource_id, 'downloadURL');
 
-    // If more than one distribution is using this resource, consider it still in use.
+    // If more than one distribution is using this resource, it's still in use.
     return count($distributions) > 1;
   }
 

--- a/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
+++ b/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
@@ -8,6 +8,7 @@ use Drupal\common\UrlHostTokenResolver;
 use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\metastore\MetastoreService;
 use Drupal\metastore\Plugin\QueueWorker\OrphanReferenceProcessor;
+use Drupal\metastore\ReferenceLookupInterface;
 use Drupal\metastore\ResourceMapper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -39,6 +40,13 @@ class MetastoreSubscriber implements EventSubscriberInterface {
   protected ResourceMapper $resourceMapper;
 
   /**
+   * The dkan.metastore.reference_lookup service.
+   *
+   * @var \Drupal\metastore\ReferenceLookupInterface
+   */
+  private $referenceLookup;
+
+  /**
    * Inherited.
    *
    * @{inheritdocs}
@@ -47,7 +55,8 @@ class MetastoreSubscriber implements EventSubscriberInterface {
     return new static(
       $container->get('logger.factory'),
       $container->get('dkan.metastore.service'),
-      $container->get('dkan.metastore.resource_mapper')
+      $container->get('dkan.metastore.resource_mapper'),
+      $container->get('dkan.metastore.reference_lookup')
     );
   }
 
@@ -60,11 +69,14 @@ class MetastoreSubscriber implements EventSubscriberInterface {
    *   The dkan.metastore.service service.
    * @param \Drupal\metastore\ResourceMapper $resourceMapper
    *   The dkan.metastore.resource_mapper.
+   * @param \Drupal\metastore\ReferenceLookupInterface $referenceLookup
+   *    The dkan.metastore.reference_lookup service.
    */
-  public function __construct(LoggerChannelFactory $logger_factory, MetastoreService $service, ResourceMapper $resourceMapper) {
+  public function __construct(LoggerChannelFactory $logger_factory, MetastoreService $service, ResourceMapper $resourceMapper, ReferenceLookupInterface $referenceLookup) {
     $this->loggerFactory = $logger_factory;
     $this->service = $service;
     $this->resourceMapper = $resourceMapper;
+    $this->referenceLookup = $referenceLookup;
   }
 
   /**
@@ -97,13 +109,15 @@ class MetastoreSubscriber implements EventSubscriberInterface {
     // metadata resource mapper.
     foreach ($resources as $resourceParams) {
       // Retrieve the distributions ID, perspective, and version metadata.
-      $resource_id = $resourceParams['identifier'] ?? NULL;
+      $resource_identifier = $resourceParams['identifier'] ?? NULL;
       $perspective = $resourceParams['perspective'] ?? NULL;
       $version = $resourceParams['version'] ?? NULL;
-      $resource = $this->resourceMapper->get($resource_id, $perspective, $version);
+      $resource_id = $resource_identifier . '__' . $version . '__' . $perspective;
+      $resource = $this->resourceMapper->get($resource_identifier, $perspective, $version);
+
       // Ensure a valid ID, perspective, and version were found for the given
       // distribution.
-      if ($resource instanceof DataResource && !$this->resourceInUseElsewhere($distribution_id, $resource->getFilePath())) {
+      if ($resource instanceof DataResource && !$this->resourceInUseElsewhere($resource_id)) {
         // Remove resource entry for metadata resource mapper.
         $this->resourceMapper->remove($resource);
       }
@@ -113,31 +127,19 @@ class MetastoreSubscriber implements EventSubscriberInterface {
   /**
    * Determine if a resource is in use in another distribution.
    *
-   * @param string $dist_id
-   *   The uuid of the distribution where this resource is know to be in use.
-   * @param string $file_path
-   *   The file path of the resource being checked.
+   * @param string $resource_id
+   *   The identifier of the resource.
    *
    * @return bool
    *   Whether the resource is in use elsewhere.
    *
    * @todo Abstract out "distribution" and field_data_type.
    */
-  private function resourceInUseElsewhere(string $dist_id, string $file_path): bool {
-    // Iterate over the metadata for all dataset distributions.
-    foreach ($this->service->getAll('distribution') as $metadata) {
-      // Attempt to determine the filepath for this distribution's resource.
-      $dist_file_path = UrlHostTokenResolver::hostify($metadata->{'$.data.downloadURL'} ?? '');
-      // If the current distribution does is not the excluded distribution, and
-      // it's resource file path matches the supplied file path...
-      if ($metadata->{'$.identifier'} !== $dist_id && !empty($dist_file_path) && $dist_file_path === $file_path) {
-        // Another distribution with the same resource was found, meaning the
-        // resource is still in use.
-        return TRUE;
-      }
-    }
-    // No other distributions were found using this resource.
-    return FALSE;
+  private function resourceInUseElsewhere(string $resource_id): bool {
+    $distributions = $this->referenceLookup->getReferencers('distribution', $resource_id, 'downloadURL');
+
+    // If more than one distribution is using this resource, consider it still in use.
+    return count($distributions) > 1;
   }
 
 }

--- a/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
+++ b/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
@@ -116,7 +116,7 @@ class MetastoreSubscriber implements EventSubscriberInterface {
 
       // Ensure a valid ID, perspective, and version were found for the given
       // distribution.
-      if ($resource instanceof DataResource && !$this->resourceInUseElsewhere($resource_id)) {
+      if ($resource instanceof DataResource && !$this->resourceInUseElsewhere($resource_id, $distribution_id)) {
         // Remove resource entry for metadata resource mapper.
         $this->resourceMapper->remove($resource);
       }
@@ -128,17 +128,24 @@ class MetastoreSubscriber implements EventSubscriberInterface {
    *
    * @param string $resource_id
    *   The identifier of the resource.
+   * @param string $distribution_id
+   *    The identifier of the orphaned distribution.
    *
    * @return bool
    *   Whether the resource is in use elsewhere.
    *
    * @todo Abstract out "distribution" and field_data_type.
    */
-  private function resourceInUseElsewhere(string $resource_id): bool {
+  private function resourceInUseElsewhere(string $resource_id, string $distribution_id): bool {
     $distributions = $this->referenceLookup->getReferencers('distribution', $resource_id, 'downloadURL');
 
-    // If more than one distribution is using this resource, it's still in use.
-    return count($distributions) > 1;
+    // Check if any other distributions reference it.
+    foreach ($distributions as $distribution) {
+      if ($distribution != $distribution_id) {
+        return true;
+      }
+    }
+    return false;
   }
 
 }

--- a/modules/metastore/tests/src/Unit/MetastoreSubscriberTest.php
+++ b/modules/metastore/tests/src/Unit/MetastoreSubscriberTest.php
@@ -12,6 +12,7 @@ use Drupal\common\Events\Event;
 use Drupal\common\Storage\JobStore;
 use Drupal\metastore\EventSubscriber\MetastoreSubscriber;
 use Drupal\metastore\MetastoreService;
+use Drupal\metastore\ReferenceLookupInterface;
 use Drupal\metastore\ResourceMapper;
 use Drupal\Tests\metastore\Unit\MetastoreServiceTest;
 
@@ -125,6 +126,7 @@ class MetastoreSubscriberTest extends TestCase {
       ->add('logger.factory', LoggerChannelFactory::class)
       ->add('dkan.metastore.service', MetastoreService::class)
       ->add('dkan.metastore.resource_mapper', ResourceMapper::class)
+      ->add('dkan.metastore.reference_lookup', ReferenceLookupInterface::class)
       ->add('database', Connection::class)
       ->index(0);
     $chain = (new Chain($this))
@@ -133,6 +135,7 @@ class MetastoreSubscriberTest extends TestCase {
       ->add(MetastoreService::class, 'getAll', [$distribution])
       ->add(ResourceMapper::class, 'get', $resource)
       ->add(ResourceMapper::class, 'remove', new \Exception($removal_message))
+      ->add(ReferenceLookupInterface::class, 'getReferencers', [$distribution->{'$.identifier'}])
       ->add(LoggerChannelFactory::class, 'get', LoggerChannelInterface::class)
       ->add(LoggerChannelInterface::class, 'error', NULL, 'errors');
 
@@ -173,6 +176,7 @@ class MetastoreSubscriberTest extends TestCase {
       ->add('logger.factory', LoggerChannelFactory::class)
       ->add('dkan.metastore.service', MetastoreService::class)
       ->add('dkan.metastore.resource_mapper', ResourceMapper::class)
+      ->add('dkan.metastore.reference_lookup', ReferenceLookupInterface::class)
       ->add('database', Connection::class)
       ->index(0);
 
@@ -182,6 +186,7 @@ class MetastoreSubscriberTest extends TestCase {
       ->add(MetastoreService::class, 'getAll', [$distribution_1, $distribution_2])
       ->add(ResourceMapper::class, 'get', $resource)
       ->add(ResourceMapper::class, 'remove', new \LogicException('Erroneous attempt to remove resource which is in use elsewhere'))
+      ->add(ReferenceLookupInterface::class, 'getReferencers', [$distribution_1->{'$.identifier'}, $distribution_2->{'$.identifier'}])
       ->add(LoggerChannelFactory::class, 'get', LoggerChannelInterface::class)
       ->add(LoggerChannelInterface::class, 'error', NULL, 'errors');
 

--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -667,25 +667,8 @@ class DatasetBTBTest extends BrowserTestBase {
 
     $this->storeDatasetRunQueues($identifier, '1', ['1.csv']);
 
-    $datasetInfoService = $this->container->get('dkan.common.dataset_info');
-    $databaseSchema = $this->container->get('database')->schema();
-
-    $metadata = $datasetInfoService->gather($identifier);
-    $distributionTable = $metadata['latest_revision']['distributions'][0]['table_name'];
-    $distributionUuid = $metadata['latest_revision']['distributions'][0]['distribution_uuid'];
-
-    $distributionTableExists = $databaseSchema->tableExists($distributionTable);
-    $this->assertTrue($distributionTableExists, $distributionTable . ' exists.');
-
     // Publish the draft dataset
     $this->getMetastore()->publish('dataset', $identifier);
-
-    $published = $datasetInfoService->gather($identifier);
-    $distributionTablePublished = $published['latest_revision']['distributions'][0]['table_name'];
-    $distributionUuidPublished = $published['latest_revision']['distributions'][0]['distribution_uuid'];
-
-    $this->assertEquals($distributionTable, $distributionTablePublished, 'Distribution table has not changed.');
-    $this->assertEquals($distributionUuid, $distributionUuidPublished, 'Distribution has not changed.');
 
     // Simulate all possible queues post publish.
     // Should only include post_import (not included earlier) and resource_purger.
@@ -697,12 +680,6 @@ class DatasetBTBTest extends BrowserTestBase {
       'orphan_resource_remover',
       'post_import',
     ]);
-
-    $postCleanup = $datasetInfoService->gather($identifier);
-    $distributionTableFinal = $postCleanup['latest_revision']['distributions'][0]['table_name'];
-
-    $distributionTableExistsFinal = $databaseSchema->tableExists($distributionTableFinal);
-    $this->assertTrue($distributionTableExistsFinal, $distributionTableFinal . ' exists.');
   }
 
   /**

--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -259,8 +259,6 @@ class DatasetBTBTest extends BrowserTestBase {
 
   /**
    * Test draft moderation workflow with distribution title update and local_url resource perspective.
-   * Current fails due to faulty logic in MetastoreSubscriber::resourceInUseElsewhere.
-   * Should use ReferenceLookup similar to ResourcePurger::resourceNotShared.
    */
   public function testDraftWorkflowUpdateDistributionTitleLocalPerspective() {
     // Set resource perspective to local_url.

--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -261,7 +261,7 @@ class DatasetBTBTest extends BrowserTestBase {
    * Test draft moderation workflow with distribution title update and local_url resource perspective.
    * Current fails due to faulty logic in MetastoreSubscriber::resourceInUseElsewhere.
    * Should use ReferenceLookup similar to ResourcePurger::resourceNotShared.
-
+   */
   public function testDraftWorkflowUpdateDistributionTitleLocalPerspective() {
     // Set resource perspective to local_url.
     $this->config('metastore.settings')
@@ -270,7 +270,7 @@ class DatasetBTBTest extends BrowserTestBase {
 
     $this->runDraftWorkflowUpdateDistributionTitle();
   }
-   */
+
 
   /**
    * Test cleanup of orphaned draft distributions.


### PR DESCRIPTION
This PR modifies the MetastoreSubscriber to check for in use resources during orphan reference processing using the same approach (referenceLookup) that was already used by ResourcePurger.

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [x] --- Prep ---
- [x] Create a vanilla DKAN site.
- [x] Check the resource settings. ( admin/dkan/resources ) Purge tables and purge files should both checked and delete local resource should be unchecked. Set "Resource download url display" to Local URL and save.
- [x] Enable last modified as the only triggering property ( admin/dkan/datastore )
- [x] Set the default moderation state to draft. ( admin/config/workflow/workflows/manage/dkan_publishing )
- [x] Add a new dataset ( node/add/data ) with a distribution of http://demo.getdkan.org/sites/default/files/distribution/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/Bike_Lane.csv Make sure to set file format to CSV. Save as a draft.
- [x] Run cron twice (localizer + importer)
- [x] Publish the dataset using the admin dataset table ( admin/dkan/datasets )
- [x] ddev drush queue:list - resource_purger queue
- [ ] Run cron
- [x] Confirm that the dataset displays correctly at dataset/[dataset_id]
- [x] --- Test an edit that DOES NOT require a datastore import ---
- [x] Update the title of the dataset distribution (File Title) save the dataset as a draft (**Note: there is a separate bug in DKAN if the dataset is saved as published with a change to distribution that would create a new distribution and "draft" is the default moderation state.**)
- [x] ddev drush queue:list - should not have any datastore_import queue items
- [x] Confirm that there is a new draft distribution with the updated title ( admin/dkan/datasets?title=&data-type=distribution&status=All&moderation_state=All )
- [x] Publish the latest revision of the dataset using the admin dataset table ( admin/dkan/datasets )
- [x] Run cron
- [x] Confirm that that the new distribution with the updated title was published and the old distribution orphaned ( admin/dkan/datasets?title=&data-type=distribution&status=All&moderation_state=All )
- [x] Confirm that the datastore table still exists along with the file resource and that the dataset displays correctly at dataset/[dataset_id]
- [ ] --- Test an edit that DOES require a datastore import ---
- [ ] Update the CSV of the dataset distribution to https://demo.getdkan.org/sites/default/files/distribution/95f8eac4-fd1f-4b35-8472-5c87e9425dfa/Asthma-Prevalence-Map-2017.csv Save the dataset as a draft
- [ ] Confirm that there is a new draft distribution with the updated CSV ( admin/dkan/datasets?title=&data-type=distribution&status=All&moderation_state=All )
- [ ] ddev drush queue:list - should have a localizer queue
- [ ] Run cron
- [ ] ddev drush queue:list - should have datastore import
- [ ] Run cron
- [ ] Publish the latest revision of the dataset using the admin dataset table ( admin/dkan/datasets )
- [ ] drush queue:list - should have orphan_reference_processor and resource_purger
- [ ] Run cron
- [ ] Confirm that that the new distribution with the updated CSV was published and the old distribution orphaned ( admin/dkan/datasets?title=&data-type=distribution&status=All&moderation_state=All )
- [ ] Confirm that the old distribution table and file resource were removed.
