### PR TITLE
Change private methods to protected in WidgetRouter

### DIFF
--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -240,7 +240,7 @@ class WidgetRouter implements ContainerInjectionInterface {
    * @return string
    *   String to be used in title.
    */
-  private function metastoreOptionTitle($item, $titleProperty): string {
+  protected function metastoreOptionTitle($item, $titleProperty): string {
     if ($titleProperty) {
       return is_object($item) ? $item->data->$titleProperty : $item;
     }
@@ -260,7 +260,7 @@ class WidgetRouter implements ContainerInjectionInterface {
    * @return string
    *   String to be used as option value.
    */
-  private function metastoreOptionValue($item, object $source, $titleProperty): string {
+  protected function metastoreOptionValue($item, object $source, $titleProperty): string {
     if (($source->returnValue ?? NULL) == 'url') {
       return 'dkan://metastore/schemas/' . $source->metastoreSchema . '/items/' . $item->identifier;
     }
@@ -273,7 +273,7 @@ class WidgetRouter implements ContainerInjectionInterface {
   /**
    * Helper function to add the value of other to current list of options.
    */
-  private function handleSelectOtherDefaultValue($element, $options) {
+  protected function handleSelectOtherDefaultValue($element, $options) {
     if (!empty($element['#default_value'])) {
       if (!array_key_exists($element['#default_value'], $options)) {
         $element['#options'][$element['#default_value']] = $element['#default_value'];


### PR DESCRIPTION
@dafeder : Some time ago we had a conversation about use of private vs protected for methods in DKAN and you indicated that you might be willing to change some methods from private to protected if there is no special reason for being private and no issues arise.

This PR is to change three methods in WidgetRouter from private to protected.

Background to this is, that I am working on an integration for Group module to allow publishers to depend on Group membership. Therefore I want to allow only those options for choosing a publisher to which the current user has access based on his group membership. I want to decorate WidgetRouter and override getOptionsFromMetastore and have the need to call metastoreOptionTitle() and metastoreOptionValue() from the decorating class which is not possible if they are private.

I changed handleSelectOtherDefaultValue() from private to protected too, though I do not needs this at this moment, but seems more consistent to have all three methods changed from private to protected.
