### PR TITLE
Apply dictionary date formats on csv downloads when in reference mode

### DIFF
--- a/modules/datastore/src/DatastoreService.php
+++ b/modules/datastore/src/DatastoreService.php
@@ -217,8 +217,8 @@ class DatastoreService implements ContainerInjectionInterface {
   /**
    * Returns the Data Dictionary fields.
    */
-  public function getDataDictionaryFields() {
-    return $this->dictionaryEnforcer->returnDataDictionaryFields();
+  public function getDataDictionaryFields($id = NULL) {
+    return $this->dictionaryEnforcer->returnDataDictionaryFields($id);
   }
 
   /**

--- a/modules/datastore/src/DatastoreService.php
+++ b/modules/datastore/src/DatastoreService.php
@@ -216,9 +216,12 @@ class DatastoreService implements ContainerInjectionInterface {
 
   /**
    * Returns the Data Dictionary fields.
+   *
+   * @param string $identifier
+   *   A resource's identifier. Used when in reference mode.
    */
-  public function getDataDictionaryFields($id = NULL) {
-    return $this->dictionaryEnforcer->returnDataDictionaryFields($id);
+  public function getDataDictionaryFields(string $identifier = NULL) {
+    return $this->dictionaryEnforcer->returnDataDictionaryFields($identifier);
   }
 
   /**

--- a/modules/datastore/src/Service/Query.php
+++ b/modules/datastore/src/Service/Query.php
@@ -129,6 +129,7 @@ class Query implements ContainerInjectionInterface {
    */
   public function runResultsQuery(DatastoreQuery $datastoreQuery, $fetch = TRUE, $csv = FALSE) {
     $primaryAlias = $datastoreQuery->{"$.resources[0].alias"};
+    $resourceId = $datastoreQuery->{"$.resources[0].id"} ?? '';
     if (!$primaryAlias) {
       return [];
     }
@@ -136,7 +137,7 @@ class Query implements ContainerInjectionInterface {
 
     $query = QueryFactory::create($datastoreQuery, $storageMap);
     // Get data dictionary fields.
-    $meta_data = $csv != FALSE ? $this->getDatastoreService()->getDataDictionaryFields() : NULL;
+    $meta_data = $csv != FALSE ? $this->getDatastoreService()->getDataDictionaryFields($resourceId) : NULL;
     // Pass the data dictionary metadata to the query.
     $query->dataDictionaryFields = $csv && $meta_data ? $meta_data : NULL;
 

--- a/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
+++ b/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
@@ -124,14 +124,25 @@ class DictionaryEnforcer implements ResourceProcessorInterface {
    *
    *  {@inheritdoc}
    */
-  public function returnDataDictionaryFields() {
-    // Get DD is mode.
+  public function returnDataDictionaryFields($id = NULL) {
+    // Get data dictionary mode.
     $dd_mode = $this->dataDictionaryDiscovery->getDataDictionaryMode();
     // Get data dictionary info.
-    if ($dd_mode == "sitewide") {
-      $dict_id = $this->dataDictionaryDiscovery->getSitewideDictionaryId();
-      return $this->metastore->get('data-dictionary', $dict_id)->{"$.data.fields"};
+    switch ($dd_mode) {
+      case "sitewide":
+        $dictionary_id = $this->dataDictionaryDiscovery->getSitewideDictionaryId();
+        break;
+
+      case "reference":
+        $resource = DataResource::getIdentifierAndVersion($id);
+        $dictionary_id = $this->dataDictionaryDiscovery->dictionaryIdFromResource($resource[0]);
+        break;
+
+      default:
+        return;
     }
+
+    return $this->metastore->get('data-dictionary', $dictionary_id)->{"$.data.fields"};
   }
 
 }

--- a/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
+++ b/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
@@ -122,9 +122,10 @@ class DictionaryEnforcer implements ResourceProcessorInterface {
   /**
    * Returning data dictionary fields from schema.
    *
-   *  {@inheritdoc}
+   * @param string $identifier
+   *   A resource's identifier. Used when in reference mode.
    */
-  public function returnDataDictionaryFields($id = NULL) {
+  public function returnDataDictionaryFields($identifier = NULL) {
     // Get data dictionary mode.
     $dd_mode = $this->dataDictionaryDiscovery->getDataDictionaryMode();
     // Get data dictionary info.
@@ -134,7 +135,7 @@ class DictionaryEnforcer implements ResourceProcessorInterface {
         break;
 
       case "reference":
-        $resource = DataResource::getIdentifierAndVersion($id);
+        $resource = DataResource::getIdentifierAndVersion($identifier);
         $dictionary_id = $this->dataDictionaryDiscovery->dictionaryIdFromResource($resource[0]);
         break;
 


### PR DESCRIPTION
ref: 21261

## QA Steps

- [ ] Set the data dictionary mode to 'reference' https://dkan.ddev.site/admin/dkan/data-dictionary/settings
- [ ] Create a data dictionary with a field of type date, set the format to %m/%d/%Y
- [ ] Create a dataset with a data file containing a date column that you used in your data dictionary, dates should be in mm/dd/YYYY format
- [ ] Use your data dictionary endpoint in the distribution describedBy field
- [ ] Save and run import queues
- [ ] Visit your dataset, adjust the url to call the streamed download, or use the link below replacing the uuid with your dataset uuid

https://dkan.ddev.site/api/1/datastore/query/505a1f80-7a95-4d9e-8eda-c57efdbf5c19/0/download?&format=csv

- [ ] Confirm the resulting csv has the dates in the DD format, not ISO

