### PR TITLE
Drupal 10.2 compatibility additions, exclude PHP 7 & Drupal 9 from testing matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,7 @@ workflows:
          matrix:
            parameters:
              dkan_recommended_branch: [ '10.0.x-dev']
-             php_version: [ '8.0', '8.1' ]
+             php_version: [ '8.1' ]
       - phpunit:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,16 +232,6 @@ workflows:
           name: install_test_cypress
           dkan_recommended_branch: '10.1.x-dev'
       - phpunit:
-          matrix:
-            parameters:
-              dkan_recommended_branch: [ '9.4.x-dev']
-              php_version: [ '7.4' ]
-      - phpunit:
-          matrix:
-            parameters:
-              dkan_recommended_branch: [ '9.5.x-dev']
-              php_version: [ '7.4', '8.0', '8.1' ]
-      - phpunit:
           name: 'Install target (Drupal 10.1, PHP 8.1)'
           report_coverage: true
           matrix:
@@ -258,6 +248,11 @@ workflows:
            parameters:
              dkan_recommended_branch: [ '10.0.x-dev']
              php_version: [ '8.1' ]
+      - phpunit:
+          matrix:
+            parameters:
+              dkan_recommended_branch: [ '10.2.x-dev']
+              php_version: [ '8.1' ]
   upgrade_and_test:
     jobs:
       - cypress:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,12 +247,12 @@ workflows:
          matrix:
            parameters:
              dkan_recommended_branch: [ '10.0.x-dev']
-             php_version: [ '8.1' ]
+             php_version: [ '8.0', '8.1' ]
       - phpunit:
           matrix:
             parameters:
               dkan_recommended_branch: [ '10.2.x-dev']
-              php_version: [ '8.1' ]
+              php_version: [ '8.1', '8.2' ]
   upgrade_and_test:
     jobs:
       - cypress:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
     parameters:
       php_version:
         description: 'PHP major.minor for DDev to use.'
-        default: '8.1'
+        default: '8.2'
         type: string
       addon_branch:
         description: 'Repo branch name for the dkan-ddev-addon you want to test against.'
@@ -34,7 +34,7 @@ commands:
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'
-        default: '10.1.x-dev'
+        default: '10.2.x-dev'
         type: string
     steps:
       - run:
@@ -124,7 +124,7 @@ jobs:
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'
-        default: '10.1.x-dev'
+        default: '10.2.x-dev'
         type: string
       report_coverage:
         description: 'Generate coverage report and send it to CodeClimate'
@@ -191,7 +191,7 @@ jobs:
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'
-        default: '10.1.x-dev'
+        default: '10.2.x-dev'
         type: string
       upgrade:
         description: 'If true, will install the latest stable DKAN version and test upgrade'
@@ -230,14 +230,14 @@ workflows:
     jobs:
       - cypress:
           name: install_test_cypress
-          dkan_recommended_branch: '10.1.x-dev'
+          dkan_recommended_branch: '10.2.x-dev'
       - phpunit:
-          name: 'Install target (Drupal 10.1, PHP 8.1)'
+          name: 'Install target (Drupal 10.2, PHP 8.2)'
           report_coverage: true
           matrix:
             parameters:
-              dkan_recommended_branch: [ '10.1.x-dev']
-              php_version: [ '8.1' ]
+              dkan_recommended_branch: [ '10.2.x-dev']
+              php_version: [ '8.2' ]
       - phpunit:
           matrix:
             parameters:
@@ -252,17 +252,17 @@ workflows:
           matrix:
             parameters:
               dkan_recommended_branch: [ '10.2.x-dev']
-              php_version: [ '8.1', '8.2' ]
+              php_version: [ '8.1' ]
   upgrade_and_test:
     jobs:
       - cypress:
           name: upgrade_test_cypress
           upgrade: true
-          dkan_recommended_branch: '10.1.x-dev'
+          dkan_recommended_branch: '10.2.x-dev'
       - phpunit:
-          name: 'Upgrade target (Drupal 10.1, PHP 8.1)'
+          name: 'Upgrade target (Drupal 10.2, PHP 8.2)'
           upgrade: true
           matrix:
             parameters:
-              dkan_recommended_branch: [ '10.1.x-dev']
-              php_version: [ '8.1' ]
+              dkan_recommended_branch: [ '10.2.x-dev']
+              php_version: [ '8.2' ]

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -195,7 +195,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    *   Drupal Schema API array.
    */
   protected function addIndexInfo(array &$schema): void {
-    if ($this->connection->getConnectionOptions()['driver'] != 'mysql') {
+    if (!str_contains($this->connection->getConnectionOptions()['driver'], 'mysql')) {
       return;
     }
 

--- a/modules/metastore/tests/src/Unit/DataDictionary/DataDictionaryDiscoveryTest.php
+++ b/modules/metastore/tests/src/Unit/DataDictionary/DataDictionaryDiscoveryTest.php
@@ -8,7 +8,7 @@ use Drupal\Core\Config\ImmutableConfig;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscovery as Discovery;
 use Drupal\metastore\Reference\MetastoreUrlGenerator;
 use Drupal\metastore\Reference\ReferenceLookup;
-use Drupal\metastore\Service;
+use Drupal\metastore\MetastoreService as Service;
 use MockChain\Chain;
 use MockChain\Options;
 use OutOfRangeException;
@@ -16,7 +16,6 @@ use PHPUnit\Framework\TestCase;
 use RootedData\RootedJsonData;
 
 class DataDictionaryDiscoveryTest extends TestCase {
-  
 
   // If mode is set to "none", we should get NULL no matter what.
   public function testModeNone() {
@@ -66,7 +65,7 @@ class DataDictionaryDiscoveryTest extends TestCase {
       $this->getMetastoreService(),
       $this->getLookup(),
       $this->getUrlGenerator()
-    );    
+    );
     $id = $discovery->dictionaryIdFromResource('resource1');
     $this->assertEquals('111', $id);
 
@@ -148,7 +147,7 @@ class DataDictionaryDiscoveryTest extends TestCase {
     $uriFromUrl = (new Options())
       ->add('https://example.com/api/1/metastore/schemas/data-dictionary/items/111', 'dkan://metastore/schemas/data-dictionary/items/111')
       ->add('dkan://metastore/schemas/dataset/items/444', 'dkan://metastore/schemas/dataset/items/444');
-      
+
     return (new Chain($this))
       ->add(MetastoreUrlGenerator::class, 'uriFromUrl', $uriFromUrl)
       ->add(MetastoreUrlGenerator::class, 'extractItemId', $extract)

--- a/modules/metastore/tests/src/Unit/DataDictionary/DataDictionaryDiscoveryTest.php
+++ b/modules/metastore/tests/src/Unit/DataDictionary/DataDictionaryDiscoveryTest.php
@@ -6,9 +6,9 @@ use DomainException;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Config\ImmutableConfig;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscovery as Discovery;
+use Drupal\metastore\MetastoreService;
 use Drupal\metastore\Reference\MetastoreUrlGenerator;
 use Drupal\metastore\Reference\ReferenceLookup;
-use Drupal\metastore\MetastoreService as Service;
 use MockChain\Chain;
 use MockChain\Options;
 use OutOfRangeException;
@@ -135,7 +135,7 @@ class DataDictionaryDiscoveryTest extends TestCase {
       ->add('444', new RootedJsonData($json4, "{}"))
       ->index(1);
     return (new Chain($this))
-      ->add(Service::class, 'get', $sequence)
+      ->add(MetastoreService::class, 'get', $sequence)
       ->getMock();
   }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -49,6 +49,9 @@
       <group>requires-database</group>
     </exclude>
   </groups>
+  <listeners>
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+  </listeners>
   <php>
     <!-- These variables may alternatively be set as environment variables. -->
     <!-- E.g., `DRUPAL_VERSION=V8 ./vendor/bin/phpunit` -->
@@ -56,6 +59,6 @@
     <env name="DTT_BASE_URL" value="http://web"/>
     <env name="SIMPLETEST_BASE_URL" value="http://web"/>
     <env name="SIMPLETEST_DB" value="mysql://drupal:123@db/drupal"/>
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
   </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -49,9 +49,6 @@
       <group>requires-database</group>
     </exclude>
   </groups>
-  <listeners>
-    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-  </listeners>
   <php>
     <!-- These variables may alternatively be set as environment variables. -->
     <!-- E.g., `DRUPAL_VERSION=V8 ./vendor/bin/phpunit` -->
@@ -59,6 +56,6 @@
     <env name="DTT_BASE_URL" value="http://web"/>
     <env name="SIMPLETEST_BASE_URL" value="http://web"/>
     <env name="SIMPLETEST_DB" value="mysql://drupal:123@db/drupal"/>
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
   </php>
 </phpunit>


### PR DESCRIPTION
Quick note that I'm using str_contains() so this won't be PHP 7.4 compatible.

Includes:

- Adjusts the DB driver check to be compatible with 10.2
- Removes PHP 7.4 and Drupal 9.x from the test matrix.
- Drupal 10 requires at least PHP 8.1 so dropping Drupal 9.x means dropping PHP < 8.1
- Adds Drupal 10.2 to test matrix with PHP 8.1 and PHP 8.2 (Currently expected to fail PHP 8.2 tests right now)

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform to confirm that the feature or fix is working. Include as much details as possible so that the reviewer doesn't lose time figuring out how to perform steps.
