### PR TITLE
#4174: Allow to activate trailing delimiter for CSV parser

### DIFF
--- a/modules/datastore/src/Service/ImportService.php
+++ b/modules/datastore/src/Service/ImportService.php
@@ -208,7 +208,7 @@ class ImportService {
     $parserConfiguration = $this->dispatchEvent(self::EVENT_CONFIGURE_PARSER, $parserConfiguration);
 
     $parser = Csv::getParser($parserConfiguration['delimiter'], $parserConfiguration['quote'], $parserConfiguration['escape'], $parserConfiguration['record_end']);
-    if (!empty($parserConfiguration['trailing_delimiter'])) {
+    if ($parserConfiguration['trailing_delimiter'] === TRUE) {
       $parser->activateTrailingDelimiter();
     }
     $parser->machine->stopRecording();

--- a/modules/datastore/src/Service/ImportService.php
+++ b/modules/datastore/src/Service/ImportService.php
@@ -202,11 +202,15 @@ class ImportService {
       'quote' => '"',
       'escape' => "\\",
       'record_end' => ["\n", "\r"],
+      'trailing_delimiter' => FALSE,
     ];
 
     $parserConfiguration = $this->dispatchEvent(self::EVENT_CONFIGURE_PARSER, $parserConfiguration);
 
     $parser = Csv::getParser($parserConfiguration['delimiter'], $parserConfiguration['quote'], $parserConfiguration['escape'], $parserConfiguration['record_end']);
+    if (!empty($parserConfiguration['trailing_delimiter'])) {
+      $parser->activateTrailingDelimiter();
+    }
     $parser->machine->stopRecording();
     return $parser;
   }


### PR DESCRIPTION
fixes #4174 

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] use a csv file with a trailing delimiter and note that the import will fail
- [ ] change the trailing_delimiter setting via EventSubscriber to true and note that the import (drush dkan:datastore:reimport) will now work
