### PR TITLE
Add css and js config objects to dkan_js_frontend

### DIFF
--- a/modules/dkan_js_frontend/README.md
+++ b/modules/dkan_js_frontend/README.md
@@ -21,3 +21,36 @@ This is a React app that will use the [Data Catalog Components](https://github.c
 If you are setting the JS frontend as the main frontend for your site, like on the demo DKAN site, you will want to do the following:
 
 * Set the `404` and `home` paths for the site to `/home`. This will make it so whenever Drupal returns a page not found it will load the JS frontend and visiting the root url the JS site will be loaded instead of a default Drupal node.
+
+## Sample Config
+```
+// The folders for the css and js compiled files.
+css_folder: '/frontend/build/static/css/'
+js_folder: '/frontend/build/static/js/'
+// Routes to load the JS application when visited.
+routes:
+  - home,/home
+  - about,/about
+  - api,/api
+  - dataset,/dataset/{id}
+  - datasetapi,/dataset/{id}/api
+  - search,/search
+  - publishers,/publishers
+// This is applied to both the CSS and JS library.
+minified: true
+preprocess: true
+js:
+  // These will overwrite the above global if set.
+  minified: true
+  preprocess: true
+  weight: 0
+  attributes:
+    - type,module
+css:
+  // Same as above, will overwrite the global config above.
+  minified: true
+  preprocess: true
+  weight: 0
+  attributes:
+    - crossorigin,anonymous
+```

--- a/modules/dkan_js_frontend/config/install/dkan_js_frontend.config.yml
+++ b/modules/dkan_js_frontend/config/install/dkan_js_frontend.config.yml
@@ -10,7 +10,6 @@ routes:
   - publishers,/publishers
 minified: true
 preprocess: true
-weight: 0
 js:
   attributes:
     - type,module

--- a/modules/dkan_js_frontend/config/install/dkan_js_frontend.config.yml
+++ b/modules/dkan_js_frontend/config/install/dkan_js_frontend.config.yml
@@ -10,3 +10,7 @@ routes:
   - publishers,/publishers
 minified: true
 preprocess: true
+weight: 0
+js:
+  attributes:
+    - type,module

--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -30,20 +30,54 @@ function dkan_js_frontend_library_info_build() {
   $preprocess = \Drupal::config('dkan_js_frontend.config')->get('preprocess');
   $js_path = \Drupal::config('dkan_js_frontend.config')->get('js_folder');
   $css_path = \Drupal::config('dkan_js_frontend.config')->get('css_folder');
+  $js = \Drupal::config('dkan_js_frontend.config')->get('js');
+  $css = \Drupal::config('dkan_js_frontend.config')->get('js');
 
   foreach(glob(\Drupal::root() . $js_path . '*.js') as $full_path) {
     $basename = basename($full_path);
-    $libraries['dkan_js_frontend']['js'][$js_path . $basename] = [
-      "minified" => $minified ?? false,
-      "preprocess" => $preprocess ?? true,
-    ];
+    if(isset($js)) {
+      // Overwrite global minified with JS specific.
+      if(isset($js['minified'])) {
+        $minified = $js['minified'];
+      }
+      // Overwrite global preprocess with JS specific.
+      if(isset($js['preprocess'])) {
+        $preprocess = $js['preprocess'];
+      }
+      // Set the weight if available.
+      if(isset($js['weight'])) {
+        $libraries['dkan_js_frontend']['js'][$js_path . $basename]['weight'] = $js['weight'];
+      }
+      // Loop through JS attributes and add to library.
+      if(isset($js['attributes'])) {
+        foreach($js['attributes'] as $attr) {
+          $exploded_attr = explode(',', $attr);
+          $js_attributes[$exploded_attr[0]] = $exploded_attr[1];
+        }
+        $libraries['dkan_js_frontend']['js'][$js_path . $basename]['attributes'] = $js_attributes;
+      }
+    }
+    $libraries['dkan_js_frontend']['js'][$js_path . $basename]['minified'] = $minified ?? false;
+    $libraries['dkan_js_frontend']['js'][$js_path . $basename]['preprocess'] = $preprocess ?? true;
   }
   foreach(glob(\Drupal::root() . $css_path . '*.css') as $full_path) {
     $basename = basename($full_path);
-    $libraries['dkan_js_frontend']['css']['theme'][$css_path . $basename] = [
-      "minified" => $minified ?? false,
-      "preprocess" => $preprocess ?? true,
-    ];
+    if(isset($css)) {
+      // Overwrite global minified with CSS specific.
+      if(isset($css['minified'])) {
+        $minified = $css['minified'];
+      }
+      // Overwrite global preprocess with CSS specific.
+      if(isset($css['preprocess'])) {
+        $preprocess = $css['preprocess'];
+      }
+      // Set the weight if available.
+      if(isset($css['weight'])) {
+        $libraries['dkan_js_frontend']['css']['theme'][$js_pcss_pathath . $basename]['weight'] = $css['weight'];
+      }
+    }
+    $libraries['dkan_js_frontend']['css']['theme'][$css_path . $basename]['minified'] = $minified ?? false;
+    $libraries['dkan_js_frontend']['css']['theme'][$css_path . $basename]['preprocess'] = $preprocess ?? true;
   }
   $libraries['dkan_js_frontend']['dependencies'] = [
     'core/drupal',


### PR DESCRIPTION
Fixes:
When splitting up JS files into chunks, they need to be loaded using `type="module"`. This is handled by Drupal via the attributes array on each library entry, but our dynamic hook in the `dkan_js_frontend` module didn't allow for granular updates like this. This PR adds a `js` and `css` object to the config that will allow for custom attributes, but also setting `weight`, `minified`, and `preprocess` for css and js separately. If only the top level minified and preprocess are set, this will still work too. 

- [ ] Documentation exists

## QA Steps

- [ ] Pull new PR
- [ ] Build the site using the decoupled frontend
- [ ] If building a new site, the install config should now add type module to the build file after install
- [ ] If tested on existing site, update config to include  js => attribute setup in the included config. 
- [ ] Once config has been imported, load a React page and view the source code and look the type module on the build/static/js file. 
- [ ] The site should still work with no obvious issues. 
