### PR TITLE
Data Dictionary Data Types

### DIFF
--- a/modules/data_dictionary_widget/src/Fields/FieldAddCreation.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldAddCreation.php
@@ -63,8 +63,11 @@ class FieldAddCreation {
       '#options' => [
         'string' => t('String'),
         'date' => t('Date'),
+        'datetime' => t('Datetime'),
         'integer' => t('Integer'),
         'number' => t('Number'),
+        'year' => t('Year'),
+        'boolean' => t('Boolean'),
       ],
       '#ajax' => [
         'callback' => '\Drupal\data_dictionary_widget\Fields\FieldCallbacks::updateFormatOptions',

--- a/modules/data_dictionary_widget/src/Fields/FieldAddCreation.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldAddCreation.php
@@ -86,7 +86,7 @@ class FieldAddCreation {
       '#type' => 'select',
       '#required' => TRUE,
       '#title' => 'Format',
-      '#description' => FieldOperations::generateFormatDescription("string"),
+      '#description' => FieldOperations::generateFormats("string", "description"),
       '#default_value' => 'default',
       '#prefix' => '<div id = field-json-metadata-format>',
       '#suffix' => '</div>',

--- a/modules/data_dictionary_widget/src/Fields/FieldCallbacks.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldCallbacks.php
@@ -27,8 +27,8 @@ class FieldCallbacks {
       $data_type = $field[0]["dictionary_fields"]["data"][$field_index]["field_collection"]["type"] ?? 'string';
     }
 
-    $format_field['#description'] = FieldOperations::generateFormatDescription($data_type);
-    $options = FieldOperations::setFormatOptions($data_type);
+    $format_field['#description'] = FieldOperations::generateFormats($data_type, "description");
+    $options = FieldOperations::generateFormats($data_type, "options");
 
     $format_field["#options"] = $options;
 

--- a/modules/data_dictionary_widget/src/Fields/FieldEditCreation.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldEditCreation.php
@@ -63,15 +63,15 @@ class FieldEditCreation {
    * Create Format field.
    */
   private static function createFormat($key, $current_fields) {
-    $format_options = FieldOperations::setFormatOptions($current_fields[$key]['type']);
-    $value = in_array($current_fields[$key]['format'], $format_options) ? $current_fields[$key]['format'] : 'other';
+    $format_options = FieldOperations::generateFormats($current_fields[$key]['type'], "options");
+    $value = in_array($current_fields[$key]['format'], $format_options, true) ? $current_fields[$key]['format'] : 'other';
     return [
       '#name' => 'field_json_metadata[0][dictionary_fields][data][' . $key . '][field_collection][format]',
       '#type' => 'select',
       '#required' => TRUE,
       '#title' => 'Format',
       '#default_value' => 'default',
-      '#description' => FieldOperations::generateFormatDescription($current_fields[$key]['type']),
+      '#description' => FieldOperations::generateFormats($current_fields[$key]['type'], "description"),
       '#value' => $value,
       '#prefix' => '<div id = field-json-metadata-' . $key . '-format>',
       '#suffix' => '</div>',
@@ -84,7 +84,7 @@ class FieldEditCreation {
    * Create Format Other field.
    */
   private static function createFormatOther($key, $current_fields) {
-    $format_options = FieldOperations::setFormatOptions($current_fields[$key]['type']);
+    $format_options = FieldOperations::generateFormats($current_fields[$key]['type'], "options");
     $value = !in_array($current_fields[$key]['format'], $format_options) ? $current_fields[$key]['format'] : NULL;
 
     return [

--- a/modules/data_dictionary_widget/src/Fields/FieldEditCreation.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldEditCreation.php
@@ -64,7 +64,7 @@ class FieldEditCreation {
    */
   private static function createFormat($key, $current_fields) {
     $format_options = FieldOperations::generateFormats($current_fields[$key]['type'], "options");
-    $value = in_array($current_fields[$key]['format'], $format_options, true) ? $current_fields[$key]['format'] : 'other';
+    $value = in_array($current_fields[$key]['format'], $format_options, TRUE) ? $current_fields[$key]['format'] : 'other';
     return [
       '#name' => 'field_json_metadata[0][dictionary_fields][data][' . $key . '][field_collection][format]',
       '#type' => 'select',

--- a/modules/data_dictionary_widget/src/Fields/FieldOperations.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldOperations.php
@@ -62,10 +62,9 @@ class FieldOperations {
    *
    * @param string $dataType
    *   Field data type.
-   *
    * @param string $property
    *   Property of array.
-   * 
+   *
    * @return string|array
    *   Description information or options list.
    *

--- a/modules/data_dictionary_widget/src/Fields/FieldOperations.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldOperations.php
@@ -118,7 +118,7 @@ class FieldOperations {
    */
   public static function setFormatOptions($dataType) {
 
-    $options = null;
+    $options = NULL;
 
     switch ($dataType) {
       case 'string':

--- a/modules/data_dictionary_widget/src/Fields/FieldOperations.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldOperations.php
@@ -74,7 +74,11 @@ class FieldOperations {
     }
 
     if ($dataType === 'date') {
-      $description = FieldValues::returnDateInfo('description');
+      $description .= FieldValues::returnDateInfo('description');
+    }
+
+    if ($dataType === 'datetime') {
+      $description .= FieldValues::returnDateTimeInfo('description');
     }
 
     if ($dataType === 'integer') {
@@ -84,6 +88,15 @@ class FieldOperations {
     if ($dataType === 'number') {
       $description .= FieldValues::returnNumberInfo('description');
     }
+
+    if ($dataType === 'year') {
+      $description .= FieldValues::returnYearInfo('description');
+    }
+
+    if ($dataType === 'boolean') {
+      $description .= FieldValues::returnBooleanInfo('description');
+    }
+
     return $description;
   }
 
@@ -106,12 +119,24 @@ class FieldOperations {
       $options = FieldValues::returnDateInfo('options');
     }
 
+    if ($dataType === 'datetime') {
+      $options = FieldValues::returnDateTimeInfo('options');
+    }
+
     if ($dataType === 'integer') {
       $options = FieldValues::returnIntegerInfo('options');
     }
 
     if ($dataType === 'number') {
       $options = FieldValues::returnNumberInfo('options');
+    }
+
+    if ($dataType === 'year') {
+      $options = FieldValues::returnYearInfo('options');
+    }
+
+    if ($dataType === 'boolean') {
+      $options = FieldValues::returnBooleanInfo('options');
     }
 
     return $options;
@@ -169,8 +194,11 @@ class FieldOperations {
     return [
       'string' => t('String'),
       'date' => t('Date'),
+      'datetime' => t('Datetime'),
       'integer' => t('Integer'),
       'number' => t('Number'),
+      'year' => t('Year'),
+      'boolean' => t('Boolean'),
     ];
   }
 
@@ -310,10 +338,16 @@ class FieldOperations {
    *   The form array to be modified.
    */
   public static function resetDateFormatOptions(array &$form) {
-    $field_collection = isset($form["field_json_metadata"]["widget"][0]["dictionary_fields"]["field_collection"]);
-    if ($field_collection && $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["field_collection"]["group"]["type"]["#value"] === "date") {
-      $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["field_collection"]["group"]["format"]["#options"] = FieldValues::returnDateInfo('options');
-      $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["field_collection"]["group"]["format"]["#description"] = FieldValues::returnDateInfo('description');
+    $data_type = $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["field_collection"]["group"]["type"]["#value"] ?? null;
+
+    if ($data_type && ($data_type === "date" || $data_type === "datetime")) {
+        $options = $data_type === "date" ? FieldValues::returnDateInfo('options') : FieldValues::returnDateTimeInfo('options');
+        $descr = $data_type === "date" ? FieldValues::returnDateInfo('description') : FieldValues::returnDateTimeInfo('description');
+        if ($options && $descr) {
+            $formatField =& $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["field_collection"]["group"]["format"];
+            $formatField["#options"] = $options;
+            $formatField["#description"] = $descr;
+        }
     }
   }
 

--- a/modules/data_dictionary_widget/src/Fields/FieldOperations.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldOperations.php
@@ -63,6 +63,9 @@ class FieldOperations {
    * @param string $dataType
    *   Field data type.
    *
+   * @param string $property
+   *   Property of array.
+   * 
    * @return string|array
    *   Description information or options list.
    *

--- a/modules/data_dictionary_widget/src/Fields/FieldOperations.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldOperations.php
@@ -65,36 +65,37 @@ class FieldOperations {
    *
    * @return string
    *   Description information.
+   * 
+   * @throws \InvalidArgumentException
    */
   public static function generateFormatDescription($dataType) {
     $description = "<p>The format of the data in this field. Supported formats depend on the specified field type:</p>";
 
-    if ($dataType === 'string') {
-      $description .= FieldValues::returnStringInfo('description');
-    }
-
-    if ($dataType === 'date') {
-      $description .= FieldValues::returnDateInfo('description');
-    }
-
-    if ($dataType === 'datetime') {
-      $description .= FieldValues::returnDateTimeInfo('description');
-    }
-
-    if ($dataType === 'integer') {
-      $description .= FieldValues::returnIntegerInfo('description');
-    }
-
-    if ($dataType === 'number') {
-      $description .= FieldValues::returnNumberInfo('description');
-    }
-
-    if ($dataType === 'year') {
-      $description .= FieldValues::returnYearInfo('description');
-    }
-
-    if ($dataType === 'boolean') {
-      $description .= FieldValues::returnBooleanInfo('description');
+    switch ($dataType) {
+      case 'string':
+        $description .= FieldValues::returnStringInfo('description');
+        break;
+      case 'date':
+        $description .= FieldValues::returnDateInfo('description');
+        break;
+      case 'datetime':
+        $description .= FieldValues::returnDateTimeInfo('description');
+        break;
+      case 'integer':
+        $description .= FieldValues::returnIntegerInfo('description');
+        break;
+      case 'number':
+        $description .= FieldValues::returnNumberInfo('description');
+        break;
+      case 'year':
+        $description .= FieldValues::returnYearInfo('description');
+        break;
+      case 'boolean':
+        $description .= FieldValues::returnBooleanInfo('description');
+        break;
+      default:
+        throw new \InvalidArgumentException("Unexpected data type: $dataType");
+        break;
     }
 
     return $description;
@@ -111,35 +112,24 @@ class FieldOperations {
    */
   public static function setFormatOptions($dataType) {
 
-    if ($dataType === 'string') {
-      $options = FieldValues::returnStringInfo('options');
+    switch ($dataType) {
+      case 'string':
+        return FieldValues::returnStringInfo('options');
+      case 'date':
+        return FieldValues::returnDateInfo('options');
+      case 'datetime':
+        return FieldValues::returnDateTimeInfo('options');
+      case 'integer':
+        return FieldValues::returnIntegerInfo('options');
+      case 'number':
+        return FieldValues::returnNumberInfo('options');
+      case 'year':
+        return FieldValues::returnYearInfo('options');
+      case 'boolean':
+        return FieldValues::returnBooleanInfo('options');
+      default:
+        return NULL;
     }
-
-    if ($dataType === 'date') {
-      $options = FieldValues::returnDateInfo('options');
-    }
-
-    if ($dataType === 'datetime') {
-      $options = FieldValues::returnDateTimeInfo('options');
-    }
-
-    if ($dataType === 'integer') {
-      $options = FieldValues::returnIntegerInfo('options');
-    }
-
-    if ($dataType === 'number') {
-      $options = FieldValues::returnNumberInfo('options');
-    }
-
-    if ($dataType === 'year') {
-      $options = FieldValues::returnYearInfo('options');
-    }
-
-    if ($dataType === 'boolean') {
-      $options = FieldValues::returnBooleanInfo('options');
-    }
-
-    return $options;
 
   }
 
@@ -338,16 +328,20 @@ class FieldOperations {
    *   The form array to be modified.
    */
   public static function resetDateFormatOptions(array &$form) {
-    $data_type = $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["field_collection"]["group"]["type"]["#value"] ?? null;
+    $data_type = $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["field_collection"]["group"]["type"]["#value"] ?? NULL;
 
-    if ($data_type && ($data_type === "date" || $data_type === "datetime")) {
-        $options = $data_type === "date" ? FieldValues::returnDateInfo('options') : FieldValues::returnDateTimeInfo('options');
-        $descr = $data_type === "date" ? FieldValues::returnDateInfo('description') : FieldValues::returnDateTimeInfo('description');
-        if ($options && $descr) {
-            $formatField =& $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["field_collection"]["group"]["format"];
-            $formatField["#options"] = $options;
-            $formatField["#description"] = $descr;
-        }
+    if (!$data_type || ($data_type !== "date" && $data_type !== "datetime")) {
+      return;
+    }
+
+    $options_method = ($data_type === "date") ? 'returnDateInfo' : 'returnDateTimeInfo';
+    $options = FieldValues::$options_method('options');
+    $description = FieldValues::$options_method('description');
+
+    if ($options && $description) {
+      $format_field =& $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["field_collection"]["group"]["format"];
+      $format_field["#options"] = $options;
+      $format_field["#description"] = $description;
     }
   }
 

--- a/modules/data_dictionary_widget/src/Fields/FieldOperations.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldOperations.php
@@ -65,7 +65,7 @@ class FieldOperations {
    *
    * @return string
    *   Description information.
-   * 
+   *
    * @throws \InvalidArgumentException
    */
   public static function generateFormatDescription($dataType) {
@@ -73,32 +73,38 @@ class FieldOperations {
 
     switch ($dataType) {
       case 'string':
-        $description .= FieldValues::returnStringInfo('description');
+        $info = FieldValues::returnStringInfo('description');
         break;
+
       case 'date':
-        $description .= FieldValues::returnDateInfo('description');
+        $info = FieldValues::returnDateInfo('description');
         break;
+
       case 'datetime':
-        $description .= FieldValues::returnDateTimeInfo('description');
+        $info = FieldValues::returnDateTimeInfo('description');
         break;
+
       case 'integer':
-        $description .= FieldValues::returnIntegerInfo('description');
+        $info = FieldValues::returnIntegerInfo('description');
         break;
+
       case 'number':
-        $description .= FieldValues::returnNumberInfo('description');
+        $info = FieldValues::returnNumberInfo('description');
         break;
+
       case 'year':
-        $description .= FieldValues::returnYearInfo('description');
+        $info = FieldValues::returnYearInfo('description');
         break;
+
       case 'boolean':
-        $description .= FieldValues::returnBooleanInfo('description');
+        $info = FieldValues::returnBooleanInfo('description');
         break;
+
       default:
         throw new \InvalidArgumentException("Unexpected data type: $dataType");
-        break;
     }
 
-    return $description;
+    return $description . $info;
   }
 
   /**
@@ -112,24 +118,42 @@ class FieldOperations {
    */
   public static function setFormatOptions($dataType) {
 
+    $options = null;
+
     switch ($dataType) {
       case 'string':
-        return FieldValues::returnStringInfo('options');
+        $options = FieldValues::returnStringInfo('options');
+        break;
+
       case 'date':
-        return FieldValues::returnDateInfo('options');
+        $options = FieldValues::returnDateInfo('options');
+        break;
+
       case 'datetime':
-        return FieldValues::returnDateTimeInfo('options');
+        $options = FieldValues::returnDateTimeInfo('options');
+        break;
+
       case 'integer':
-        return FieldValues::returnIntegerInfo('options');
+        $options = FieldValues::returnIntegerInfo('options');
+        break;
+
       case 'number':
-        return FieldValues::returnNumberInfo('options');
+        $options = FieldValues::returnNumberInfo('options');
+        break;
+
       case 'year':
-        return FieldValues::returnYearInfo('options');
+        $options = FieldValues::returnYearInfo('options');
+        break;
+
       case 'boolean':
-        return FieldValues::returnBooleanInfo('options');
+        $options = FieldValues::returnBooleanInfo('options');
+        break;
+
       default:
-        return NULL;
+        throw new \InvalidArgumentException("Unexpected data type: $dataType");
     }
+
+    return $options;
 
   }
 

--- a/modules/data_dictionary_widget/src/Fields/FieldOperations.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldOperations.php
@@ -63,98 +63,48 @@ class FieldOperations {
    * @param string $dataType
    *   Field data type.
    *
-   * @return string
-   *   Description information.
+   * @return string|array
+   *   Description information or options list.
    *
    * @throws \InvalidArgumentException
    */
-  public static function generateFormatDescription($dataType) {
+  public static function generateFormats($dataType, $property) {
     $description = "<p>The format of the data in this field. Supported formats depend on the specified field type:</p>";
 
     switch ($dataType) {
       case 'string':
-        $info = FieldValues::returnStringInfo('description');
+        $info = FieldValues::returnStringInfo($property);
         break;
 
       case 'date':
-        $info = FieldValues::returnDateInfo('description');
+        $info = FieldValues::returnDateInfo($property);
         break;
 
       case 'datetime':
-        $info = FieldValues::returnDateTimeInfo('description');
+        $info = FieldValues::returnDateTimeInfo($property);
         break;
 
       case 'integer':
-        $info = FieldValues::returnIntegerInfo('description');
+        $info = FieldValues::returnIntegerInfo($property);
         break;
 
       case 'number':
-        $info = FieldValues::returnNumberInfo('description');
+        $info = FieldValues::returnNumberInfo($property);
         break;
 
       case 'year':
-        $info = FieldValues::returnYearInfo('description');
+        $info = FieldValues::returnYearInfo($property);
         break;
 
       case 'boolean':
-        $info = FieldValues::returnBooleanInfo('description');
+        $info = FieldValues::returnBooleanInfo($property);
         break;
 
       default:
         throw new \InvalidArgumentException("Unexpected data type: $dataType");
     }
 
-    return $description . $info;
-  }
-
-  /**
-   * Function to generate the options for the "Format" field.
-   *
-   * @param string $dataType
-   *   Field data type.
-   *
-   * @return array
-   *   List of format options.
-   */
-  public static function setFormatOptions($dataType) {
-
-    $options = NULL;
-
-    switch ($dataType) {
-      case 'string':
-        $options = FieldValues::returnStringInfo('options');
-        break;
-
-      case 'date':
-        $options = FieldValues::returnDateInfo('options');
-        break;
-
-      case 'datetime':
-        $options = FieldValues::returnDateTimeInfo('options');
-        break;
-
-      case 'integer':
-        $options = FieldValues::returnIntegerInfo('options');
-        break;
-
-      case 'number':
-        $options = FieldValues::returnNumberInfo('options');
-        break;
-
-      case 'year':
-        $options = FieldValues::returnYearInfo('options');
-        break;
-
-      case 'boolean':
-        $options = FieldValues::returnBooleanInfo('options');
-        break;
-
-      default:
-        throw new \InvalidArgumentException("Unexpected data type: $dataType");
-    }
-
-    return $options;
-
+    return ($property === "description") ? ($description . $info) : $info;
   }
 
   /**
@@ -332,8 +282,8 @@ class FieldOperations {
     ]);
 
     if ($type) {
-      $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["edit_fields"][$index]["format"]["#options"] = FieldOperations::setFormatOptions($type);
-      $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["edit_fields"][$index]["format"]["#description"] = FieldOperations::generateFormatDescription($type);
+      $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["edit_fields"][$index]["format"]["#options"] = FieldOperations::generateFormats($type, "options");
+      $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["edit_fields"][$index]["format"]["#description"] = FieldOperations::generateFormats($type, "description");
     }
   }
 

--- a/modules/data_dictionary_widget/src/Fields/FieldValues.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldValues.php
@@ -26,7 +26,7 @@ class FieldValues {
   }
 
   /**
-   * Retrun information about the string field option.
+   * Return information about the string field option.
    */
   public static function returnStringInfo($type) {
     if ($type == 'options') {
@@ -52,7 +52,7 @@ class FieldValues {
   }
 
   /**
-   * Retrun information about the date field option.
+   * Return information about the date field option.
    */
   public static function returnDateInfo($type) {
     if ($type == 'options') {
@@ -74,7 +74,29 @@ class FieldValues {
   }
 
   /**
-   * Retrun information about the integer field option.
+   * Return information about the datetime field option.
+   */
+  public static function returnDateTimeInfo($type) {
+    if ($type == 'options') {
+      return [
+        'default' => 'default',
+        'any' => 'any',
+        'other' => 'other',
+      ];
+    }
+    elseif ($type == 'description') {
+      return "
+        <ul>
+          <li><b>default</b>: An ISO8601 format string of datetime.</li>
+          <li><b>any</b>: Any parsable representation of a date. The implementing library can attept to parse the datetime via a range of strategies.</li>
+          <li><b>other</b>: If your date values follow a collective but non-ISO8601 pattern, select this option and define the incoming format using the syntax of <a href='https://strftime.org/'>C / Python strftime</a>.
+            For example, if your data had dates formatted as MM/DD/YYYY, you would enter %m/%d/%Y into the Other format field.</li>
+        </ul>";
+    }
+  }
+
+  /**
+   * Return information about the integer field option.
    */
   public static function returnIntegerInfo($type) {
     if ($type == 'options') {
@@ -91,9 +113,43 @@ class FieldValues {
   }
 
   /**
-   * Retrun information about the number field option.
+   * Return information about the number field option.
    */
   public static function returnNumberInfo($type) {
+    if ($type == 'options') {
+      return [
+        'default' => 'default',
+      ];
+    }
+    elseif ($type == 'description') {
+      return "
+        <ul>
+          <li><b>default</b>: Any valid string.</li>
+        </ul>";
+    }
+  }
+
+  /**
+   * Return information about the year field option.
+   */
+  public static function returnYearInfo($type) {
+    if ($type == 'options') {
+      return [
+        'default' => 'default',
+      ];
+    }
+    elseif ($type == 'description') {
+      return "
+        <ul>
+          <li><b>default</b>: Any valid string.</li>
+        </ul>";
+    }
+  }
+
+  /**
+   * Return information about the year field option.
+   */
+  public static function returnBooleanInfo($type) {
     if ($type == 'options') {
       return [
         'default' => 'default',

--- a/modules/data_dictionary_widget/src/Fields/FieldValues.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldValues.php
@@ -124,7 +124,7 @@ class FieldValues {
     elseif ($type == 'description') {
       return "
         <ul>
-          <li><b>default</b>: Any valid string.</li>
+          <li><b>default</b>: An exact fixed-point number. No non-numeric characters allowed other than the decimal.</li>
         </ul>";
     }
   }

--- a/modules/data_dictionary_widget/src/Fields/FieldValues.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldValues.php
@@ -141,7 +141,7 @@ class FieldValues {
     elseif ($type == 'description') {
       return "
         <ul>
-          <li><b>default</b>: Any valid string.</li>
+          <li><b>default</b>: 4-digit numbers in the range 1901 to 2155.</li>
         </ul>";
     }
   }
@@ -158,7 +158,7 @@ class FieldValues {
     elseif ($type == 'description') {
       return "
         <ul>
-          <li><b>default</b>: Any valid string.</li>
+          <li><b>default</b>: 1/0 values, or True/False values (not case sensitive).</li>
         </ul>";
     }
   }

--- a/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildTest.php
+++ b/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildTest.php
@@ -4,12 +4,9 @@ namespace Drupal\Tests\data_dictionary_widget\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Drupal\data_dictionary_widget\Fields\FieldAddCreation;
-use Drupal\data_dictionary_widget\Fields\FieldButtons;
 use Drupal\data_dictionary_widget\Fields\FieldCallbacks;
 use Drupal\data_dictionary_widget\Fields\FieldCreation;
-use Drupal\data_dictionary_widget\Fields\FieldEditCreation;
 use Drupal\data_dictionary_widget\Fields\FieldOperations;
-use Drupal\data_dictionary_widget\Fields\FieldValues;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityFormInterface;
@@ -212,6 +209,8 @@ class DataDictionaryWidgetBuildTest extends TestCase {
       ]
     ];
 
+    
+
     $dataDictionaryWidget = new DataDictionaryWidget (
       $plugin_id,
       $plugin_definition,
@@ -392,8 +391,8 @@ class DataDictionaryWidgetBuildTest extends TestCase {
     $user_input = [
       'field_json_metadata' => [
         0 => [
-          'identifier' => 'Kaise',
-          'title' => 'Kaise',
+          'identifier' => 'test_identifier',
+          'title' => 'test_title',
           'dictionary_fields' => [
             'data' => [
               0 => [

--- a/modules/data_dictionary_widget/tests/src/Unit/FieldCallbacksTest.php
+++ b/modules/data_dictionary_widget/tests/src/Unit/FieldCallbacksTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Drupal\Tests\data_dictionary_widget\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Drupal\data_dictionary_widget\Fields\FieldCallbacks;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Test class for FieldCallback.
+ *
+ * @group dkan
+ * @group data_dictionary_widget
+ * @group unit
+ */
+class FieldCallbacksTest extends TestCase {
+
+  public function testDescriptionsAndFormats() {
+    $formState = $this->createMock(FormStateInterface::class);
+
+    $types = ['string', 'date', 'datetime', 'integer', 'number', 'year', 'boolean'];
+
+    $field_json_metadata_string = [
+      [
+        'identifier' => 'test_identifier',
+        'title' => 'test_title',
+        'dictionary_fields' => [
+          'field_collection' => [
+            'group' => [
+              'name' => 'test_edit',
+              'title' => 'test_edit',
+              'type' => 'string',
+              'format' => 'default',
+              'format_other' => '',
+              'description' => 'test_edit',
+            ]
+          ]
+        ]
+      ]
+    ];
+
+    $field_json_metadata_date = [
+      [
+        'identifier' => 'test_identifier',
+        'title' => 'test_title',
+        'dictionary_fields' => [
+          'field_collection' => [
+            'group' => [
+              'name' => 'test_edit',
+              'title' => 'test_edit',
+              'type' => 'date',
+              'format' => 'default',
+              'format_other' => '',
+              'description' => 'test_edit',
+            ]
+          ]
+        ]
+      ]
+    ];
+
+    $field_json_metadata_datetime = [
+      [
+        'identifier' => 'test_identifier',
+        'title' => 'test_title',
+        'dictionary_fields' => [
+          'field_collection' => [
+            'group' => [
+              'name' => 'test_edit',
+              'title' => 'test_edit',
+              'type' => 'datetime',
+              'format' => 'default',
+              'format_other' => '',
+              'description' => 'test_edit',
+            ]
+          ]
+        ]
+      ]
+    ];
+
+    $field_json_metadata_integer = [
+      [
+        'identifier' => 'test_identifier',
+        'title' => 'test_title',
+        'dictionary_fields' => [
+          'field_collection' => [
+            'group' => [
+              'name' => 'test_edit',
+              'title' => 'test_edit',
+              'type' => 'integer',
+              'format' => 'default',
+              'format_other' => '',
+              'description' => 'test_edit',
+            ]
+          ]
+        ]
+      ]
+    ];
+
+    $field_json_metadata_number = [
+      [
+        'identifier' => 'test_identifier',
+        'title' => 'test_title',
+        'dictionary_fields' => [
+          'field_collection' => [
+            'group' => [
+              'name' => 'test_edit',
+              'title' => 'test_edit',
+              'type' => 'number',
+              'format' => 'default',
+              'format_other' => '',
+              'description' => 'test_edit',
+            ]
+          ]
+        ]
+      ]
+    ];
+
+    $field_json_metadata_year = [
+      [
+        'identifier' => 'test_identifier',
+        'title' => 'test_title',
+        'dictionary_fields' => [
+          'field_collection' => [
+            'group' => [
+              'name' => 'test_edit',
+              'title' => 'test_edit',
+              'type' => 'year',
+              'format' => 'default',
+              'format_other' => '',
+              'description' => 'test_edit',
+            ]
+          ]
+        ]
+      ]
+    ];
+
+    $field_json_metadata_boolean = [
+      [
+        'identifier' => 'test_identifier',
+        'title' => 'test_title',
+        'dictionary_fields' => [
+          'field_collection' => [
+            'group' => [
+              'name' => 'test_edit',
+              'title' => 'test_edit',
+              'type' => 'boolean',
+              'format' => 'default',
+              'format_other' => '',
+              'description' => 'test_edit',
+            ]
+          ]
+        ]
+      ]
+    ];
+
+    $field_json_metadata_variables = [
+      'string' => $field_json_metadata_string,
+      'date' => $field_json_metadata_date,
+      'datetime' => $field_json_metadata_datetime,
+      'integer' => $field_json_metadata_integer,
+      'number' => $field_json_metadata_number,
+      'year' => $field_json_metadata_year,
+      'boolean' => $field_json_metadata_boolean,
+    ];
+
+    $formState->method('getValue')
+      ->with(['field_json_metadata'])
+      ->willReturnOnConsecutiveCalls(
+        $field_json_metadata_string,
+        $field_json_metadata_date,
+        $field_json_metadata_datetime,
+        $field_json_metadata_integer,
+        $field_json_metadata_number,
+        $field_json_metadata_year,
+        $field_json_metadata_boolean
+      );
+
+    $trigger = ['#op' => 'type'];
+
+    $formState->expects($this->any())
+      ->method('getTriggeringElement')
+      ->willReturn($trigger);
+
+    $form["field_json_metadata"]["widget"][0]['dictionary_fields']["field_collection"]["group"]["format"] = [
+      '#description' => '',
+      '#options' => [],
+    ];
+
+    foreach ($types as $type) {
+      $format_field = FieldCallbacks::updateFormatOptions($form, $formState);
+      $field_json_metadata_type = $field_json_metadata_variables[$type];
+      $field_json_metadata = $field_json_metadata_type[0]['dictionary_fields']['field_collection']['group']['type'];
+
+      $this->assertEquals($type, $field_json_metadata);
+      $this->assertNotNull($format_field["#description"]);
+      $this->assertNotNull($format_field["#options"]);
+    }
+  }
+}


### PR DESCRIPTION
fixes [org/repo/issue#]

- [x] Test coverage exists
- [x] Documentation exists

## QA Steps

- [ ] Navigate to Data Dictionary Form here /node/add/data?schema=data-dictionary
- [ ] Fill out required fields
- [ ] Select Add field
- [ ] Confirm you see these new data types under the Data type dropdown:
datetime
year
boolean
- [ ] Select datetime and confirm you see the following format options
default
any
other
- [ ] Select year and confirm you see the following format options
default
- [ ] Select boolean and confirm you see the following format options
default
- [ ] Confirm when selecting each data type that the description below shows the correct descriptions.
- [ ] Datetime
The format of the data in this field. Supported formats depend on the specified field type:
default: An ISO8601 format string of datetime.
any: Any parsable representation of a date. The implementing library can attept to parse the datetime via a range of strategies.
other: If your date values follow a collective but non-ISO8601 pattern, select this option and define the incoming format using the syntax of [C / Python strftime](https://strftime.org/). For example, if your data had dates formatted as MM/DD/YYYY, you would enter %m/%d/%Y into the Other format field.
- [ ] Year
The format of the data in this field. Supported formats depend on the specified field type:
default: 4-digit numbers in the range 1901 to 2155.
- [ ] Boolean
The format of the data in this field. Supported formats depend on the specified field type:
default: 1/0 values, or True/False values (not case sensitive).
- [ ] Continue adding/editing fields and confirm all the above still functions correctly.
