### PR TITLE
Add link to list of data dictionaries

### DIFF
--- a/cypress/integration/09_admin_links.spec.js
+++ b/cypress/integration/09_admin_links.spec.js
@@ -6,7 +6,26 @@ context('Administration pages', () => {
     cy.visit(baseurl + "/admin/dkan")
   })
 
-  it('I should see a link for the dataset properties configuration', () => {
+  it('DKAN menu contains expected links.', () => {
+    const links = [
+      'Datasets',
+      'Datastore Import Status',
+      'Datastore settings',
+      'Data Dictionary',
+      'Harvests',
+      'Metastore settings',
+      'Resources'
+    ]
+
+    cy.visit(`${baseurl}/admin`)
+    cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').parent().then(($menu) => {
+      links.forEach((link) => {
+        cy.get($menu).contains(link)
+      })
+    })
+  })
+
+  it('Admin can access the Metastore settings.', () => {
     cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=>{
         cy.wrap($el).invoke('show')
         cy.wrap($el).contains('Metastore settings')
@@ -15,7 +34,7 @@ context('Administration pages', () => {
     cy.get('.option').should('contain.text', 'Distribution (distribution)')
   })
 
-  it('I should see a link for the datastore configuration', () => {
+  it('Admin can access the Datastore settings.', () => {
     cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=>{
         cy.wrap($el).invoke('show')
         cy.wrap($el).contains('Datastore settings')
@@ -24,7 +43,7 @@ context('Administration pages', () => {
     cy.get('label[for="edit-rows-limit"]').should('have.text', 'Rows limit')
   })
 
-  it('I should see a link for the datastore status', () => {
+  it('Admin can access the Datastore import status dashboard.', () => {
     cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=>{
         cy.wrap($el).invoke('show')
         cy.wrap($el).contains('Datastore Import Status')
@@ -33,7 +52,7 @@ context('Administration pages', () => {
     cy.contains('h1', 'Datastore Import Status');
   })
 
-  it('I should see a link for the harvest status', () => {
+  it('Admin can access the Harvest dashboard', () => {
     cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=>{
         cy.wrap($el).invoke('show')
         cy.wrap($el).contains('Harvests')
@@ -42,11 +61,34 @@ context('Administration pages', () => {
     cy.contains('h1', 'Harvests');
   })
 
-  it('There is a link in the admin menu to the datasets admin screen.', () => {
+  it('Admin can access the dataset content view and can click a button to open the dataset form.', () => {
     cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=> {
-        cy.wrap($el).invoke('show')
-        cy.wrap($el).contains('Datasets')
+      cy.wrap($el).invoke('show')
+      cy.wrap($el).contains('Datasets').click({ force:true })
     })
+    cy.contains('h1', 'Datasets');
+
+    cy.get('.button').contains('+ Add new dataset').click( { force:true })
+    cy.contains('h1', 'Create Data');
+  })
+
+  it('DKAN menu contains link to create a dataset.', () => {
+    cy.get('.toolbar-icon-system-admin-dkan').contains('DKAN').next('.toolbar-menu').then($el=> {
+      cy.wrap($el).invoke('show')
+      cy.wrap($el).contains('Datasets').parent().within(() => {
+        cy.get('li.menu-item a').contains('Create').click({ force:true })
+      })
+      cy.contains('h1', 'Create Data')
+    })
+  })
+
+  it('DKAN menu contains link to create a data dictionary.', () => {
+    cy.get('.toolbar-icon-system-admin-dkan').parent().within(() => {
+      cy.get('li.menu-item a').contains('Data Dictionary').click({ force:true })
+    })
+    cy.contains('h1', 'DKAN Metastore (Data Dictionaries)');
+    cy.get('.button').contains('+ Add new data dictionary').click( { force:true })
+    cy.get('summary').contains('Project Open Data Data-Dictionary');
   })
 
 })

--- a/modules/metastore/metastore.links.menu.yml
+++ b/modules/metastore/metastore.links.menu.yml
@@ -6,15 +6,15 @@ dkan.metastore.config_properties:
   weight: 14
 
 metastore.data_dictionary:
-  title: Data-Dictionary
-  description: Data-Dictionary Pages
+  title: Data Dictionary
+  description: Data Dictionary Pages
   parent: system.admin_dkan
   route_name: metastore.data_dictionary
   weight: 13
 
 metastore.data_dictionary.create:
   title: Create
-  description: Create Data-Dictionary
+  description: Create Data Dictionary
   parent: metastore.data_dictionary
   route_name: node.add
   route_parameters:
@@ -22,9 +22,16 @@ metastore.data_dictionary.create:
     schema: data-dictionary
   weight: 1
 
+metastore.data_dictionary.list:
+  title: List
+  description: Data Dictionary List
+  parent: metastore.data_dictionary
+  route_name: metastore.data_dictionary.list
+  weight: 2
+
 metastore.data_dictionary.settings_form:
   title: Settings
-  description: Data-Dictionary Settings
+  description: Data Dictionary Settings
   parent: metastore.data_dictionary
   route_name: metastore.data_dictionary.settings
-  weight: 2
+  weight: 3

--- a/modules/metastore/metastore.links.menu.yml
+++ b/modules/metastore/metastore.links.menu.yml
@@ -7,7 +7,7 @@ dkan.metastore.config_properties:
 
 metastore.data_dictionary:
   title: Data Dictionary
-  description: Data Dictionary Pages
+  description: Data Dictionary List
   parent: system.admin_dkan
   route_name: metastore.data_dictionary
   weight: 13
@@ -22,16 +22,26 @@ metastore.data_dictionary.create:
     schema: data-dictionary
   weight: 1
 
-metastore.data_dictionary.list:
-  title: List
-  description: Data Dictionary List
-  parent: metastore.data_dictionary
-  route_name: metastore.data_dictionary.list
-  weight: 2
-
 metastore.data_dictionary.settings_form:
   title: Settings
   description: Data Dictionary Settings
   parent: metastore.data_dictionary
   route_name: metastore.data_dictionary.settings
   weight: 3
+
+metastore.datasets:
+  title: Datasets
+  description: Dataset content view
+  parent: system.admin_dkan
+  route_name: metastore.datasets
+  weight: 1
+
+metastore.datasets.create:
+  title: Create
+  description: Create Dataset
+  parent: metastore.datasets
+  route_name: node.add
+  route_parameters:
+    node_type: data
+    schema: dataset
+  weight: 1

--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -160,10 +160,9 @@ dkan.metastore.config_properties:
     _admin_route: TRUE
 
 metastore.data_dictionary:
-  path: '/admin/dkan/data-dictionary'
+  path: '/admin/dkan/data-dictionaries'
   defaults:
-    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
-    _title: 'Data Dictionary'
+    _title: 'Data Dictionary List'
   requirements:
     _permission: 'create data content'
 
@@ -175,9 +174,18 @@ metastore.data_dictionary.settings:
   requirements:
     _permission: 'administer data dictionary settings'
 
-metastore.data_dictionary.list:
-  path: '/admin/dkan/data-dictionaries'
+metastore.datasets:
+  path: '/admin/dkan/datasets'
   defaults:
-    _title: 'Data Dictionary List'
+    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+    _title: 'Datasets'
   requirements:
-    _permission: 'administer data dictionary settings'
+    _permission: 'create data content'
+
+metastore.datasets.create:
+  path: '/admin/dkan/datasets'
+  defaults:
+    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+    _title: 'Create Dataset'
+  requirements:
+    _permission: 'create data content'

--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -163,14 +163,21 @@ metastore.data_dictionary:
   path: '/admin/dkan/data-dictionary'
   defaults:
     _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
-    _title: 'Data-Dictionary'
+    _title: 'Data Dictionary'
   requirements:
     _permission: 'create data content'
 
 metastore.data_dictionary.settings:
   path: '/admin/dkan/data-dictionary/settings'
   defaults:
-    _title: 'Data-Dictionary Settings'
+    _title: 'Data Dictionary Settings'
     _form: '\Drupal\metastore\Form\DataDictionarySettingsForm'
+  requirements:
+    _permission: 'administer data dictionary settings'
+
+metastore.data_dictionary.list:
+  path: '/admin/dkan/data-dictionaries'
+  defaults:
+    _title: 'Data Dictionary List'
   requirements:
     _permission: 'administer data dictionary settings'

--- a/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
+++ b/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
@@ -984,6 +984,554 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      fields:
+        node_bulk_form:
+          id: node_bulk_form
+          table: node
+          field: node_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: node_bulk_form
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: include
+          selected_actions:
+            - archive_current
+            - hide_current
+            - node_delete_action
+            - publish_latest
+        uuid:
+          id: uuid
+          table: node
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: uuid
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: '/dataset/{{ uuid }}'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_data_type:
+          id: field_data_type
+          table: node__field_data_type
+          field: field_data_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Data Type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: uid
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+          element_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: user_name
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: field
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+          element_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: boolean
+          settings:
+            format: custom
+            format_custom_false: Unpublished
+            format_custom_true: Published
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: moderation_state_field
+          label: 'Moderation state'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: content_moderation_state
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        revision_timestamp:
+          id: revision_timestamp
+          table: node_revision
+          field: revision_timestamp
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: revision_timestamp
+          plugin_id: field
+          label: 'Last Update'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: custom
+          label: Edit
+          exclude: false
+          alter:
+            alter_text: true
+            text: edit
+            make_link: true
+            path: '/node/{{ nid }}/edit'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+      defaults:
+        fields: false
       display_extenders: {  }
       path: admin/dkan/datasets
       menu:
@@ -1001,6 +1549,837 @@ display:
         description: 'Find and manage content'
         weight: -10
         menu_name: admin
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_data_type'
+        - 'config:workflow_list'
+  page_2:
+    id: page_2
+    display_title: 'Page 2'
+    display_plugin: page
+    position: 2
+    display_options:
+      title: 'DKAN Metastore (Data Dictionaries)'
+      fields:
+        node_bulk_form:
+          id: node_bulk_form
+          table: node
+          field: node_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: node_bulk_form
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: include
+          selected_actions:
+            - archive_current
+            - hide_current
+            - node_delete_action
+            - publish_latest
+        uuid:
+          id: uuid
+          table: node
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: uuid
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: true
+            path: '/api/1/metastore/schemas/data-dictionary/items/{{ uuid }}'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_data_type:
+          id: field_data_type
+          table: node__field_data_type
+          field: field_data_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Data Type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: uid
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+          element_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: user_name
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: field
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+          element_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: boolean
+          settings:
+            format: custom
+            format_custom_false: Unpublished
+            format_custom_true: Published
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: moderation_state_field
+          label: 'Moderation state'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: content_moderation_state
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        revision_timestamp:
+          id: revision_timestamp
+          table: node_revision
+          field: revision_timestamp
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: revision_timestamp
+          plugin_id: field
+          label: 'Last Update'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: custom
+          label: Edit
+          exclude: false
+          alter:
+            alter_text: true
+            text: edit
+            make_link: true
+            path: '/node/{{ nid }}/edit'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+      filters:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: title_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_data_type_value:
+          id: field_data_type_value
+          table: node__field_data_type
+          field: field_data_type_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: '='
+          value: data-dictionary
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_data_type_value_op
+            label: 'Data Type'
+            description: ''
+            use_operator: false
+            operator: field_data_type_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: data-type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              api_user: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Status
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: true
+          group_info:
+            label: 'Published status'
+            description: ''
+            identifier: status
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Published
+                operator: '='
+                value: '1'
+              2:
+                title: Unpublished
+                operator: '='
+                value: '0'
+        status_extra:
+          id: status_extra
+          table: node_field_data
+          field: status_extra
+          entity_type: node
+          plugin_id: node_status
+          operator: '='
+          value: false
+          group: 1
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: moderation_state_filter
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: moderation_state_op
+            label: 'Moderation state'
+            description: ''
+            use_operator: false
+            operator: moderation_state_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: moderation_state
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_editor: '0'
+              administrator: '0'
+              api_user: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            data: data
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      defaults:
+        title: false
+        fields: false
+        filters: false
+        filter_groups: false
+        header: false
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: 'Add dataset button'
+          plugin_id: text_custom
+          empty: true
+          content: '<div class="form-actions"><a class="button button--primary" href="/node/add/data?schema=data-dictionary">+ Add new data dictionary</a></div>'
+          tokenize: false
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: true
+          content: 'Displaying @start - @end of @total'
+      display_extenders: {  }
+      path: admin/dkan/data-dictionaries
     cache_metadata:
       max-age: 0
       contexts:

--- a/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
+++ b/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
@@ -4,7 +4,6 @@ dependencies:
   config:
     - field.storage.node.field_data_type
     - node.type.data
-    - system.menu.admin
   module:
     - content_moderation
     - node
@@ -1535,7 +1534,7 @@ display:
       display_extenders: {  }
       path: admin/dkan/datasets
       menu:
-        type: normal
+        type: none
         title: Datasets
         description: 'Administer all content in the DKAN metastore'
         weight: -10

--- a/modules/metastore/modules/metastore_admin/metastore_admin.install
+++ b/modules/metastore/modules/metastore_admin/metastore_admin.install
@@ -113,3 +113,13 @@ function metastore_admin_update_8011() {
 
   drupal_flush_all_caches();
 }
+
+/**
+ * Reinstall DKAN Metastore Admin configuration to include new dkan menu items.
+ */
+function metastore_admin_update_8012() {
+  \Drupal::service('config.installer')
+    ->installDefaultConfig('module', 'metastore_admin');
+
+  drupal_flush_all_caches();
+}

--- a/modules/metastore/modules/metastore_admin/metastore_admin.module
+++ b/modules/metastore/modules/metastore_admin/metastore_admin.module
@@ -14,7 +14,9 @@ use Drupal\Core\Url;
  * Implements hook_form_FORM_ID_alter().
  */
 function metastore_admin_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if (isset($form['#id']) && $form['#id'] == 'views-exposed-form-dkan-dataset-content-page-1') {
+  if (isset($form['#id'])
+    && $form['#id'] == 'views-exposed-form-dkan-dataset-content-page-1'
+    || $form['#id'] == 'views-exposed-form-dkan-dataset-content-page-2') {
     $schemaRetriever = \Drupal::service('dkan.metastore.schema_retriever');
     $schemaIds = array_filter($schemaRetriever->getAllIds(), function ($schemaId) {
       return substr($schemaId, -3) != '.ui';

--- a/modules/metastore/modules/metastore_admin/metastore_admin.module
+++ b/modules/metastore/modules/metastore_admin/metastore_admin.module
@@ -35,18 +35,17 @@ function metastore_admin_form_views_exposed_form_alter(&$form, FormStateInterfac
  * Implements template_preprocess_views_view_fields().
  */
 function metastore_admin_preprocess_views_view_field(&$vars) {
-  if (isset($vars['view'])
-    && ($vars['view']->id() == 'dkan_dataset_content')
-    && ($vars['view']->current_display == 'page_1')) {
+
+  if (isset($vars['view']) && ($vars['view']->id() == 'dkan_dataset_content')) {
     // To access current row entity.
     $entity = $vars['row']->_entity;
+    $entity_id = $entity->id();
+    $entity_uuid = $entity->uuid();
 
     // Nodes without field_data_type should be skipped.
     if (!isset($entity->field_json_metadata)) {
       return;
     }
-
-    $entity_id = $entity->id();
 
     // Modify data titles to display the metadata title values rather than uuids.
     $data = json_decode($entity->field_json_metadata->value);
@@ -85,26 +84,47 @@ function metastore_admin_preprocess_views_view_field(&$vars) {
             ),
           ];
           break;
+
+        case 'data-dictionary':
+          $vars['output'] = [
+            '#markup' => Markup::create(
+              metastore_admin_create_text_link($title['data']->title, 'internal:/api/1/metastore/schemas/data-dictionary/items/' . $entity_uuid)
+            ),
+          ];
+          break;
       }
     }
   }
   // Check if the frontend module is enabled. If not, dataset titles
   // should link to the drupal node rather than the REACT frontend.
   if (isset($vars['view'])
-    && ($vars['view']->id() == 'dkan_dataset')
+    && ($vars['view']->id() == 'dkan_dataset_content')
     && ($vars['view']->current_display == 'page_1')) {
 
-    $moduleHandler = \Drupal::moduleHandler();
-    $moduleExist = $moduleHandler->moduleExists('frontend');
+    $entity = $vars['row']->_entity;
+    $entity_id = $entity->id();
+    $entity_uuid = $entity->uuid();
 
-    if ($vars['field']->field == 'title' && !$moduleExist) {
-      $entity = $vars['row']->_entity;
-      $entity_id = $entity->id();
-      $title = $entity->title->value;
+    $moduleExists = \Drupal::moduleHandler()->moduleExists('dkan_js_frontend');
+    $title = $entity->title->value;
+
+    if ($vars['field']->field == 'title'
+      && $entity->field_data_type->value == 'dataset'
+      && !$moduleExists) {
 
       $vars['output'] = [
         '#markup' => Markup::create(
           metastore_admin_create_text_link($title, 'internal:/node/' . $entity_id)
+        ),
+      ];
+    }
+    elseif ($vars['field']->field == 'title'
+      && $entity->field_data_type->value == 'dataset'
+      && $moduleExists) {
+
+      $vars['output'] = [
+        '#markup' => Markup::create(
+          metastore_admin_create_text_link($title, 'internal:/dataset/' . $entity_uuid)
         ),
       ];
     }


### PR DESCRIPTION
- Updates the 'Data Dictionary' menu item to take user to a data dictionary view
- Title links in the data dictionary view send you to the API endpoint
- The default dataset content view alter code updated to check if the **dkan_js_frontend** module is enabled. If yes, titles link to the react dataset page. If no, titles link to the Drupal node route.

## QA Steps

- [x] Checkout this branch
- [x] ddev drush en sample-content dkan_js_frontend -y
- [x] ddev dkan-frontend-install
- [x] ddev dkan-frontend-build
- [x] ddev drush dkan:sample-content:create
- [x] ddev drush cron
- [x] ddev drush uli
- [x] Use the DKAN menu, click on "Data Dictionary"
- [x] Confirm you end up on a data dictionary view 
- [x] Confirm there is a button for adding a new data dictionary
- [x] Create a data dictionary and return to the list view
- [x] Click the title of the data dictionary
- [x] Confirm you see the API endpoint for the data dictionary
- [x] Visit /admin/dkan/datasets
- [x] Confirm title links take you to the react dataset page
- [x] ddev drush pmu dkan_js_frontend -y
- [x] ddev drush cr
- [x] Visit /admin/dkan/datasets
- [x] Confirm the title links take you to the /node/nid page
