### PR TITLE
Show 100% when import done in info/dashboard.

### DIFF
--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -256,4 +256,9 @@ class MysqlImport extends ImportJob {
     ]);
   }
 
+  protected function getBytesProcessed() {
+    $chunksProcessed = $this->getStateProperty('chunksProcessed', 0);
+    return $chunksProcessed * self::BYTES_PER_CHUNK;
+  }
+
 }

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -256,9 +256,4 @@ class MysqlImport extends ImportJob {
     ]);
   }
 
-  protected function getBytesProcessed() {
-    $chunksProcessed = $this->getStateProperty('chunksProcessed', 0);
-    return $chunksProcessed * self::BYTES_PER_CHUNK;
-  }
-
 }

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -469,9 +469,9 @@ class DashboardForm extends FormBase {
             '#file_path' => UrlHostTokenResolver::resolve($dist['source_path']),
           ],
         ],
-        $this->buildStatusCell($dist['fetcher_status'], $dist['fetcher_percent_done']),
+        $this->buildStatusCell($dist['fetcher_status']),
         $this->buildStatusCell($dist['importer_status'], $dist['importer_percent_done'], $this->cleanUpError($dist['importer_error'])),
-        $this->buildPostImportStatusCell($status, $error),
+        $this->buildStatusCell($status, NULL, $error),
       ];
     }
     return ['', '', '', ''];
@@ -482,7 +482,7 @@ class DashboardForm extends FormBase {
    *
    * @param string $status
    *   Current job status.
-   * @param int $percentDone
+   * @param int|null $percentDone
    *   Percent done, 0-100.
    * @param null|string $error
    *   An error message, if any.
@@ -490,12 +490,12 @@ class DashboardForm extends FormBase {
    * @return array
    *   Renderable array.
    */
-  protected function buildStatusCell(string $status, int $percentDone, ?string $error = NULL) {
+  protected function buildStatusCell(string $status, ?int $percentDone = NULL, ?string $error = NULL) {
     return [
       'data' => [
         '#theme' => 'datastore_dashboard_status_cell',
         '#status' => $status,
-        '#percent' => $percentDone,
+        '#percent' => $percentDone ?? NULL,
         '#error' => $error,
       ],
       'class' => str_replace('_', '-', $status),

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -471,7 +471,7 @@ class DashboardForm extends FormBase {
         ],
         $this->buildStatusCell($dist['fetcher_status']),
         $this->buildStatusCell($dist['importer_status'], $dist['importer_percent_done'], $this->cleanUpError($dist['importer_error'])),
-        $this->buildStatusCell($status, NULL, $error),
+        $this->buildPostImportStatusCell($status, NULL, $error),
       ];
     }
     return ['', '', '', ''];

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -471,7 +471,7 @@ class DashboardForm extends FormBase {
         ],
         $this->buildStatusCell($dist['fetcher_status']),
         $this->buildStatusCell($dist['importer_status'], $dist['importer_percent_done'], $this->cleanUpError($dist['importer_error'])),
-        $this->buildPostImportStatusCell($status, NULL, $error),
+        $this->buildPostImportStatusCell($status, $error),
       ];
     }
     return ['', '', '', ''];

--- a/modules/datastore/src/Service/Info/ImportInfo.php
+++ b/modules/datastore/src/Service/Info/ImportInfo.php
@@ -152,10 +152,14 @@ class ImportInfo {
    * @param \Procrastinator\Job\Job $job
    *   Either a FileFetcher or Importer object.
    *
-   * @return float
+   * @return float|null
    *   Percentage.
    */
-  private function getPercentDone(Job $job): float {
+  private function getPercentDone(Job $job): ?float {
+    // If the job is done, but precent < 100, NULL.
+    if ($job->getResult()->getStatus() == Result::DONE) {
+      return 100;
+    }
     $bytes = $this->getBytesProcessed($job);
     $filesize = $this->getFileSize($job);
     return ($filesize > 0) ? round($bytes / $filesize * 100) : 0;

--- a/modules/datastore/templates/datastore-dashboard-status-cell.html.twig
+++ b/modules/datastore/templates/datastore-dashboard-status-cell.html.twig
@@ -1,1 +1,1 @@
-{{ status }} (<span class="datastore-status-details">{{ error|default(percent ~ '%') }}</span>)
+{{ status }} {% if percent is not null %}(<span class="datastore-status-details">{{ error|default(percent ~ '%') }}</span>){% endif %}

--- a/modules/datastore/templates/datastore-dashboard-status-cell.html.twig
+++ b/modules/datastore/templates/datastore-dashboard-status-cell.html.twig
@@ -1,1 +1,1 @@
-{{ status }} {% if percent is not null %}(<span class="datastore-status-details">{{ error|default(percent ~ '%') }}</span>){% endif %}
+{{ status }} (<span class="datastore-status-details">{{ error|default(percent ~ '%') }}</span>)

--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -454,6 +454,12 @@ class DatasetBTBTest extends BrowserTestBase {
 
     $this->runQueues(['localize_import', 'datastore_import']);
 
+    // Assert dataset info shows 100%
+    $datasetInfoService = $this->container->get('dkan.common.dataset_info');
+    $metadata = $datasetInfoService->gather($dataset->identifier);
+    $dist = array_shift($metadata['latest_revision']['distributions']);
+    $this->assertEquals(100, $dist['fetcher_percent_done']);
+
     $queryString = '[SELECT * FROM ' . $this->getResourceDatastoreTable($resource) . '][WHERE lon = "61.33"][ORDER BY lat DESC][LIMIT 1 OFFSET 0];';
     $this->queryResource($resource, $queryString);
   }


### PR DESCRIPTION
In the output from dataset-info, and by extension in the datastore import dashboard, we have a longstanding issue where when using the mysql import module, the percent done stays at zero (0) even though the import process has finished. This is because the mysql importer performs the entire import at once and provides no feedback on amount complete. It was, in hindsight, not such a good idea to assume any job like this would provide "bites processed" information and build the whole dataset info gathering workflow around that assumption.

While the dataset info and datastore dashboard are probably both due for an overhaul, for now we just want coherent information provided to the user. We had two options:

1. Remove the percent done measure completely for import, as we did for filefetcher, or
2. Force the value to be 100 if the status is "done".

Since the percent done is still useful for people using the CSV parser, and the status value seems to be more reliable than the bytes processed value, I went with #2. This is definitely to be considered a stopgap.

## QA Steps

1. Install new vanilla site, enable datastore_mysql_import
2. Import sample content
3. Visit datastore import dashboard. Confirm that one any imports that are "done," it reads "100%" not "0%".