### PR TITLE
Include security vunerability report process

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ DKAN and related modules are freely-available under the ["GNU General Public Lic
 
 ---
 
+## Security
+
+If you have found a vunerability in DKAN, please report this by e-mailing dkan-security@civicactions.com.
+
+---
+
 ## History
 
 - DKAN’s initial v1.0 release was in 2014 (this code is still available on the [7.x-1.x branch](https://github.com/GetDKAN/dkan/tree/7.x-1.x), although no longer supported).


### PR DESCRIPTION
I think we had something along these lines on the old website, but that isn't active currently, so would be good to include here. This alias goes to our main internal DKAN list.
