### PR TITLE
Return 400 if invalid run payload in Harvest API

### DIFF
--- a/modules/harvest/src/WebServiceApi.php
+++ b/modules/harvest/src/WebServiceApi.php
@@ -155,7 +155,7 @@ class WebServiceApi implements ContainerInjectionInterface {
           'message' => 'Invalid payload.',
           'documentation' => '/api/1/harvest',
         ];
-        return $this->jsonResponse($return, 422);
+        return $this->jsonResponse($return, 400);
       }
 
       $id = $payload->plan_id;

--- a/modules/harvest/tests/src/Kernel/WebServiceApiTest.php
+++ b/modules/harvest/tests/src/Kernel/WebServiceApiTest.php
@@ -392,7 +392,7 @@ class WebServiceApiTest extends KernelTestBase {
   public function testRunErrors() {
     $controller = WebServiceApi::create($this->container);
     $this->assertInstanceOf(Response::class, $response = $controller->run());
-    $this->assertEquals(422, $response->getStatusCode());
+    $this->assertEquals(400, $response->getStatusCode());
     $this->assertIsObject($payload = json_decode($response->getContent()));
     $this->assertEquals('Invalid payload.', $payload->message);
     $this->assertEquals('/api/1/harvest', $payload->documentation);


### PR DESCRIPTION
The /api/1/harvest/run POST endpoint can return a 422 if the JSON doesn't parse correctly. Using 422 for invalid JSON - whether invalid on its own or against a schema - is not consistent with the rest of DKAN or most other REST APIs. Changing to 400. This error was not included in the spec in the first place so it is not breaking what's published, and this API is not used much anyway. But should be noted in case any automations have been built around this endpoint.