### PR TITLE
Updated the data dictionary description field type to a textarea

### DIFF
--- a/modules/data_dictionary_widget/src/Fields/FieldAddCreation.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldAddCreation.php
@@ -138,7 +138,7 @@ class FieldAddCreation {
   private static function createDescriptionField() {
     return [
       '#name' => 'field_json_metadata[0][dictionary_fields][field_collection][group][description]',
-      '#type' => 'textfield',
+      '#type' => 'textarea',
       '#required' => TRUE,
       '#title' => 'Description',
       '#description' => t('Information about the field data.'),

--- a/modules/data_dictionary_widget/src/Fields/FieldEditCreation.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldEditCreation.php
@@ -122,7 +122,7 @@ class FieldEditCreation {
   private static function createDescriptionField($key, $current_fields) {
     return [
       '#name' => 'field_json_metadata[0][dictionary_fields][data][' . $key . '][field_collection][description]',
-      '#type' => 'textfield',
+      '#type' => 'textarea',
       '#value' => $current_fields[$key]['description'],
       '#required' => TRUE,
       '#title' => 'Description',


### PR DESCRIPTION
fixes [org/repo/issue#] WCMS-21356

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

- [ ] Navigate to an existing Data Dictionary or a new data dictionary ie: /node/add/data?schema=data-dictionary
- [ ] Select Add Field button
- [ ] Confirm description is a textarea and can handle larger descriptions.
- [ ] Confirm you can add a field and save dd without issues.
- [ ] Confirm you can edit the dd field and the description on the edit experience is also a textarea.
- [ ] Confirm you can save the node and that the endpoint for the newly added dd looks correct with respect to the description field.
