### PR TITLE
Update info.yml files to minimum Drupal 10 core.

### DIFF
--- a/dkan.info.yml
+++ b/dkan.info.yml
@@ -1,7 +1,7 @@
 name: DKAN
 description: 'DKAN Open Data Portal'
 type: module
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^10
 package: DKAN
 dependencies:
   - dkan:metastore

--- a/modules/common/common.info.yml
+++ b/modules/common/common.info.yml
@@ -1,5 +1,5 @@
 name: Common
 description: Provides common utilities, functions, and base api endpoints used by other DKAN modules.
 type: module
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^10
 package: DKAN

--- a/modules/common/modules/dkan_alt_api/dkan_alt_api.info.yml
+++ b/modules/common/modules/dkan_alt_api/dkan_alt_api.info.yml
@@ -1,7 +1,7 @@
 name: 'Alternate API'
 description: 'Provides alternate routes to access data and allows varying permissions on an api when logged in or anonymous.'
 type: module
-core_version_requirement: ^9.4 || ^10
+core_version_requirement: ^10
 package: DKAN
 dependencies:
   - metastore

--- a/modules/common/tests/modules/custom_processor_test/custom_processor_test.info.yml
+++ b/modules/common/tests/modules/custom_processor_test/custom_processor_test.info.yml
@@ -2,4 +2,4 @@ name: 'Processor API Test'
 type: module
 description: 'Support module for testing custom processor APIs.'
 package: Testing
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10

--- a/modules/datastore/datastore.info.yml
+++ b/modules/datastore/datastore.info.yml
@@ -1,7 +1,7 @@
 name: Datastore
 description: Provides integration with the datastore library.
 type: module
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^10
 package: DKAN
 dependencies:
   - dkan:common

--- a/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.info.yml
+++ b/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.info.yml
@@ -1,7 +1,7 @@
 name: Datastore MySQL Import
 description: Provides a MySQL Importer class.
 type: module
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^10
 package: DKAN
 dependencies:
   - dkan:common

--- a/modules/dkan_js_frontend/dkan_js_frontend.info.yml
+++ b/modules/dkan_js_frontend/dkan_js_frontend.info.yml
@@ -1,7 +1,7 @@
 name: DKAN JS Frontend
 description: Provides the routing connection between Drupal and a decoupled JavaScript frontend.
 type: module
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^10
 dependencies:
   - drupal:field
 package: DKAN

--- a/modules/frontend/frontend.info.yml
+++ b/modules/frontend/frontend.info.yml
@@ -1,7 +1,7 @@
 name: Front End
 description: Provides the routing connection between Drupal and a decoupled frontend.
 type: module
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^10
 dependencies:
   - drupal:field
 package: DKAN

--- a/modules/harvest/harvest.info.yml
+++ b/modules/harvest/harvest.info.yml
@@ -1,7 +1,7 @@
 name: Harvest
 description: Provides integration with the harvest library.
 type: module
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^10
 package: DKAN
 dependencies:
   - dkan:common

--- a/modules/json_form_widget/json_form_widget.info.yml
+++ b/modules/json_form_widget/json_form_widget.info.yml
@@ -2,7 +2,7 @@ name: JSON Form Widget
 description: Provides a widget for generating a form based on JSON Schema.
 package: DKAN
 type: module
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^10
 dependencies:
   - select_or_other
   - select2

--- a/modules/metastore/metastore.info.yml
+++ b/modules/metastore/metastore.info.yml
@@ -1,7 +1,7 @@
 name: Metastore
 description: Provides integration with the metastore library and creates the "Data" content type for storing metadata.
 type: module
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^10
 package: DKAN
 dependencies:
   - dkan:common

--- a/modules/metastore/modules/metastore_admin/metastore_admin.info.yml
+++ b/modules/metastore/modules/metastore_admin/metastore_admin.info.yml
@@ -1,7 +1,7 @@
 name: Administration
 description: Provides administrative views for managing dataset content.
 type: module
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^10
 dependencies:
   - dkan:metastore
   - drupal:breakpoint

--- a/modules/metastore/modules/metastore_facets/metastore_facets.info.yml
+++ b/modules/metastore/modules/metastore_facets/metastore_facets.info.yml
@@ -1,7 +1,7 @@
 name: DKAN Metastore Facets
 description: Provides facet blocks for DKAN Metastore Search.
 type: module
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^10
 dependencies:
   - dkan:metastore_search
   - facets:facets

--- a/modules/metastore/modules/metastore_search/metastore_search.info.yml
+++ b/modules/metastore/modules/metastore_search/metastore_search.info.yml
@@ -1,7 +1,7 @@
 name: Search
 description: Provides an endpoint to perform searches against DKAN's metadata.
 type: module
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^10
 dependencies:
   - dkan:metastore
   - drupal:search_api

--- a/modules/sample_content/sample_content.info.yml
+++ b/modules/sample_content/sample_content.info.yml
@@ -1,7 +1,7 @@
 name: Sample Content
 description: Provides sample content for tests or standing up a demo instance.
 type: module
-core_version_requirement: ^9.5 || ^10
+core_version_requirement: ^10
 package: DKAN
 dependencies:
   - dkan:harvest


### PR DESCRIPTION
We've dropped official support for Drupal 9 and PHP 7, so we should update the `info.yml` files in our project to reflect that.