### PR TITLE
Update image source in dkan_metastore.rst

### DIFF
--- a/docs/source/components/dkan_metastore.rst
+++ b/docs/source/components/dkan_metastore.rst
@@ -17,7 +17,7 @@ Some more details of DKAN's metastore:
 * The structure and format of dataset metadata in DKAN are determined by a `JSON schema <https://json-schema.org/>`_. By default, DKAN provides and utilizes the `DCAT-US metadata schema <https://resources.data.gov/resources/dcat-us/>`_ to store datasets, but :doc:`custom schemas <../user-guide/guide_custom_schemas>` can be added to the codebase to override this.
 * In DCAT-US, resources are placed in a sub-schema of the parent dataset called a *distribution*.
 
-.. image:: https://project-open-data.cio.gov/v1.1/schema-diagram.svg
+.. image:: https://resources.data.gov/schemas/dcat-us/v1.1/schema-diagram.svg
   :width: 400
   :alt: Dataset Structure
 


### PR DESCRIPTION
fixes #4242 

## QA Steps

- [x] Navigate to the dkan metastore page and confirm the image below 'In DCAT-US, resources are placed in a sub-schema of the parent dataset called a distribution.' loads. E.g. https://dkan--4243.org.readthedocs.build/en/4243/components/dkan_metastore.html
