### PR TITLE
Adapt to changes in ilbee/csv-response 1.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "getdkan/procrastinator": "^5.0.0",
         "getdkan/rooted-json-data": "^0.2.1",
         "guzzlehttp/guzzle" : "^6.5.8 || ^7.4.5",
-        "ilbee/csv-response": "^1.1.1",
+        "ilbee/csv-response": "^1.2.0",
         "justinrainbow/json-schema": "^5.2",
         "m1x0n/opis-json-schema-error-presenter": "^0.5.3",
         "fylax/forceutf8": "~3.0",

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -4,7 +4,7 @@ namespace Drupal\datastore\Controller;
 
 use Drupal\datastore\Service\DatastoreQuery;
 use RootedData\RootedJsonData;
-use Ilbee\CSVResponse\CSVResponse as CsvResponse;
+use Ilbee\CSVResponse\CSVResponse;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
 /**
@@ -37,7 +37,7 @@ class QueryController extends AbstractQueryController {
   ) {
     switch ($datastoreQuery->{"$.format"}) {
       case 'csv':
-        $response = new CsvResponse($result->{"$.results"}, 'data', ',');
+        $response = new CSVResponse($result->{"$.results"}, 'data.csv', ',');
         return $this->addCacheHeaders($response);
 
       case 'json':


### PR DESCRIPTION
Somewhere in the short time between the last CI run for #4027 and when it was merged, ilbee/csv-response did a release which broke BC.

This PR:
- Constrains to ilbee/csv-response 1.2.0 and above.
- Modifies our code to the new changes.