### PR TITLE
Unset maxlength in textarea

### DIFF
--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -319,6 +319,7 @@ class WidgetRouter implements ContainerInjectionInterface {
    */
   public function handleTextareaElement(mixed $spec, array $element) {
     $element['#type'] = 'textarea';
+    unset($element['#maxlength']);
     if (isset($spec->rows)) {
       $element['#rows'] = $spec->rows;
     }

--- a/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
+++ b/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
@@ -44,9 +44,47 @@ class WidgetRouterTest extends TestCase {
       ->add(MetastoreService::class, 'getAll', $metastoreGetAllOptions);
   }
 
+  /**
+   * Data provider.
+   *
+   * Each dataset gets is an array with three elements:
+   * 1. The spec object.
+   * 2. The element array.
+   * 3. The expected handled element array.
+   */
   public static function dataProvider(): array {
     return [
-      // Tag field is a free-tagging autocomplete that populates from metastore.
+      // Ensure regular textfield with maxlength comes through.
+      'textField' => [
+        (object) [
+          'widget' => 'textfield',
+        ],
+        [
+          '#type' => 'textfield',
+          '#title' => 'textField',
+          '#maxlength' => 256,
+        ],
+        [
+          '#type' => 'textfield',
+          '#title' => 'textField',
+          '#maxlength' => 256,
+        ],
+      ],
+      // Textarea should not have maxlength after being handled.
+      'textArea' => [
+        (object) [
+          'widget' => 'textarea',
+        ],
+        [
+          '#type' => 'textfield',
+          '#title' => 'textArea',
+          '#maxlength' => 256,
+        ],
+        [
+          '#type' => 'textarea',
+          '#title' => 'textArea',
+        ],
+      ],
       'tagField' => [
         (object) [
           'widget' => 'list',


### PR DESCRIPTION
Fixes bug introduced in #4212 where textareas are now limited to 256 characters.

## QA steps

Edit or create a dataset with a description longer than 256 characters; confirm the data passes form validation.