### PR TITLE
Drupal's RequestStack is deprecated

### DIFF
--- a/modules/metastore/tests/src/Unit/Reference/MetastoreUrlGeneratorTest.php
+++ b/modules/metastore/tests/src/Unit/Reference/MetastoreUrlGeneratorTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\metastore\Unit\Reference;
 use Drupal\common\StreamWrapper\DkanStreamWrapper;
 use Drupal\Core\File\FileSystem;
 use Drupal\Core\GeneratedUrl;
-use Drupal\Core\Http\RequestStack;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Drupal\Core\Path\PathValidator;
 use Drupal\Core\Render\MetadataBubblingUrlGenerator;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
@@ -100,7 +100,7 @@ class MetastoreUrlGeneratorTest extends TestCase {
   }
 
   /**
-   * 
+   *
    */
   public function testExtractItemId() {
     $generator = $this->getGenerator();
@@ -121,7 +121,7 @@ class MetastoreUrlGeneratorTest extends TestCase {
         ->index(0)
       )
       ->add(PathValidator::class, 'getPathAttributes', ['_route' => "dkan.common.api.version", '_raw_variables' => new ParameterBag()])
-      ->add(UnroutedUrlAssembler::class, 'assemble', "/api/1/metastore/schemas/data-dictionary/items/111") 
+      ->add(UnroutedUrlAssembler::class, 'assemble', "/api/1/metastore/schemas/data-dictionary/items/111")
       ->add(MetadataBubblingUrlGenerator::class, 'generateFromRoute', GeneratedUrl::class)
       ->add(GeneratedUrl::class, 'getGeneratedUrl', 'http://web/api/1')
       ->getMock();


### PR DESCRIPTION
`Drupal\Core\Http\RequestStack` is deprecated in Drupal 10.0.0.

It's used in one place in DKAN: `Drupal\Tests\metastore\Unit\Reference\MetastoreUrlGeneratorTest`

We'll modify `MetastoreUrlGeneratorTest` so it uses the non-deprecated `Symfony\Component\HttpFoundation\RequestStack`

### QA steps:
- Use Drupal 10.1.x in a local environment.
- Configure PHPUnit to use symfony/phpunit-bridge to report deprecations.
  - Add listener to phpunit.xml file.
  - Configure SYMFONY_DEPRECATIONS_HELPER to be max[self]=0
  - Docs: https://symfony.com/doc/current/components/phpunit_bridge.html#installation
- Run tests.
- Verify that no deprecation messages related `Drupal\Core\Http\RequestStack` arise.