### PR TITLE
Skip the data dictionary when one does not exist

### DIFF
--- a/modules/datastore/src/DatastoreService.php
+++ b/modules/datastore/src/DatastoreService.php
@@ -219,8 +219,11 @@ class DatastoreService implements ContainerInjectionInterface {
    *
    * @param string $identifier
    *   A resource's identifier. Used when in reference mode.
+   *
+   * @return array|null
+   *   An array of dictionary fields or null if no dictionary is in use.
    */
-  public function getDataDictionaryFields(string $identifier = NULL) {
+  public function getDataDictionaryFields(string $identifier = NULL): ?array {
     return $this->dictionaryEnforcer->returnDataDictionaryFields($identifier);
   }
 

--- a/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
+++ b/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
@@ -95,12 +95,12 @@ class DictionaryEnforcer implements ResourceProcessorInterface {
   protected function getDataDictionaryForResource(DataResource $resource): RootedJsonData {
     $resource_id = $resource->getIdentifier();
     $resource_version = $resource->getVersion();
-    $dict_id = $this->dataDictionaryDiscovery->dictionaryIdFromResource($resource_id, $resource_version);
+    $dictionary_id = $this->dataDictionaryDiscovery->dictionaryIdFromResource($resource_id, $resource_version);
 
-    if (!isset($dict_id)) {
+    if (!isset($dictionary_id)) {
       throw new \UnexpectedValueException(sprintf('No data-dictionary found for resource with id "%s" and version "%s".', $resource_id, $resource_version));
     }
-    return $this->metastore->get('data-dictionary', $dict_id);
+    return $this->metastore->get('data-dictionary', $dictionary_id);
   }
 
   /**

--- a/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
+++ b/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
@@ -143,7 +143,12 @@ class DictionaryEnforcer implements ResourceProcessorInterface {
         return;
     }
 
-    return $this->metastore->get('data-dictionary', $dictionary_id)->{"$.data.fields"};
+    if ($dictionary_id) {
+      return $this->metastore->get('data-dictionary', $dictionary_id)->{"$.data.fields"};
+    }
+    else {
+      return;
+    }
   }
 
 }

--- a/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
+++ b/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
@@ -124,8 +124,11 @@ class DictionaryEnforcer implements ResourceProcessorInterface {
    *
    * @param string $identifier
    *   A resource's identifier. Used when in reference mode.
+   *
+   * @return array|null
+   *   An array of dictionary fields or null if no dictionary is in use.
    */
-  public function returnDataDictionaryFields($identifier = NULL) {
+  public function returnDataDictionaryFields(string $identifier = NULL): ?array {
     // Get data dictionary mode.
     $dd_mode = $this->dataDictionaryDiscovery->getDataDictionaryMode();
     // Get data dictionary info.
@@ -140,15 +143,10 @@ class DictionaryEnforcer implements ResourceProcessorInterface {
         break;
 
       default:
-        return;
+        return NULL;
     }
 
-    if ($dictionary_id) {
-      return $this->metastore->get('data-dictionary', $dictionary_id)->{"$.data.fields"};
-    }
-    else {
-      return;
-    }
+    return $dictionary_id ? $this->metastore->get('data-dictionary', $dictionary_id)->{"$.data.fields"} : NULL;
   }
 
 }


### PR DESCRIPTION
ref: 21364

## QA Steps

- [ ] Put site in DD [reference mode](https://dkan.ddev.site/admin/dkan/data-dictionary/settings)
- [ ] Create a dataset without a DD
- [ ] Go to the dataset page, create a filter, grab the query url
- [ ] Add download bits like the following
```
https://dkan.ddev.site/api/1/datastore/query/c59d6e04-0735-5a18-b07b-a41b27b0659b/0/download?limit=20&offset=0&conditions[0][property]=year&conditions[0][value]=2012&conditions[0][operator]==&format=csv
```
- [ ] Confirm you get a file with the results you expect
- [ ] Confirm no errors in the file