### PR TITLE
Referencer/Dereferencer logger error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "symfony/polyfill-php80": "^1.27"
     },
     "require-dev": {
+        "colinodell/psr-testlogger": "^1.2",
         "drush/drush": "^12@stable",
         "getdkan/mock-chain": "^1.3.7",
         "osteel/openapi-httpfoundation-testing": "<1.0",

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -101,16 +101,14 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
   protected function prepareData(string $data, string $id = NULL): array {
     $decoded = json_decode($data);
     if ($decoded === NULL) {
-      $this->logger->log(
-        'datastore_import',
+      $this->logger->error(
         'Error decoding id:@id, data: @data.',
         ['@id' => $id, '@data' => $data]
       );
       throw new \Exception('Import for ' . $id . ' error when decoding ' . $data);
     }
     elseif (!is_array($decoded)) {
-      $this->logger->log(
-        'datastore_import',
+      $this->logger->error(
         'Array expected while decoding id:@id, data: @data.',
         ['@id' => $id, '@data' => $data]
       );

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -101,17 +101,17 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
   protected function prepareData(string $data, string $id = NULL): array {
     $decoded = json_decode($data);
     if ($decoded === NULL) {
-      $this->logger->error(
-        'Error decoding id:@id, data: @data.',
-        ['@id' => $id, '@data' => $data]
-      );
+      $this->logger->error('Error decoding id:@id, data: @data.', [
+        '@id' => $id,
+        '@data' => $data,
+      ]);
       throw new \Exception('Import for ' . $id . ' error when decoding ' . $data);
     }
     elseif (!is_array($decoded)) {
-      $this->logger->error(
-        'Array expected while decoding id:@id, data: @data.',
-        ['@id' => $id, '@data' => $data]
-      );
+      $this->logger->error('Array expected while decoding id:@id, data: @data.', [
+        '@id' => $id,
+        '@data' => $data,
+      ]);
       throw new \Exception('Import for ' . $id . ' returned an error when preparing table header: ' . $data);
     }
     return $decoded;

--- a/modules/datastore/tests/src/Kernel/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Kernel/Storage/DatabaseTableTest.php
@@ -109,6 +109,7 @@ class DatabaseTableTest extends KernelTestBase {
     // We can't use expectException() because we also want to look at the log.
     try {
       $ref_prepare_data->invokeArgs($database_table, [$data]);
+      $this->assertTrue(FALSE, 'We expected this call to throw an exception.');
     }
     catch (\Exception $e) {
       $this->assertSame($e->getMessage(), $expected_exception);

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -215,9 +215,10 @@ class MetastoreService implements ContainerInjectionInterface {
           });
         }
         catch (\Exception) {
-          $this->logger->log('metastore', 'A JSON string failed validation.',
-            ['@schema_id' => $schema_id, '@json' => $jsonString]
-          );
+          $this->logger->error('A JSON string failed validation.', [
+            '@schema_id' => $schema_id,
+            '@json' => $jsonString,
+          ]);
           return NULL;
         }
       }, $jsonStringsArray);

--- a/modules/metastore/src/Reference/Dereferencer.php
+++ b/modules/metastore/src/Reference/Dereferencer.php
@@ -167,13 +167,10 @@ class Dereferencer {
 
     // If a property node was not found, it most likely means it was deleted
     // while still being referenced.
-    $this->logger->error(
-      'Property @property_id reference @uuid not found',
-      [
-        '@property_id' => $property_id,
-        '@uuid' => var_export($uuid, TRUE),
-      ]
-    );
+    $this->logger->error('Property @property_id reference @uuid not found', [
+      '@property_id' => $property_id,
+      '@uuid' => var_export($uuid, TRUE),
+    ]);
 
     return [NULL, NULL];
   }

--- a/modules/metastore/src/Reference/Dereferencer.php
+++ b/modules/metastore/src/Reference/Dereferencer.php
@@ -103,11 +103,10 @@ class Dereferencer {
       return $this->dereferenceSingle($property_id, $uuid);
     }
     else {
-      $this->logger->log('value_referencer', 'Unexpected data type when dereferencing property_id: @property_id with uuid: @uuid',
-        [
-          '@property_id' => $property_id,
-          '@uuid' => var_export($uuid, TRUE),
-        ]);
+      $this->logger->error('Unexpected data type when dereferencing property_id: @property_id with uuid: @uuid', [
+        '@property_id' => $property_id,
+        '@uuid' => var_export($uuid, TRUE),
+      ]);
       return NULL;
     }
   }
@@ -168,8 +167,7 @@ class Dereferencer {
 
     // If a property node was not found, it most likely means it was deleted
     // while still being referenced.
-    $this->logger->log(
-      'value_referencer',
+    $this->logger->error(
       'Property @property_id reference @uuid not found',
       [
         '@property_id' => $property_id,

--- a/modules/metastore/src/Reference/Referencer.php
+++ b/modules/metastore/src/Reference/Referencer.php
@@ -175,7 +175,6 @@ class Referencer {
    *   The Uuid reference, or NULL on failure.
    */
   private function referenceSingle(string $property_id, $value) {
-
     if ($property_id == 'distribution') {
       $value = $this->distributionHandling($value);
     }
@@ -188,14 +187,12 @@ class Referencer {
       return $uuid;
     }
     else {
-      $this->logger->log(
-        'value_referencer',
-        'Neither found an existing nor could create a new reference for property_id: @property_id with value: @value',
-        [
-          '@property_id' => $property_id,
-          '@value' => var_export($value, TRUE),
-        ]
-      );
+      // @todo Based on the fact that we can't make a test hit these lines, it
+      //   seems that they are dead code.
+      $this->logger->error('Neither found an existing nor could create a new reference for property_id: @property_id with value: @value', [
+        '@property_id' => $property_id,
+        '@value' => var_export($value, TRUE),
+      ]);
       return NULL;
     }
   }
@@ -349,7 +346,7 @@ class Referencer {
     // If we couldn't find a mime type, log an error notifying the user.
     if (is_null($mime_type)) {
       $filename = basename($downloadUrl);
-      $this->logger->log('value_referencer', 'Unable to determine mime type of file with name "@name".', [
+      $this->logger->error('Unable to determine mime type of file with name "@name".', [
         '@name' => $filename,
       ]);
     }

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -456,21 +456,20 @@ abstract class Data implements MetastoreEntityStorageInterface {
    *
    * @return string
    *   Filtered string.
-   *
-   * @codeCoverageIgnore
    */
   private function htmlPurifier(string $input) {
     // Initialize HTML Purifier cache config settings array.
     $config = [];
 
     // Determine path to tmp directory.
+    // @todo Inject this service.
     $tmp_path = \Drupal::service('file_system')->getTempDirectory();
     // Specify custom location in tmp directory for storing HTML Purifier cache.
     $cache_dir = rtrim($tmp_path, '/') . '/html_purifier_cache';
 
     // Ensure the tmp cache directory exists.
     if (!is_dir($cache_dir) && !mkdir($cache_dir)) {
-      $this->logger->log('metastore', 'Failed to create cache directory for HTML purifier');
+      $this->logger->error('Failed to create cache directory for HTML purifier');
     }
     else {
       $config['Cache.SerializerPath'] = $cache_dir;

--- a/modules/metastore/src/Storage/ResourceMapperDatabaseTable.php
+++ b/modules/metastore/src/Storage/ResourceMapperDatabaseTable.php
@@ -4,7 +4,6 @@ namespace Drupal\metastore\Storage;
 
 use Drupal\Core\Database\Connection;
 use Drupal\common\Storage\AbstractDatabaseTable;
-use Psr\Log\LogLevel;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/modules/metastore/src/Storage/ResourceMapperDatabaseTable.php
+++ b/modules/metastore/src/Storage/ResourceMapperDatabaseTable.php
@@ -105,22 +105,18 @@ class ResourceMapperDatabaseTable extends AbstractDatabaseTable {
     }
 
     if ($decoded === NULL) {
-      $this->logger->log(
-        'dkan_metastore_filemapper',
-        "Error decoding id:@id, data: @data.",
-        ['@id' => $id, '@data' => $data],
-        LogLevel::ERROR
-      );
-      throw new \Exception("Import for {$id} error when decoding {$data}");
+      $this->logger->error('Error decoding id:@id, data: @data.', [
+        '@id' => $id,
+        '@data' => $data,
+      ]);
+      throw new \Exception('Import for ' . $id . ' error when decoding ' . $data);
     }
     elseif (!is_object($decoded)) {
-      $this->logger->log(
-        'dkan_metastore_filemapper',
-        "Object expected while decoding id:@id, data: @data.",
-        ['@id' => $id, '@data' => $data],
-        LogLevel::ERROR
-      );
-      throw new \Exception("Import for {$id} returned an error when preparing table header: {$data}");
+      $this->logger->error('Object expected while decoding id:@id, data: @data.', [
+        '@id' => $id,
+        '@data' => $data,
+      ]);
+      throw new \Exception('Import for ' . $id . ' returned an error when preparing table header: ' . $data);
     }
     return (array) $decoded;
   }

--- a/modules/metastore/tests/src/Functional/Storage/DataTest.php
+++ b/modules/metastore/tests/src/Functional/Storage/DataTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Drupal\Tests\metastore\Functional\Storage;
+
+use ColinODell\PsrTestLogger\TestLogger;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystem;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\metastore\Storage\Data;
+use Psr\Log\LoggerInterface;
+use org\bovigo\vfs\vfsStream;
+
+/**
+ * Test the Data class.
+ *
+ * Because of the tight coupling and unification of concerns, this is a
+ * BrowserTestBase test. A Kernel test would be too complex and fragile.
+ *
+ * @covers \Drupal\metastore\Storage\Data
+ * @coversDefaultClass \Drupal\metastore\Storage\Data
+ *
+ * @group dkan
+ * @group metastore
+ * @group functional
+ * @group btb
+ */
+class DataTest extends BrowserTestBase {
+
+  protected $defaultTheme = 'stark';
+
+  protected static $modules = [
+    'metastore',
+    'node',
+  ];
+
+  /**
+   * Test the logging of htmlPurifier().
+   *
+   * @covers ::htmlPurifier
+   */
+  public function testHtmlPurifierLogging() {
+    // Set up a read-only temp directory.
+    $temp = vfsStream::setup('temp');
+    $temp_dir = vfsStream::newDirectory('mytemp', 0000)
+      ->at($temp);
+
+    // Tell the file system service to use this temp directory, which will
+    // prevent the HTML purifier from writing its cache directory, and it
+    // should log this fact.
+    $fs = $this->getMockBuilder(FileSystem::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['getTempDirectory'])
+      ->getMock();
+    $fs->expects($this->any())
+      ->method('getTempDirectory')
+      ->willReturn($temp_dir->url());
+
+    // Let's keep the old filesystem object so we can set it back.
+    $old_fs = $this->container->get('file_system');
+    $this->container->set('file_system', $fs);
+
+    // Create a Data object with a testable logger.
+    $logger = new TestLogger();
+    $data = new StubData(
+      'dataset',
+      $this->container->get('entity_type.manager'),
+      $this->container->get('config.factory'),
+      $logger
+    );
+
+    $uuid = '05aea36e-9e24-452e-9cf9-9727ab90c198';
+
+    // Since filterHtml() and htmlPurifier() are private, we call in from
+    // store() with crafted data.
+    $identifier = $data->store(json_encode((object) [
+      'identifier' => $uuid,
+      'title' => 'title',
+      'data' => (object) [
+        'description' => 'purify me',
+      ],
+    ]));
+
+    // We stored a node.
+    $this->assertEquals($uuid, $identifier);
+    // We logged that the cache directory was not created.
+    $this->assertTrue(
+      $logger->hasErrorThatContains('Failed to create cache directory for HTML purifier')
+    );
+
+    // Test can't clean up if we don't set back the old file system service.
+    $this->container->set('file_system', $old_fs);
+  }
+
+}
+
+/**
+ * Stub out the abstract Data class with just enough to make it run.
+ *
+ * Values are copied from NodeData.
+ */
+class StubData extends Data {
+
+  public function __construct(string $schemaId, EntityTypeManagerInterface $entityTypeManager, ConfigFactoryInterface $config_factory, LoggerInterface $loggerChannel) {
+    $this->entityType = 'node';
+    $this->bundle = 'data';
+    $this->bundleKey = 'type';
+    $this->labelKey = 'title';
+    $this->schemaIdField = 'field_data_type';
+    $this->metadataField = 'field_json_metadata';
+    parent::__construct($schemaId, $entityTypeManager, $config_factory, $loggerChannel);
+  }
+
+  public function retrieveContains(string $string, bool $caseSensitive): array {
+    return [];
+  }
+
+  public function retrieveByHash($hash, $schemaId) {
+  }
+
+}

--- a/modules/metastore/tests/src/Functional/Storage/DataTest.php
+++ b/modules/metastore/tests/src/Functional/Storage/DataTest.php
@@ -82,7 +82,7 @@ class DataTest extends BrowserTestBase {
     ]));
 
     // We stored a node.
-    $this->assertEquals($uuid, $identifier);
+    $this->assertSame($uuid, $identifier);
     // We logged that the cache directory was not created.
     $this->assertTrue(
       $logger->hasErrorThatContains('Failed to create cache directory for HTML purifier')

--- a/modules/metastore/tests/src/Kernel/Reference/ReferencerTest.php
+++ b/modules/metastore/tests/src/Kernel/Reference/ReferencerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\Tests\metastore\Kernel\Reference;
+
+use ColinODell\PsrTestLogger\TestLogger;
+use Drupal\KernelTests\KernelTestBase;
+use Symfony\Component\Mime\MimeTypeGuesserInterface;
+
+/**
+ * @covers \Drupal\metastore\Reference\Referencer
+ * @coversDefaultClass \Drupal\metastore\Reference\Referencer
+ *
+ * @group dkan
+ * @group metastore
+ * @group kernel
+ */
+class ReferencerTest extends KernelTestBase {
+
+  protected $strictConfigSchema = FALSE;
+
+  protected static $modules = [
+    'common',
+    'metastore',
+  ];
+
+  /**
+   * @covers ::getLocalMimeType
+   */
+  public function testGetLocalMimeTypeLogging() {
+    // Test logger we can assert against.
+    $logger = new TestLogger();
+    $this->container->set('dkan.common.logger_channel', $logger);
+
+    // The guesser service always returns NULL.
+    $guesser = $this->getMockBuilder(MimeTypeGuesserInterface::class)
+      ->onlyMethods(['guessMimeType'])
+      ->getMockForAbstractClass();
+    $guesser->expects($this->any())
+      ->method('guessMimeType')
+      ->willReturn(NULL);
+    $this->container->set('file.mime_type.guesser.extension', $guesser);
+
+    $referencer = $this->container->get('dkan.metastore.referencer');
+
+    $ref_get_local_mime_type = new \ReflectionMethod($referencer, 'getLocalMimeType');
+    $ref_get_local_mime_type->setAccessible(TRUE);
+
+    $this->assertNull(
+      $ref_get_local_mime_type->invokeArgs($referencer, ['download/url/file.txt'])
+    );
+    $this->assertTrue(
+      $logger->hasErrorThatContains('Unable to determine mime type of file with name')
+    );
+  }
+
+}

--- a/modules/metastore/tests/src/Unit/Storage/DataTest.php
+++ b/modules/metastore/tests/src/Unit/Storage/DataTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
+ * @coversDefaultClass \Drupal\metastore\Storage\Data
+ *
  * @group dkan
  * @group metastore
  * @group unit
@@ -116,6 +118,8 @@ class DataTest extends TestCase {
 
   /**
    * Test \Drupal\metastore\Storage\Data::count() method.
+   *
+   * @covers ::count
    */
   public function testCount(): void {
     // Set constant which should be returned by the ::count() method.
@@ -140,6 +144,8 @@ class DataTest extends TestCase {
 
   /**
    * Test \Drupal\metastore\Storage\Data::retrieveIds() method.
+   *
+   * @covers ::retrieveIds
    */
   public function testRetrieveRangeUuids(): void {
     // Generate dataset nodes for testing ::retrieveIds().


### PR DESCRIPTION
Fixes https://github.com/GetDKAN/dkan/issues/4207

Originally, this was reported against `Referencer` and `Dereferencer`, but it's not just those.

https://github.com/GetDKAN/dkan/pull/4140 broke a bunch of logging functionality, so we fix it here.

Explicitly adds `colinodell/psr-testlogger` to our dev dependencies, but it's already a dependency of `drupal/core-dev`: https://git.drupalcode.org/project/drupal/-/blob/10.1.x/composer.json?ref_type=heads#L21

All the classes that use logging incorrectly:
- `modules/datastore/src/Storage/DatabaseTable.php`
- `modules/metastore/src/MetastoreService.php`
- `modules/metastore/src/Reference/Dereferencer.php`
- `modules/metastore/src/Reference/Referencer.php`
- `modules/metastore/src/Storage/Data.php`
- `modules/metastore/src/Storage/ResourceMapperDatabaseTable.php`

All these classes now call their logger as if it were a `\Psr\Log\LoggerInterface` (because it is).

All these classes now have tests which touch the logging call, except `ResourceMapperDatabaseTable`, which is deprecated (but still fixed).

Another notable exception is `Referencer::referenceSingle()`, where the logging code seems to be unreachable by test. One wonders if it counts as dead code.

QA steps include:
- Looking for obvious errors.
- Verifying that these lines of code are covered by tests in a coverage report (see the CircleCI Artifacts tab, for the Install Target build). The exception here is `ResourceMapperDatabaseTable`, which we didn't add tests for because it's deprecated.
