### PR TITLE
Data dictionary form fields table is not mobile friendly

### DIFF
--- a/modules/data_dictionary_widget/css/dataDictionaryWidget.css
+++ b/modules/data_dictionary_widget/css/dataDictionaryWidget.css
@@ -50,3 +50,7 @@
   color: #666;
   cursor: not-allowed;
 }
+
+#field-json-metadata-dictionary-edit-field {
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
Resolve an issue where the field table on the data dictionaries admin form is overflowing into the sidebar causing the gear icon to not be clickable. This is primarily happening on mobile views

On small screens the layout-region--node-secondary "sidebar" on the right will overlap the data dictionary form on the left. This makes the gear inaccessible.

Or if the width triggers the sidebar to slide down to a stacked location, the table will expand outside the size of the browser.


## QA Steps

- [ ] Create a data dictionary and save.
- [ ] Edit the data dictionary to open the form.
- [ ] Reduce the width of your browser to ~900px
- [ ] Confirm the gears are visible and clickable
