### PR TITLE
Add information about the differences in import options

### DIFF
--- a/modules/datastore/modules/datastore_mysql_import/README.md
+++ b/modules/datastore/modules/datastore_mysql_import/README.md
@@ -4,3 +4,9 @@ This module will import CSVs into the DKAN datastore using MySQL's native LOAD D
 `LOAD DATA LOCAL INFILE`.
 
 To use, simply enable _datastore_mysql_import_ and clear your cache.
+
+## Differences in behavior with the default DKAN importer.
+
+* Any "blank" rows in your data file, including carriage returns, will be imported into the datastore as empty rows. The default importer will ignore these rows.
+* If you have column headings exceeding 64 characters in your data file, these headings will be truncated to a max of 64 characters with the last 4 characters containing a hash value to insure uniqueness. This is the same for both importers as the character limit is from MySQL. However, if you already have imported data with one importer, and switch to the other importer, the hash values will be different. This may disrupt established queries depending on the previous header values.
+* If your data includes a field containing the literal word NULL, it will be interpreted as empty unless you enclose it with quotes to be interpreted as a string.


### PR DESCRIPTION
The differences between the default importer and the datastore_mysql_import module can trip up users if there is a switch from one importer to the other after data has already been imported.