### PR TITLE
Use Request in harvest WebServiceApi

### DIFF
--- a/modules/harvest/src/WebServiceApi.php
+++ b/modules/harvest/src/WebServiceApi.php
@@ -6,7 +6,6 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Harvest API controller.
@@ -202,6 +201,8 @@ class WebServiceApi implements ContainerInjectionInterface {
    *
    * @param string $identifier
    *   The harvest run identifier.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The HTTP request we're handling.
    */
   public function infoRun($identifier, Request $request) {
 

--- a/modules/harvest/tests/src/Unit/WebServiceApiTest.php
+++ b/modules/harvest/tests/src/Unit/WebServiceApiTest.php
@@ -101,7 +101,7 @@ class WebServiceApiTest extends TestCase {
   public function testBadPlan() {
     $this->request = new Request();
     $controller = WebServiceApi::create($this->getContainer());
-    $response = $controller->register();
+    $response = $controller->register($this->request);
     $this->assertInstanceOf(JsonResponse::class, $response);
     $this->assertEquals($response->getContent(), json_encode(["message" => "Harvest plan must be a php object."]));
   }
@@ -126,7 +126,7 @@ class WebServiceApiTest extends TestCase {
     $this->request = $request;
 
     $controller = WebServiceApi::create($this->getContainer());
-    $response = $controller->register();
+    $response = $controller->register($request);
     $this->assertInstanceOf(JsonResponse::class, $response);
     $this->assertEquals($response->getContent(), json_encode(["identifier" => "test"]));
 
@@ -139,7 +139,6 @@ class WebServiceApiTest extends TestCase {
    */
   public function testRun() {
     $options = (new Options())
-      ->add("request_stack", RequestStack::class)
       ->add("dkan.harvest.service", HarvestService::class)
       ->index(0);
 
@@ -150,13 +149,15 @@ class WebServiceApiTest extends TestCase {
 
     $container = (new Chain($this))
       ->add(Container::class, "get", $options)
-      ->add(RequestStack::class, 'getCurrentRequest', Request::class)
-      ->add(Request::class, 'getContent', json_encode((object) ['plan_id' => 'test']))
       ->add(HarvestService::class, "runHarvest", Result::class)
       ->getMock();
 
+    $request = new Request([], [], [], [], [], [],
+      json_encode((object) ['plan_id' => 'test'])
+    );
+
     $controller = WebServiceApi::create($container);
-    $response = $controller->run();
+    $response = $controller->run($request);
     $this->assertInstanceOf(JsonResponse::class, $response);
   }
 


### PR DESCRIPTION
- Removes useage of request_stack service in the harvest WebServiceApi controller.
- Adjusts tests to reflect this new reality.