### PR TITLE
Change minimum Drupal core to 9.5+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,11 +234,6 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              dkan_recommended_branch: [ '9.4.x-dev']
-              php_version: [ '7.4' ]
-      - phpunit:
-          matrix:
-            parameters:
               dkan_recommended_branch: [ '9.5.x-dev']
               php_version: [ '7.4', '8.0', '8.1' ]
       - phpunit:

--- a/dkan.info.yml
+++ b/dkan.info.yml
@@ -1,7 +1,7 @@
 name: DKAN
 description: 'DKAN Open Data Portal'
 type: module
-core_version_requirement: ^9.4 || ^10
+core_version_requirement: ^9.5 || ^10
 package: DKAN
 dependencies:
   - metastore

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -20,11 +20,12 @@ Requirements
 
 DKAN is based on `Drupal software <https://www.drupal.org/docs/getting-started/system-requirements>`_ and -- generally -- runs anywhere Drupal is supported. For the most common setup, we reccomend:
 
+-  Drupal 9.5+/10
 -  MySQL: minimum version 5.7.8+ with PDO
 -  PHP: minimum version 8.0 or 8.1
 -  Apache: minimum version 2.4.7
 -  Drush: minimum version 10.x.
--  Node: minimum version 16 (if using the decoupled frontend)
+-  Node: minimum version 18 (if using the decoupled frontend)
 
 Starting a new DKAN project
 ---------------------------


### PR DESCRIPTION
- Formally declares Drupal core 9.5.x as the minimum compatible Drupal core version to use with DKAN.
- Updates the `dkan.info.yml` file to `core_version_requirement: ^9.5 || ^10`
- Removes Drupal 9.4.x from the CI testing matrix.