### PR TITLE
Editable Index

### DIFF
--- a/modules/data_dictionary_widget/src/Fields/FieldCallbacks.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldCallbacks.php
@@ -40,8 +40,8 @@ class FieldCallbacks {
    */
   public static function editSubformCallback(array &$form, FormStateInterface $form_state) {
     // Get the current fields data
-    $current_dictionary_fields = $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["data"]["#rows"];
-    $current_index_fields = $form["field_json_metadata"]["widget"][0]["indexes"]["fields"]["data"]["#rows"];
+    $current_dictionary_fields = $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["data"]["#rows"] ?? [];
+    $current_index_fields = $form["field_json_metadata"]["widget"][0]["indexes"]["fields"]["data"]["#rows"] ?? [];
     // Get the field index from the triggering op attribute
     // so we can use it to store the respective field later
     $op_index = explode("_", $form_state->getTriggeringElement()['#op']);

--- a/modules/data_dictionary_widget/src/Fields/FieldCallbacks.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldCallbacks.php
@@ -103,7 +103,7 @@ class FieldCallbacks {
     $form_state->set('add_new_field', '');
     $current_dictionary_fields = $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["data"]["#rows"];
     $current_index = $form["field_json_metadata"]["widget"][0]['indexes']["data"]["#rows"];
-    $current_index_fields = $form["field_json_metadata"]["widget"][0]['indexes']["fields"]["data"]["#rows"];
+    $current_index_fields = $form["field_json_metadata"]["widget"][0]['indexes']["fields"]["data"]["#rows"] ?? [];
 
     if ($current_dictionary_fields) {
       $form_state->set('current_dictionary_fields', $current_dictionary_fields);

--- a/modules/data_dictionary_widget/src/Fields/FieldOperations.php
+++ b/modules/data_dictionary_widget/src/Fields/FieldOperations.php
@@ -196,14 +196,26 @@ class FieldOperations {
   /**
    * Set the elements associated with adding a new field.
    */
-  public static function setAddFormState($add_new_field, $element) {
+  public static function setAddDictionaryFieldFormState($add_new_field, $element) {
     if ($add_new_field) {
+      unset($element['dictionary_fields']["edit_buttons"]);
       $element['dictionary_fields']['field_collection'] = $add_new_field;
       $element['dictionary_fields']['field_collection']['#access'] = TRUE;
       $element['dictionary_fields']['add_row_button']['#access'] = FALSE;
       $element['identifier']['#required'] = FALSE;
       $element['title']['#required'] = FALSE;
     }
+    return $element;
+  }
+
+  /**
+   * Set the elements associated with editing a dictionary field.
+   */
+  public static function editDictionaryFieldFormState($edit_dictionary_field, $element) {
+    if ($edit_dictionary_field) {
+      unset($element['dictionary_fields']["edit_buttons"]);
+    } 
+
     return $element;
   }
 

--- a/modules/data_dictionary_widget/src/Indexes/IndexFieldAddCreation.php
+++ b/modules/data_dictionary_widget/src/Indexes/IndexFieldAddCreation.php
@@ -3,12 +3,12 @@
 namespace Drupal\data_dictionary_widget\Indexes;
 
 /**
- * Various operations for creating Data Dictionary Widget add fields.
+ * Various operations for creating Index fields.
  */
 class IndexFieldAddCreation {
 
  /**
-  * Create add fields for Data Dictionary Widget.
+  * Create fields for adding an index.
   */
  public static function addIndex() {
   $add_index['#access'] = FALSE;
@@ -16,7 +16,7 @@ class IndexFieldAddCreation {
     '#type' => 'fieldset',
     '#title' => t('Index'),
     '#open' => TRUE,
-    '#prefix' => '<div id = field-json-metadata-dictionary-index>',
+    '#prefix' => '<div id = field-json-metadata-index>',
     '#suffix' => '</div>',
     '#element_validate' => [
       ['\Drupal\data_dictionary_widget\Indexes\IndexValidation', 'indexFieldsValidation']
@@ -48,7 +48,7 @@ class IndexFieldAddCreation {
   $add_index['group']['index']['fields'] = [
     '#type' => 'fieldset',
     '#title' => t('Fields'),
-    '#prefix' => '<div id = field-json-metadata-dictionary-index-fields>',
+    '#prefix' => '<div id = field-json-metadata-index-fields>',
     '#suffix' => '</div>',
     '#markup' => t('<div class="claro-details__description">One or more fields included in index. Must be keys from the fields object.</div>'),
     '#attributes' => [
@@ -64,10 +64,10 @@ class IndexFieldAddCreation {
  }
 
   /**
-   * Create add fields for Data Dictionary Widget.
+   * Create fields for adding an index field.
    */
   public static function addIndexFields($current_index_fields) {
-    $id = "field-json-metadata-dictionary-index-fields-new";
+    $id = "field-json-metadata-index-fields-new";
     $add_index_fields['#access'] = FALSE;
     $add_index_fields['group'] = [
       '#type' => 'fieldset',

--- a/modules/data_dictionary_widget/src/Indexes/IndexFieldButtons.php
+++ b/modules/data_dictionary_widget/src/Indexes/IndexFieldButtons.php
@@ -3,7 +3,7 @@
 namespace Drupal\data_dictionary_widget\Indexes;
 
 /**
- * Various operations for creating Data Dictionary Widget fields.
+ * Various operations for index widget buttons.
  */
 class IndexFieldButtons {
 
@@ -25,7 +25,7 @@ class IndexFieldButtons {
       ],
       '#ajax' => [
         'callback' => '\Drupal\data_dictionary_widget\Indexes\IndexFieldCallbacks::subIndexFormAjax',
-        'wrapper' => 'field-json-metadata-dictionary-index-fields',
+        'wrapper' => 'field-json-metadata-index-fields',
         'effect' => 'fade',
       ],
       '#limit_validation_errors' => [],
@@ -50,7 +50,7 @@ class IndexFieldButtons {
       ],
       '#ajax' => [
         'callback' => '\Drupal\data_dictionary_widget\Indexes\IndexFieldCallbacks::indexFormAjax',
-        'wrapper' => 'field-json-metadata-dictionary-index',
+        'wrapper' => 'field-json-metadata-index',
         'effect' => 'fade',
       ],
       '#limit_validation_errors' => [],
@@ -61,10 +61,19 @@ class IndexFieldButtons {
    * Returns the edit buttons.
    */
   public static function editIndexButtons($indexKey) {
+    if (str_contains($indexKey, 'field')) {
+      $callback = 'indexEditSubformCallback';
+      $id = 'field-json-metadata-index-fields';
+      $function = 'subIndexFormAjax';
+    } else {
+      $callback = 'indexEditCallback';
+      $id = 'field-json-metadata-index';
+      $function = 'indexFormAjax';
+    }
     return [
       '#type' => 'image_button',
-      '#name' => 'edit_index_' . $indexKey,
-      '#id' => 'edit_index_' . $indexKey,
+      '#name' => 'edit_' . $indexKey,
+      '#id' => 'edit_' . $indexKey,
       '#access' => TRUE,
       '#op' => 'edit_' . $indexKey,
       '#src' => 'core/misc/icons/787878/cog.svg',
@@ -75,12 +84,12 @@ class IndexFieldButtons {
       '#submit' => [
           [
             '\Drupal\data_dictionary_widget\Indexes\IndexFieldCallbacks',
-            'indexEditSubformCallback',
+            $callback,
           ],
       ],
       '#ajax' => [
-        'callback' => '\Drupal\data_dictionary_widget\Indexes\IndexFieldCallbacks::subIndexFormAjax',
-        'wrapper' => 'field-json-metadata-dictionary-index-fields',
+        'callback' => '\Drupal\data_dictionary_widget\Indexes\IndexFieldCallbacks::' . $function,
+        'wrapper' => $id,
         'effect' => 'fade',
       ],
       '#limit_validation_errors' => [
@@ -96,6 +105,7 @@ class IndexFieldButtons {
     $callbackClass = $location == 'edit' ? 'indexEditSubformCallback' : 'indexAddSubformCallback';
     $op = !empty($indexKey) ? 'update_' . $indexKey : 'add_index_field';
     $value = $location == 'edit' ? 'Save' : 'Add ';
+    $function = $location == 'edit' ? 'subIndexFormAjax' : 'subIndexFormAjax';
     $edit_index_button = [
       '#type' => 'submit',
       '#value' => $value,
@@ -107,8 +117,8 @@ class IndexFieldButtons {
         ],
       ],
       '#ajax' => [
-        'callback' => 'Drupal\data_dictionary_widget\Indexes\IndexFieldCallbacks::subIndexFormAjax',
-        'wrapper' => 'field-json-metadata-dictionary-index-fields',
+        'callback' => 'Drupal\data_dictionary_widget\Indexes\IndexFieldCallbacks::' . $function,
+        'wrapper' => 'field-json-metadata-index-fields',
         'effect' => 'fade',
       ],
       '#limit_validation_errors' => [
@@ -151,7 +161,7 @@ class IndexFieldButtons {
       ],
       '#ajax' => [
         'callback' => 'Drupal\data_dictionary_widget\Indexes\IndexFieldCallbacks::indexFormAjax',
-        'wrapper' => 'field-json-metadata-dictionary-index',
+        'wrapper' => 'field-json-metadata-index',
         'effect' => 'fade',
       ],
       '#limit_validation_errors' => [
@@ -170,7 +180,7 @@ class IndexFieldButtons {
    * Create Cancel button.
    */
   public static function cancelIndexFieldButton($location, $indexKey, $id) {
-    $callbackId = ($id === 'field-json-metadata-dictionary-index-fields-new') ? 'subIndexFormExistingFieldAjax' : 'subIndexFormAjax';
+    $callbackId = ($id === 'field-json-metadata-index-fields-new') ? 'subIndexFormExistingFieldAjax' : 'subIndexFormAjax';
     $callbackClass = $location == 'edit' ? 'indexEditSubformCallback' : 'indexAddSubformCallback';
     $op = $location == 'edit' && $indexKey ? 'abort_' . $indexKey : 'cancel_index_field';
     $cancel_index_button = [
@@ -217,7 +227,7 @@ class IndexFieldButtons {
       ],
       '#ajax' => [
         'callback' => 'Drupal\data_dictionary_widget\Indexes\IndexFieldCallbacks::indexFormAjax',
-        'wrapper' => 'field-json-metadata-dictionary-index',
+        'wrapper' => 'field-json-metadata-index',
         'effect' => 'fade',
       ],
       '#limit_validation_errors' => [],
@@ -232,7 +242,7 @@ class IndexFieldButtons {
   /**
    * Create Delete button.
    */
-  public static function deleteIndexButton($indexKey) {
+  public static function deleteIndexFieldButton($indexKey) {
     return [
       '#type' => 'submit',
       '#name' => 'index_delete_' . $indexKey,
@@ -246,7 +256,31 @@ class IndexFieldButtons {
       ],
       '#ajax' => [
         'callback' => 'Drupal\data_dictionary_widget\Indexes\IndexFieldCallbacks::subIndexFormAjax',
-        'wrapper' => 'field-json-metadata-dictionary-index-fields',
+        'wrapper' => 'field-json-metadata-index-fields',
+        'effect' => 'fade',
+      ],
+      '#limit_validation_errors' => [],
+    ];
+  }
+
+  /**
+   * Create Delete button.
+   */
+  public static function deleteIndexButton($indexKey) {
+    return [
+      '#type' => 'submit',
+      '#name' => 'index_delete_' . $indexKey,
+      '#value' => t('Delete index'),
+      '#op' => 'delete_' . $indexKey,
+      '#submit' => [
+        [
+          '\Drupal\data_dictionary_widget\Indexes\IndexFieldCallbacks',
+          'indexEditCallback',
+        ],
+      ],
+      '#ajax' => [
+        'callback' => 'Drupal\data_dictionary_widget\Indexes\IndexFieldCallbacks::indexFormAjax',
+        'wrapper' => 'field-json-metadata-index',
         'effect' => 'fade',
       ],
       '#limit_validation_errors' => [],

--- a/modules/data_dictionary_widget/src/Indexes/IndexFieldCallbacks.php
+++ b/modules/data_dictionary_widget/src/Indexes/IndexFieldCallbacks.php
@@ -14,9 +14,9 @@ class IndexFieldCallbacks {
   public static function indexAddSubformCallback(array &$form, FormStateInterface $form_state) {
     $trigger = $form_state->getTriggeringElement();
     $op = $trigger['#op'];
-    $current_dictionary_fields = $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["data"]["#rows"];
-    $current_index = $form["field_json_metadata"]["widget"][0]['indexes']["data"]["#rows"];
-    $current_index_fields = $form["field_json_metadata"]["widget"][0]['indexes']["fields"]["data"]["#rows"];
+    $current_dictionary_fields = $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["data"]["#rows"] ?? [];
+    $current_index = $form["field_json_metadata"]["widget"][0]['indexes']["data"]["#rows"] ?? [];
+    $current_index_fields = $form["field_json_metadata"]["widget"][0]['indexes']["fields"]["data"]["#rows"] ?? [];
 
     if ($current_index_fields) {
       $form_state->set('current_index_fields', $current_index_fields);
@@ -141,9 +141,9 @@ class IndexFieldCallbacks {
    */
   public static function indexEditCallback(array &$form, FormStateInterface $form_state) {
     $trigger = $form_state->getTriggeringElement();
-    $current_index_fields = $form["field_json_metadata"]["widget"][0]["indexes"]["fields"]["data"]["#rows"];
-    $current_index = $form["field_json_metadata"]["widget"][0]["indexes"]["data"]["#rows"];
-    $current_dictionary_fields = $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["data"]["#rows"];
+    $current_index_fields = $form["field_json_metadata"]["widget"][0]["indexes"]["fields"]["data"]["#rows"] ?? [];
+    $current_index = $form["field_json_metadata"]["widget"][0]["indexes"]["data"]["#rows"] ?? [];
+    $current_dictionary_fields = $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["data"]["#rows"] ?? [];
     $op = $trigger['#op'];
     $op_index = explode("_", $trigger['#op']);
     $currently_modifying_index_fields = $form_state->get('index_fields_being_modified') != NULL ? $form_state->get('index_fields_being_modified') : [];

--- a/modules/data_dictionary_widget/src/Indexes/IndexFieldCreation.php
+++ b/modules/data_dictionary_widget/src/Indexes/IndexFieldCreation.php
@@ -3,17 +3,17 @@
 namespace Drupal\data_dictionary_widget\Indexes;
 
 /**
- * Various operations for creating Data Dictionary Widget fields.
+ * Various operations for creating Index fields.
  */
 class IndexFieldCreation {
   /**
-   * Create basic widget.
+   * Create basic index fields fieldset.
    */
   public static function createGeneralIndexFields($element) {
     $element['indexes']['fields'] = [
       '#type' => 'fieldset',
       '#title' => t('Fields'),
-      '#prefix' => '<div id = field-json-metadata-dictionary-index-fields>',
+      '#prefix' => '<div id = field-json-metadata-index-fields>',
       '#suffix' => '</div>',
       '#markup' => t('<div class="claro-details__description">One or more fields included in index. Must be keys from the fields object.</div>'),
       '#required' => TRUE,
@@ -23,13 +23,13 @@ class IndexFieldCreation {
   }
 
   /**
-   * Create basic widget.
+   * Create basic indexes fieldset.
    */
   public static function createGeneralIndex($element, $current_indexes) {
     $element['indexes'] = [
       '#type' => 'fieldset',
       '#title' => t('Indexes'),
-      '#prefix' => '<div id = field-json-metadata-dictionary-index>',
+      '#prefix' => '<div id = field-json-metadata-index>',
       '#suffix' => '</div>',
       '#markup' => t('<div class="claro-details__description">Adding indexes to your datastore tables can improve response times from common queries.</div>'),
     ];
@@ -63,7 +63,7 @@ class IndexFieldCreation {
       '#access' => ((bool) $current_indexes || (bool) $index_data_results),
       '#type' => 'table',
       '#header' => ['NAME', 'TYPE', 'FIELDS'],
-      '#prefix' => '<div id = field-json-metadata-dictionary-indexes>',
+      '#prefix' => '<div id = field-json-metadata-indexes>',
       '#suffix' => '</div>',
       '#rows' => $form_state->get('cancel_index') ? $current_indexes : ($index_data_results ?? []),
       '#tree' => TRUE,

--- a/modules/data_dictionary_widget/src/Indexes/IndexFieldEditCreation.php
+++ b/modules/data_dictionary_widget/src/Indexes/IndexFieldEditCreation.php
@@ -3,15 +3,15 @@
 namespace Drupal\data_dictionary_widget\Indexes;
 
 /**
- * Various operations for creating Data Dictionary Widget add fields.
+ * Various operations for creating edit fields for indexes.
  */
 
 class IndexFieldEditCreation {
   /**
-   * Create edit fields for Data Dictionary Widget.
+   * Create edit index fields.
    */
   public static function editIndexFields($indexKey, $current_index_fields, $index_fields_being_modified) {
-    $id = $current_index_fields ? "field-json-metadata-dictionary-index-fields" : "field-json-metadata-dictionary-index-fields-new";
+    $id = $current_index_fields ? "field-json-metadata-index-fields" : "field-json-metadata-index-fields-new";
     $indexKeyExplode = explode("_", $indexKey);
     $edit_index_fields['name'] = [
       '#name' => 'field_json_metadata[0][indexes][fields][edit_index_fields][' . $indexKeyExplode[3] . '][name]',
@@ -28,31 +28,53 @@ class IndexFieldEditCreation {
       '#required' => TRUE,
     ];
 
-    $edit_index_fields['update_index_field']['actions'] = self::createIndexActionFields($indexKey, $id);
+    $edit_index_fields['update_index_field']['actions'] = self::createIndexFieldsActionFields($indexKey, $id);
 
     return $edit_index_fields;
   }
 
   /**
-   * Create edit fields for Data Dictionary Widget.
+   * Create edit index.
    */
-  public static function editIndex($indexKey, $current_index) {
-    $id = $current_index ? "field-json-metadata-dictionary-index-fields-new" : "field-json-metadata-dictionary-index-fields";
+  public static function editIndex($indexKey, $current_index, $index_being_modified, $form_state) {
+    $id = $current_index ? "field-json-metadata-index-new" : "field-json-metadata-index";
     $indexKeyExplode = explode("_", $indexKey);
-    $edit_index['name'] = [
-      '#name' => 'field_json_metadata[0][index][data][' . $indexKeyExplode[3] . '][field_collection][name]',
+
+    $edit_index['description'] = [
+      '#name' => "field_json_metadata[0][indexes][edit_index][index_key_" . $indexKeyExplode[2] . "][description]",
       '#type' => 'textfield',
-      '#value' => $current_index[$indexKeyExplode[3]]['name'],
+      '#value' => $current_index[$indexKeyExplode[2]]['description'],
       '#title' => 'Name',
     ];
-    $edit_index['length'] = [
-      '#name' => 'field_json_metadata[0][index][data]['. $indexKeyExplode[3] .'][field_collection][length]',
-      '#type' => 'number',
-      '#value' => $current_index[$indexKeyExplode[3]]['length'],
-      '#title' => 'Length',
+    $edit_index['type'] = [
+      '#name' => "field_json_metadata[0][indexes][edit_index][index_key_" . $indexKeyExplode[2] . "][type]",
+      '#type' => 'select',
+      '#description' => t('Index type.'),
+      '#title' => 'Index Type',
+      '#default_value' => 'index',
+      '#op' => 'index_type',
+      '#required' => TRUE,
+      '#options' => [
+        'index' => t('index'),
+        'fulltext' => t('fulltext'),
+      ],
+      '#value' => $current_index[$indexKeyExplode[2]]['type'],
     ];
 
-    $edit_index['update_index_field']['actions'] = self::createIndexActionFields($indexKey, $id );
+    $edit_index['group'] = [
+      '#type' => 'fieldset',
+      '#title' => t('Fields'),
+      '#prefix' => '<div id = field-json-metadata-index-fields>',
+      '#suffix' => '</div>',
+      '#markup' => t('<div class="claro-details__description">One or more fields included in index. Must be keys from the fields object.</div>'),
+      '#attributes' => [
+        'class' => ['index-fields-form'],
+      ],    
+    ];
+
+    $edit_index['group']['fields']['data'] = IndexFieldCreation::createIndexFieldsDataRows($current_index[$indexKeyExplode[2]]['fields'], $current_index[$indexKeyExplode[2]]['fields'], $current_index[$indexKeyExplode[2]]['fields'], $form_state);
+
+    $edit_index['update_index']['actions'] = self::createIndexActionFields($indexKey, $id );
 
     return $edit_index;
   }
@@ -63,9 +85,21 @@ class IndexFieldEditCreation {
   private static function createIndexActionFields($indexKey, $id) {
     return [
       '#type' => 'actions',
+      'save_update' => IndexFieldButtons::submitIndexButton('edit', $indexKey),
+      'cancel_updates' => IndexFieldButtons::cancelIndexButton('edit', $indexKey, $id),
+      'delete_index' => IndexFieldButtons::deleteIndexButton($indexKey),
+    ];
+  }
+
+  /**
+   * Create Action buttons.
+   */
+  private static function createIndexFieldsActionFields($indexKey, $id) {
+    return [
+      '#type' => 'actions',
       'save_update' => IndexFieldButtons::submitIndexFieldButton('edit', $indexKey),
-      'cancel_updates' => IndexFieldButtons::cancelIndexFieldButton('edit', $indexKey, $id),
-      'delete_field' => IndexFieldButtons::deleteIndexButton($indexKey),
+      'cancel_updates' => IndexFieldButtons::cancelIndexButton('edit', $indexKey, $id),
+      'delete_field' => IndexFieldButtons::deleteIndexFieldButton($indexKey),
     ];
   }
 

--- a/modules/data_dictionary_widget/src/Indexes/IndexFieldOperations.php
+++ b/modules/data_dictionary_widget/src/Indexes/IndexFieldOperations.php
@@ -3,62 +3,89 @@
 namespace Drupal\data_dictionary_widget\Indexes;
 
 /**
- * Various operations for the Data Dictionary Widget.
+ * Various operations for structuring indexes and fields before rendering.
  */
 class IndexFieldOperations {
   /**
-   * Setting ajax elements.
+   * Setting ajax elements when editing newly added index fields.
    */
-  public static function setIndexFieldsAjaxElements(array $dictionaryIndexFields) {
-    if ($dictionaryIndexFields["data"]) {
-      foreach ($dictionaryIndexFields['data']['#rows'] as $row => $data) {
-        $edit_index_button = $dictionaryIndexFields['edit_index_buttons']['index_field_key_' . $row] ?? NULL;
-        $edit_index_fields = $dictionaryIndexFields['edit_index_fields']['index_field_key_' . $row] ?? NULL;
+  public static function setIndexFieldsAjaxElementsOnAdd(array $indexFields) {
+    if ($indexFields["data"]) {
+      foreach ($indexFields['data']['#rows'] as $row => $data) {
+        $edit_index_button = $indexFields['edit_index_buttons']['index_field_key_' . $row] ?? NULL;
+        $edit_index_fields = $indexFields['edit_index_fields']['index_field_key_' . $row] ?? NULL;
         // Setting the ajax fields if they exsist.
         if ($edit_index_button) {
-          $dictionaryIndexFields['data']['#rows'][$row] = array_merge($data, $edit_index_button);
-          unset($dictionaryIndexFields['edit_index_buttons']['index_field_key_' . $row]);
+          $indexFields['data']['#rows'][$row] = array_merge($data, $edit_index_button);
+          unset($indexFields['edit_index_buttons']['index_field_key_' . $row]);
         }
         elseif ($edit_index_fields) {
-          unset($dictionaryIndexFields['data']['#rows']['index_field_key_' . $row]);
-          $dictionaryIndexFields['data']['#rows'][$row]['field_collection'] = $edit_index_fields;
+          unset($indexFields['data']['#rows']['index_field_key_' . $row]);
+          $indexFields['data']['#rows'][$row]['field_collection'] = $edit_index_fields;
           // Remove the buttons so they don't show up twice.
-          unset($dictionaryIndexFields['edit_index_fields']['index_field_key_' . $row]);
-          ksort($dictionaryIndexFields['data']['#rows']);
+          unset($indexFields['edit_index_fields']['index_field_key_' . $row]);
+          ksort($indexFields['data']['#rows']);
         }
       }
     }
 
-    return $dictionaryIndexFields;
+    return $indexFields;
   }
 
   /**
-   * Setting ajax elements.
+   * Setting ajax elements when editing existing index fields.
    */
-  public static function setIndexAjaxElements(array $dictionaryIndexes) {
-    foreach ($dictionaryIndexes['data']['#rows'] as $row => $data) {
-      $edit_index_button = $dictionaryIndexes['edit_index_buttons']['index_key_' . $row] ?? NULL;
-      $edit_index_fields = $dictionaryIndexes['edit_index_fields']['index_key_' . $row] ?? NULL;
+  public static function setIndexFieldsAjaxElements(array $indexFields) {
+    if ($indexFields["data"]) {
+      foreach ($indexFields['data']['#rows'] as $row => $data) {
+        $edit_index_fields_button = $indexFields['fields']['edit_index_fields_buttons']['index_field_key_' . $row] ?? NULL;
+        $edit_index_fields = $indexFields['fields']['edit_index_fields']['index_field_key_' . $row] ?? NULL;
+        // Setting the ajax fields if they exsist.
+        if ($edit_index_fields_button) {
+          //$indexFields["data"]["#rows"][0] = array_merge($data, $edit_index_fields_button);
+          $indexFields["data"]["#rows"][$row] = array_merge($data, $edit_index_fields_button);
+          unset($indexFields["fields"]["edit_index_fields_buttons"]['index_field_key_' . $row]);
+        }
+        elseif ($edit_index_fields) {
+          unset($indexFields['data']['#rows']['index_field_key_' . $row]);
+          $indexFields['data']['#rows'][$row]['field_collection'] = $edit_index_fields;
+          // Remove the buttons so they don't show up twice.
+          unset($indexFields['edit_index_fields']['index_field_key_' . $row]);
+          ksort($indexFields['data']['#rows']);
+        }
+      }
+    }
+
+    return $indexFields;
+  }
+
+  /**
+   * Setting index ajax elements.
+   */
+  public static function setIndexAjaxElements(array $indexes) {
+    foreach ($indexes['data']['#rows'] as $row => $data) {
+      $edit_index_button = $indexes['edit_index_buttons']['index_key_' . $row] ?? NULL;
+      $edit_index = $indexes['edit_index']['index_key_' . $row] ?? NULL;
       // Setting the ajax fields if they exsist.
       if ($edit_index_button) {
-        $dictionaryIndexes['data']['#rows'][$row] = array_merge($data, $edit_index_button);
-        unset($dictionaryIndexes['edit_index_buttons']['index_key_' . $row]);
+        $indexes['data']['#rows'][$row] = array_merge($data, $edit_index_button);
+        unset($indexes['edit_index_buttons']['index_key_' . $row]);
       }
-      elseif ($edit_index_fields) {
-        unset($dictionaryIndexes['data']['#rows']['index_key_' . $row]);
-        $dictionaryIndexes['data']['#rows'][$row]['field_collection'] = $edit_index_fields;
+      elseif ($edit_index) {
+        unset($indexes['data']['#rows']['index_key_' . $row]);
+        $indexes['data']['#rows'][$row]['field_collection'] = $edit_index;
         // Remove the buttons so they don't show up twice.
-        unset($dictionaryIndexes['edit_index_fields']['index_key_' . $row]);
-        ksort($dictionaryIndexes['data']['#rows']);
+        unset($indexes['edit_index']['index_key_' . $row]);
+        ksort($indexes['data']['#rows']);
       }
 
     }
 
-    return $dictionaryIndexes;
+    return $indexes;
   }
 
   /**
-   * Cleaning the data up.
+   * Prepare index field data results.
    */
   public static function processIndexFieldsDataResults($index_data_results, $current_index_fields, $index_field_values, $op) {
     if (isset($current_index_fields)) {
@@ -84,7 +111,7 @@ class IndexFieldOperations {
   }
 
   /**
-   * Cleaning the data up.
+   * Prepare index data results.
    */
   public static function processIndexDataResults($index_results, $current_indexes, $index_values, $index_fields_data_results, $op) {
     if (isset($current_indexes)) {
@@ -124,7 +151,18 @@ class IndexFieldOperations {
   }
 
   /**
-   * Set the elements associated with adding a new field.
+   * Set the elements associated with editing an index.
+   */
+  public static function editIndexFormState($edit_index, $element) {
+    if ($edit_index) {
+      unset($element["indexes"]["edit_index_buttons"]);
+    } 
+
+    return $element;
+  }
+
+  /**
+   * Set the elements associated with adding a new index field.
    */
   public static function setAddIndexFieldFormState($add_new_index_field, $element) {
     if ($add_new_index_field) {
@@ -140,10 +178,11 @@ class IndexFieldOperations {
   }
 
   /**
-   * Set the elements associated with adding a new field.
+   * Set the elements associated with adding a new index
    */
   public static function setAddIndexFormState($add_new_index, $element) {
     if ($add_new_index) {
+      unset($element["indexes"]["edit_index_buttons"]);
       $element['indexes']['field_collection'] = $add_new_index;
       $element['indexes']['field_collection']['#access'] = TRUE;
       $element['indexes']['add_row_button']['#access'] = FALSE;
@@ -155,9 +194,9 @@ class IndexFieldOperations {
   }
 
   /**
-   * Create edit and update fields where needed.
+   * Create edit and update fields for index fields.
    */
-  public static function createDictionaryIndexFieldOptions($op_index, $index_data_results, $index_fields_being_modified, $element) {
+  public static function createIndexFieldOptions($op_index, $index_data_results, $index_fields_being_modified, $element) {
     $current_index_fields = $index_data_results ?? NULL;
     // Creating ajax buttons/fields to be placed in correct location later.
     foreach ($index_data_results as $indexKey => $data) {
@@ -165,6 +204,7 @@ class IndexFieldOperations {
         $element['edit_index_fields']['index_field_key_' . $indexKey] = IndexFieldEditCreation::editIndexFields('index_field_key_' . $indexKey, $current_index_fields, $index_fields_being_modified);
       }
       else {
+        //$element['edit_index_fields_buttons']['index_field_key_' . $indexKey]['edit_index_fields_button'] = IndexFieldButtons::editIndexButtons('index_field_key_' . $indexKey);
         $element['edit_index_buttons']['index_field_key_' . $indexKey]['edit_index_button'] = IndexFieldButtons::editIndexButtons('index_field_key_' . $indexKey);
       }
     }
@@ -174,14 +214,15 @@ class IndexFieldOperations {
   }
 
   /**
-   * Create edit and update fields where needed.
+   * Create edit and update fields for indexes.
    */
-  public static function createDictionaryIndexOptions($op_index, $index_data_results, $index_fields_being_modified, $element) {
+  public static function createIndexOptions($op_index, $index_data_results, $index_being_modified, $index_field_being_modified, $element, $form_state) {
     $current_indexes = $element['current_index'];
+
     // Creating ajax buttons/fields to be placed in correct location later.
     foreach ($index_data_results as $indexKey => $data) {
-      if (self::checkIndexEditingField('index_key_' . $indexKey, $op_index, $index_fields_being_modified)) {
-        $element['edit_index']['index_key_' . $indexKey] = IndexFieldEditCreation::editIndex('index_key_' . $indexKey, $current_indexes, $index_fields_being_modified);
+      if (self::checkIndexEditing('index_key_' . $indexKey, $op_index, $index_being_modified)) {
+        $element['edit_index']['index_key_' . $indexKey] = IndexFieldEditCreation::editIndex('index_key_' . $indexKey, $current_indexes, $index_being_modified, $form_state);
       }
       else {
         $element['edit_index_buttons']['index_key_' . $indexKey]['edit_index_button'] = IndexFieldButtons::editIndexButtons('index_key_' . $indexKey);
@@ -193,7 +234,7 @@ class IndexFieldOperations {
   }
 
   /**
-   * Return true if field is being edited.
+   * Return true if index field is being edited.
    */
   public static function checkIndexEditingField($indexKey, $op_index, $index_fields_being_modified) {
     $action_list = IndexFieldOperations::editIndexActions();
@@ -204,5 +245,23 @@ class IndexFieldOperations {
     else {
       return FALSE;
     }
+  }
+
+  /**
+   * Return true if index is being edited.
+   */
+  public static function checkIndexEditing($indexKey, $op_index, $index_being_modified) {
+    if (isset($op_index)) {
+        $op_index_string = implode('_', $op_index);
+        if (str_contains($op_index_string, 'edit_index_key')) {
+            $action_list = IndexFieldOperations::editIndexActions();
+            $indexKeyExplode = explode("_", $indexKey); 
+            if (isset($op_index[0]) && in_array($op_index[0], $action_list) && array_key_exists($indexKeyExplode[2], $index_being_modified)) {
+                return TRUE;
+            }
+        }
+    }
+
+    return FALSE;
   }
 }

--- a/modules/data_dictionary_widget/src/Indexes/IndexFieldOperations.php
+++ b/modules/data_dictionary_widget/src/Indexes/IndexFieldOperations.php
@@ -252,14 +252,14 @@ class IndexFieldOperations {
    */
   public static function checkIndexEditing($indexKey, $op_index, $index_being_modified) {
     if (isset($op_index)) {
-        $op_index_string = implode('_', $op_index);
-        if (str_contains($op_index_string, 'edit_index_key')) {
-            $action_list = IndexFieldOperations::editIndexActions();
-            $indexKeyExplode = explode("_", $indexKey); 
-            if (isset($op_index[0]) && in_array($op_index[0], $action_list) && array_key_exists($indexKeyExplode[2], $index_being_modified)) {
-                return TRUE;
-            }
+      $op_index_string = implode('_', $op_index);
+      if (str_contains($op_index_string, 'edit_index_key')) {
+        $action_list = IndexFieldOperations::editIndexActions();
+        $indexKeyExplode = explode("_", $indexKey); 
+        if (isset($op_index[0]) && in_array($op_index[0], $action_list) && array_key_exists($indexKeyExplode[2], $index_being_modified)) {
+          return TRUE;
         }
+      }
     }
 
     return FALSE;

--- a/modules/data_dictionary_widget/src/Indexes/IndexFieldValues.php
+++ b/modules/data_dictionary_widget/src/Indexes/IndexFieldValues.php
@@ -3,7 +3,7 @@
 namespace Drupal\data_dictionary_widget\Indexes;
 
 /**
- * Various operations for creating index fields.
+ * Various operations for returning index values when editing the field.
  */
 class IndexFieldValues {
   /**
@@ -16,6 +16,21 @@ class IndexFieldValues {
     return [
       'name' => $name,
       'length' => (int)$length,
+    ];
+  }
+
+  /**
+   * Return updated index values after edit.
+   */
+  public static function updateIndexValues($field_index, $update_values, $current_index) {
+    $description = $update_values["field_json_metadata"][0]["indexes"]["edit_index"]['index_key_' . $field_index]["description"];
+    $type = $update_values["field_json_metadata"][0]["indexes"]["edit_index"]['index_key_' . $field_index]["type"];
+    $fields = $current_index[$field_index]["fields"];
+
+    return [
+      'description' => $description,
+      'type' => $type,
+      'fields' => $fields,
     ];
   }
 }

--- a/modules/data_dictionary_widget/src/Plugin/Field/FieldWidget/DataDictionaryWidget.php
+++ b/modules/data_dictionary_widget/src/Plugin/Field/FieldWidget/DataDictionaryWidget.php
@@ -30,59 +30,80 @@ class DataDictionaryWidget extends WidgetBase implements TrustedCallbackInterfac
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
-    // Retrieve values from form state
+    // Retrieve data-dictionary form_state values to be used for various operations.
     $dictionary_field_values = $form_state->get("new_dictionary_fields");
-    $index_values = $form_state->get('new_index');
-    $index_field_values = $form_state->get("new_index_fields");
-    $add_index_field = $form_state->get('add_new_index_field');
-    $add_new_index = $form_state->get('add_new_index');
     $add_new_dictionary_field = $form_state->get('add_new_field');
     $current_dictionary_fields = $form_state->get('current_dictionary_fields');
-    $current_indexes = $form_state->get('current_index');
-    $current_index_fields = $form_state->get('current_index_fields');
     $dictionary_fields_being_modified = $form_state->get("dictionary_fields_being_modified") ?? NULL;
+
+    // Retrieve indexes form_state values to be used for various operations.
+    $current_indexes = $form_state->get('current_index');
+    $index_values = $form_state->get('new_index');
+    $add_new_index = $form_state->get('add_new_index');
+    $index_being_modified = $form_state->get("index_being_modified") ?? NULL;
+
+    // Retrieve index fields form_state values to be used for various operations.
+    $current_index_fields = $form_state->get('current_index_fields');
+    $index_field_values = $form_state->get("new_index_fields");
+    $add_index_field = $form_state->get('add_new_index_field');
     $index_fields_being_modified = $form_state->get("index_fields_being_modified") ?? NULL;
 
+    // Retrieve triggered element to be used for various operations.
     $op = $form_state->getTriggeringElement()['#op'] ?? NULL;
-    $field_json_metadata = !empty($items[0]->value) ? json_decode($items[0]->value, TRUE) : [];
-    $op_index = isset($form_state->getTriggeringElement()['#op']) ? explode("_", $form_state->getTriggeringElement()['#op']) : NULL;
+    $op_index = isset($op) ? explode("_", $op) : NULL;
 
-    // Retrieve initial data results from field JSON metadata
+    // Retrieve form element item values.
+    $field_json_metadata = !empty($items[0]->value) ? json_decode($items[0]->value, TRUE) : [];
+
+    // Retrieve initial data results from field JSON metadata.
     $data_results = $field_json_metadata["data"]["fields"] ?? [];
     $index_fields_results = $field_json_metadata["data"]["indexes"][0]["fields"] ?? [];
     $index_results = $field_json_metadata["data"]["indexes"] ?? [];
 
-    // Process data results
+    // Process data results.
     $data_results = FieldOperations::processDataResults($data_results, $current_dictionary_fields, $dictionary_field_values, $op);
     $index_fields_data_results = IndexFieldOperations::processIndexFieldsDataResults($index_fields_results, $current_index_fields, $index_field_values, $op);
     $index_data_results = IndexFieldOperations::processIndexDataResults($index_results, $current_indexes, $index_values, $index_fields_data_results, $op);
 
-    // Create form elements
+    // Create form elements.
     $element = FieldCreation::createGeneralFields($element, $field_json_metadata, $current_dictionary_fields, $form_state);
     $element = IndexFieldCreation::createGeneralIndex($element, $current_indexes);
-    $element = IndexFieldCreation::createGeneralIndexFields($element);
+    if ($index_field_values || $add_index_field || $index_fields_being_modified) {
+      $element = IndexFieldCreation::createGeneralIndexFields($element);
+    }
 
-    // Add pre-render functions
+    // Add pre-render functions.
     $element['dictionary_fields']['#pre_render'] = [[$this, 'preRenderForm']];
     $element['indexes']['#pre_render'] = [[$this, 'preRenderIndexForm']];
-    $element['indexes']['fields']['#pre_render'] = [[$this, 'preRenderIndexFieldForm']];
+    $element['indexes']['fields']['#pre_render'] = [[$this, 'preRenderIndexFieldFormOnAdd']];
 
-    // Add data rows to display in tables
+    // Add data rows to display in tables.
     $element['dictionary_fields']['data'] = FieldCreation::createDictionaryDataRows($current_dictionary_fields, $data_results, $form_state);
     $element['indexes']['data'] = IndexFieldCreation::createIndexDataRows($current_indexes, $index_data_results, $form_state);
     $element['indexes']['fields']['data'] = IndexFieldCreation::createIndexFieldsDataRows($index_field_values, $current_index_fields, $index_fields_data_results, $form_state);
 
-    // Create dictionary fields/buttons for editing
+    // Create dictionary fields/buttons for editing.
     $element['dictionary_fields'] = FieldOperations::createDictionaryFieldOptions($op_index, $data_results, $dictionary_fields_being_modified, $element['dictionary_fields']);
     $element['dictionary_fields']['add_row_button']['#access'] = $dictionary_fields_being_modified == NULL ? TRUE : FALSE;
     
-    // Create index fields/buttons for editing
-    $element['indexes'] = IndexFieldOperations::createDictionaryIndexOptions($op_index, $index_data_results, $index_fields_being_modified, $element['indexes']);
+    // Create index fields/buttons for editing.
+    $element['indexes'] = IndexFieldOperations::createIndexOptions($op_index, $index_data_results, $index_being_modified, $index_fields_being_modified, $element['indexes'], $form_state);
+    //$element['indexes'] = IndexFieldOperations::createIndexOptions($op_index, $index_data_results, $index_fields_being_modified, $element['indexes'], $form_state);
+
+    // Create edit buttons and fields for index fields.
     if ($index_field_values || $current_index_fields) {
-      $element["indexes"]["fields"] = IndexFieldOperations::createDictionaryIndexFieldOptions($op_index, $index_fields_data_results, $index_fields_being_modified, $element['indexes']['fields']);
+      $element["indexes"]["fields"] = IndexFieldOperations::createIndexFieldOptions($op_index, $index_fields_data_results, $index_fields_being_modified, $element['indexes']['fields']);
     }
+
+    // Set access to index fields Add button when index fields being modified.
     $element['indexes']['fields']['add_row_button']['#access'] = $index_fields_being_modified == NULL ? TRUE : FALSE;
-    
+
+    // if ($index_field_values || $current_index_fields || $index_being_modified || $index_fields_being_modified) {
+    //   $element["indexes"]["edit_index"]["index_key_0"]["group"]["fields"]["fields"] = IndexFieldOperations::createDictionaryIndexFieldOptions($op_index, $index_fields_data_results, $index_fields_being_modified, $element['indexes']['fields']);
+    //   $element["indexes"]["edit_index"]["index_key_0"]["group"]["fields"]['#pre_render'] = [[$this, 'preRenderIndexFieldForm']];
+    //   //$element["indexes"]['edit_index_fields']["index_field_key_0"]['#pre_render'] = [[$this, 'preRenderIndexFieldForm']];
+    // }
+
     // Get form entity
     $form_object = $form_state->getFormObject();
     if (!($form_object instanceof EntityFormInterface)) {
@@ -99,6 +120,7 @@ class DataDictionaryWidget extends WidgetBase implements TrustedCallbackInterfac
     $element = FieldOperations::setAddFormState($add_new_dictionary_field, $element);
     $element = IndexFieldOperations::setAddIndexFormState($add_new_index, $element);
     $element = IndexFieldOperations::setAddIndexFieldFormState($add_index_field, $element);
+    $element = IndexFieldOperations::editIndexFormState($index_being_modified, $element);
 
     // Display index fields only when new index fields are being created.
     if ($add_index_field || $index_field_values) {
@@ -117,22 +139,22 @@ class DataDictionaryWidget extends WidgetBase implements TrustedCallbackInterfac
     $current_dictionary_fields = $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["data"]["#rows"];
     $current_indexes = $form["field_json_metadata"]["widget"][0]["indexes"]["data"]["#rows"];
     $field_collection = $values[0]['dictionary_fields']["field_collection"]["group"] ?? [];
-    $indexes_collection = $values[0]["indexes"]["fields"]["field_collection"]["group"] ?? [];
+    $indexes_collection = isset($values[0]["indexes"]["fields"]["field_collection"]["group"]) ? $values[0]["indexes"]["fields"]["field_collection"]["group"] : [];
 
     $fields_input = !empty($field_collection) ? [
       [
-        "name" => $field_collection["name"],
-        "title" => $field_collection["title"],
-        "type" => $field_collection["type"],
-        "format" => $field_collection["format"],
-        "description" => $field_collection["description"],
+        "name" => $field_collection["name"] ?? '',
+        "title" => $field_collection["title"] ?? '',
+        "type" => $field_collection["type"] ?? '',
+        "format" => $field_collection["format"] ?? '',
+        "description" => $field_collection["description"] ?? '',
       ],
     ] : [];
 
     $index_inputs = !empty($indexes_collection) ? [
       [
-        "name" => $indexes_collection["indexes"]["fields"]["name"],
-        "length" => (int)$indexes_collection["indexes"]["fields"]["length"],
+        "name" => $indexes_collection["indexes"]["fields"]["name"] ?? '',
+        "length" => (int)$indexes_collection["indexes"]["fields"]["length"] ?? 0,
       ],
     ] : [];
 
@@ -176,6 +198,15 @@ class DataDictionaryWidget extends WidgetBase implements TrustedCallbackInterfac
   }
 
   /**
+   * Prerender callback for the index field form.
+   *
+   * Moves the buttons into the table.
+   */
+  public function preRenderIndexFieldFormOnAdd(array $indexFields) {
+    return IndexFieldOperations::setIndexFieldsAjaxElementsOnAdd($indexFields);
+  }
+
+  /**
    * Prerender callback for the index form.
    *
    * Moves the buttons into the table.
@@ -188,7 +219,7 @@ class DataDictionaryWidget extends WidgetBase implements TrustedCallbackInterfac
    * {@inheritdoc}
    */
   public static function trustedCallbacks() {
-    return ['preRenderForm', 'preRenderIndexFieldForm', 'preRenderIndexForm'];
+    return ['preRenderForm', 'preRenderIndexFieldFormOnAdd', 'preRenderIndexFieldForm', 'preRenderIndexForm'];
   }
 
 }

--- a/modules/data_dictionary_widget/src/Plugin/Field/FieldWidget/DataDictionaryWidget.php
+++ b/modules/data_dictionary_widget/src/Plugin/Field/FieldWidget/DataDictionaryWidget.php
@@ -96,7 +96,7 @@ class DataDictionaryWidget extends WidgetBase implements TrustedCallbackInterfac
     }
 
     // Set access to index fields Add button when index fields being modified.
-    $element['indexes']['fields']['add_row_button']['#access'] = $index_fields_being_modified == NULL ? TRUE : FALSE;
+    $element['indexes']['add_row_button']['#access'] = $index_being_modified == NULL ? TRUE : FALSE;
 
     // if ($index_field_values || $current_index_fields || $index_being_modified || $index_fields_being_modified) {
     //   $element["indexes"]["edit_index"]["index_key_0"]["group"]["fields"]["fields"] = IndexFieldOperations::createDictionaryIndexFieldOptions($op_index, $index_fields_data_results, $index_fields_being_modified, $element['indexes']['fields']);
@@ -117,7 +117,8 @@ class DataDictionaryWidget extends WidgetBase implements TrustedCallbackInterfac
     }
 
     // Set form state for adding fields and indexes
-    $element = FieldOperations::setAddFormState($add_new_dictionary_field, $element);
+    $element = FieldOperations::setAddDictionaryFieldFormState($add_new_dictionary_field, $element);
+    $element = FieldOperations::editDictionaryFieldFormState($dictionary_fields_being_modified, $element);
     $element = IndexFieldOperations::setAddIndexFormState($add_new_index, $element);
     $element = IndexFieldOperations::setAddIndexFieldFormState($add_index_field, $element);
     $element = IndexFieldOperations::editIndexFormState($index_being_modified, $element);

--- a/modules/data_dictionary_widget/templates/custom-index-fields-table.html.twig
+++ b/modules/data_dictionary_widget/templates/custom-index-fields-table.html.twig
@@ -6,7 +6,7 @@
       <th colspan="2">{{ header[2] }}</th>
     </tr>
   </thead>
-  <tbody  id="field-json-metadata-dictionary-index-edit-field">
+  <tbody  id="field-json-metadata-index-edit-field">
     {% for row in rows %}
         {% if row.field_collection %}
         <tr>
@@ -20,6 +20,7 @@
           <td>{{ row.length }}</td>
           <td>
           {{ row.edit_index_button }}
+          {# {{ row.edit_index_fields_button }} #}
           </td>
         </tr>
       {% endif %}

--- a/modules/data_dictionary_widget/templates/custom-index-table.html.twig
+++ b/modules/data_dictionary_widget/templates/custom-index-table.html.twig
@@ -6,7 +6,7 @@
       <th colspan="2">{{ header[2] }}</th>
     </tr>
   </thead>
-  <tbody  id="field-json-metadata-dictionary-edit-index">
+  <tbody  id="field-json-metadata-edit-index">
     {% for row in rows %}
       {% if row.field_collection %}
         <tr>

--- a/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildTest.php
+++ b/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildTest.php
@@ -320,7 +320,7 @@ class DataDictionaryWidgetBuildTest extends TestCase {
       ->method('set')
       ->with('field_data_type', 'data-dictionary');
 
-    $formState->expects($this->exactly(13))
+    $formState->expects($this->exactly(14))
       ->method('get')
       ->willReturnOnConsecutiveCalls(NULL, NULL, NULL, FALSE, NULL, NULL, $current_fields);
 

--- a/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildTest.php
+++ b/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildTest.php
@@ -322,7 +322,7 @@ class DataDictionaryWidgetBuildTest extends TestCase {
 
     $formState->expects($this->exactly(14))
       ->method('get')
-      ->willReturnOnConsecutiveCalls(NULL, NULL, NULL, FALSE, NULL, NULL, $current_fields);
+      ->willReturnOnConsecutiveCalls(NULL, NULL, $current_fields, FALSE, NULL, NULL, NULL);
 
     $dataDictionaryWidget = new DataDictionaryWidget (
       $plugin_id,
@@ -472,15 +472,41 @@ class DataDictionaryWidgetBuildTest extends TestCase {
     $formState->expects($this->any())
       ->method('get')
       ->willReturnOnConsecutiveCalls(
-        [], [], $user_input, [], [], [], [], [], $current_dictionary_fields, [], [], $current_dictionary_fields, [],
-        [], [], $user_input, [], [], [], [], [], [], [], [], $updated_dictionary_fields, [], [], $current_dictionary_fields, [],
+        [], 
+        $current_dictionary_fields, 
+        [], 
+        [], 
+        [], 
+        $current_dictionary_fields, 
+        [], 
+        [], 
+        [], 
+        [], 
+        [], 
+        [], 
+        [],
+        [], 
+        [], 
+        $user_input, 
+        [],
+        $current_dictionary_fields, 
+        [], 
+        [], 
+        [], 
+        [], 
+        $updated_dictionary_fields, 
+        [], 
+        [], 
+        [], 
+        [], 
+        []
       );
 
     $formState->expects($this->any())
       ->method('getTriggeringElement')
       ->willReturnOnConsecutiveCalls(
-        ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op],
-        ['#op' => 'update_0'], ['#op' => 'update_0'], ['#op' => 'update_0'], ['#op' => 'update_0'], ['#op' => 'update_0'], ['#op' => 'update_0'], ['#op' => 'update_0'], ['#op' => 'update_0'], ['#op' => 'update_0'], ['#op' => 'update_0'],
+        ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op],
+        ['#op' => 'update_0'], ['#op' => 'update_0'], ['#op' => 'update_0'], ['#op' => 'update_0'], ['#op' => 'update_0'],
       );
 
     $formState->expects($this->any())

--- a/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildTest.php
+++ b/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildTest.php
@@ -112,7 +112,7 @@ class DataDictionaryWidgetBuildTest extends TestCase {
 
     $add_fields = FieldAddCreation::addFields();
 
-    $element = FieldOperations::setAddFormState($add_fields, $element);
+    $element = FieldOperations::setAddDictionaryFieldFormState($add_fields, $element);
 
     $this->assertNotNull($element);
     $this->assertNotNull($element["dictionary_fields"]["field_collection"]);
@@ -238,7 +238,7 @@ class DataDictionaryWidgetBuildTest extends TestCase {
 
     $add_fields = FieldAddCreation::addFields();
 
-    $element = FieldOperations::setAddFormState($add_fields, $element);
+    $element = FieldOperations::setAddDictionaryFieldFormState($add_fields, $element);
 
     // Set up a triggering element with '#op' set to 'add'.
     $trigger = ['#op' => 'add'];


### PR DESCRIPTION
fixes [org/repo/issue#]

- [ ] Test coverage exists
- [ ] Documentation exists

## QA Steps

Test Data File:
[test_data.csv](https://github.com/user-attachments/files/16382383/test_data.csv)

PART 1
 - [ ] Navigate to form /node/add/data?schema=data-dictionary
 - [ ] Enter a Title: Data Dictionary and Index
 - [ ] Select 'Add Field'
 - [ ] Enter the following Name: termination_date
 - [ ] Enter the following Title: Termination Date
 - [ ] Select 'date' for the Data Type
 - [ ] Select 'other' Format
 - [ ] Enter the following for Other Format: %m/%d/%Y
 - [ ] Enter the following description: Termination Date
 - [ ] Select Add
 - [ ] Select Add field
 - [ ] Enter the following Name: fda_approval_date
 - [ ] Enter the following Title: FDA Approval Date
 - [ ] Select 'date' for the Data Type
 - [ ] Select 'other' Format
 - [ ] Enter the following for Other Format: %m/%d/%Y
 - [ ] Enter the following description: FDA Approval Date
 - [ ] Select Add
 - [ ] Select Add Index
 - [ ] Enter Name: Index
 - [ ] Select Add field within the 'Fields' fieldset
 - [ ] Enter the following Name: termination_date
 - [ ] Enter the following Length: 20
 - [ ] Select Add field to enter another field
 - [ ] Enter the following Name: fda_approval_date
 - [ ] Enter the following Length: 20
 - [ ] Select Add
 - [ ] Select Submit Index
 - [ ] Confirm the Data Dictionary Fields Added are correct
 - [ ] Confirm the Indexes and fields added are correct
 - [ ] Save the node

PART 2
- [ ] Navigate to: /node/add/data?schema=dataset
- [ ] Enter a Title: Dataset Test
- [ ] Enter a Description: Description Test
- [ ] Enter a Last Update date and time
- [ ] Enter a Publisher Name
- [ ] Enter a Contact Name and Email
- [ ] Enter a Tag under Tags
- [ ] Enter the following for File Title:
- [ ] Enter the following for File Description
- [ ] Enter the following File Format: CSV
- [ ] Upload a Data File, you can use the Test Data File provided
- [ ] Save the dataset
- [ ] Navigate back to the previously created Data Dictionary and Index from PART 1
- [ ] Grab the identifier. It will look something like this 	example: fc034f0d-c96d-484e-b1e4-79a9aed7c2e6
- [ ] Navigate to the endpoint api/1/metastore/schemas/data-dictionary/items/{identifier goes here}
- [ ] Confirm the endpoint json looks like this:
`{
  "identifier": "fc034f0d-c96d-484e-b1e4-79a9aed7c2e6",
  "data": {
    "title": "Data Dictionary and Index",
    "fields": [
      {
        "name": "termination_date",
        "title": "Termination Date",
        "type": "date",
        "format": "%m/%d/%Y",
        "description": "Termination Date"
      },
      {
        "name": "fda_approval_date",
        "title": "FDA Approval Date",
        "type": "date",
        "format": "%m/%d/%Y",
        "description": "FDA Approval Date"
      }
    ],
    "indexes": [
      {
        "description": "Data Index",
        "type": "index",
        "fields": [
          {
            "name": "termination_date",
            "length": 20
          },
          {
            "name": "fda_approval_date",
            "length": 20
          }
        ]
      }
    ]
  }
}`

PART 3
- [ ] Navigate to /admin/dkan/data-dictionary/settings
- [ ] Select Dictionary Mode : Sitewide
- [ ] Enter the identifier into the Sitewide Dictionary ID
- [ ] Save Configuration

PART 4
- [ ] Navigate to /admin/dkan/datastore/status
- [ ] Confirm you see the Dataset row with the Title 'Dataset Test' from PART 2 and that the FETCH, STORE and POST IMPORT are all in 'Waiting'
- [ ] You should now run CRON twice
- [ ] Navigate to /admin/dkan/datastore/status
- [ ] Confirm the FETCH, STORE, POST IMPORT are all in 'done'

PART 5
- [ ] Navigate to /admin/dkan/datastore/status
- [ ] Grab the Dataset uuid from the row you created
- [ ] Navigate to your terminal and use the following command to see the dataset info: `ddev drush dkan:dataset-info {{uuid here}}`
- [ ] Take note of the "table_name"
- [ ] Navigate to your db 'example: `ddev drush sqlc`'
- [ ] Enter the following sql describe `{{table_name goes here}};`
- [ ] Confirm that the termination_date and fda_approval_date has a type of date

PART 6
- [ ] In the same terminal enter the following sql: `show index from datastore_0dbbe7015bf8d423d859697cff8fe729;`
- [ ] Confirm you see the index created for both the termination_date and fda_approval_date