### PR TITLE
Use original headers on csv downloads

### DIFF
--- a/modules/datastore/src/Controller/AbstractQueryController.php
+++ b/modules/datastore/src/Controller/AbstractQueryController.php
@@ -3,15 +3,15 @@
 namespace Drupal\datastore\Controller;
 
 use Drupal\common\DatasetInfo;
+use Drupal\common\JsonResponseTrait;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\datastore\Service\DatastoreQuery;
 use Drupal\datastore\Service\Query as QueryService;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\common\JsonResponseTrait;
-use RootedData\RootedJsonData;
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\metastore\MetastoreApiResponse;
 use JsonSchema\Validator;
+use RootedData\RootedJsonData;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -170,9 +170,9 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
    *
    * Abstract method; override in specific implementations.
    *
-   * @param Drupal\datastore\Service\DatastoreQuery $datastoreQuery
+   * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
    *   A datastore query object.
-   * @param RootedData\RootedJsonData $result
+   * @param \RootedData\RootedJsonData $result
    *   The result of the datastore query.
    * @param array $dependencies
    *   A dependency array for use by \Drupal\metastore\MetastoreApiResponse.
@@ -225,6 +225,10 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     if ($identifier) {
       $resource = (object) ["id" => $identifier, "alias" => "t"];
       $data->resources = [$resource];
+    }
+    // Force schema if CSV.
+    if (($data->format ?? NULL) == 'csv') {
+      $data->schema = TRUE;
     }
     return new DatastoreQuery(json_encode($data), $this->getRowsLimit());
   }
@@ -342,6 +346,59 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     $validator = new Validator();
     $validator->coerce($data, json_decode($schema));
     return json_encode($data, JSON_PRETTY_PRINT);
+  }
+
+  /**
+   * Build a CSV header row based on a query and result.
+   *
+   * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
+   *   A datastore query object.
+   * @param \RootedData\RootedJsonData $result
+   *   The result of the datastore query.
+   *
+   * @return array
+   *   Array of strings for a CSV header row.
+   */
+  protected function getHeaderRow(DatastoreQuery $datastoreQuery, RootedJsonData &$result) {
+    $schema_fields = $result->{'$.schema..fields'}[0] ?? [];
+    if (empty($schema_fields)) {
+      throw new \DomainException("Could not generate header for CSV.");
+    }
+    if (empty($datastoreQuery->{'$.properties'})) {
+      return array_keys($schema_fields);
+    }
+
+    $header_row = [];
+    foreach ($datastoreQuery->{'$.properties'} ?? [] as $property) {
+      $normalized_prop = $this->propToString($property, $datastoreQuery);
+      $header_row[] = $schema_fields[$normalized_prop]['description'] ?? $normalized_prop;
+    }
+
+    return $header_row;
+  }
+
+  /**
+   * Transform any property into a string for mapping to schema.
+   *
+   * @param string|array $property
+   *   A property from a DataStore Query.
+   *
+   * @return string
+   *   String version of property.
+   */
+  protected function propToString(string|array $property): string {
+    if (is_string($property)) {
+      return $property;
+    }
+    elseif (isset($property['property'])) {
+      return $property['property'];
+    }
+    elseif (isset($property['alias'])) {
+      return $property['alias'];
+    }
+    else {
+      throw new \DomainException("Invalid property: " . print_r($property, TRUE));
+    }
   }
 
 }

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -57,10 +57,19 @@ class QueryController extends AbstractQueryController {
    */
   private function fixHeaderRow(RootedJsonData &$result) {
     try {
-      $schema = $result->{'$.schema'};
-      // Query has are no explicit properties; we should assume one table.
-      $header_row = array_column(reset($schema)['fields'], 'description');
-
+      // if (!empty($result->{'$.query.properties'})) {
+      //   $header_row = $result->{'$.query.properties'};
+      //   array_walk($header_row, function (&$header) {
+      //     if (is_array($header)) {
+      //       $header = $header['alias'] ?? $header['property'];
+      //     }
+      //   });
+      // }
+      // else {
+        $schema = $result->{'$.schema'};
+        // Query has are no explicit properties; we should assume one table.
+        $header_row = array_column(reset($schema)['fields'], 'description');
+      // }
       if (empty($header_row) || !is_array($header_row)) {
         throw new \DomainException("Could not generate header for CSV.");
       }

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -37,7 +37,7 @@ class QueryController extends AbstractQueryController {
   ) {
     switch ($datastoreQuery->{"$.format"}) {
       case 'csv':
-        $results = $this->fixHeaderRow($datastoreQuery, $result);
+        $results = $this->useCsvHeaders($datastoreQuery, $result);
         $response = new CSVResponse($results, 'data.csv', ',');
         return $this->addCacheHeaders($response);
 
@@ -48,7 +48,7 @@ class QueryController extends AbstractQueryController {
   }
 
   /**
-   * Add the header row from specified properties or the schema.
+   * Use the original csv column names based on specified properties or the schema.
    *
    * Alters the data array.
    *
@@ -57,7 +57,7 @@ class QueryController extends AbstractQueryController {
    * @param \RootedData\RootedJsonData $result
    *   The result of the datastore query.
    */
-  private function fixHeaderRow(DatastoreQuery $datastoreQuery, RootedJsonData &$result) {
+  private function useCsvHeaders(DatastoreQuery $datastoreQuery, RootedJsonData &$result) {
     $header_row = $this->getHeaderRow($datastoreQuery, $result);
     $rows = $result->{"$.results"};
     $newResults = [];

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -48,7 +48,7 @@ class QueryController extends AbstractQueryController {
   }
 
   /**
-   * Use the original csv column names based on specified properties or the schema.
+   * Use csv column names based on specified properties or the schema.
    *
    * Alters the data array.
    *

--- a/modules/datastore/src/Controller/QueryController.php
+++ b/modules/datastore/src/Controller/QueryController.php
@@ -56,25 +56,9 @@ class QueryController extends AbstractQueryController {
    *   The result of a DatastoreQuery.
    */
   private function fixHeaderRow(RootedJsonData &$result) {
-    try {
-      // if (!empty($result->{'$.query.properties'})) {
-      //   $header_row = $result->{'$.query.properties'};
-      //   array_walk($header_row, function (&$header) {
-      //     if (is_array($header)) {
-      //       $header = $header['alias'] ?? $header['property'];
-      //     }
-      //   });
-      // }
-      // else {
-        $schema = $result->{'$.schema'};
-        // Query has are no explicit properties; we should assume one table.
-        $header_row = array_column(reset($schema)['fields'], 'description');
-      // }
-      if (empty($header_row) || !is_array($header_row)) {
-        throw new \DomainException("Could not generate header for CSV.");
-      }
-    }
-    catch (\Exception $e) {
+    $schema = $result->{'$.schema'};
+    $header_row = array_column(reset($schema)['fields'], 'description');
+    if (empty($header_row) || !is_array($header_row)) {
       throw new \DomainException("Could not generate header for CSV.");
     }
 

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -135,7 +135,7 @@ class QueryDownloadController extends AbstractQueryController {
       else {
         $schema = $result->{'$.schema'};
         // Query has are no explicit properties; we should assume one table.
-        $header_row = array_keys(reset($schema)['fields']);
+        $header_row = array_column(reset($schema)['fields'], 'description');
       }
       if (empty($header_row) || !is_array($header_row)) {
         throw new \DomainException("Could not generate header for CSV.");

--- a/modules/datastore/src/Service/Query.php
+++ b/modules/datastore/src/Service/Query.php
@@ -52,7 +52,7 @@ class Query implements ContainerInjectionInterface {
   public function runQuery(DatastoreQuery $datastoreQuery) {
     $return = (object) [];
 
-    $this->fixProperties($datastoreQuery);
+    $this->getProperties($datastoreQuery);
     if ($datastoreQuery->{"$.results"} !== FALSE) {
       $return->results = $this->runResultsQuery($datastoreQuery);
     }
@@ -222,7 +222,7 @@ class Query implements ContainerInjectionInterface {
    * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
    *   Datastore query object to be modified.
    */
-  private function fixProperties(DatastoreQuery $datastoreQuery) {
+  private function getProperties(DatastoreQuery $datastoreQuery) {
     $primaryAlias = $datastoreQuery->{"$.resources[0].alias"};
     if (!$primaryAlias) {
       return [];

--- a/modules/datastore/src/Service/Query.php
+++ b/modules/datastore/src/Service/Query.php
@@ -3,11 +3,11 @@
 namespace Drupal\datastore\Service;
 
 use Drupal\common\DataResource;
-use RootedData\RootedJsonData;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\datastore\DatastoreService;
 use Drupal\datastore\Storage\QueryFactory;
+use RootedData\RootedJsonData;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Datastore query service.
@@ -51,6 +51,8 @@ class Query implements ContainerInjectionInterface {
    */
   public function runQuery(DatastoreQuery $datastoreQuery) {
     $return = (object) [];
+
+    $this->fixProperties($datastoreQuery);
     if ($datastoreQuery->{"$.results"} !== FALSE) {
       $return->results = $this->runResultsQuery($datastoreQuery);
     }
@@ -132,12 +134,6 @@ class Query implements ContainerInjectionInterface {
     }
     $storageMap = $this->getQueryStorageMap($datastoreQuery);
 
-    $storage = $storageMap[$primaryAlias];
-
-    if (empty($datastoreQuery->{"$.rowIds"}) && empty($datastoreQuery->{"$.properties"}) && $storage->getSchema()) {
-      $schema = $this->filterSchemaFields($storage->getSchema(), $storage->primaryKey());
-      $datastoreQuery->{"$.properties"} = array_keys($schema['fields']);
-    }
     $query = QueryFactory::create($datastoreQuery, $storageMap);
     // Get data dictionary fields.
     $meta_data = $csv != FALSE ? $this->getDatastoreService()->getDataDictionaryFields() : NULL;
@@ -218,6 +214,27 @@ class Query implements ContainerInjectionInterface {
     unset($query->limit, $query->offset);
     $query->count();
     return (int) $storageMap[$primaryAlias]->query($query, $primaryAlias)[0]->expression;
+  }
+
+  /**
+   * Under most circumstances, we want an explicit list of properties.
+   *
+   * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
+   *   Datastore query object to be modified.
+   */
+  private function fixProperties(DatastoreQuery $datastoreQuery) {
+    $primaryAlias = $datastoreQuery->{"$.resources[0].alias"};
+    if (!$primaryAlias) {
+      return [];
+    }
+    $storageMap = $this->getQueryStorageMap($datastoreQuery);
+
+    $storage = $storageMap[$primaryAlias];
+
+    if (!($datastoreQuery->{"$.rowIds"} ?? FALSE) && empty($datastoreQuery->{"$.properties"}) && $storage->getSchema()) {
+      $schema = $this->filterSchemaFields($storage->getSchema(), $storage->primaryKey());
+      $datastoreQuery->{"$.properties"} = array_keys($schema['fields'] ?? []);
+    }
   }
 
 }

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -307,7 +307,7 @@ class QueryControllerTest extends TestCase {
   }
 
   private function getQueryResult($data, $id = NULL, $index = NULL, $info = []) {
-    $container = $this->getQueryContainer($data, $info)->getMock();
+    $container = $this->getQueryContainer($data, $info, true)->getMock();
     $webServiceApi = QueryController::create($container);
     $request = $this->mockRequest($data);
     if ($id === NULL && $index === NULL) {

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -319,9 +319,6 @@ class QueryControllerTest extends TestCase {
     return $webServiceApi->queryDatasetResource($id, $index, $request);
   }
 
-  /**
-   *
-   */
   public function testResourceQueryCsv() {
     $data = json_encode([
       "properties" => [
@@ -333,8 +330,40 @@ class QueryControllerTest extends TestCase {
       "results" => TRUE,
       "format" => "csv",
     ]);
-    $result = $this->getQueryResult($data);
+    $result = $this->getQueryResult($data, "2");
     $this->assertTrue($result instanceof CsvResponse);
+    $csv = explode("\n", $result->getContent());
+    $this->assertEquals('State', $csv[0]);
+    $this->assertEquals('Alabama', $csv[1]);
+    $this->assertEquals(200, $result->getStatusCode());
+  }
+
+
+  public function testResourceExpressionQueryCsv() {
+    $data = json_encode([
+      "properties" => [
+        "state",
+        "year",
+        [
+          "expression" => [
+            "operator" => "+",
+            "operands" => [
+              "year",
+              1,
+            ],
+          ],
+          "alias" => "year_plus_1",
+        ],
+      ],
+      "results" => TRUE,
+      "format" => "csv",
+    ]);
+    $result = $this->getQueryResult($data, "2");
+    $this->assertTrue($result instanceof CsvResponse);
+
+    $csv = explode("\n", $result->getContent());
+    $this->assertEquals('State,Year,year_plus_1', $csv[0]);
+    $this->assertEquals('Alabama,2010,2011', $csv[1]);
     $this->assertEquals(200, $result->getStatusCode());
   }
 

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -324,11 +324,16 @@ class QueryControllerTest extends TestCase {
    */
   public function testResourceQueryCsv() {
     $data = json_encode([
+      "properties" => [
+        [
+          "resource" => "t",
+          "property" => "state",
+        ],
+      ],
       "results" => TRUE,
       "format" => "csv",
     ]);
     $result = $this->getQueryResult($data);
-
     $this->assertTrue($result instanceof CsvResponse);
     $this->assertEquals(200, $result->getStatusCode());
   }

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -301,7 +301,7 @@ class QueryControllerTest extends TestCase {
     $this->assertEquals(200, $result->getStatusCode());
 
     $csv = explode("\n", $result->getContent());
-    $this->assertEquals('state,year', $csv[0]);
+    $this->assertEquals('State,Year', $csv[0]);
     $this->assertEquals('Alabama,2010', $csv[1]);
     $this->assertStringContainsString('data.csv', $result->headers->get('Content-Disposition'));
   }

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -35,7 +35,7 @@ class QueryControllerTest extends TestCase {
 
   protected function setUp(): void {
     parent::setUp();
-    // Set cache services
+    // Set cache services.
     $options = (new Options)
       ->add('cache_contexts_manager', CacheContextsManager::class)
       ->index(0);
@@ -269,8 +269,8 @@ class QueryControllerTest extends TestCase {
             "value" => [
               "resource" => "t",
               "property" => "record_number",
-            ]
-          ]
+            ],
+          ],
         ],
       ],
     ]);
@@ -508,9 +508,9 @@ class QueryControllerTest extends TestCase {
     );
     $storage->setSchema([
       'fields' => [
-        'record_number' => ['type' => 'int', 'not null' => TRUE],
-        'state' => ['type' => 'text'],
-        'year' => ['type' => 'int'],
+        'record_number' => ['type' => 'int', 'description' => 'Record Number', 'not null' => TRUE],
+        'state' => ['type' => 'text', 'description' => 'State'],
+        'year' => ['type' => 'int', 'description' => 'Year'],
       ],
     ]);
     return $storage;

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -150,6 +150,7 @@ class QueryDownloadControllerTest extends TestCase {
    */
   public function testStreamedJoinCsv() {
     $data = [
+      "schema" => TRUE,
       "resources" => [
         [
           "id" => "2",
@@ -368,14 +369,34 @@ class QueryDownloadControllerTest extends TestCase {
     $connection = new SqliteConnection(new \PDO('sqlite::memory:'), []);
 
     $schema2 = [
-      'record_number' => ['type' => 'int', 'not null' => TRUE],
-      'state' => ['type' => 'text'],
-      'year' => ['type' => 'int'],
+      'record_number' => [
+        'type' => 'int',
+        'description' => 'Record Number',
+        'not null' => TRUE,
+      ],
+      'state' => [
+        'type' => 'text',
+        'description' => 'State',
+      ],
+      'year' => [
+        'type' => 'int',
+        'description' => 'Year',
+      ],
     ];
     $schema3 = [
-      'record_number' => ['type' => 'int', 'not null' => TRUE],
-      'year' => ['type' => 'int'],
-      'color' => ['type' => 'text'],
+      'record_number' => [
+        'type' => 'int',
+        'description' => 'Record Number',
+        'not null' => TRUE,
+      ],
+      'year' => [
+        'type' => 'int',
+        'description' => 'Year',
+      ],
+      'color' => [
+        'type' => 'text',
+        'description' => 'Color',
+      ],
     ];
 
     $storage2 = $this->mockDatastoreTable($connection, "2", 'states_with_dupes.csv', $schema2);


### PR DESCRIPTION
Replaces machine names with original CSV headers in CSV download.

## QA Steps

- On a demo site, try the following request:

```http
POST https://csvdown.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0

{
    "format": "csv",
    "properties": [
        "roadway"    
    ],
    "limit": 10
}
```
Note that the column header is ROADWAY.

- Now try with an expression:

```http
POST https://csvdown.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0

{
    "format": "csv",
    "properties": [
        "roadway",
        {
            "expression": {
                "operator": "+",
                "operands": [
                    "objectid",
                    1
                ]
            },
            "alias": "objectid_plus_1"
        }
    ],
    "limit": 10
}
```
Note that ROADWAY is shown in caps, and alias is preserved.

If you want to try a join, try this but you will need to find the correct distribution IDs:

```http
POST https://csvdown.ddev.site/api/1/datastore/query

{
    "format": "csv",
    "resources": [
        {
            "id": "5733123b-6b70-5ff2-8876-c4e3a7c58398",
            "alias": "t"
        },
        {
            "id": "a180fe3c-e88d-55d9-841f-912ab0c4362d",
            "alias": "s"
        }
    ],
    "joins": [
        {
            "resource": "s",
            "condition": {
                "resource": "t",
                "property": "record_number",
                "value": {
                    "resource": "s",
                    "property": "record_number"
                }
            }
        }
    ],
    "properties": [
        "roadway",
        {
            "resource": "s",
            "property": "city"
        },
        {
            "resource": "s",
            "property": "violent_crimes"
        } 
    ],
    "limit": 10
}
```

## Known issues

* ~If `schema` property in request is set to `false`, the machine names will be shown. This is arguably expected behavior?~ The "schema" property in the request will be ignored if the format is "csv", and forced to true behind the scenes.
* In the case of a join, the properties from the second resource will have their machine names. Decided this was out of scope for this PR and will fix in the future.
* If "rowIds" is set to TRUE, adding the record_number column, we will still return machine names for all other columns as well.
* In general a lot of the CSV header logic relies on information pulled from the query or results objects which seems less than ideal.