### PR TITLE
Pass empty array if no schema is found

### DIFF
--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -391,7 +391,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    * Get the schema for this table.
    *
    * @return array
-   *   A schema array.
+   *   A Drupal Schema API array, or an empty array if none found.
    */
   public function getSchema(): array {
     return $this->schema ?? [];

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -394,7 +394,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    *   A schema array.
    */
   public function getSchema(): array {
-    return $this->schema ? $this->schema : [];
+    return $this->schema ?? [];
   }
 
   /**

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -394,7 +394,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    *   A schema array.
    */
   public function getSchema(): array {
-    return $this->schema;
+    return $this->schema ? $this->schema : [];
   }
 
   /**

--- a/modules/datastore/tests/src/Functional/Api1/DatastoreQueryApiTest.php
+++ b/modules/datastore/tests/src/Functional/Api1/DatastoreQueryApiTest.php
@@ -11,17 +11,21 @@ class DatastoreQueryApiTest extends Api1TestBase {
     return 'api/1/metastore/schemas/dataset/items';
   }
 
+  /**
+   * Confirm a 400 response prior to running the datastore_import.
+   */
   public function testBasicQuery() {
     $dataset = $this->getSampleDataset();
     $this->post($dataset, FALSE);
-
     $dataset_id = $dataset->identifier;
+
     $response = $this->httpClient->get("api/1/datastore/query/$dataset_id/0", [
       RequestOptions::HTTP_ERRORS => FALSE,
     ]);
     $this->assertEquals(400, $response->getStatusCode());
     $this->validator->validate($response, "/api/1/datastore/query/{datasetId}/{index}", 'get');
 
+    // Confirm a 200 response after the datastore_import has run.
     $dataset_info = \Drupal::service('dkan.common.dataset_info')->gather($dataset_id);
     $resource_id = $dataset_info['latest_revision']['distributions'][0]['resource_id'];
     \Drupal::service('dkan.datastore.service')->import($resource_id, FALSE);
@@ -31,4 +35,31 @@ class DatastoreQueryApiTest extends Api1TestBase {
     $this->assertEquals(200, $response->getStatusCode());
     $this->validator->validate($response, "/api/1/datastore/query/{datasetId}/{index}", 'get');
   }
+
+  /**
+   * Query on in progress datastore updates.
+   *
+   * Confirm a 400 response after a resource is updated, localize_import
+   * has run, but the datastore_import queue has not yet run.
+   */
+  public function testBasicQueryAfterTableDrop() {
+    $dataset = $this->getSampleDataset();
+    $this->post($dataset, FALSE);
+    $dataset_id = $dataset->identifier;
+
+    $dataset_info = \Drupal::service('dkan.common.dataset_info')->gather($dataset_id);
+    $resource_id = $dataset_info['latest_revision']['distributions'][0]['resource_id'];
+    \Drupal::service('dkan.datastore.service')->import($resource_id, FALSE);
+
+    $dataset_info = \Drupal::service('dkan.common.dataset_info')->gather($dataset_id);
+    $datastore_table = $dataset_info['latest_revision']['distributions'][0]['table_name'];
+    \Drupal::database()->schema()->dropTable($datastore_table);
+
+    $response = $this->httpClient->get("api/1/datastore/query/$dataset_id/0", [
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(400, $response->getStatusCode());
+    $this->validator->validate($response, "/api/1/datastore/query/{datasetId}/{index}", 'get');
+  }
+
 }

--- a/modules/datastore/tests/src/Functional/Api1/DatastoreQueryApiTest.php
+++ b/modules/datastore/tests/src/Functional/Api1/DatastoreQueryApiTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\Tests\datastore\Functional\Api1;
+
+use Drupal\Tests\common\Functional\Api1TestBase;
+use GuzzleHttp\RequestOptions;
+
+class DatastoreQueryApiTest extends Api1TestBase {
+
+  public function getEndpoint():string {
+    return 'api/1/metastore/schemas/dataset/items';
+  }
+
+  public function testBasicQuery() {
+    $dataset = $this->getSampleDataset();
+    $this->post($dataset, FALSE);
+
+    $dataset_id = $dataset->identifier;
+    $response = $this->httpClient->get("api/1/datastore/query/$dataset_id/0", [
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(400, $response->getStatusCode());
+    $this->validator->validate($response, "/api/1/datastore/query/{datasetId}/{index}", 'get');
+
+    $dataset_info = \Drupal::service('dkan.common.dataset_info')->gather($dataset_id);
+    $resource_id = $dataset_info['latest_revision']['distributions'][0]['resource_id'];
+    \Drupal::service('dkan.datastore.service')->import($resource_id, FALSE);
+    $response = $this->httpClient->get("api/1/datastore/query/$dataset_id/0", [
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->validator->validate($response, "/api/1/datastore/query/{datasetId}/{index}", 'get');
+  }
+}


### PR DESCRIPTION
ref: 20621

```
TypeError: Drupal\common\Storage\AbstractDatabaseTable::getSchema(): Return value must be of type array, null returned in Drupal\common\Storage\AbstractDatabaseTable->getSchema() (line 397 of /var/www/html/dkan/modules/common/src/Storage/AbstractDatabaseTable.php). 
```

When data publishers rely on cron to run the queues, a datastore query may return the above 500 error on getSchema() when:
1. a data file (downloadURL) has been updated
2. the localize_import has run
3. the datastore_import has not run 
4. a datastore/query API call is made to the missing datastore

To avoid the 500 error:
Allow **getSchema** to return an empty array, the query will then be caught by **queryResource** and return a 400

