### PR TITLE
Update the form alter in data dictionary widget to only target node_data_form

### DIFF
--- a/modules/data_dictionary_widget/data_dictionary_widget.module
+++ b/modules/data_dictionary_widget/data_dictionary_widget.module
@@ -76,7 +76,7 @@ function data_dictionary_widget__data_dictionary_data_type_checker($context) {
 function data_dictionary_widget_form_alter(&$form, &$form_state, $form_id) {
   $formObject = $form_state->getFormObject();
 
-  if ($formObject instanceof \Drupal\Core\Entity\EntityFormInterface) {
+  if ($formObject instanceof \Drupal\Core\Entity\EntityFormInterface && $form_id == 'node_data_form') {
     $entity = $formObject->getEntity();
     $data_type = $entity->get('field_data_type')->value;
     if (isset($form["field_json_metadata"]["widget"][0]["dictionary_fields"])) {

--- a/modules/data_dictionary_widget/data_dictionary_widget.module
+++ b/modules/data_dictionary_widget/data_dictionary_widget.module
@@ -75,8 +75,9 @@ function data_dictionary_widget__data_dictionary_data_type_checker($context) {
  */
 function data_dictionary_widget_form_alter(&$form, &$form_state, $form_id) {
   $formObject = $form_state->getFormObject();
+  $target_form_ids = ['node_data_edit_form', 'node_data_form'];
 
-  if ($formObject instanceof \Drupal\Core\Entity\EntityFormInterface && $form_id == 'node_data_form') {
+  if ($formObject instanceof \Drupal\Core\Entity\EntityFormInterface && in_array($form_id, $target_form_ids)) {
     $entity = $formObject->getEntity();
     $data_type = $entity->get('field_data_type')->value;
     if (isset($form["field_json_metadata"]["widget"][0]["dictionary_fields"])) {
@@ -93,9 +94,7 @@ function data_dictionary_widget_form_alter(&$form, &$form_state, $form_id) {
         $form['actions']['submit']['#submit'][] = 'data_dictionary_widget_form_submit';
       }
     }
-  }
 
-  if ($form_id == 'node_data_edit_form' || $form_id == 'node_data_form') {
     $form['#validate'][] = 'data_dictionary_widget_validate_unique_identifier';
     $current_fields = !empty($form["field_json_metadata"]["widget"][0]["dictionary_fields"]["current_fields"]) ? $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["current_fields"] : NULL;
 


### PR DESCRIPTION
Fixes error when trying to edit a user account.

```
InvalidArgumentException: Field field_data_type is unknown. in Drupal\Core\Entity\ContentEntityBase->getTranslatedField() (line 583 of core/lib/Drupal/Core/Entity/ContentEntityBase.php).

Drupal\Core\Entity\ContentEntityBase->get('field_data_type') (Line: 81)
data_dictionary_widget_form_alter(Array, Object, 'user_form') (Line: 545)
```

## QA Steps

- [x] drush en data_dictionary_widget
- [x] drush uli
- [x] Visit /user/1/edit
- [x] Confirm you do not see the error above.
- [x] Visit /node/add/data?schema=data-dictionary
- [x] Confirm you see the new DD form
