### PR TITLE
#4208: New permission for administering metastore settings

### DIFF
--- a/modules/metastore/metastore.permissions.yml
+++ b/modules/metastore/metastore.permissions.yml
@@ -4,7 +4,9 @@
 'administer data dictionary settings':
   title: 'Metastore: Administer Data Dictionary Settings'
   description: 'Administer data dictionary settings'
-
+'administer metastore settings':
+  title: 'Metastore: Administer Metastore Settings'
+  description: 'Administer metastore settings'
 
 
 administer resource mapping:

--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -155,7 +155,7 @@ dkan.metastore.config_properties:
     _form: '\Drupal\metastore\Form\DkanDataSettingsForm'
     _title: 'Metastore settings'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'administer metastore settings'
   options:
     _admin_route: TRUE
 


### PR DESCRIPTION
fixes #4208 

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] check permissions under admin/people/permissions at section Metastore and see the new permission 'Metastore: Administer Metastore Settings"
- [ ] grant this permission to a role
- [ ] check that the role with this permission can access admin/dkan/properties
- [ ] check that a role without this permission cannot access admin/dkan/properties
