### PR TITLE
Remove psr/log from reimport command

### DIFF
--- a/modules/datastore/src/Commands/ReimportCommands.php
+++ b/modules/datastore/src/Commands/ReimportCommands.php
@@ -5,7 +5,6 @@ namespace Drupal\datastore\Commands;
 use Drupal\common\DatasetInfo;
 use Drupal\datastore\DatastoreService;
 use Drush\Commands\DrushCommands;
-use Psr\Log\LoggerInterface;
 
 /**
  * Drush command file for data store reimportation.
@@ -35,17 +34,13 @@ class ReimportCommands extends DrushCommands {
    *   The dkan.datastore.service service.
    * @param \Drupal\common\DatasetInfo $dataset_info
    *   Dataset information service.
-   * @param \Psr\Log\LoggerInterface $loggerChannel
-   *   Logger channel service.
    */
   public function __construct(
     DatastoreService $datastore_service,
-    DatasetInfo $dataset_info,
-    LoggerInterface $loggerChannel
+    DatasetInfo $dataset_info
   ) {
     $this->datastoreService = $datastore_service;
     $this->datasetInfo = $dataset_info;
-    $this->setLogger($loggerChannel);
     parent::__construct();
   }
 


### PR DESCRIPTION
fixes 20258

```
TypeError: Drush\Commands\DrushCommands::logger(): Return value must be of type ?Drush\Log\DrushLoggerManager, Drupal\Core\Logger\LoggerChannel returned in /var/www/html/vendor/drush/drush/src/Commands/DrushCommands.php on line 85 #0 /var/www/html/dkan/modules/datastore/src/Commands/ReimportCommands.php(78): Drush\Commands\DrushCommands->logger()
#1 [internal function]: Drupal\datastore\Commands\ReimportCommands->datastoreReimport('a54d7605-b780-4...', Array)
#2 /var/www/html/vendor/consolidation/annotated-command/src/CommandProcessor.php(276): call_user_func_array(Array, Array)
#3 /var/www/html/vendor/consolidation/annotated-command/src/CommandProcessor.php(212): Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback(Array, Object(Consolidation\AnnotatedCommand\CommandData))
#4 /var/www/html/vendor/consolidation/annotated-command/src/CommandProcessor.php(176): Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter(Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#5 /var/www/html/vendor/consolidation/annotated-command/src/AnnotatedCommand.php(391): Consolidation\AnnotatedCommand\CommandProcessor->process(Object(Symfony\Component\Console\Output\ConsoleOutput), Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#6 /var/www/html/vendor/symfony/console/Command/Command.php(326): Consolidation\AnnotatedCommand\AnnotatedCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /var/www/html/vendor/symfony/console/Application.php(1096): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /var/www/html/vendor/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand(Object(Consolidation\AnnotatedCommand\AnnotatedCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /var/www/html/vendor/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 /var/www/html/vendor/drush/drush/src/Runtime/Runtime.php(110): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 /var/www/html/vendor/drush/drush/src/Runtime/Runtime.php(40): Drush\Runtime\Runtime->doRun(Array, Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /var/www/html/vendor/drush/drush/drush.php(139): Drush\Runtime\Runtime->run(Array)
#13 /var/www/html/vendor/drush/drush/drush(4): require('/var/www/html/v...')
#14 /var/www/html/vendor/bin/drush(119): include('/var/www/html/v...')
#15 {main}
TypeError: Drush\Commands\DrushCommands::logger(): Return value must be of type ?Drush\Log\DrushLoggerManager, Drupal\Core\Logger\LoggerChannel returned in Drush\Commands\DrushCommands->logger() (line 85 of /var/www/html/vendor/drush/drush/src/Commands/DrushCommands.php).
```

## QA Steps

- [ ] Get the dataset ID from a distribution with an existing datastore
- [ ] Run `drush dkan:datastore:reimport {uuid}`
- [ ] Confirm the import completes without error
