### PR TITLE
Use Drupal’s mime type guesser service to determine local mime type

### DIFF
--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -42,6 +42,7 @@ services:
       - '@dkan.metastore.storage'
       - '@dkan.metastore.url_generator'
       - '@http_client'
+      - '@file.mime_type.guesser.extension'
     calls:
       - [setLoggerFactory, ['@logger.factory']]
 

--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -59,10 +59,10 @@ class Referencer {
   protected $mimeTypeGuesser;
 
   /**
-   * Constructor
+   * Constructor.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configService
-   *   Drupal config factory service
+   *   Drupal config factory service.
    * @param \Contracts\FactoryInterface $storageFactory
    *   DKAN contracts factory.
    * @param \Drupal\metastore\Reference\MetastoreUrlGenerator $metastoreUrlGenerator
@@ -333,7 +333,7 @@ class Referencer {
    *   The detected mime type or NULL on failure.
    */
   private function getLocalMimeType(string $downloadUrl): ?string {
-    // Use Drupal's mime type guesser service to get the mime type
+    // Use Drupal's mime type guesser service to get the mime type.
     $mime_type = $this->mimeTypeGuesser->guessMimeType($downloadUrl);
 
     // If we couldn't find a mime type, log an error notifying the user.

--- a/modules/metastore/tests/src/Unit/Reference/ReferencerTest.php
+++ b/modules/metastore/tests/src/Unit/Reference/ReferencerTest.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\File\FileSystem;
+use Drupal\Core\File\MimeType\ExtensionMimeTypeGuesser;
 use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\Core\StreamWrapper\PublicStream;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
@@ -35,6 +36,7 @@ use RootedData\RootedJsonData;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Mime\MimeTypeGuesserInterface;
 
 /**
  * @covers \Drupal\metastore\Reference\Referencer
@@ -119,11 +121,16 @@ class ReferencerTest extends TestCase {
       ->add(MetastoreUrlGenerator::class, 'uriFromUrl', 'dkan://metastore/schemas/data-dictionary/items/111')
       ->getMock();
 
+    $mimeTypeGuesser = (new Chain($this))
+      ->add(MimeTypeGuesserInterface::class, 'guessMimeType', self::MIME_TYPE)
+      ->getMock();
+
     return new Referencer(
       $configService,
       $storageFactory,
       $urlGenerator,
-      new Client()
+      new Client(),
+      $mimeTypeGuesser
     );
   }
 
@@ -394,11 +401,16 @@ class ReferencerTest extends TestCase {
       ->add(MetastoreUrlGenerator::class, 'uriFromUrl', '')
       ->getMock();
 
+    $mimeTypeGuesser = (new Chain($this))
+      ->add(MimeTypeGuesserInterface::class, 'guessMimeType', self::MIME_TYPE)
+      ->getMock();
+
     $referencer = new Referencer(
       $configService,
       $storageFactory,
       $urlGenerator,
-      new Client()
+      new Client(),
+      $mimeTypeGuesser
     );
 
     // Test Mime Type detection using the resource `mediaType` property.
@@ -454,11 +466,16 @@ class ReferencerTest extends TestCase {
       ->disableOriginalConstructor()
       ->getMock();
 
+    $mimeTypeGuesser = (new Chain($this))
+      ->add(MimeTypeGuesserInterface::class, 'guessMimeType', self::MIME_TYPE)
+      ->getMock();
+
     $referencer = new Referencer(
       $configService,
       $storageFactory,
       $urlGenerator,
-      $http_client
+      $http_client,
+      $mimeTypeGuesser
     );
 
     if ($describedBy instanceof \Exception) {

--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -514,8 +514,6 @@ class DatasetBTBTest extends BrowserTestBase {
       $distribution = new \stdClass();
       $distribution->title = 'Distribution #' . $key . ' for ' . $identifier;
       $distribution->downloadURL = $this->getDownloadUrl($downloadUrl);
-      $distribution->format = 'csv';
-      $distribution->mediaType = 'text/csv';
 
       $data->distribution[] = $distribution;
     }

--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -514,6 +514,7 @@ class DatasetBTBTest extends BrowserTestBase {
       $distribution = new \stdClass();
       $distribution->title = 'Distribution #' . $key . ' for ' . $identifier;
       $distribution->downloadURL = $this->getDownloadUrl($downloadUrl);
+      // Don't provide mime type or format fields since they're not required.
 
       $data->distribution[] = $distribution;
     }


### PR DESCRIPTION
Fixes the ability to use a draft workflow with resource_perspective_display set to local_url without explicitly setting mediaType or file format. Correctly calculate the mime type of a file that was not uploaded to and is managed by Drupal.

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] --- Prep ---
- [ ] Create a vanilla DKAN site.
- [ ] Check the resource settings. ( admin/dkan/resources ) Purge tables and purge files should both checked and delete local resource should be unchecked. Set "Resource download url display" to Local URL and save.
- [ ] Enable last modified as the only triggering property ( admin/dkan/datastore )
- [ ] Set the default moderation state to draft. ( admin/config/workflow/workflows/manage/dkan_publishing )
- [ ] Add a new dataset ( node/add/data ) with a distribution of http://demo.getdkan.org/sites/default/files/distribution/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/Bike_Lane.csv Leave file format blank. Save as a draft.
- [ ] Run cron twice (localizer + importer)
- [ ] Publish the dataset using the admin dataset table ( admin/dkan/datasets )
- [ ] ddev drush queue:list - resource_purger queue
- [ ] Run cron
- [ ] Confirm that the dataset imported correctly by checking the datastore/query endpoint. (Note that without format selected, the frontend will not display a preview.)
- [ ] Check the dkan_metastore_resource_mapper table; there should be 3 entries for the resource all with a mimetype of "text/csv".
- [ ] --- Test an edit that DOES NOT require a datastore import ---
- [ ] Update the title of the dataset distribution (File Title) save the dataset as a draft (**Note: there is a separate bug in DKAN if the dataset is saved as published with a change to distribution that would create a new distribution and "draft" is the default moderation state.**)
- [ ] ddev drush queue:list - should not have any datastore_import queue items
- [ ] Confirm that there is a new draft distribution with the updated title ( admin/dkan/datasets?title=&data-type=distribution&status=All&moderation_state=All )
- [ ] Publish the latest revision of the dataset using the admin dataset table ( admin/dkan/datasets )
- [ ] Run cron
- [ ] Confirm that that the new distribution with the updated title was published and the old distribution orphaned ( admin/dkan/datasets?title=&data-type=distribution&status=All&moderation_state=All )
- [ ] Confirm that the datastore table still exists along with the file resource.
- [ ] Check the dkan_metastore_resource_mapper table; there should be the same 3 entries for the resource.
- [ ] --- Test by uploading a TSV file ---
- [ ] Create a new dataset, uploading a TSV file for the distribution. Leave format blank. Save the dataset as a draft
- [ ] ddev drush queue:list - should have a localizer queue
- [ ] Run cron twice (localizer + importer)
- [ ] Publish the dataset using the admin dataset table ( admin/dkan/datasets )
- [ ] Run cron
- [ ] Confirm that the dataset imported correctly by checking the datastore/query endpoint. (Note that without format selected, the frontend will not display a preview.)
- [ ] Check the dkan_metastore_resource_mapper table; there should be 3 entries for the resource all with a mimetype of "text/tab-separated-values".

