### PR TITLE
Fix broken reference in OpenAPI spec, improve validation tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,33 +236,33 @@ workflows:
           report_coverage: true
           matrix:
             parameters:
-              dkan_recommended_branch: [ '10.2.x-dev']
+              dkan_recommended_branch: [ 'osteel-openapi-10-2']
               php_version: [ '8.3' ]
       - phpunit:
           matrix:
             parameters:
-              dkan_recommended_branch: [ '10.2.x-dev']
+              dkan_recommended_branch: [ 'osteel-openapi-10-2']
               php_version: [ '8.1', '8.2' ]
       - phpunit:
           matrix:
             parameters:
-              dkan_recommended_branch: [ '10.1.x-dev']
+              dkan_recommended_branch: [ 'osteel-openapi']
               php_version: [ '8.2' ]
       - phpunit:
          matrix:
            parameters:
-             dkan_recommended_branch: [ '10.0.x-dev']
+             dkan_recommended_branch: [ 'osteel-openapi-10-0']
              php_version: [ '8.1' ]
   upgrade_and_test:
     jobs:
       - cypress:
           name: upgrade_test_cypress
           upgrade: true
-          dkan_recommended_branch: '10.2.x-dev'
+          dkan_recommended_branch: 'osteel-openapi-10-2'
       - phpunit:
           name: 'Upgrade target (Drupal 10.2, PHP 8.2)'
           upgrade: true
           matrix:
             parameters:
-              dkan_recommended_branch: [ '10.2.x-dev']
+              dkan_recommended_branch: [ 'osteel-openapi-10-2']
               php_version: [ '8.2' ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,11 +248,6 @@ workflows:
             parameters:
               dkan_recommended_branch: [ '10.1.x-dev']
               php_version: [ '8.2' ]
-      - phpunit:
-         matrix:
-           parameters:
-             dkan_recommended_branch: [ '10.0.x-dev']
-             php_version: [ '8.1' ]
   upgrade_and_test:
     jobs:
       - cypress:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,11 +248,6 @@ workflows:
             parameters:
               dkan_recommended_branch: [ 'osteel-openapi-10-1-dev']
               php_version: [ '8.2' ]
-      - phpunit:
-         matrix:
-           parameters:
-             dkan_recommended_branch: [ 'osteel-openapi-10-0-dev']
-             php_version: [ '8.1' ]
   upgrade_and_test:
     jobs:
       - cypress:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              dkan_recommended_branch: [ 'osteel-openapi-dev']
+              dkan_recommended_branch: [ 'osteel-openapi-10-1-dev']
               php_version: [ '8.2' ]
       - phpunit:
          matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,29 +236,29 @@ workflows:
           report_coverage: true
           matrix:
             parameters:
-              dkan_recommended_branch: [ 'osteel-openapi-10-2']
+              dkan_recommended_branch: [ 'osteel-openapi-10-2-dev']
               php_version: [ '8.3' ]
       - phpunit:
           matrix:
             parameters:
-              dkan_recommended_branch: [ 'osteel-openapi-10-2']
+              dkan_recommended_branch: [ 'osteel-openapi-10-2-dev']
               php_version: [ '8.1', '8.2' ]
       - phpunit:
           matrix:
             parameters:
-              dkan_recommended_branch: [ 'osteel-openapi']
+              dkan_recommended_branch: [ 'osteel-openapi-dev']
               php_version: [ '8.2' ]
       - phpunit:
          matrix:
            parameters:
-             dkan_recommended_branch: [ 'osteel-openapi-10-0']
+             dkan_recommended_branch: [ 'osteel-openapi-10-0-dev']
              php_version: [ '8.1' ]
   upgrade_and_test:
     jobs:
       - cypress:
           name: upgrade_test_cypress
           upgrade: true
-          dkan_recommended_branch: 'osteel-openapi-10-2'
+          dkan_recommended_branch: 'osteel-openapi-10-2-dev'
       - phpunit:
           name: 'Upgrade target (Drupal 10.2, PHP 8.2)'
           upgrade: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,11 +258,11 @@ workflows:
       - cypress:
           name: upgrade_test_cypress
           upgrade: true
-          dkan_recommended_branch: 'osteel-openapi-10-2-dev'
+          dkan_recommended_branch: '10.2.x-dev'
       - phpunit:
           name: 'Upgrade target (Drupal 10.2, PHP 8.2)'
           upgrade: true
           matrix:
             parameters:
-              dkan_recommended_branch: [ 'osteel-openapi-10-2']
+              dkan_recommended_branch: [ 'osteel-openapi-10-2-dev']
               php_version: [ '8.2' ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,18 +236,23 @@ workflows:
           report_coverage: true
           matrix:
             parameters:
-              dkan_recommended_branch: [ 'osteel-openapi-10-2-dev']
+              dkan_recommended_branch: [ '10.2.x-dev']
               php_version: [ '8.3' ]
       - phpunit:
           matrix:
             parameters:
-              dkan_recommended_branch: [ 'osteel-openapi-10-2-dev']
+              dkan_recommended_branch: [ '10.2.x-dev']
               php_version: [ '8.1', '8.2' ]
       - phpunit:
           matrix:
             parameters:
-              dkan_recommended_branch: [ 'osteel-openapi-10-1-dev']
+              dkan_recommended_branch: [ '10.1.x-dev']
               php_version: [ '8.2' ]
+      - phpunit:
+         matrix:
+           parameters:
+             dkan_recommended_branch: [ '10.0.x-dev']
+             php_version: [ '8.1' ]
   upgrade_and_test:
     jobs:
       - cypress:
@@ -259,5 +264,5 @@ workflows:
           upgrade: true
           matrix:
             parameters:
-              dkan_recommended_branch: [ 'osteel-openapi-10-2-dev']
+              dkan_recommended_branch: [ '10.2.x-dev']
               php_version: [ '8.2' ]

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     "require-dev": {
         "drush/drush": "^12@stable",
         "getdkan/mock-chain": "^1.3.7",
+        "osteel/openapi-httpfoundation-testing": "<1.0",
         "phpunit/phpunit": "^8.5.14 || ^9",
         "weitzman/drupal-test-traits": "^2.0.1"
     },

--- a/modules/common/tests/src/Functional/Api1TestBase.php
+++ b/modules/common/tests/src/Functional/Api1TestBase.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
 use Opis\JsonSchema\Schema;
 use Opis\JsonSchema\Validator;
+use Osteel\OpenApi\Testing\ValidatorBuilder;
 
 abstract class Api1TestBase extends BrowserTestBase {
   use UserCreationTrait;
@@ -22,6 +23,13 @@ abstract class Api1TestBase extends BrowserTestBase {
   protected $spec;
   protected $auth;
   protected $endpoint;
+
+  /**
+   * OpenApi Validator.
+   *
+   * @var \Osteel\OpenApi\Testing\ValidatorInterface
+   */
+  protected $validator;
 
   protected $defaultTheme = 'stark';
   protected $strictConfigSchema = FALSE;
@@ -49,6 +57,7 @@ abstract class Api1TestBase extends BrowserTestBase {
 
     // Load the API spec for use by tests.
     $response = $this->httpClient->request('GET', 'api/1');
+    $this->validator = ValidatorBuilder::fromJsonString($response->getBody())->getValidator();
     $this->spec = json_decode($response->getBody());
   }
 

--- a/modules/metastore/docs/openapi_spec.json
+++ b/modules/metastore/docs/openapi_spec.json
@@ -45,6 +45,19 @@
                     }
                 }
             },
+            "409MetadataAlreadyExists": {
+                "description": "Conflict; tried to create a record using an existing ID, or metadata contains identifier that doesn't match the request path.",
+                "content": {
+                    "application/json": {
+                        "schema": { "$ref": "#/components/schemas/errorResponse" },
+                        "example": {
+                            "message": "dataset/00000000-0000-0000-0000-000000000000 already exists.",
+                            "status": 409,
+                            "timestamp": "2021-06-14T13:46:06+00:00"
+                        }
+                    }
+                }
+            },
             "412MetadataObjectNotFound": {
                 "description": "Missing object, usually due to incorrect identifier.",
                 "content": {

--- a/modules/metastore/docs/openapi_spec.json
+++ b/modules/metastore/docs/openapi_spec.json
@@ -25,22 +25,22 @@
             }
         },
         "responses": {
+            "200MetadataUpdated": {
+                "description": "Metadata update successful.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/metastoreWriteResponse"
+                        }
+                    }
+                }
+            },
             "201MetadataCreated": {
                 "description": "Metadata creation successful.",
                 "content": {
                     "application/json": {
                         "schema": {
-                            "type": "object",
-                            "properties": {
-                                "endpoint": {
-                                    "type": "string",
-                                    "description": "Path to the metadata from the API."
-                                },
-                                "identifier": {
-                                    "type": "string",
-                                    "description": "Identifier for metadata just created or modified."
-                                }
-                            }
+                            "$ref": "#/components/schemas/metastoreWriteResponse"
                         }
                     }
                 }
@@ -61,6 +61,20 @@
 
         },
         "schemas": {
+            "metastoreWriteResponse": {
+                "type": "object",
+                "properties": {
+                    "endpoint": {
+                        "type": "string",
+                        "description": "Path to the metadata from the API."
+                    },
+                    "identifier": {
+                        "type": "string",
+                        "description": "Identifier for metadata just created or modified."
+                    }
+                },
+                "additionalProperties": false
+            },
             "metastoreRevision": {
                 "type": "object",
                 "properties": {
@@ -181,7 +195,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Ok",
+                        "description": "Full list of all items for the given schema",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/modules/metastore/src/Plugin/DkanApiDocs/MetastoreApiDocs.php
+++ b/modules/metastore/src/Plugin/DkanApiDocs/MetastoreApiDocs.php
@@ -49,7 +49,7 @@ class MetastoreApiDocs extends DkanApiDocsBase {
     $pluginDefinition,
     ModuleHandlerInterface $moduleHandler,
     TranslationInterface $stringTranslation,
-    MetastoreService $metastore
+    MetastoreService $metastore,
   ) {
     parent::__construct($configuration, $pluginId, $pluginDefinition, $moduleHandler, $stringTranslation);
     $this->metastore = $metastore;
@@ -73,7 +73,7 @@ class MetastoreApiDocs extends DkanApiDocsBase {
     ContainerInterface $container,
     array $configuration,
     $pluginId,
-    $pluginDefinition
+    $pluginDefinition,
   ) {
     return new static(
       $configuration,
@@ -347,7 +347,7 @@ class MetastoreApiDocs extends DkanApiDocsBase {
     return [
       "operationId" => "$schemaId-put",
       "summary" => $this->t("Replace a :schemaId", $tSchema),
-      "description" => $this->t("Object will be completely replaced; optional properties not included in the request will be deleted.\n\nAutomatic example not yet available; try retrieving a :schemaId via GET, changing values, and pasting to test.", $tSchema),
+      "description" => $this->t("Object will be completely replaced; optional properties not included in the request will be deleted.\n\nAutomatic example not yet available; try retrieving a :schemaId via GET, changing values, and pasting to test. If no item exists with the provided identifier, it will be created.", $tSchema),
       "tags" => [$this->t("Metastore: :schemaId", $tSchema)],
       "security" => [
         ['basic_auth' => []],
@@ -362,9 +362,9 @@ class MetastoreApiDocs extends DkanApiDocsBase {
         ],
       ],
       "responses" => [
-        "200" => [
-          "description" => "Ok.",
-        ],
+        "200" => ['$ref' => '#/components/responses/200MetadataUpdated'],
+        "201" => ['$ref' => '#/components/responses/201MetadataCreated'],
+        '400' => ['$ref' => '#/components/responses/400BadJson'],
         "412" => ['$ref' => '#/components/responses/412MetadataObjectNotFound'],
       ],
     ];
@@ -401,9 +401,8 @@ class MetastoreApiDocs extends DkanApiDocsBase {
         ],
       ],
       "responses" => [
-        "200" => [
-          "description" => "Ok.",
-        ],
+        "200" => ['$ref' => '#/components/responses/200MetadataUpdated'],
+        '400' => ['$ref' => '#/components/responses/400BadJson'],
         "412" => ['$ref' => '#/components/responses/412MetadataObjectNotFound'],
       ],
     ];

--- a/modules/metastore/src/Plugin/DkanApiDocs/MetastoreApiDocs.php
+++ b/modules/metastore/src/Plugin/DkanApiDocs/MetastoreApiDocs.php
@@ -296,6 +296,7 @@ class MetastoreApiDocs extends DkanApiDocsBase {
           ],
         ],
         '400' => ['$ref' => '#/components/responses/400BadJson'],
+        '409' => ['$ref' => '#/components/responses/409MetadataAlreadyExists'],
       ],
     ];
   }
@@ -365,6 +366,7 @@ class MetastoreApiDocs extends DkanApiDocsBase {
         "200" => ['$ref' => '#/components/responses/200MetadataUpdated'],
         "201" => ['$ref' => '#/components/responses/201MetadataCreated'],
         '400' => ['$ref' => '#/components/responses/400BadJson'],
+        '409' => ['$ref' => '#/components/responses/409MetadataAlreadyExists'],
         "412" => ['$ref' => '#/components/responses/412MetadataObjectNotFound'],
       ],
     ];

--- a/modules/metastore/tests/src/Functional/Api1/DatasetRevisionTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetRevisionTest.php
@@ -20,10 +20,7 @@ class DatasetRevisionTest extends Api1TestBase {
     ]);
 
     // Test individual item endpoint.
-    $responseSchema = $this->spec->components->responses->{"201MetadataCreated"}->content->{"application/json"}->schema;
-
-    $responseBody = json_decode($response->getBody());
-    $this->assertJsonIsValid($responseSchema, $responseBody);
+    $this->validator->validate($response, "api/1/metastore/schemas/dataset/items", 'post');
 
     $response = $this->httpClient->get($this->endpoint, [
       RequestOptions::AUTH => $this->auth,
@@ -115,7 +112,6 @@ class DatasetRevisionTest extends Api1TestBase {
       'archived' => FALSE,
       'hidden' => TRUE,
     ];
-    $responseSchema = $this->spec->components->responses->{"201MetadataCreated"}->content->{"application/json"}->schema;
 
     $count = 1;
     foreach ($states as $state => $public) {
@@ -126,7 +122,7 @@ class DatasetRevisionTest extends Api1TestBase {
 
       // Validate response object.
       $responseBody = json_decode($response->getBody());
-      $this->assertJsonIsValid($responseSchema, $responseBody);
+      $this->validator->validate($response, $this->endpoint, 'post');
 
       // Validate URL and contents of response object.
       $response = $this->httpClient->get($responseBody->endpoint, [

--- a/modules/metastore/tests/src/Functional/Api1/DistributionHandlingTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DistributionHandlingTest.php
@@ -95,9 +95,7 @@ class DistributionHandlingTest extends Api1TestBase {
     $this->assertEquals(201, $response->getStatusCode());
 
     $responseBody = json_decode($response->getBody());
-    $responseSchema = $this->spec->components->responses->{"201MetadataCreated"}->content->{"application/json"}->schema;
 
-    $this->assertJsonIsValid($responseSchema, $responseBody);
     // Unless JSON changes, we should always get same id back.
     $this->assertEquals("47f1d697-f469-5b41-a613-80cdfac7a326", $responseBody->identifier);
 


### PR DESCRIPTION
There were some inconsistencies in the responses for the metastore section of the OpenAPI spec. Changing them broke the crude response validator I had implemented using OPIS schema validation. This fixes up the spec and switches to using [osteel/openapi-httpfoundation-testing](https://github.com/osteel/openapi-httpfoundation-testing) for response validation, which is I think a better approach.

## QA Steps

1. Stand up side, and grab the full spec from /api/1
2. Paste the spec into https://editor.swagger.io/ and confirm it throws no errors
3. Perform any additional validation you wish

## Merging instructions

1. Review and approve this PR. DO NOT MERGE YET
2. Merge GetDKAN/recommended-project#39
3. Merge GetDKAN/recommended-project#40
4. Update .circleci/config.yml to use correct branches of GetDKAN/recommended-project again (feel free to reassign back to @dafeder for this part)
5. Confirm tests still pass and merge this PR

## Notes

Re: codeclimate, that function is completely declarative and wouldn't benefit from breaking up, so I think ok to override.

This PR removes Drupal 10.0 from the CI matrix, which was creating dependency issues for the openapi library. 10.0 is no longer supported so we feel comfortable dropping testing for it. This does not mean that production builds with DKAN will fail for 10.0, but core PHPUnit tests will.