### PR TITLE
JobStoreTest throws deprecation messages.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,13 +234,8 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              dkan_recommended_branch: [ '9.4.x-dev']
-              php_version: [ '7.4' ]
-      - phpunit:
-          matrix:
-            parameters:
               dkan_recommended_branch: [ '9.5.x-dev']
-              php_version: [ '7.4', '8.0', '8.1' ]
+              php_version: [ '8.0', '8.1' ]
       - phpunit:
           name: 'Install target (Drupal 10.1, PHP 8.1)'
           report_coverage: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,8 +234,13 @@ workflows:
       - phpunit:
           matrix:
             parameters:
+              dkan_recommended_branch: [ '9.4.x-dev']
+              php_version: [ '8.0' ]
+      - phpunit:
+          matrix:
+            parameters:
               dkan_recommended_branch: [ '9.5.x-dev']
-              php_version: [ '8.0', '8.1' ]
+              php_version: [ '7.4', '8.0', '8.1' ]
       - phpunit:
           name: 'Install target (Drupal 10.1, PHP 8.1)'
           report_coverage: true

--- a/modules/common/tests/src/Unit/Storage/JobStoreTest.php
+++ b/modules/common/tests/src/Unit/Storage/JobStoreTest.php
@@ -52,6 +52,7 @@ class JobStoreTest extends TestCase {
       (object) ['Field' => "job_data"],
     ];
 
+    // Substitute StatementWrapper as necessary for Drupal 10.0.x BC.
     $statement_wrapper_class = class_exists(StatementWrapperIterator::class)
       ? StatementWrapperIterator::class : StatementWrapper::class;
 
@@ -88,6 +89,7 @@ class JobStoreTest extends TestCase {
       ->add($fieldInfo)
       ->add([$job]);
 
+    // Substitute StatementWrapper as necessary for Drupal 10.0.x BC.
     $statement_wrapper_class = class_exists(StatementWrapperIterator::class)
       ? StatementWrapperIterator::class : StatementWrapper::class;
 
@@ -121,6 +123,7 @@ class JobStoreTest extends TestCase {
       (object) ['Field' => "job_data"],
     ];
 
+    // Substitute StatementWrapper as necessary for Drupal 10.0.x BC.
     $statement_wrapper_class = class_exists(StatementWrapperIterator::class)
       ? StatementWrapperIterator::class : StatementWrapper::class;
 
@@ -154,6 +157,7 @@ class JobStoreTest extends TestCase {
       (object) ['Field' => "job_data"],
     ];
 
+    // Substitute StatementWrapper as necessary for Drupal 10.0.x BC.
     $statement_wrapper_class = class_exists(StatementWrapperIterator::class)
       ? StatementWrapperIterator::class : StatementWrapper::class;
 

--- a/modules/common/tests/src/Unit/Storage/JobStoreTest.php
+++ b/modules/common/tests/src/Unit/Storage/JobStoreTest.php
@@ -2,15 +2,15 @@
 
 namespace Drupal\Tests\common\Unit\Storage;
 
+use Contracts\Mock\Storage\Memory;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Query\Delete;
 use Drupal\Core\Database\Query\Select;
 use Drupal\Core\Database\Query\Update;
 use Drupal\Core\Database\Schema;
 use Drupal\Core\Database\StatementWrapper;
+use Drupal\Core\Database\StatementWrapperIterator;
 use Drupal\common\Storage\JobStore;
-
-use Contracts\Mock\Storage\Memory;
 use FileFetcher\FileFetcher;
 use MockChain\Chain;
 use MockChain\Sequence;
@@ -19,7 +19,10 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \Drupal\common\Storage\JobStore
  * @coversDefaultClass \Drupal\common\Storage\JobStore
+ *
+ * @group dkan
  * @group common
+ * @group unit
  */
 class JobStoreTest extends TestCase {
 
@@ -49,16 +52,19 @@ class JobStoreTest extends TestCase {
       (object) ['Field' => "job_data"],
     ];
 
+    $statement_wrapper_class = class_exists(StatementWrapperIterator::class)
+      ? StatementWrapperIterator::class : StatementWrapper::class;
+
     $chain = (new Chain($this))
       ->add(Connection::class, "schema", Schema::class)
       ->add(Schema::class, "tableExists", TRUE)
       ->add(Connection::class, 'select', Select::class, 'select_1')
       ->add(Select::class, 'fields', Select::class)
       ->add(Select::class, 'condition', Select::class)
-      ->add(Select::class, 'execute', StatementWrapper::class)
-      ->add(StatementWrapper::class, 'fetch', $job)
-      ->add(Connection::class, 'query', StatementWrapper::class)
-      ->add(StatementWrapper::class, 'fetchAll', $fieldInfo);
+      ->add(Select::class, 'execute', $statement_wrapper_class)
+      ->add($statement_wrapper_class, 'fetch', $job)
+      ->add(Connection::class, 'query', $statement_wrapper_class)
+      ->add($statement_wrapper_class, 'fetchAll', $fieldInfo);
 
     $jobStore = new JobStore(FileFetcher::class, $chain->getMock());
     $this->assertEquals($job_data, $jobStore->retrieve("1", FileFetcher::class));
@@ -82,14 +88,17 @@ class JobStoreTest extends TestCase {
       ->add($fieldInfo)
       ->add([$job]);
 
+    $statement_wrapper_class = class_exists(StatementWrapperIterator::class)
+      ? StatementWrapperIterator::class : StatementWrapper::class;
+
     $chain = (new Chain($this))
       ->add(Connection::class, "schema", Schema::class)
       ->add(Schema::class, "tableExists", TRUE)
       ->add(Connection::class, 'select', Select::class, 'select_1')
       ->add(Select::class, 'fields', Select::class)
-      ->add(Select::class, 'execute', StatementWrapper::class)
-      ->add(Connection::class, 'query', StatementWrapper::class)
-      ->add(StatementWrapper::class, 'fetchAll', $sequence);
+      ->add(Select::class, 'execute', $statement_wrapper_class)
+      ->add(Connection::class, 'query', $statement_wrapper_class)
+      ->add($statement_wrapper_class, 'fetchAll', $sequence);
 
     $jobStore = new JobStore(FileFetcher::class, $chain->getMock());
     $this->assertTrue(is_array($jobStore->retrieveAll()));
@@ -112,20 +121,23 @@ class JobStoreTest extends TestCase {
       (object) ['Field' => "job_data"],
     ];
 
+    $statement_wrapper_class = class_exists(StatementWrapperIterator::class)
+      ? StatementWrapperIterator::class : StatementWrapper::class;
+
     $connection = (new Chain($this))
       ->add(Connection::class, "schema", Schema::class)
       ->add(Schema::class, "tableExists", TRUE)
       ->add(Connection::class, 'select', Select::class, 'select_1')
       ->add(Select::class, 'fields', Select::class)
       ->add(Select::class, 'condition', Select::class)
-      ->add(Select::class, 'execute', StatementWrapper::class)
-      ->add(StatementWrapper::class, 'fetch', $job)
+      ->add(Select::class, 'execute', $statement_wrapper_class)
+      ->add($statement_wrapper_class, 'fetch', $job)
       ->add(Connection::class, 'update', Update::class)
       ->add(Update::class, "fields", Update::class)
       ->add(Update::class, "condition", Update::class)
       ->add(Update::class, "execute", NULL)
-      ->add(Connection::class, 'query', StatementWrapper::class)
-      ->add(StatementWrapper::class, 'fetchAll', $fieldInfo)
+      ->add(Connection::class, 'query', $statement_wrapper_class)
+      ->add($statement_wrapper_class, 'fetchAll', $fieldInfo)
       ->getMock();
 
     $jobStore = new JobStore(FileFetcher::class, $connection);
@@ -142,14 +154,17 @@ class JobStoreTest extends TestCase {
       (object) ['Field' => "job_data"],
     ];
 
+    $statement_wrapper_class = class_exists(StatementWrapperIterator::class)
+      ? StatementWrapperIterator::class : StatementWrapper::class;
+
     $connection = (new Chain($this))
       ->add(Connection::class, "schema", Schema::class)
       ->add(Schema::class, "tableExists", TRUE)
       ->add(Connection::class, "delete", Delete::class)
       ->add(Delete::class, "condition", Delete::class)
       ->add(Delete::class, "execute", NULL)
-      ->add(Connection::class, 'query', StatementWrapper::class)
-      ->add(StatementWrapper::class, 'fetchAll', $fieldInfo)
+      ->add(Connection::class, 'query', $statement_wrapper_class)
+      ->add($statement_wrapper_class, 'fetchAll', $fieldInfo)
       ->getMock();
 
     $jobStore = new JobStore(FileFetcher::class, $connection);


### PR DESCRIPTION
`Drupal\Tests\common\Unit\Storage\JobStoreTest` throws this deprecation error:
```
  1x: \Drupal\Core\Database\StatementWrapper is deprecated in drupal:10.1.0 and is removed from drupal:11.0.0. Use \Drupal\Core\Database\StatementWrapperIterator instead. See https://www.drupal.org/node/3265938
    1x in JobStoreTest::testRetrieve from Drupal\Tests\common\Unit\Storage 
Change record: https://www.drupal.org/node/3265938
```
`StatementWrapperIterator` was introduced in Drupal 10.1, so this is no backwards compatibility to Drupal 10.0.

However... `StatementWrapper` is only used in the test, for a mock, so we should conditionalize the class we mock based on whether `class_exists()`. This gives backwards compatibility.

QA steps:

- Use Drupal 10.1.x in a local environment.
- Configure PHPUnit to use symfony/phpunit-bridge to report deprecations.
  - Add listener to phpunit.xml file.
  - Configure SYMFONY_DEPRECATIONS_HELPER to be max[self]=0
  - Docs: https://symfony.com/doc/current/components/phpunit_bridge.html#installation
- Run JobStoreTest: ddev dkan-phpunit --filter JobStoreTest
- Verify that no deprecation messages related to StatementWrapper arise.