### PR TITLE
Fix JsonPath error on dkan:datastore:drop-all

### DIFF
--- a/modules/datastore/src/Drush.php
+++ b/modules/datastore/src/Drush.php
@@ -245,8 +245,7 @@ class Drush extends DrushCommands {
   public function dropAll() {
     /** @var \RootedData\RootedJsonData $distribution*/
     foreach ($this->metastoreService->getAll('distribution') as $distribution) {
-      $data = $distribution->get('$.data');
-      if ($uuid = $data['%Ref:downloadURL'][0]['data']['identifier'] ?? FALSE) {
+      if ($uuid = $distribution->get('$[data]["%Ref:downloadURL"][0][data][identifier]') ?? FALSE) {
         $this->drop($uuid);
       }
     }


### PR DESCRIPTION
The `RootedJsonData` query was somehow wrong in this instance. Fixing that is not so hard.

Using the sample content, we also encounter the "Market Value Analysis - Urban Redevelopment Authority" dataset, which does not have distributions that can be imported into the database... Since drop-all now works, it tries to drop non-existent datastores, which halts all progress.

So now `dkan:datastore:drop` (not `drop-all`)  will catch these exceptions and report them as warnings.

Here's your set of QA commands:
```
ddev dkan-site-install
ddev drush pm-enable sample_content
ddev drush dkan:sample-content:create
ddev drush cron
ddev drush cron
ddev drush dkan:datastore:drop-all
```
This should all happen without error, but with warnings for three of the datasets:
```
 [notice] Successfully dropped the datastore for resource 3a187a87dc6cd47c48b6b4c4785224b7
 [notice] Successfully removed the post import job status for resource 3a187a87dc6cd47c48b6b4c4785224b7
 [warning] Unable to drop datastore for ad62ad1179fa1b0e44c8b9226c2266a8
 [notice] Successfully removed the post import job status for resource ad62ad1179fa1b0e44c8b9226c2266a8
 [warning] Unable to drop datastore for 9f076e2af8927b72db5cf0e05e8cd5f2
 [notice] Successfully removed the post import job status for resource 9f076e2af8927b72db5cf0e05e8cd5f2
 [warning] Unable to drop datastore for 60d78924087b2516acf1e57ff1fc8b83
....etc
```