### PR TITLE
Allow null on getHarvestRunResult

### DIFF
--- a/modules/harvest/src/Entity/HarvestRun.php
+++ b/modules/harvest/src/Entity/HarvestRun.php
@@ -149,6 +149,7 @@ final class HarvestRun extends HarvestEntityBase implements HarvestRunInterface 
       $result['status']['extracted_items_ids'][] = $field->getString();
     }
 
+    $result['status']['orphan_ids'] = [];
     foreach ($this->get('orphan_uuid') as $field) {
       $result['status']['orphan_ids'][] = $field->getString();
     }

--- a/modules/harvest/src/HarvestService.php
+++ b/modules/harvest/src/HarvestService.php
@@ -255,7 +255,12 @@ class HarvestService implements ContainerInjectionInterface {
    *   Array of status info from the run.
    */
   public function getHarvestRunResult(string $plan_id, string $run_id): array {
-    return $this->runRepository->loadEntity($plan_id, $run_id)->toResult();
+    if ($entity = $this->runRepository->loadEntity($plan_id, $run_id)) {
+      return $entity->toResult();
+    }
+    else {
+      return [];
+    }
   }
 
   /**

--- a/modules/harvest/tests/src/Kernel/HarvestServiceTest.php
+++ b/modules/harvest/tests/src/Kernel/HarvestServiceTest.php
@@ -188,4 +188,36 @@ class HarvestServiceTest extends KernelTestBase {
     );
   }
 
+  /**
+   * @covers ::getHarvestRunResult
+   */
+  public function testGetHarvestRunResult() {
+    // There should be no harvest runs at the beginning of this test method, so
+    // getHarvestRunResult should return an empty array.
+    /** @var \Drupal\harvest\HarvestService $harvest_service */
+    $harvest_service = $this->container->get('dkan.harvest.service');
+    $this->assertEquals([], $harvest_service->getHarvestRunResult('any_plan', 'any_id'));
+
+    // Register a harvest and run it.
+    $plan_identifier = 'test_plan';
+    $plan = (object) [
+      'identifier' => $plan_identifier,
+      'extract' => (object) [
+        'type' => DataJson::class,
+        'uri' => 'file://' . realpath(__DIR__ . '/../../files/data.json'),
+      ],
+      'transforms' => [],
+      'load' => (object) [
+        'type' => Simple::class,
+      ],
+    ];
+    $this->assertEquals($plan_identifier, $harvest_service->registerHarvest($plan));
+
+    $run_result = $harvest_service->runHarvest($plan_identifier);
+    $this->assertNotEmpty($run_id = $run_result['identifier']);
+
+    // Compare the reloaded results to the ones from the original run.
+    $this->assertEquals($run_result, $harvest_service->getHarvestRunResult($plan_identifier, $run_id));
+  }
+
 }


### PR DESCRIPTION
fixes 20484
```
Error: Call to a member function toResult() on null in Drupal\harvest\HarvestService->getHarvestRunResult() (line 258 of modules/contrib/dkan/modules/harvest/src/HarvestService.php). 
```

## QA Steps

- [x] Stand up a local site with existing harvests.
- [x] ddev updb -y
- [x] ddev cr
- [x] Visit /admin/dkan/datastore/status
- [x] Confirm you see the dashboard and not the error
