### PR TITLE
Use logger channel service rather than factory

### DIFF
--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -93,7 +93,7 @@ services:
     class: \Drupal\datastore\EventSubscriber\DatastoreSubscriber
     arguments:
       - '@config.factory'
-      - '@logger.factory'
+      - '@dkan.datastore.logger_channel'
       - '@dkan.datastore.service'
       - '@dkan.datastore.service.resource_purger'
       - '@dkan.datastore.import_job_store_factory'

--- a/modules/datastore/drush.services.yml
+++ b/modules/datastore/drush.services.yml
@@ -21,6 +21,6 @@ services:
     arguments:
       - '@dkan.datastore.service'
       - '@dkan.common.dataset_info'
-      - '@logger.factory'
+      - '@dkan.datastore.logger_channel'
     tags:
       - { name: drush.command }

--- a/modules/datastore/src/Commands/ReimportCommands.php
+++ b/modules/datastore/src/Commands/ReimportCommands.php
@@ -3,9 +3,9 @@
 namespace Drupal\datastore\Commands;
 
 use Drupal\common\DatasetInfo;
-use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\datastore\DatastoreService;
 use Drush\Commands\DrushCommands;
+use Psr\Log\LoggerInterface;
 
 /**
  * Drush command file for data store reimportation.
@@ -13,13 +13,6 @@ use Drush\Commands\DrushCommands;
  * @codeCoverageIgnore
  */
 class ReimportCommands extends DrushCommands {
-
-  /**
-   * Logger service.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelFactory
-   */
-  protected $loggerFactory;
 
   /**
    * The datastore service.
@@ -42,17 +35,17 @@ class ReimportCommands extends DrushCommands {
    *   The dkan.datastore.service service.
    * @param \Drupal\common\DatasetInfo $dataset_info
    *   Dataset information service.
-   * @param \Drupal\Core\Logger\LoggerChannelFactory $logger_factory
-   *   LoggerChannelFactory service.
+   * @param \Psr\Log\LoggerInterface $loggerChannel
+   *   Logger channel service.
    */
   public function __construct(
     DatastoreService $datastore_service,
     DatasetInfo $dataset_info,
-    LoggerChannelFactory $logger_factory
+    LoggerInterface $loggerChannel
   ) {
     $this->datastoreService = $datastore_service;
     $this->datasetInfo = $dataset_info;
-    $this->loggerFactory = $logger_factory;
+    $this->setLogger($loggerChannel);
     parent::__construct();
   }
 
@@ -79,14 +72,14 @@ class ReimportCommands extends DrushCommands {
       if ($distributions = $info['latest_revision']['distributions'] ?? FALSE) {
         // Reimport whatever distributions we found.
         $this->reimportDistributions($distributions);
-        $this->loggerFactory->get('datastore')->notice(count($info) . ' distribution(s) found for ' . $uuid);
+        $this->logger()->notice(count($info) . ' distribution(s) found for ' . $uuid);
       }
       else {
-        $this->loggerFactory->get('datastore')->error('Unable to find distributions for ' . $uuid);
+        $this->logger()->error('Unable to find distributions for ' . $uuid);
       }
     }
     else {
-      $this->loggerFactory->get('datastore')->error('Unable to find dataset info for ' . $uuid);
+      $this->logger()->error('Unable to find dataset info for ' . $uuid);
     }
   }
 
@@ -102,10 +95,10 @@ class ReimportCommands extends DrushCommands {
     foreach ($distributions as $distribution) {
       if ($resource_id = $distribution['resource_id'] ?? FALSE) {
         $this->datastoreService->drop($resource_id);
-        $this->loggerFactory->get('datastore')->notice('Reimporting distribution: ' . $resource_id);
+        $this->logger()->notice('Reimporting distribution: ' . $resource_id);
         $result = $this->datastoreService->import($resource_id);
         $status = $result['ImportService'] ? $result['ImportService']->getStatus() : 'failed, resource not found';
-        $this->loggerFactory->get('datastore')->notice("Ran import for $resource_id; status: $status");
+        $this->logger()->notice("Ran import for $resource_id; status: $status");
       }
     }
   }

--- a/modules/datastore/src/Plugin/QueueWorker/ImportQueueWorker.php
+++ b/modules/datastore/src/Plugin/QueueWorker/ImportQueueWorker.php
@@ -3,17 +3,14 @@
 namespace Drupal\datastore\Plugin\QueueWorker;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
-
 use Drupal\common\Storage\DatabaseConnectionFactoryInterface;
 use Drupal\common\Storage\ImportedItemInterface;
 use Drupal\datastore\DatastoreService;
 use Drupal\metastore\Reference\ReferenceLookup;
-
 use Procrastinator\Result;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -68,9 +65,9 @@ class ImportQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
   /**
    * Logger service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   * @var \Psr\Log\LoggerInterface
    */
-  protected LoggerChannelInterface $logger;
+  protected LoggerInterface $logger;
 
   /**
    * Constructs a \Drupal\Component\Plugin\PluginBase object.
@@ -85,7 +82,7 @@ class ImportQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
    *   A config factory instance.
    * @param \Drupal\datastore\DatastoreService $datastore
    *   A DKAN datastore service instance.
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
+   * @param \Psr\Log\LoggerInterface $loggerChannel
    *   A logger channel factory instance.
    * @param \Drupal\metastore\Reference\ReferenceLookup $referenceLookup
    *   The reference lookup service.
@@ -100,7 +97,7 @@ class ImportQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
     $plugin_definition,
     ConfigFactoryInterface $configFactory,
     DatastoreService $datastore,
-    LoggerChannelFactoryInterface $loggerFactory,
+    LoggerInterface $loggerChannel,
     ReferenceLookup $referenceLookup,
     DatabaseConnectionFactoryInterface $defaultConnectionFactory,
     DatabaseConnectionFactoryInterface $datastoreConnectionFactory
@@ -111,7 +108,7 @@ class ImportQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
     $this->datastoreConfig = $configFactory->get('datastore.settings');
     $this->databaseQueue = $datastore->getQueueFactory()->get($plugin_id);
     $this->fileSystem = $datastore->getResourceLocalizer()->getFileSystem();
-    $this->logger = $loggerFactory->get('datastore');
+    $this->logger = $loggerChannel;
     // Set the timeout for database connections to the queue lease time.
     // This ensures that database connections will remain open for the
     // duration of the time the queue is being processed.
@@ -130,7 +127,7 @@ class ImportQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
       $plugin_definition,
       $container->get('config.factory'),
       $container->get('dkan.datastore.service'),
-      $container->get('logger.factory'),
+      $container->get('dkan.datastore.logger_channel'),
       $container->get('dkan.metastore.reference_lookup'),
       $container->get('dkan.common.database_connection_factory'),
       $container->get('dkan.datastore.database_connection_factory')

--- a/modules/datastore/src/Plugin/QueueWorker/LocalizeQueueWorker.php
+++ b/modules/datastore/src/Plugin/QueueWorker/LocalizeQueueWorker.php
@@ -8,6 +8,7 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
 use Drupal\datastore\Service\ResourceLocalizer;
 use Procrastinator\Result;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -34,9 +35,9 @@ class LocalizeQueueWorker extends QueueWorkerBase implements ContainerFactoryPlu
   /**
    * Logger service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   * @var \Psr\Log\LoggerInterface
    */
-  protected LoggerChannelInterface $logger;
+  protected LoggerInterface $logger;
 
   /**
    * Constructs a \Drupal\Component\Plugin\PluginBase object.
@@ -50,7 +51,7 @@ class LocalizeQueueWorker extends QueueWorkerBase implements ContainerFactoryPlu
    *   A DKAN datastore service instance.
    * @param \Drupal\datastore\Service\ResourceLocalizer $resourceLocalizer
    *   Resource localizer service.
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
+   * @param \Psr\Log\LoggerInterface $loggerChannel
    *   A logger channel factory instance.
    */
   public function __construct(
@@ -58,11 +59,11 @@ class LocalizeQueueWorker extends QueueWorkerBase implements ContainerFactoryPlu
     $plugin_id,
     $plugin_definition,
     ResourceLocalizer $resourceLocalizer,
-    LoggerChannelFactoryInterface $loggerFactory
+    LoggerInterface $loggerChannel
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->resourceLocalizer = $resourceLocalizer;
-    $this->logger = $loggerFactory->get('datastore');
+    $this->logger = $loggerChannel;
   }
 
   /**
@@ -74,7 +75,7 @@ class LocalizeQueueWorker extends QueueWorkerBase implements ContainerFactoryPlu
       $plugin_id,
       $plugin_definition,
       $container->get('dkan.datastore.service.resource_localizer'),
-      $container->get('logger.factory')
+      $container->get('dkan.datastore.logger_channel')
     );
   }
 

--- a/modules/datastore/src/Plugin/QueueWorker/LocalizeQueueWorker.php
+++ b/modules/datastore/src/Plugin/QueueWorker/LocalizeQueueWorker.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\datastore\Plugin\QueueWorker;
 
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
 use Drupal\datastore\Service\ResourceLocalizer;

--- a/modules/datastore/src/Plugin/QueueWorker/PostImportResourceProcessor.php
+++ b/modules/datastore/src/Plugin/QueueWorker/PostImportResourceProcessor.php
@@ -6,7 +6,6 @@ use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
-
 use Drupal\common\DataResource;
 use Drupal\datastore\DataDictionary\AlterTableQueryBuilderInterface;
 use Drupal\datastore\Service\ResourceProcessorCollector;
@@ -15,7 +14,7 @@ use Drupal\datastore\PostImportResult;
 use Drupal\metastore\Reference\ReferenceLookup;
 use Drupal\datastore\Service\PostImport;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscoveryInterface;
-
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -35,9 +34,9 @@ class PostImportResourceProcessor extends QueueWorkerBase implements ContainerFa
   /**
    * A logger channel for this plugin.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   * @var \Psr\Log\LoggerInterface
    */
-  protected LoggerChannelInterface $logger;
+  protected LoggerInterface $logger;
 
   /**
    * The metastore resource mapper service.
@@ -85,7 +84,7 @@ class PostImportResourceProcessor extends QueueWorkerBase implements ContainerFa
    *   The plugin implementation definition.
    * @param \Drupal\datastore\DataDictionary\AlterTableQueryBuilderInterface $alter_table_query_builder
    *   The alter table query factory service.
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_channel
    *   A logger channel factory instance.
    * @param \Drupal\metastore\ResourceMapper $resource_mapper
    *   The metastore resource mapper service.
@@ -103,7 +102,7 @@ class PostImportResourceProcessor extends QueueWorkerBase implements ContainerFa
     $plugin_id,
     $plugin_definition,
     AlterTableQueryBuilderInterface $alter_table_query_builder,
-    LoggerChannelFactoryInterface $logger_factory,
+    LoggerInterface $logger_channel,
     ResourceMapper $resource_mapper,
     ResourceProcessorCollector $processor_collector,
     PostImport $post_import,
@@ -111,7 +110,7 @@ class PostImportResourceProcessor extends QueueWorkerBase implements ContainerFa
     ReferenceLookup $referenceLookup
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->logger = $logger_factory->get('datastore');
+    $this->logger = $logger_channel;
     $this->resourceMapper = $resource_mapper;
     $this->resourceProcessorCollector = $processor_collector;
     $this->postImport = $post_import;
@@ -133,7 +132,7 @@ class PostImportResourceProcessor extends QueueWorkerBase implements ContainerFa
       $plugin_id,
       $plugin_definition,
       $container->get('dkan.datastore.data_dictionary.alter_table_query_builder.mysql'),
-      $container->get('logger.factory'),
+      $container->get('dkan.datastore.logger_channel'),
       $container->get('dkan.metastore.resource_mapper'),
       $container->get('dkan.datastore.service.resource_processor_collector'),
       $container->get('dkan.datastore.service.post_import'),

--- a/modules/datastore/src/Plugin/QueueWorker/PostImportResourceProcessor.php
+++ b/modules/datastore/src/Plugin/QueueWorker/PostImportResourceProcessor.php
@@ -2,18 +2,16 @@
 
 namespace Drupal\datastore\Plugin\QueueWorker;
 
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
 use Drupal\common\DataResource;
 use Drupal\datastore\DataDictionary\AlterTableQueryBuilderInterface;
-use Drupal\datastore\Service\ResourceProcessorCollector;
-use Drupal\metastore\ResourceMapper;
 use Drupal\datastore\PostImportResult;
-use Drupal\metastore\Reference\ReferenceLookup;
 use Drupal\datastore\Service\PostImport;
+use Drupal\datastore\Service\ResourceProcessorCollector;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscoveryInterface;
+use Drupal\metastore\Reference\ReferenceLookup;
+use Drupal\metastore\ResourceMapper;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -84,7 +82,7 @@ class PostImportResourceProcessor extends QueueWorkerBase implements ContainerFa
    *   The plugin implementation definition.
    * @param \Drupal\datastore\DataDictionary\AlterTableQueryBuilderInterface $alter_table_query_builder
    *   The alter table query factory service.
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_channel
+   * @param \Psr\Log\LoggerInterface $logger_channel
    *   A logger channel factory instance.
    * @param \Drupal\metastore\ResourceMapper $resource_mapper
    *   The metastore resource mapper service.

--- a/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/ImportQueueWorkerTest.php
+++ b/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/ImportQueueWorkerTest.php
@@ -2,18 +2,19 @@
 
 namespace Drupal\Tests\datastore\Kernel\Plugin\QueueWorker;
 
-use Drupal\common\Storage\ImportedItemInterface;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\common\Storage\ImportedItemInterface;
 use Drupal\datastore\DatastoreService;
 use Drupal\datastore\Plugin\QueueWorker\ImportQueueWorker;
-use Drupal\KernelTests\KernelTestBase;
 use Procrastinator\Result;
+use Psr\Log\LoggerInterface;
 
 /**
  * @covers \Drupal\datastore\Plugin\QueueWorker\ImportQueueWorker
  * @coversDefaultClass \Drupal\datastore\Plugin\QueueWorker\ImportQueueWorker
  *
+ * @group dkan
  * @group datastore
  * @group kernel
  */
@@ -56,18 +57,14 @@ class ImportQueueWorkerTest extends KernelTestBase {
     $this->container->set('dkan.datastore.service', $datastore_service);
 
     // Mock the logger so we can tell when the error occurs.
-    $logger = $this->getMockForAbstractClass(LoggerChannelInterface::class);
+    $logger = $this->getMockForAbstractClass(LoggerInterface::class);
     // We expect an error to be logged.
     $logger->expects($this->once())
       ->method('error');
     // We don't expect a notice to be logged.
     $logger->expects($this->never())
       ->method('notice');
-    $logger_factory = $this->getMockForAbstractClass(LoggerChannelFactoryInterface::class);
-    $logger_factory->method('get')
-      ->willReturn($logger);
-    // Add our log factory mock to the container.
-    $this->container->set('logger.factory', $logger_factory);
+    $this->container->set('dkan.datastore.logger_channel', $logger);
 
     $queue_worker = ImportQueueWorker::create(
       $this->container,
@@ -113,11 +110,7 @@ class ImportQueueWorkerTest extends KernelTestBase {
     // We expect a notice to be logged.
     $logger->expects($this->once())
       ->method('notice');
-    $logger_factory = $this->getMockForAbstractClass(LoggerChannelFactoryInterface::class);
-    $logger_factory->method('get')
-      ->willReturn($logger);
-    // Add our log factory mock to the container.
-    $this->container->set('logger.factory', $logger_factory);
+    $this->container->set('dkan.datastore.logger_channel', $logger);
 
     $queue_worker = ImportQueueWorker::create(
       $this->container,
@@ -154,7 +147,7 @@ class ImportQueueWorkerTest extends KernelTestBase {
       ['cron' => ['lease_time' => 10]],
       $this->container->get('config.factory'),
       $this->container->get('dkan.datastore.service'),
-      $this->container->get('logger.factory'),
+      $this->container->get('dkan.datastore.logger_channel'),
       $this->container->get('dkan.metastore.reference_lookup'),
       $this->container->get('dkan.common.database_connection_factory'),
       $this->container->get('dkan.datastore.database_connection_factory')
@@ -179,11 +172,7 @@ class ImportQueueWorkerTest extends KernelTestBase {
     // We don't expect a notice to be logged.
     $logger->expects($this->never())
       ->method('notice');
-    $logger_factory = $this->getMockForAbstractClass(LoggerChannelFactoryInterface::class);
-    $logger_factory->method('get')
-      ->willReturn($logger);
-    // Add our log factory mock to the container.
-    $this->container->set('logger.factory', $logger_factory);
+    $this->container->set('dkan.datastore.logger_channel', $logger);
 
     $queue_worker = $this->createPartialMock(
       ImportQueueWorker::class,
@@ -200,7 +189,7 @@ class ImportQueueWorkerTest extends KernelTestBase {
       ['cron' => ['lease_time' => 10]],
       $this->container->get('config.factory'),
       $this->container->get('dkan.datastore.service'),
-      $this->container->get('logger.factory'),
+      $this->container->get('dkan.datastore.logger_channel'),
       $this->container->get('dkan.metastore.reference_lookup'),
       $this->container->get('dkan.common.database_connection_factory'),
       $this->container->get('dkan.datastore.database_connection_factory')

--- a/modules/datastore/tests/src/Unit/EventSubscriber/DatastoreSubscriberTest.php
+++ b/modules/datastore/tests/src/Unit/EventSubscriber/DatastoreSubscriberTest.php
@@ -2,31 +2,33 @@
 
 namespace Drupal\Tests\datastore\Unit\EventSubscriber;
 
-use Drupal\common\DataResource;
-use Drupal\common\Storage\JobStoreFactory;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Database\Connection;
-use Drupal\Core\Logger\LoggerChannelFactory;
-use Drupal\Core\Logger\LoggerChannelInterface;
-use Drupal\datastore\EventSubscriber\DatastoreSubscriber;
+use Drupal\common\DataResource;
+use Drupal\common\Events\Event;
+use Drupal\common\Storage\JobStore;
+use Drupal\common\Storage\JobStoreFactory;
 use Drupal\datastore\DatastoreService;
+use Drupal\datastore\EventSubscriber\DatastoreSubscriber;
+use Drupal\datastore\Service\Factory\ImportServiceFactory;
+use Drupal\datastore\Service\ImportService;
 use Drupal\datastore\Service\ResourcePurger;
 use Drupal\datastore\Storage\DatabaseTable;
-use Drupal\common\Events\Event;
 use Drupal\datastore\Storage\ImportJobStoreFactory;
+use Drupal\metastore\MetastoreItemInterface;
 use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Container;
-use Drupal\datastore\Service\Factory\ImportServiceFactory;
-use Drupal\datastore\Service\ImportService;
-use Drupal\common\Storage\JobStore;
-use Drupal\metastore\MetastoreItemInterface;
 
 /**
+ * @coversDefaultClass \Drupal\datastore\EventSubscriber\DatastoreSubscriber
  *
+ * @group dkan
+ * @group datastore
+ * @group unit
  */
 class DatastoreSubscriberTest extends TestCase {
 

--- a/modules/datastore/tests/src/Unit/EventSubscriber/DatastoreSubscriberTest.php
+++ b/modules/datastore/tests/src/Unit/EventSubscriber/DatastoreSubscriberTest.php
@@ -18,6 +18,7 @@ use Drupal\datastore\Storage\ImportJobStoreFactory;
 use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Drupal\datastore\Service\Factory\ImportServiceFactory;
 use Drupal\datastore\Service\ImportService;
@@ -100,7 +101,7 @@ class DatastoreSubscriberTest extends TestCase {
 
     $options = (new Options())
       ->add('config.factory', $this->getImmutableConfigMock())
-      ->add('logger.factory', LoggerChannelFactory::class)
+      ->add('dkan.datastore.logger_channel', LoggerInterface::class)
       ->add('dkan.datastore.service', DatastoreService::class)
       ->add('dkan.datastore.service.resource_purger', ResourcePurger::class)
       ->add('dkan.common.job_store', JobStoreFactory::class)
@@ -117,12 +118,11 @@ class DatastoreSubscriberTest extends TestCase {
       ->add(JobStoreFactory::class, 'getInstance', JobStore::class)
       ->add(ImportJobStoreFactory::class, 'getInstance', JobStore::class)
       ->add(JobStore::class, 'remove')
-      ->add(LoggerChannelFactory::class, 'get', LoggerChannelInterface::class)
-      ->add(LoggerChannelInterface::class, 'error', NULL, 'errors')
-      ->add(LoggerChannelInterface::class, 'notice', NULL, "notices");
+      ->add(LoggerInterface::class, 'error', NULL, 'errors')
+      ->add(LoggerInterface::class, 'notice', NULL, 'notices');
 
     $subscriber = DatastoreSubscriber::create($chain->getMock());
-    $test = $subscriber->drop($event);
+    $subscriber->drop($event);
     $this->assertStringContainsString('Dropping datastore', $chain->getStoredInput('notices')[0]);
     $this->assertEmpty($chain->getStoredInput('errors'));
   }
@@ -137,7 +137,7 @@ class DatastoreSubscriberTest extends TestCase {
 
     $options = (new Options())
       ->add('config.factory', $this->getImmutableConfigMock())
-      ->add('logger.factory', LoggerChannelFactory::class)
+      ->add('dkan.datastore.logger_channel', LoggerInterface::class)
       ->add('dkan.datastore.service', DatastoreService::class)
       ->add('dkan.datastore.service.resource_purger', ResourcePurger::class)
       ->add('dkan.common.job_store', JobStoreFactory::class)
@@ -153,12 +153,11 @@ class DatastoreSubscriberTest extends TestCase {
       ->add(JobStoreFactory::class, 'getInstance', JobStore::class)
       ->add(ImportJobStoreFactory::class, 'getInstance', JobStore::class)
       ->add(JobStore::class, 'remove')
-      ->add(LoggerChannelFactory::class, 'get', LoggerChannelInterface::class)
-      ->add(LoggerChannelInterface::class, 'error', NULL, 'errors')
-      ->add(LoggerChannelInterface::class, 'notice', NULL, "notices");
+      ->add(LoggerInterface::class, 'error', NULL, 'errors')
+      ->add(LoggerInterface::class, 'notice', NULL, 'notices');
 
     $subscriber = DatastoreSubscriber::create($chain->getMock());
-    $test = $subscriber->drop($event);
+    $subscriber->drop($event);
     $this->assertStringContainsString('Failed to drop', $chain->getStoredInput('errors')[0]);
   }
 
@@ -172,7 +171,7 @@ class DatastoreSubscriberTest extends TestCase {
 
     $options = (new Options())
       ->add('config.factory', $this->getImmutableConfigMock())
-      ->add('logger.factory', LoggerChannelFactory::class)
+      ->add('dkan.datastore.logger_channel', LoggerInterface::class)
       ->add('dkan.datastore.service', DatastoreService::class)
       ->add('dkan.datastore.service.resource_purger', ResourcePurger::class)
       ->add('dkan.common.job_store', JobStoreFactory::class)
@@ -188,12 +187,11 @@ class DatastoreSubscriberTest extends TestCase {
       ->add(JobStoreFactory::class, 'getInstance', JobStore::class)
       ->add(ImportJobStoreFactory::class, 'getInstance', JobStore::class)
       ->add(JobStore::class, 'remove', new \Exception('error'))
-      ->add(LoggerChannelFactory::class, 'get', LoggerChannelInterface::class)
-      ->add(LoggerChannelInterface::class, 'error', NULL, 'errors')
-      ->add(LoggerChannelInterface::class, 'notice', NULL, "notices");
+      ->add(LoggerInterface::class, 'error', NULL, 'errors')
+      ->add(LoggerInterface::class, 'notice', NULL, 'notices');
 
     $subscriber = DatastoreSubscriber::create($chain->getMock());
-    $test = $subscriber->drop($event);
+    $subscriber->drop($event);
     $this->assertStringContainsString('Failed to remove importer job', $chain->getStoredInput('errors')[0]);
   }
 
@@ -203,7 +201,7 @@ class DatastoreSubscriberTest extends TestCase {
   private function getContainerChain() {
     $options = (new Options())
       ->add('config.factory', $this->getImmutableConfigMock())
-      ->add('logger.factory', LoggerChannelFactory::class)
+      ->add('dkan.datastore.logger_channel', LoggerInterface::class)
       ->add('dkan.datastore.service', DatastoreService::class)
       ->add('dkan.datastore.service.resource_purger', ResourcePurger::class)
       ->add('dkan.common.job_store', JobStoreFactory::class)

--- a/modules/datastore/tests/src/Unit/Plugin/QueueWorker/PostImportResourceProcessorTest.php
+++ b/modules/datastore/tests/src/Unit/Plugin/QueueWorker/PostImportResourceProcessorTest.php
@@ -3,30 +3,34 @@
 namespace Drupal\Tests\datastore\Unit\Plugin\QueueWorker;
 
 use Drupal\Core\DependencyInjection\Container;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\StreamWrapper\PublicStream;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
-
 use Drupal\common\DataResource;
 use Drupal\datastore\DataDictionary\AlterTableQueryBuilderInterface;
 use Drupal\datastore\DataDictionary\AlterTableQueryInterface;
 use Drupal\datastore\Plugin\QueueWorker\PostImportResourceProcessor;
-use Drupal\datastore\Service\ResourceProcessorInterface;
+use Drupal\datastore\Service\PostImport;
 use Drupal\datastore\Service\ResourceProcessorCollector;
+use Drupal\datastore\Service\ResourceProcessorInterface;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscovery;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscoveryInterface;
-use Drupal\metastore\ResourceMapper;
-use Drupal\datastore\Service\PostImport;
 use Drupal\metastore\MetastoreService;
 use Drupal\metastore\Reference\ReferenceLookup;
+use Drupal\metastore\ResourceMapper;
 use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use RootedData\RootedJsonData;
 
 /**
  * Test \Drupal\datastore\Plugin\QueueWorker\PostImportResourceProcessor.
+ *
+ * @coversDefaultClass \Drupal\datastore\Plugin\QueueWorker\PostImportResourceProcessor
+ *
+ * @group dkan
+ * @group datastore
+ * @group unit
  */
 class PostImportResourceProcessorTest extends TestCase {
 
@@ -230,7 +234,7 @@ class PostImportResourceProcessorTest extends TestCase {
     $options = (new Options())
       ->add('dkan.datastore.data_dictionary.alter_table_query_builder.mysql', AlterTableQueryBuilderInterface::class)
       ->add('dkan.metastore.data_dictionary_discovery', DataDictionaryDiscovery::class)
-      ->add('logger.factory', LoggerChannelFactoryInterface::class)
+      ->add('dkan.datastore.logger_channel', LoggerInterface::class)
       ->add('dkan.metastore.service', MetastoreService::class)
       ->add('dkan.metastore.data_dictionary_discovery', DataDictionaryDiscoveryInterface::class)
       ->add('stream_wrapper_manager', StreamWrapperManager::class)
@@ -244,9 +248,8 @@ class PostImportResourceProcessorTest extends TestCase {
 
     return (new Chain($this))
       ->add(Container::class, 'get', $options)
-      ->add(LoggerChannelFactoryInterface::class, 'get', LoggerChannelInterface::class)
-      ->add(LoggerChannelInterface::class, 'error', NULL, 'error')
-      ->add(LoggerChannelInterface::class, 'notice', '', 'notice')
+      ->add(LoggerInterface::class, 'error', NULL, 'error')
+      ->add(LoggerInterface::class, 'notice', '', 'notice')
       ->add(MetastoreService::class, 'get', new RootedJsonData($json))
       ->add(AlterTableQueryBuilderInterface::class, 'setConnectionTimeout', AlterTableQueryBuilderInterface::class)
       ->add(AlterTableQueryBuilderInterface::class, 'getQuery', AlterTableQueryInterface::class)

--- a/modules/datastore/tests/src/Unit/Service/ResourceProcessor/DictionaryEnforcerTest.php
+++ b/modules/datastore/tests/src/Unit/Service/ResourceProcessor/DictionaryEnforcerTest.php
@@ -3,30 +3,34 @@
 namespace Drupal\Tests\datastore\Unit\Service\ResourceProcessor;
 
 use Drupal\Core\DependencyInjection\Container;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\StreamWrapper\PublicStream;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
-
 use Drupal\common\DataResource;
 use Drupal\datastore\DataDictionary\AlterTableQueryBuilderInterface;
 use Drupal\datastore\DataDictionary\AlterTableQueryInterface;
 use Drupal\datastore\Plugin\QueueWorker\PostImportResourceProcessor;
+use Drupal\datastore\Service\PostImport;
 use Drupal\datastore\Service\ResourceProcessorCollector;
 use Drupal\datastore\Service\ResourceProcessor\DictionaryEnforcer;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscovery;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscoveryInterface;
-use Drupal\datastore\Service\PostImport;
-use Drupal\metastore\ResourceMapper;
 use Drupal\metastore\MetastoreService;
 use Drupal\metastore\Reference\ReferenceLookup;
+use Drupal\metastore\ResourceMapper;
 use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use RootedData\RootedJsonData;
 
 /**
  * Test \Drupal\datastore\Service\ResourceProcessor\DictionaryEnforcer.
+ *
+ * @coversDefaultClass \Drupal\datastore\Service\ResourceProcessor\DictionaryEnforcer
+ *
+ * @group dkan
+ * @group datastore
+ * @group unit
  */
 class DictionaryEnforcerTest extends TestCase {
 
@@ -183,7 +187,7 @@ class DictionaryEnforcerTest extends TestCase {
     $options = (new Options())
       ->add('dkan.datastore.data_dictionary.alter_table_query_builder.mysql', AlterTableQueryBuilderInterface::class)
       ->add('dkan.metastore.data_dictionary_discovery', DataDictionaryDiscovery::class)
-      ->add('logger.factory', LoggerChannelFactoryInterface::class)
+      ->add('dkan.datastore.logger_channel', LoggerInterface::class)
       ->add('dkan.metastore.service', MetastoreService::class)
       ->add('dkan.metastore.data_dictionary_discovery', DataDictionaryDiscoveryInterface::class)
       ->add('stream_wrapper_manager', StreamWrapperManager::class)
@@ -198,8 +202,7 @@ class DictionaryEnforcerTest extends TestCase {
 
     return (new Chain($this))
       ->add(Container::class, 'get', $options)
-      ->add(LoggerChannelFactoryInterface::class, 'get', LoggerChannelInterface::class)
-      ->add(LoggerChannelInterface::class, 'error', NULL, 'error')
+      ->add(LoggerInterface::class, 'error', NULL, 'error')
       ->add(MetastoreService::class, 'get', new RootedJsonData($json))
       ->add(AlterTableQueryBuilderInterface::class, 'setConnectionTimeout', AlterTableQueryBuilderInterface::class)
       ->add(AlterTableQueryBuilderInterface::class, 'getQuery', AlterTableQueryInterface::class)

--- a/modules/json_form_widget/json_form_widget.services.yml
+++ b/modules/json_form_widget/json_form_widget.services.yml
@@ -1,7 +1,7 @@
 services:
   json_form.builder:
     class: \Drupal\json_form_widget\FormBuilder
-    arguments: ['@dkan.metastore.schema_retriever','@json_form.router', '@json_form.schema_ui_handler', '@logger.factory']
+    arguments: ['@dkan.metastore.schema_retriever','@json_form.router', '@json_form.schema_ui_handler', '@dkan.json_form.logger_channel']
   json_form.router:
     class: \Drupal\json_form_widget\FieldTypeRouter
     arguments: ['@json_form.string_helper','@json_form.object_helper', '@json_form.array_helper', '@json_form.integer_helper']
@@ -22,4 +22,7 @@ services:
     arguments: ['@uuid','@json_form.string_helper', '@dkan.metastore.service']
   json_form.schema_ui_handler:
     class: \Drupal\json_form_widget\SchemaUiHandler
-    arguments: ['@dkan.metastore.schema_retriever', '@logger.factory', '@json_form.widget_router']
+    arguments: ['@dkan.metastore.schema_retriever', '@dkan.json_form.logger_channel', '@json_form.widget_router']
+  dkan.json_form.logger_channel:
+    parent: logger.channel_base
+    arguments: ['json_form_widget']

--- a/modules/json_form_widget/src/FormBuilder.php
+++ b/modules/json_form_widget/src/FormBuilder.php
@@ -41,11 +41,11 @@ class FormBuilder implements ContainerInjectionInterface {
   protected $router;
 
   /**
-   * Logger service.
+   * Logger channel service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   * @var \Psr\Log\LoggerInterface
    */
-  protected $loggerFactory;
+  private LoggerInterface $logger;
 
   /**
    * Inherited.

--- a/modules/json_form_widget/src/FormBuilder.php
+++ b/modules/json_form_widget/src/FormBuilder.php
@@ -4,8 +4,8 @@ namespace Drupal\json_form_widget;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\metastore\SchemaRetriever;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Logger\LoggerChannelFactory;
 
 /**
  * Form builder service.
@@ -57,18 +57,23 @@ class FormBuilder implements ContainerInjectionInterface {
       $container->get('dkan.metastore.schema_retriever'),
       $container->get('json_form.router'),
       $container->get('json_form.schema_ui_handler'),
-      $container->get('logger.factory')
+      $container->get('dkan.json_form.logger_channel')
     );
   }
 
   /**
    * Constructor.
    */
-  public function __construct(SchemaRetriever $schema_retriever, FieldTypeRouter $router, SchemaUiHandler $schema_ui_handler, LoggerChannelFactory $logger_factory) {
+  public function __construct(
+    SchemaRetriever $schema_retriever,
+    FieldTypeRouter $router,
+    SchemaUiHandler $schema_ui_handler,
+    LoggerInterface $loggerChannel
+  ) {
     $this->schemaRetriever = $schema_retriever;
     $this->router = $router;
     $this->schemaUiHandler = $schema_ui_handler;
-    $this->loggerFactory = $logger_factory;
+    $this->logger = $loggerChannel;
   }
 
   /**
@@ -85,7 +90,7 @@ class FormBuilder implements ContainerInjectionInterface {
       $this->router->setSchema($this->schema);
     }
     catch (\Exception $exception) {
-      $this->loggerFactory->get('json_form_widget')->notice("The JSON Schema for $schema_name does not exist.");
+      $this->logger->notice("The JSON Schema for $schema_name does not exist.");
     }
   }
 

--- a/modules/json_form_widget/src/SchemaUiHandler.php
+++ b/modules/json_form_widget/src/SchemaUiHandler.php
@@ -4,8 +4,8 @@ namespace Drupal\json_form_widget;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\metastore\SchemaRetriever;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Logger\LoggerChannelFactory;
 
 /**
  * JSON form widget schema UI handler service.
@@ -27,11 +27,11 @@ class SchemaUiHandler implements ContainerInjectionInterface {
   protected $schemaRetriever;
 
   /**
-   * Logger service.
+   * Json form widget logger channel service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   * @var \Psr\Log\LoggerInterface
    */
-  protected $loggerFactory;
+  private LoggerInterface $logger;
 
   /**
    * WidgetRotuer Service.
@@ -48,7 +48,7 @@ class SchemaUiHandler implements ContainerInjectionInterface {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('dkan.metastore.schema_retriever'),
-      $container->get('logger.factory'),
+      $container->get('dkan.json_form.logger_channel'),
       $container->get('json_form.widget_router')
     );
   }
@@ -56,17 +56,21 @@ class SchemaUiHandler implements ContainerInjectionInterface {
   /**
    * Constructor.
    *
-   * @param Drupal\metastore\SchemaRetriever $schema_retriever
+   * @param \Drupal\metastore\SchemaRetriever $schema_retriever
    *   SchemaRetriever service.
-   * @param Drupal\Core\Logger\LoggerChannelFactory $logger_factory
-   *   LoggerChannelFactory service.
+   * @param \Psr\Log\LoggerInterface $loggerChannel
+   *   Logger channel service.
    * @param WidgetRouter $widget_router
    *   WidgetRouter service.
    */
-  public function __construct(SchemaRetriever $schema_retriever, LoggerChannelFactory $logger_factory, WidgetRouter $widget_router) {
+  public function __construct(
+    SchemaRetriever $schema_retriever,
+    LoggerInterface $loggerChannel,
+    WidgetRouter $widget_router
+  ) {
     $this->schemaRetriever = $schema_retriever;
     $this->schemaUi = FALSE;
-    $this->loggerFactory = $logger_factory;
+    $this->logger = $loggerChannel;
     $this->widgetRouter = $widget_router;
   }
 
@@ -82,7 +86,7 @@ class SchemaUiHandler implements ContainerInjectionInterface {
       $this->schemaUi = json_decode($schema_ui);
     }
     catch (\Exception $exception) {
-      $this->loggerFactory->get('json_form_widget')->notice("The UI Schema for $schema_name does not exist.");
+      $this->logger->notice("The UI Schema for $schema_name does not exist.");
     }
   }
 

--- a/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
+++ b/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
@@ -2,24 +2,22 @@
 
 namespace Drupal\Tests\json_form_widget\Unit;
 
-use PHPUnit\Framework\TestCase;
-use Drupal\json_form_widget\FormBuilder;
-use Drupal\json_form_widget\ArrayHelper;
-use MockChain\Chain;
 use Drupal\Component\DependencyInjection\Container;
 use Drupal\Component\Utility\EmailValidator;
 use Drupal\Core\Form\FormState;
-use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\Core\StringTranslation\TranslationManager;
+use Drupal\json_form_widget\ArrayHelper;
 use Drupal\json_form_widget\FieldTypeRouter;
+use Drupal\json_form_widget\FormBuilder;
 use Drupal\json_form_widget\IntegerHelper;
 use Drupal\json_form_widget\ObjectHelper;
 use Drupal\json_form_widget\SchemaUiHandler;
 use Drupal\json_form_widget\StringHelper;
 use Drupal\metastore\SchemaRetriever;
+use MockChain\Chain;
 use MockChain\Options;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use stdClass;
 
 /**
  * Test class for JsonFormWidget.
@@ -169,7 +167,7 @@ class JsonFormBuilderTest extends TestCase {
         ],
       ],
     ];
-    $default_data = new stdClass();
+    $default_data = new \stdClass();
     $default_data->test = "Some value.";
     $this->assertEquals($expected, $form_builder->getJsonForm($default_data));
 

--- a/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
+++ b/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
@@ -18,6 +18,7 @@ use Drupal\json_form_widget\SchemaUiHandler;
 use Drupal\json_form_widget\StringHelper;
 use Drupal\metastore\SchemaRetriever;
 use MockChain\Options;
+use Psr\Log\LoggerInterface;
 use stdClass;
 
 /**
@@ -39,7 +40,7 @@ class JsonFormBuilderTest extends TestCase {
       ->add('json_form.object_helper', ObjectHelper::class)
       ->add('json_form.array_helper', ArrayHelper::class)
       ->add('json_form.schema_ui_handler', SchemaUiHandler::class)
-      ->add('logger.factory', LoggerChannelFactory::class)
+      ->add('dkan.json_form.logger_channel', LoggerInterface::class)
       ->add('json_form.router', FieldTypeRouter::class)
       ->index(0);
 
@@ -68,7 +69,7 @@ class JsonFormBuilderTest extends TestCase {
       ->add('dkan.metastore.schema_retriever', SchemaRetriever::class)
       ->add('json_form.router', $router)
       ->add('json_form.schema_ui_handler', SchemaUiHandler::class)
-      ->add('logger.factory', LoggerChannelFactory::class)
+      ->add('dkan.json_form.logger_channel', LoggerInterface::class)
       ->add('string_translation', TranslationManager::class)
       ->index(0);
 

--- a/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
@@ -18,6 +18,7 @@ use Drupal\json_form_widget\WidgetRouter;
 use Drupal\metastore\SchemaRetriever;
 use Drupal\metastore\MetastoreService;
 use MockChain\Options;
+use Psr\Log\LoggerInterface;
 
 /**
  * Test class for SchemaUiHandlerTest.
@@ -49,7 +50,7 @@ class SchemaUiHandlerTest extends TestCase {
     $options = (new Options())
       ->add('dkan.metastore.schema_retriever', SchemaRetriever::class)
       ->add('json_form.string_helper', StringHelper::class)
-      ->add('logger.factory', LoggerChannelFactory::class)
+      ->add('dkan.json_form.logger_channel', LoggerInterface::class)
       ->add('uuid', Php::class)
       ->add('json_form.widget_router', $widget_router)
       ->add('language_manager', $language_manager)
@@ -626,7 +627,7 @@ class SchemaUiHandlerTest extends TestCase {
     $options = (new Options())
       ->add('dkan.metastore.schema_retriever', SchemaRetriever::class)
       ->add('json_form.string_helper', StringHelper::class)
-      ->add('logger.factory', LoggerChannelFactory::class)
+      ->add('dkan.json_form.logger_channel', LoggerInterface::class)
       ->add('uuid', Php::class)
       ->add('json_form.widget_router', $widget_router)
       ->index(0);
@@ -702,7 +703,7 @@ class SchemaUiHandlerTest extends TestCase {
     $options = (new Options())
       ->add('dkan.metastore.schema_retriever', SchemaRetriever::class)
       ->add('json_form.string_helper', StringHelper::class)
-      ->add('logger.factory', LoggerChannelFactory::class)
+      ->add('dkan.json_form.logger_channel', LoggerInterface::class)
       ->add('uuid', Php::class)
       ->add('json_form.widget_router', $widget_router)
       ->index(0);
@@ -764,7 +765,7 @@ class SchemaUiHandlerTest extends TestCase {
     $options = (new Options())
       ->add('dkan.metastore.schema_retriever', SchemaRetriever::class)
       ->add('json_form.string_helper', StringHelper::class)
-      ->add('logger.factory', LoggerChannelFactory::class)
+      ->add('dkan.json_form.logger_channel', LoggerInterface::class)
       ->add('uuid', Php::class)
       ->add('json_form.widget_router', $widget_router)
       ->index(0);

--- a/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
@@ -2,22 +2,21 @@
 
 namespace Drupal\Tests\json_form_widget\Unit;
 
-use Drupal\Tests\metastore\Unit\MetastoreServiceTest;
-use PHPUnit\Framework\TestCase;
-use MockChain\Chain;
 use Drupal\Component\DependencyInjection\Container;
-use Drupal\Component\Uuid\Php;
-use Drupal\Core\Logger\LoggerChannelFactory;
-use Drupal\json_form_widget\SchemaUiHandler;
 use Drupal\Component\Utility\EmailValidator;
+use Drupal\Component\Uuid\Php;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Language\LanguageDefault;
 use Drupal\Core\Language\LanguageManager;
+use Drupal\Tests\metastore\Unit\MetastoreServiceTest;
+use Drupal\json_form_widget\SchemaUiHandler;
 use Drupal\json_form_widget\StringHelper;
 use Drupal\json_form_widget\WidgetRouter;
-use Drupal\metastore\SchemaRetriever;
 use Drupal\metastore\MetastoreService;
+use Drupal\metastore\SchemaRetriever;
+use MockChain\Chain;
 use MockChain\Options;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -75,7 +75,6 @@ services:
   dkan.metastore.event_subscriber:
     class: \Drupal\metastore\EventSubscriber\MetastoreSubscriber
     arguments:
-      - '@logger.factory'
       - '@dkan.metastore.service'
       - '@dkan.metastore.resource_mapper'
       - '@dkan.metastore.reference_lookup'

--- a/modules/metastore/modules/metastore_admin/metastore_admin.services.yml
+++ b/modules/metastore/modules/metastore_admin/metastore_admin.services.yml
@@ -1,0 +1,4 @@
+services:
+  dkan.metastore_admin.logger_channel:
+    parent: logger.channel_base
+    arguments: [ 'metastore_admin' ]

--- a/modules/metastore/modules/metastore_admin/src/Plugin/Action/HideCurrentRevisionAction.php
+++ b/modules/metastore/modules/metastore_admin/src/Plugin/Action/HideCurrentRevisionAction.php
@@ -5,11 +5,10 @@ namespace Drupal\metastore_admin\Plugin\Action;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Action\ActionBase;
 use Drupal\Core\Entity\RevisionLogInterface;
-use Drupal\Core\Logger\LoggerChannelInterface;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -51,9 +50,9 @@ class HideCurrentRevisionAction extends ActionBase implements ContainerFactoryPl
   /**
    * Logger channel.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   * @var \Psr\Log\LoggerInterface
    */
-  private LoggerChannelInterface $logger;
+  private LoggerInterface $logger;
 
   /**
    * Constructor.
@@ -65,7 +64,7 @@ class HideCurrentRevisionAction extends ActionBase implements ContainerFactoryPl
    *   The plugin_id for the plugin instance.
    * @param mixed $pluginDefinition
    *   The plugin implementation definition.
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
+   * @param \Psr\Log\LoggerInterface $loggerChannel
    *   A logger channel factory instance.
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    *   Messenger.
@@ -78,13 +77,13 @@ class HideCurrentRevisionAction extends ActionBase implements ContainerFactoryPl
     array $configuration,
     $pluginId,
     $pluginDefinition,
-    LoggerChannelFactoryInterface $loggerFactory,
+    LoggerInterface $loggerChannel,
     MessengerInterface $messenger,
     AccountInterface $currentUser,
     TimeInterface $timeInterface
   ) {
     parent::__construct($configuration, $pluginId, $pluginDefinition);
-    $this->logger = $loggerFactory->get('metastore_admin');
+    $this->logger = $loggerChannel;
     $this->messenger = $messenger;
     $this->currentUser = $currentUser;
     $this->timeInterface = $timeInterface;
@@ -96,14 +95,14 @@ class HideCurrentRevisionAction extends ActionBase implements ContainerFactoryPl
   public static function create(
     ContainerInterface $container,
     array $configuration,
-    $pluginId,
-    $pluginDefinition
+    $plugin_id,
+    $plugin_definition
   ) {
     return new static(
       $configuration,
-      $pluginId,
-      $pluginDefinition,
-      $container->get('logger.factory'),
+      $plugin_id,
+      $plugin_definition,
+      $container->get('dkan.metastore_admin.logger_channel'),
       $container->get('messenger'),
       $container->get('current_user'),
       $container->get('datetime.time'),

--- a/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
+++ b/modules/metastore/src/EventSubscriber/MetastoreSubscriber.php
@@ -4,7 +4,6 @@ namespace Drupal\metastore\EventSubscriber;
 
 use Drupal\common\DataResource;
 use Drupal\common\Events\Event;
-use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\metastore\MetastoreService;
 use Drupal\metastore\Plugin\QueueWorker\OrphanReferenceProcessor;
 use Drupal\metastore\ReferenceLookupInterface;
@@ -16,13 +15,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * Event subscriber for Metastore.
  */
 class MetastoreSubscriber implements EventSubscriberInterface {
-
-  /**
-   * Logger service.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelFactory
-   */
-  protected LoggerChannelFactory $loggerFactory;
 
   /**
    * Metastore service.
@@ -52,7 +44,6 @@ class MetastoreSubscriber implements EventSubscriberInterface {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('logger.factory'),
       $container->get('dkan.metastore.service'),
       $container->get('dkan.metastore.resource_mapper'),
       $container->get('dkan.metastore.reference_lookup')
@@ -62,8 +53,6 @@ class MetastoreSubscriber implements EventSubscriberInterface {
   /**
    * Constructor.
    *
-   * @param Drupal\Core\Logger\LoggerChannelFactory $logger_factory
-   *   LoggerChannelFactory service.
    * @param \Drupal\metastore\MetastoreService $service
    *   The dkan.metastore.service service.
    * @param \Drupal\metastore\ResourceMapper $resourceMapper
@@ -71,8 +60,11 @@ class MetastoreSubscriber implements EventSubscriberInterface {
    * @param \Drupal\metastore\ReferenceLookupInterface $referenceLookup
    *   The dkan.metastore.reference_lookup service.
    */
-  public function __construct(LoggerChannelFactory $logger_factory, MetastoreService $service, ResourceMapper $resourceMapper, ReferenceLookupInterface $referenceLookup) {
-    $this->loggerFactory = $logger_factory;
+  public function __construct(
+    MetastoreService $service,
+    ResourceMapper $resourceMapper,
+    ReferenceLookupInterface $referenceLookup
+  ) {
     $this->service = $service;
     $this->resourceMapper = $resourceMapper;
     $this->referenceLookup = $referenceLookup;


### PR DESCRIPTION
Modifies the following services to use a logger channel service instead of using a logger factory service to make its own channel:

- `dkan.datastore.event_subscriber`
- `json_form.builder`
- `json_form.schema_ui_handler`
- `datastore.reimport.commands`

We also discover that some plugins generate their own logger channel objects rather than injecting existing ones.
- `ImportQueueWorker`
- `LocalizeQueueWorker`
- `PostImportResourceProcessor`
- `HideCurrentRevisionAction`

In addition, analysis reveals that `dkan.metastore.event_subscriber` doesn't actually use a logger at all, so we remove that dependency from the service declaration.

Modify tests to pass.

Minor CS changes.