### PR TITLE
Data dictionary widget php errors fixes

### DIFF
--- a/modules/data_dictionary_widget/data_dictionary_widget.module
+++ b/modules/data_dictionary_widget/data_dictionary_widget.module
@@ -66,7 +66,7 @@ function data_dictionary_widget__data_dictionary_data_type_checker($context) {
  *
  * Setting form validation for unique identifier.
  * 
- * Re-formatting current_fields array structure to prevent errors in element render array.
+ * Modifying current_fields array structure to prevent errors in element render array.
  */
 function data_dictionary_widget_form_alter(&$form, &$form_state, $form_id) {
   if ($form_id == 'node_data_edit_form' || $form_id == 'node_data_form') {
@@ -96,17 +96,16 @@ function data_dictionary_widget_form_alter(&$form, &$form_state, $form_id) {
  */
 function data_dictionary_widget_validate_unique_identifier($form, &$form_state) {
   $op = $form_state->getFormObject()->getOperation();
-  $current_nid = $op != 'default' ?? \Drupal::routeMatch()->getParameter('node')->id();
-  $exsisting_identifiers = FieldOperations::getDataDictionaries();
-
+  $current_nid = ($op != "default") ? \Drupal::routeMatch()->getParameter('node')->id() : false;
+  $existing_data_dictionary_nodes = FieldOperations::getDataDictionaries();
   $submitted_identifier = $form["field_json_metadata"]["widget"][0]["identifier"]["#value"];
 
-  if ($current_nid && isset($exsisting_identifiers[$current_nid]) && $exsisting_identifiers[$current_nid] == $submitted_identifier) {
-    return;
+  foreach ($existing_data_dictionary_nodes as $node) {
+    if ($current_nid !== $node["nid"] && strtolower($submitted_identifier) === strtolower($node["identifier"])) {
+      $form_state->setError($form["field_json_metadata"]["widget"][0]["identifier"], 'The identifier you entered is taken. Please choose another one.');
+      return $form_state;
+    }
+  }
 
-  }
-  elseif (in_array($submitted_identifier, $exsisting_identifiers) && array_search($submitted_identifier, $exsisting_identifiers) != $current_nid) {
-    $form_state->setError($form["field_json_metadata"]["widget"][0]["identifier"], 'The identifier you entered is taken. Please choose another one.');
-    return $form_state;
-  }
+  return;
 }

--- a/modules/data_dictionary_widget/data_dictionary_widget.module
+++ b/modules/data_dictionary_widget/data_dictionary_widget.module
@@ -62,11 +62,32 @@ function data_dictionary_widget__data_dictionary_data_type_checker($context) {
 }
 
 /**
+ * Implements hook_form_alter().
+ *
  * Setting form validation for unique identifier.
+ * 
+ * Re-formatting current_fields array structure to prevent errors in element render array.
  */
 function data_dictionary_widget_form_alter(&$form, &$form_state, $form_id) {
   if ($form_id == 'node_data_edit_form' || $form_id == 'node_data_form') {
     $form['#validate'][] = 'data_dictionary_widget_validate_unique_identifier';
+    $current_fields = !empty($form["field_json_metadata"]["widget"][0]["dictionary_fields"]["current_fields"]) ? $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["current_fields"] : NULL;
+
+    // The form element render array prefers child keys to be stored as arrays with a #value property.
+    if ($current_fields) {
+      foreach ($current_fields as $key => $value) {
+          $keys = array_keys($value);
+          $formatted_current_fields[$key] = [];
+  
+          foreach ($keys as $attr) {
+            $formatted_current_fields[$key][$attr] = [
+                  '#value' => $value[$attr]
+              ];
+          }
+      }
+      $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["current_fields"] = $formatted_current_fields;
+    }
+
   }
 }
 

--- a/modules/data_dictionary_widget/src/Controller/Widget/FieldCallbacks.php
+++ b/modules/data_dictionary_widget/src/Controller/Widget/FieldCallbacks.php
@@ -67,6 +67,11 @@ class FieldCallbacks extends ControllerBase {
       $currently_modifying[$op_index[1]] = $current_fields[$op_index[1]];
     }
 
+    // Reindex the current_fields array
+    if ($current_fields) {
+      $current_fields = array_values($current_fields);
+    }
+
     $form_state->set('fields_being_modified', $currently_modifying);
     $form_state->set('current_fields', $current_fields);
     $form_state->setRebuild();

--- a/modules/data_dictionary_widget/src/Controller/Widget/FieldOperations.php
+++ b/modules/data_dictionary_widget/src/Controller/Widget/FieldOperations.php
@@ -13,7 +13,7 @@ class FieldOperations extends ControllerBase {
    * Get a list of data dictionaries.
    */
   public static function getDataDictionaries() {
-    $exsisting_identifiers = [];
+    $existing_identifiers = [];
     $node_storage = \Drupal::entityTypeManager()->getStorage('node');
     $query = $node_storage
       ->getQuery()
@@ -23,10 +23,13 @@ class FieldOperations extends ControllerBase {
     $nodes_ids = $query->execute();
     $nodes = $node_storage->loadMultiple($nodes_ids);
     foreach ($nodes as $node) {
-      $exsisting_identifiers[$node->id()] .= $node->uuid();
+      $existing_identifiers[] = [
+        'nid' => $node->id(),
+        'identifier' => $node->uuid(),
+      ];
     }
 
-    return $exsisting_identifiers;
+    return $existing_identifiers;
   }
 
   /**


### PR DESCRIPTION
fixes [org/repo/issue#]

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [x] Navigate to https://dkan-project.ddev.site/node/add/data?schema=data-dictionary 
- [x] Create a new data dictionary, enter an Identifier, Title, Add at least 3 fields.
- [x] Confirm you are able to save and are not seeing any php errors on the form/log
- [x] Create another data-dictionary but this time use the same Identifier you used before and Save
- [x] Confirm you are unable to save and that validation shows the following message on the form: 'The identifier you entered is taken. Please choose another one.'
- [x] Change the Identifier
- [x] Select the gear icon for the very first field in the data dictionary fields table, select Delete
- [x] Save
- [x] Confirm you are able to Save and are not seeing any errors like this: "The attribute expected to be of type ''array'' but 'object' given."
