### PR TITLE
Redirect to data-dictionary list after form submission

### DIFF
--- a/cypress/integration/09_admin_links.spec.js
+++ b/cypress/integration/09_admin_links.spec.js
@@ -88,7 +88,7 @@ context('Administration pages', () => {
     })
     cy.contains('h1', 'DKAN Metastore (Data Dictionaries)');
     cy.get('.button').contains('+ Add new data dictionary').click( { force:true })
-    cy.get('summary').contains('Data Dictionary Fields');
+    cy.get('fieldset').contains('Data Dictionary Fields');
   })
 
 })

--- a/cypress/integration/09_admin_links.spec.js
+++ b/cypress/integration/09_admin_links.spec.js
@@ -88,7 +88,7 @@ context('Administration pages', () => {
     })
     cy.contains('h1', 'DKAN Metastore (Data Dictionaries)');
     cy.get('.button').contains('+ Add new data dictionary').click( { force:true })
-    cy.get('summary').contains('Project Open Data Data-Dictionary');
+    cy.get('summary').contains('Data Dictionary Fields');
   })
 
 })

--- a/dkan.install
+++ b/dkan.install
@@ -11,3 +11,10 @@ function dkan_update_9001() {
   $modules = ['path', 'config'];
   \Drupal::service('module_installer')->install($modules);
 }
+
+/**
+ * Enable data dictionary widget.
+ */
+function dkan_update_9002() {
+  \Drupal::service('module_installer')->install(['data_dictionary_widget']);
+}

--- a/modules/data_dictionary_widget/data_dictionary_widget.module
+++ b/modules/data_dictionary_widget/data_dictionary_widget.module
@@ -75,11 +75,22 @@ function data_dictionary_widget__data_dictionary_data_type_checker($context) {
  */
 function data_dictionary_widget_form_alter(&$form, &$form_state, $form_id) {
   $formObject = $form_state->getFormObject();
+
   if ($formObject instanceof \Drupal\Core\Entity\EntityFormInterface) {
     $entity = $formObject->getEntity();
+    $data_type = $entity->get('field_data_type')->value;
     if (isset($form["field_json_metadata"]["widget"][0]["dictionary_fields"])) {
       if ($entity->getEntityTypeId() === 'node' && in_array($entity->bundle(), ['data'])) {
         $form['#attached']['library'][] = 'data_dictionary_widget/dataDictionaryWidget';
+      }
+    }
+
+    // If we are saving a data dictionary alter the submit.
+    foreach (array_keys($form['actions']) as $action) {
+      if ( isset($form['actions'][$action]['#type'])
+        && $form['actions'][$action]['#type'] === 'submit'
+        && $data_type == 'data-dictionary') {
+        $form['actions']['submit']['#submit'][] = 'data_dictionary_widget_form_submit';
       }
     }
   }
@@ -110,20 +121,14 @@ function data_dictionary_widget_form_alter(&$form, &$form_state, $form_id) {
       $form["field_json_metadata"]["widget"][0]["identifier"]['#default_value'] = $uuid;
       $form["field_json_metadata"]["widget"][0]["identifier"]['#description'] = t('<div class="form-item__description">This is the UUID of this Data Dictionary. To assign this data dictionary to a specific distribution use this <a href="/api/1/metastore/schemas/data-dictionary/items/' .$uuid. '" target="_blank">URL</a>.</div>');
     }
-
-    foreach (array_keys($form['actions']) as $action) {
-      if ( isset($form['actions'][$action]['#type'])
-        && $form['actions'][$action]['#type'] === 'submit') {
-        $form['actions']['submit']['#submit'][] = 'data_dictionary_widget_form_submit';
-      }
-    }
   }
 }
 
+/**
+ * Redirect to the data dictionary view after saving a data dictionary.
+ */
 function data_dictionary_widget_form_submit($form, FormStateInterface $form_state) {
   $url = Url::fromRoute('metastore.data_dictionary');
-  // $form_state->setRedirectUrl($url);
-
   $response = new RedirectResponse($url->toString());
   $response->send();
   return;

--- a/modules/data_dictionary_widget/data_dictionary_widget.module
+++ b/modules/data_dictionary_widget/data_dictionary_widget.module
@@ -6,8 +6,11 @@
  */
 
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\data_dictionary_widget\Fields\FieldOperations;
 use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Implements hook_theme().
@@ -65,9 +68,9 @@ function data_dictionary_widget__data_dictionary_data_type_checker($context) {
  * Implements hook_form_alter().
  *
  * Setting form validation for unique identifier.
- * 
+ *
  * Modifying current_fields array structure to prevent errors in element render array.
- * 
+ *
  * Attaching module library to render theme changes.
  */
 function data_dictionary_widget_form_alter(&$form, &$form_state, $form_id) {
@@ -90,7 +93,7 @@ function data_dictionary_widget_form_alter(&$form, &$form_state, $form_id) {
       foreach ($current_fields as $key => $value) {
           $keys = array_keys($value);
           $formatted_current_fields[$key] = [];
-  
+
           foreach ($keys as $attr) {
             $formatted_current_fields[$key][$attr] = [
                   '#value' => $value[$attr]
@@ -107,7 +110,23 @@ function data_dictionary_widget_form_alter(&$form, &$form_state, $form_id) {
       $form["field_json_metadata"]["widget"][0]["identifier"]['#default_value'] = $uuid;
       $form["field_json_metadata"]["widget"][0]["identifier"]['#description'] = t('<div class="form-item__description">This is the UUID of this Data Dictionary. To assign this data dictionary to a specific distribution use this <a href="/api/1/metastore/schemas/data-dictionary/items/' .$uuid. '" target="_blank">URL</a>.</div>');
     }
+
+    foreach (array_keys($form['actions']) as $action) {
+      if ( isset($form['actions'][$action]['#type'])
+        && $form['actions'][$action]['#type'] === 'submit') {
+        $form['actions']['submit']['#submit'][] = 'data_dictionary_widget_form_submit';
+      }
+    }
   }
+}
+
+function data_dictionary_widget_form_submit($form, FormStateInterface $form_state) {
+  $url = Url::fromRoute('metastore.data_dictionary');
+  // $form_state->setRedirectUrl($url);
+
+  $response = new RedirectResponse($url->toString());
+  $response->send();
+  return;
 }
 
 /**
@@ -120,7 +139,7 @@ function data_dictionary_widget_validate_unique_identifier($form, &$form_state) 
 
   if (isset($form["field_json_metadata"]["widget"][0]["identifier"]["#value"])) {
     $submitted_identifier = $form["field_json_metadata"]["widget"][0]["identifier"]["#value"];
-    
+
     foreach ($existing_data_dictionary_nodes as $node) {
       if ($current_nid !== $node["nid"] && strtolower($submitted_identifier) === strtolower($node["identifier"])) {
         $form_state->setError($form["field_json_metadata"]["widget"][0]["identifier"], 'The identifier you entered is taken. Please choose another one.');

--- a/modules/metastore/metastore.install
+++ b/modules/metastore/metastore.install
@@ -145,8 +145,15 @@ function metastore_update_8009() {
     $dict->save();
     $count++;
   }
-  return t("Updated $count dictionaries. If you have overridden DKAN's core schemas, 
+  return t("Updated $count dictionaries. If you have overridden DKAN's core schemas,
     you must update your site's data dictionary schema after this update. Copy
     modules/contrib/dkan/schema/collections/data-dictionary.json over you local
     site version before attempting to read or write any data dictionaries.");
+}
+
+/**
+ * Enable data dictionary widget.
+ */
+function metastore_update_8010() {
+  \Drupal::service('module_installer')->install(['data_dictionary_widget']);
 }

--- a/modules/metastore/metastore.install
+++ b/modules/metastore/metastore.install
@@ -150,10 +150,3 @@ function metastore_update_8009() {
     modules/contrib/dkan/schema/collections/data-dictionary.json over you local
     site version before attempting to read or write any data dictionaries.");
 }
-
-/**
- * Enable data dictionary widget.
- */
-function metastore_update_8010() {
-  \Drupal::service('module_installer')->install(['data_dictionary_widget']);
-}


### PR DESCRIPTION
When user submits a new data dictionary, and it saves successfully, user should end up on /admin/dkan/data-dictionaries.

## QA Steps

- [ ] checkout this branch
- [ ] ddev dkan-site-install
- [ ] ddev drush uli
- [ ] Under the DKAN menu, select Datasets > Create
- [ ] Save new dataset
- [ ] Confirm you end up on the datasets admin view
- [ ] Under the DKAN menu, select Data Dictionary > Create
- [ ] Save new data dictionary
- [ ] Confirm you end up on the data dictionary admin view
