### PR TITLE
Fix drush dkan:datastore:list

### DIFF
--- a/modules/datastore/drush.services.yml
+++ b/modules/datastore/drush.services.yml
@@ -7,6 +7,7 @@ services:
       - '@dkan.datastore.service.post_import'
       - '@dkan.datastore.service.resource_localizer'
       - '@dkan.metastore.resource_mapper'
+      - '@dkan.datastore.import_info_list'
     tags:
       - { name: drush.command }
   datastore.purger.commands:

--- a/modules/datastore/src/Drush.php
+++ b/modules/datastore/src/Drush.php
@@ -5,6 +5,7 @@ namespace Drupal\datastore;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Consolidation\OutputFormatters\StructuredData\UnstructuredListData;
 use Drupal\common\DataResource;
+use Drupal\datastore\Service\Info\ImportInfoList;
 use Drupal\datastore\Service\ResourceLocalizer;
 use Drupal\metastore\MetastoreService;
 use Drupal\datastore\Service\PostImport;
@@ -55,6 +56,13 @@ class Drush extends DrushCommands {
   protected ResourceMapper $resourceMapper;
 
   /**
+   * Import info list service.
+   *
+   * @var \Drupal\datastore\Service\Info\ImportInfoList
+   */
+  private ImportInfoList $importInfoList;
+
+  /**
    * Constructor for DkanDatastoreCommands.
    */
   public function __construct(
@@ -62,7 +70,8 @@ class Drush extends DrushCommands {
     DatastoreService $datastoreService,
     PostImport $postImport,
     ResourceLocalizer $resourceLocalizer,
-    ResourceMapper $resourceMapper
+    ResourceMapper $resourceMapper,
+    ImportInfoList $importInfoList
   ) {
     parent::__construct();
     $this->metastoreService = $metastoreService;
@@ -70,6 +79,7 @@ class Drush extends DrushCommands {
     $this->postImport = $postImport;
     $this->resourceLocalizer = $resourceLocalizer;
     $this->resourceMapper = $resourceMapper;
+    $this->importInfoList = $importInfoList;
   }
 
   /**
@@ -147,7 +157,7 @@ class Drush extends DrushCommands {
     $status = $options['status'];
     $uuid_only = $options['uuid-only'];
 
-    $list = $this->datastoreService->list();
+    $list = $this->importInfoList->buildList();
     $rows = [];
     foreach ($list as $uuid => $item) {
       $rows[] = $this->createRow($uuid, $item);


### PR DESCRIPTION
One use of `DatastoreService::list()` that we didn't catch in https://github.com/GetDKAN/dkan/pull/4050