### PR TITLE
Catch unavailable remote download URLs before they hit the filefetcher

### DIFF
--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -28,6 +28,7 @@ services:
       - '@dkan.common.drupal_files'
       - '@dkan.common.filefetcher_job_store_factory'
       - '@queue'
+      - '@http_client'
 
   dkan.datastore.service.resource_processor_collector:
     class: \Drupal\datastore\Service\ResourceProcessorCollector

--- a/modules/datastore/src/Service/ResourceLocalizer.php
+++ b/modules/datastore/src/Service/ResourceLocalizer.php
@@ -14,7 +14,6 @@ use Drupal\metastore\Exception\AlreadyRegistered;
 use Drupal\metastore\ResourceMapper;
 use FileFetcher\FileFetcher;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
 use Procrastinator\Result;
 
 /**
@@ -91,19 +90,6 @@ class ResourceLocalizer {
 
   /**
    * Constructor.
-   *
-   * @param \Drupal\metastore\ResourceMapper $fileMapper
-   *   The file mapper.
-   * @param \Contracts\FactoryInterface $fileFetcherFactory
-   *   The file fetcher.
-   * @param \Drupal\common\Util\DrupalFiles $drupalFiles
-   *   The files.
-   * @param \Drupal\common\Storage\FileFetcherJobStoreFactory $fileFetcherJobStoreFactory
-   *   The job.
-   * @param \Drupal\Core\Queue\QueueFactory $queueFactory
-   *   The queue.
-   * @param \GuzzleHttp\Client $httpClient
-   *   The http client.
    */
   public function __construct(
     ResourceMapper $fileMapper,
@@ -130,7 +116,7 @@ class ResourceLocalizer {
     if ($resource = $this->getResourceSource($identifier, $version)) {
       try {
         // Confirm the source is available, a 404 will throw an exception.
-        $response = $this->httpClient->get($resource->getFilePath());
+        $this->httpClient->get($resource->getFilePath());
         $ff = $this->getFileFetcher($resource);
         $result = $ff->run();
         // The result object should report DONE, even if the file has previously

--- a/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/LocalizeQueueWorkerTest.php
+++ b/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/LocalizeQueueWorkerTest.php
@@ -138,6 +138,7 @@ class LocalizeQueueWorkerTest extends KernelTestBase {
         $this->container->get('dkan.common.drupal_files'),
         $this->container->get('dkan.common.filefetcher_job_store_factory'),
         $this->container->get('queue'),
+        $this->container->get('http_client'),
       ])
       ->onlyMethods(['localizeTask'])
       ->getMock();
@@ -172,6 +173,7 @@ class LocalizeQueueWorkerTest extends KernelTestBase {
         $this->container->get('dkan.common.drupal_files'),
         $this->container->get('dkan.common.filefetcher_job_store_factory'),
         $this->container->get('queue'),
+        $this->container->get('http_client'),
       ])
       ->onlyMethods(['localizeTask'])
       ->getMock();

--- a/modules/datastore/tests/src/Unit/Service/ResourceLocalizerTest.php
+++ b/modules/datastore/tests/src/Unit/Service/ResourceLocalizerTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\TestCase;
 use Procrastinator\Result;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use GuzzleHttp\Client;
 
 /**
  * @group dkan
@@ -65,7 +66,8 @@ class ResourceLocalizerTest extends TestCase {
       $fileFetcher,
       $this->getDrupalFilesChain()->getMock(),
       $this->getJobStoreFactoryChain()->getMock(),
-      $this->createMock(QueueFactory::class)
+      $this->createMock(QueueFactory::class),
+      new Client()
     );
 
     \Drupal::setContainer($this->getContainer()->getMock());


### PR DESCRIPTION
When creating a dataset distribution with a remote file that is invalid or not yet available, user will get an error when the localize_import queue runs:

```
[error]  Error: Call to a member function setupState() on null in FileFetcher\FileFetcher->runIt() (line 106 of /var/www/html/vendor/getdkan/file-fetcher/src/FileFetcher.php) #0 /var/www/html/vendor/getdkan/procrastinator/src/Job/Job.php(43): FileFetcher\FileFetcher->runIt()
```

## QA Steps

- [ ] Enable dblog
- [ ] Create a dataset with a remote url distribution, enter a non-existing url into the field and save
- [ ] Run drush queue:run localize_import
- [ ] Confirm there are no errors to the screen
- [ ] Check the logs
- [ ] Confirm you see a message stating the url provided can not be reached.
