### PR TITLE
Add invalidateCacheTags to post_import queueworker

### DIFF
--- a/modules/datastore/src/Plugin/QueueWorker/PostImportResourceProcessor.php
+++ b/modules/datastore/src/Plugin/QueueWorker/PostImportResourceProcessor.php
@@ -150,7 +150,7 @@ class PostImportResourceProcessor extends QueueWorkerBase implements ContainerFa
     if ($postImportResult->getStatus() === Result::DONE) {
       $this->invalidateCacheTags(DataResource::buildUniqueIdentifier(
         $data->getIdentifier(),
-        $data->getVersion
+        $data->getVersion(),
         DataResource::DEFAULT_SOURCE_PERSPECTIVE
       );
     }

--- a/modules/datastore/src/Plugin/QueueWorker/PostImportResourceProcessor.php
+++ b/modules/datastore/src/Plugin/QueueWorker/PostImportResourceProcessor.php
@@ -147,9 +147,13 @@ class PostImportResourceProcessor extends QueueWorkerBase implements ContainerFa
    */
   public function processItem($data) {
     $postImportResult = $this->postImportProcessItem($data);
-    $id = $data->getIdentifier();
-    $version = $data->getVersion();
-    $this->invalidateCacheTags($id . '__' . $version . '__source');
+    if ($postImportResult->getStatus() === Result::DONE) {
+      $this->invalidateCacheTags(DataResource::buildUniqueIdentifier(
+        $data->getIdentifier(),
+        $data->getVersion
+        DataResource::DEFAULT_SOURCE_PERSPECTIVE
+      );
+    }
     // Store the results of the PostImportResult object.
     $postImportResult->storeResult();
   }

--- a/modules/datastore/src/Plugin/QueueWorker/PostImportResourceProcessor.php
+++ b/modules/datastore/src/Plugin/QueueWorker/PostImportResourceProcessor.php
@@ -184,6 +184,7 @@ class PostImportResourceProcessor extends QueueWorkerBase implements ContainerFa
       else {
         array_map(fn ($processor) => $processor->process($resource), $processors);
         $postImportResult = $this->createPostImportResult('done', NULL, $resource);
+        $this->logger->notice('Post import job for resource @id completed.', ['@id' => (string) $resource->getIdentifier()]);
       }
     }
     catch (\Exception $e) {

--- a/modules/datastore/src/Plugin/QueueWorker/PostImportResourceProcessor.php
+++ b/modules/datastore/src/Plugin/QueueWorker/PostImportResourceProcessor.php
@@ -16,6 +16,7 @@ use Drupal\metastore\Reference\ReferenceLookup;
 use Drupal\datastore\Service\PostImport;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscoveryInterface;
 
+use Procrastinator\Result;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -152,7 +153,7 @@ class PostImportResourceProcessor extends QueueWorkerBase implements ContainerFa
         $data->getIdentifier(),
         $data->getVersion(),
         DataResource::DEFAULT_SOURCE_PERSPECTIVE
-      );
+      ));
     }
     // Store the results of the PostImportResult object.
     $postImportResult->storeResult();

--- a/modules/datastore/src/Plugin/QueueWorker/PostImportResourceProcessor.php
+++ b/modules/datastore/src/Plugin/QueueWorker/PostImportResourceProcessor.php
@@ -16,7 +16,6 @@ use Drupal\metastore\Reference\ReferenceLookup;
 use Drupal\datastore\Service\PostImport;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscoveryInterface;
 
-use Procrastinator\Result;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -148,7 +147,7 @@ class PostImportResourceProcessor extends QueueWorkerBase implements ContainerFa
    */
   public function processItem($data) {
     $postImportResult = $this->postImportProcessItem($data);
-    if ($postImportResult->getStatus() === Result::DONE) {
+    if ($postImportResult->getPostImportStatus() === 'done') {
       $this->invalidateCacheTags(DataResource::buildUniqueIdentifier(
         $data->getIdentifier(),
         $data->getVersion(),

--- a/modules/datastore/tests/src/Unit/Plugin/QueueWorker/PostImportResourceProcessorTest.php
+++ b/modules/datastore/tests/src/Unit/Plugin/QueueWorker/PostImportResourceProcessorTest.php
@@ -19,7 +19,7 @@ use Drupal\metastore\DataDictionary\DataDictionaryDiscoveryInterface;
 use Drupal\metastore\ResourceMapper;
 use Drupal\datastore\Service\PostImport;
 use Drupal\metastore\MetastoreService;
-
+use Drupal\metastore\Reference\ReferenceLookup;
 use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;
@@ -74,7 +74,7 @@ class PostImportResourceProcessorTest extends TestCase {
 
     // Ensure resources were processed.
     $notices = $container_chain->getStoredInput('notice');
-    $this->assertEmpty($notices);
+    $this->assertContains('Post import job for resource @id completed.', $notices);
     // Ensure no exceptions were thrown.
     $errors = $container_chain->getStoredInput('error');
     $this->assertEmpty($errors);
@@ -237,6 +237,7 @@ class PostImportResourceProcessorTest extends TestCase {
       ->add('dkan.metastore.resource_mapper', ResourceMapper::class)
       ->add('dkan.datastore.service.resource_processor_collector', ResourceProcessorCollector::class)
       ->add('dkan.datastore.service.post_import', PostImport::class)
+      ->add('dkan.metastore.reference_lookup', ReferenceLookup::class)
       ->index(0);
 
     $json = '{"identifier":"foo","title":"bar","data":{"fields":[]}}';
@@ -245,7 +246,7 @@ class PostImportResourceProcessorTest extends TestCase {
       ->add(Container::class, 'get', $options)
       ->add(LoggerChannelFactoryInterface::class, 'get', LoggerChannelInterface::class)
       ->add(LoggerChannelInterface::class, 'error', NULL, 'error')
-      ->add(LoggerChannelInterface::class, 'notice', NULL, 'notice')
+      ->add(LoggerChannelInterface::class, 'notice', '', 'notice')
       ->add(MetastoreService::class, 'get', new RootedJsonData($json))
       ->add(AlterTableQueryBuilderInterface::class, 'setConnectionTimeout', AlterTableQueryBuilderInterface::class)
       ->add(AlterTableQueryBuilderInterface::class, 'getQuery', AlterTableQueryInterface::class)

--- a/modules/datastore/tests/src/Unit/Service/ResourceProcessor/DictionaryEnforcerTest.php
+++ b/modules/datastore/tests/src/Unit/Service/ResourceProcessor/DictionaryEnforcerTest.php
@@ -19,7 +19,7 @@ use Drupal\metastore\DataDictionary\DataDictionaryDiscoveryInterface;
 use Drupal\datastore\Service\PostImport;
 use Drupal\metastore\ResourceMapper;
 use Drupal\metastore\MetastoreService;
-
+use Drupal\metastore\Reference\ReferenceLookup;
 use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;
@@ -191,6 +191,7 @@ class DictionaryEnforcerTest extends TestCase {
       ->add('dkan.datastore.service.resource_processor_collector', ResourceProcessorCollector::class)
       ->add('dkan.datastore.service.resource_processor.dictionary_enforcer', DictionaryEnforcer::class)
       ->add('dkan.datastore.service.post_import', PostImport::class)
+      ->add('dkan.metastore.reference_lookup', ReferenceLookup::class)
       ->index(0);
 
     $json = '{"identifier":"foo","title":"bar","data":{"fields":[]}}';


### PR DESCRIPTION
Temporary fix for stale cache after post_import

## QA Steps

1. Set up vanilla site
2. ddev drush en sample_content
3. ddev drush dkan-sample-content:create
4. ddev drush dkan:datastore:import 3a187a87dc6cd47c48b6b4c4785224b7
5. Confirm datastore results: curl http://dkan.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0 
6. Confirm endpoint is cached: curl -I http://dkan.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0 , look for x-drupal-cache: HIT
7. ddev drush queue:run post_import
8. Confirm endpoint is now not cached: curl -I http://test1.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0 , x-drupal-cache should be MISS or simply not present


