### PR TITLE
Check if downloadURL isset before rendering

### DIFF
--- a/modules/metastore/metastore.theme.inc
+++ b/modules/metastore/metastore.theme.inc
@@ -15,6 +15,7 @@ function metastore_preprocess_node__data(&$variables) {
   $json = $variables['node']->get('field_json_metadata')->value;
   $rows = [];
   $metadata = json_decode($json);
+  $variables['metastore'] = $metadata;
   if (property_exists($metadata, 'description')) {
     $variables['dataset']['description'] = $metadata->description;
   }
@@ -98,7 +99,7 @@ function metastore_preprocess_node__data(&$variables) {
         }
       }
       // Fallback to display file path for link title.
-      if ($rows['downloadURL'] && !property_exists($d, 'title')) {
+      if (isset($rows['downloadURL']) && !property_exists($d, 'title')) {
         $rows['title'] = $rows['downloadURL'];
       }
       $variables['dataset']['distributions'][] = $rows;

--- a/modules/metastore/templates/node--data.html.twig
+++ b/modules/metastore/templates/node--data.html.twig
@@ -4,6 +4,7 @@
     * Default theme implementation to display a node.
     *
     * Available variables:
+    * metastore: The field_json_metadata decoded JSON object. 
     * dataset: The information from the dataset metadata store.
     *  - dataset.medata_table will return a table with the caption "Additional
     *    metadata", that includes all the information in a single table, except


### PR DESCRIPTION
fixes #4194 

## QA Steps

1. [ ] Build the demo site and install sample data. Visit a dataset /node page to make sure the template still adds the download urls to the page.
2. [ ] Create a new dataset. Fill in the required fields.
3. [ ] For the distribution section, add a new distribution, leaving Download URL section empty and adding an Access URL. This will make the frontend render this section and you will not see the error. (The access url does not render well since it didn't have an explicit variable set in the theme file.)

I've also added the variable `metastore` for templates to use. This is just the raw json object with no processing on it. This is the first step towards deprecating the dataset variables. The new metastore variable can be used in node--data templates by using something like `metastore.title` or `metastore.keyword[0]`.

`Warning: Undefined array key "downloadURL" in metastore_preprocess_node__data() (line 101 of /var/www/html/docroot/modules/contrib/dkan/modules/metastore/metastore.theme.inc)`
