### PR TITLE
Adds QueueRunnerTrait for consistency in testing + DRY

### DIFF
--- a/modules/common/tests/src/Traits/QueueRunnerTrait.php
+++ b/modules/common/tests/src/Traits/QueueRunnerTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\Tests\common\Traits;
+
+use Drupal\Core\Queue\QueueFactoryInterface;
+use Drupal\Core\Queue\QueueWorkerManagerInterface;
+
+/**
+ * Adds a predictable way to run queues in a specific order.
+ */
+trait QueueRunnerTrait {
+
+  /**
+   * Run queues in a predictable order.
+   *
+   * @param string[] $relevantQueues
+   *   Names of queues to run, in order.
+   * @param \Drupal\Core\Queue\QueueWorkerManagerInterface|null $queue_worker_manager
+   *   (Optional) The plugin.manager.queue_worker service.
+   * @param \Drupal\Core\Queue\QueueFactoryInterface|null $queue_factory
+   *   (Optional) The queue service.
+   */
+  public function runQueues(
+    array $relevantQueues = [],
+    QueueWorkerManagerInterface $queue_worker_manager = NULL,
+    QueueFactoryInterface $queue_factory = NULL
+  ): void {
+    if (empty($queue_worker_manager)) {
+      $queue_worker_manager = \Drupal::service('plugin.manager.queue_worker');
+    }
+    if (empty($queue_factory)) {
+      $queue_factory = \Drupal::service('queue');
+    }
+    foreach ($relevantQueues as $queueName) {
+      $worker = $queue_worker_manager->createInstance($queueName);
+      $queue = $queue_factory->get($queueName);
+      while ($item = $queue->claimItem()) {
+        $worker->processItem($item->data);
+        $queue->deleteItem($item);
+      }
+    }
+  }
+
+}

--- a/modules/common/tests/src/Traits/QueueRunnerTrait.php
+++ b/modules/common/tests/src/Traits/QueueRunnerTrait.php
@@ -13,7 +13,7 @@ trait QueueRunnerTrait {
   /**
    * Run queues in a predictable order.
    *
-   * @param string[] $relevantQueues
+   * @param string[] $relevant_queues
    *   Names of queues to run, in order.
    * @param \Drupal\Core\Queue\QueueWorkerManagerInterface|null $queue_worker_manager
    *   (Optional) The plugin.manager.queue_worker service.
@@ -21,7 +21,7 @@ trait QueueRunnerTrait {
    *   (Optional) The queue service.
    */
   public function runQueues(
-    array $relevantQueues = [],
+    array $relevant_queues = [],
     QueueWorkerManagerInterface $queue_worker_manager = NULL,
     QueueFactoryInterface $queue_factory = NULL
   ): void {
@@ -31,9 +31,9 @@ trait QueueRunnerTrait {
     if (empty($queue_factory)) {
       $queue_factory = \Drupal::service('queue');
     }
-    foreach ($relevantQueues as $queueName) {
-      $worker = $queue_worker_manager->createInstance($queueName);
-      $queue = $queue_factory->get($queueName);
+    foreach ($relevant_queues as $queue_name) {
+      $worker = $queue_worker_manager->createInstance($queue_name);
+      $queue = $queue_factory->get($queue_name);
       while ($item = $queue->claimItem()) {
         $worker->processItem($item->data);
         $queue->deleteItem($item);

--- a/modules/datastore/tests/src/Functional/DictionaryEnforcerTest.php
+++ b/modules/datastore/tests/src/Functional/DictionaryEnforcerTest.php
@@ -9,6 +9,7 @@ use Drupal\metastore\DataDictionary\DataDictionaryDiscovery;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\common\Traits\CleanUp;
 use Drupal\Tests\common\Traits\GetDataTrait;
+use Drupal\Tests\common\Traits\QueueRunnerTrait;
 use Drupal\Tests\metastore\Unit\MetastoreServiceTest;
 
 use RootedData\RootedJsonData;
@@ -24,7 +25,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class DictionaryEnforcerTest extends BrowserTestBase {
 
-  use GetDataTrait, CleanUp;
+  use GetDataTrait, CleanUp, QueueRunnerTrait;
 
   protected $defaultTheme = 'stark';
 
@@ -273,24 +274,6 @@ class DictionaryEnforcerTest extends BrowserTestBase {
       ],
       'numOfRows' => 3,
     ], $result);
-  }
-
-  /**
-   * Process queues in a predictable order.
-   */
-  private function runQueues(array $relevantQueues = []) {
-    /** @var \Drupal\Core\Queue\QueueWorkerManager $queueWorkerManager */
-    $queueWorkerManager = \Drupal::service('plugin.manager.queue_worker');
-    /** @var \Drupal\Core\Queue\QueueFactory $queueFactory */
-    $queueFactory = $this->container->get('queue');
-    foreach ($relevantQueues as $queueName) {
-      $worker = $queueWorkerManager->createInstance($queueName);
-      $queue = $queueFactory->get($queueName);
-      while ($item = $queue->claimItem()) {
-        $worker->processItem($item->data);
-        $queue->deleteItem($item);
-      }
-    }
   }
 
 }

--- a/modules/datastore/tests/src/Functional/Service/ResourcePurgerTest.php
+++ b/modules/datastore/tests/src/Functional/Service/ResourcePurgerTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\datastore\Functional\Service;
 
 use Drupal\Tests\common\Traits\CleanUp;
 use Drupal\Tests\common\Traits\GetDataTrait;
+use Drupal\Tests\common\Traits\QueueRunnerTrait;
 use Drupal\Tests\metastore\Unit\MetastoreServiceTest;
 
 use weitzman\DrupalTestTraits\ExistingSiteBase;
@@ -18,6 +19,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 class ResourcePurgerTest extends ExistingSiteBase {
   use GetDataTrait;
   use CleanUp;
+  use QueueRunnerTrait;
 
   /**
    * DKAN dataset storage service.
@@ -159,20 +161,4 @@ class ResourcePurgerTest extends ExistingSiteBase {
     return $resources;
   }
 
-  /**
-   * Process the supplied queue list.
-   *
-   * @param string[] $relevant_queues
-   *   A list of queues to process.
-   */
-  protected function runQueues(array $relevant_queues = []): void {
-    foreach ($relevant_queues as $queue_name) {
-      $worker = $this->queueWorkerManager->createInstance($queue_name);
-      $queue = $this->queue->get($queue_name);
-      while ($item = $queue->claimItem()) {
-        $worker->processItem($item->data);
-        $queue->deleteItem($item);
-      }
-    }
-  }
 }

--- a/modules/json_form_widget/tests/src/Functional/AdminDatasetFileUploadTest.php
+++ b/modules/json_form_widget/tests/src/Functional/AdminDatasetFileUploadTest.php
@@ -4,6 +4,7 @@ namespace Drupal\json_form_widget\Tests\Functional;
 
 use Drupal\Core\StreamWrapper\PublicStream;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\common\Traits\QueueRunnerTrait;
 
 /**
  * Test the json form widget.
@@ -17,6 +18,8 @@ use Drupal\Tests\BrowserTestBase;
  */
 class AdminDatasetFileUploadTest extends BrowserTestBase {
 
+  use QueueRunnerTrait;
+
   protected static $modules = [
     'dkan',
     'json_form_widget',
@@ -29,24 +32,6 @@ class AdminDatasetFileUploadTest extends BrowserTestBase {
    * @todo Remove this when we drop support for Drupal 10.0.
    */
   protected $strictConfigSchema = FALSE;
-
-  /**
-   * Process queues in a predictable order.
-   */
-  private function runQueues(array $relevantQueues = []) {
-    /** @var \Drupal\Core\Queue\QueueWorkerManager $queueWorkerManager */
-    $queueWorkerManager = $this->container->get('plugin.manager.queue_worker');
-    /** @var \Drupal\Core\Queue\QueueFactory $queueFactory */
-    $queueFactory = $this->container->get('queue');
-    foreach ($relevantQueues as $queueName) {
-      $worker = $queueWorkerManager->createInstance($queueName);
-      $queue = $queueFactory->get($queueName);
-      while ($item = $queue->claimItem()) {
-        $worker->processItem($item->data);
-        $queue->deleteItem($item);
-      }
-    }
-  }
 
   /**
    * Test creating datasets.

--- a/modules/metastore/tests/src/Functional/MetastoreApiPageCacheTest.php
+++ b/modules/metastore/tests/src/Functional/MetastoreApiPageCacheTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\metastore\Functional;
 
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\common\Traits\QueueRunnerTrait;
 use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\ResponseInterface;
 use RootedData\RootedJsonData;
@@ -16,6 +17,8 @@ use RootedData\RootedJsonData;
  * @group btb
  */
 class MetastoreApiPageCacheTest extends BrowserTestBase {
+
+  use QueueRunnerTrait;
 
   protected static $modules = [
     'common',
@@ -210,24 +213,6 @@ class MetastoreApiPageCacheTest extends BrowserTestBase {
 
     $valid_metadata_factory = $this->container->get('dkan.metastore.valid_metadata');
     return $valid_metadata_factory->get(json_encode($data), 'dataset');
-  }
-
-  /**
-   * Process queues in a predictable order.
-   */
-  private function runQueues(array $relevantQueues = []) {
-    /** @var \Drupal\Core\Queue\QueueWorkerManager $queueWorkerManager */
-    $queueWorkerManager = \Drupal::service('plugin.manager.queue_worker');
-    /** @var \Drupal\Core\Queue\QueueFactory $queueFactory */
-    $queueFactory = $this->container->get('queue');
-    foreach ($relevantQueues as $queueName) {
-      $worker = $queueWorkerManager->createInstance($queueName);
-      $queue = $queueFactory->get($queueName);
-      while ($item = $queue->claimItem()) {
-        $worker->processItem($item->data);
-        $queue->deleteItem($item);
-      }
-    }
   }
 
   private function renderDatasetNodesForCache() {

--- a/modules/metastore/tests/src/Functional/OrphanCheckerTest.php
+++ b/modules/metastore/tests/src/Functional/OrphanCheckerTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\metastore\Functional;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Tests\common\Traits\CleanUp;
 use Drupal\Tests\common\Traits\GetDataTrait;
+use Drupal\Tests\common\Traits\QueueRunnerTrait;
 use Drupal\Tests\metastore\Unit\MetastoreServiceTest;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
 
@@ -17,6 +18,7 @@ use weitzman\DrupalTestTraits\ExistingSiteBase;
 class OrphanCheckerTest extends ExistingSiteBase {
   use GetDataTrait;
   use CleanUp;
+  use QueueRunnerTrait;
 
   /**
    * The ValidMetadataFactory class used for testing.
@@ -50,20 +52,4 @@ class OrphanCheckerTest extends ExistingSiteBase {
     $this->assertNull($success);
   }
 
-  private function runQueues(array $relevantQueues = []) {
-    /** @var \Drupal\Core\Queue\QueueWorkerManager $queueWorkerManager */
-    $queueWorkerManager = \Drupal::service('plugin.manager.queue_worker');
-    foreach ($relevantQueues as $queueName) {
-      $worker = $queueWorkerManager->createInstance($queueName);
-      $queue = $this->getQueueService()->get($queueName);
-      while ($item = $queue->claimItem()) {
-        $worker->processItem($item->data);
-        $queue->deleteItem($item);
-      }
-    }
-  }
-
-  private function getQueueService() : QueueFactory {
-    return \Drupal::service('queue');
-  }
 }

--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -11,6 +11,7 @@ use Drupal\metastore\MetastoreService;
 use Drupal\node\NodeStorage;
 use Drupal\search_api\Entity\Index;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\common\Traits\QueueRunnerTrait;
 use Harvest\ETL\Extract\DataJson;
 use RootedData\RootedJsonData;
 
@@ -21,6 +22,8 @@ use RootedData\RootedJsonData;
  * @group functional
  */
 class DatasetBTBTest extends BrowserTestBase {
+
+  use QueueRunnerTrait;
 
   /**
    * {@inheritdoc}
@@ -572,22 +575,6 @@ class DatasetBTBTest extends BrowserTestBase {
 
     // Simulate a cron on queues relevant to this scenario.
     $this->runQueues(['localize_import', 'datastore_import', 'resource_purger']);
-  }
-
-  /**
-   * Process queues in a predictable order.
-   */
-  private function runQueues(array $relevantQueues = []) {
-    /** @var \Drupal\Core\Queue\QueueWorkerManager $queueWorkerManager */
-    $queueWorkerManager = $this->container->get('plugin.manager.queue_worker');
-    foreach ($relevantQueues as $queueName) {
-      $worker = $queueWorkerManager->createInstance($queueName);
-      $queue = $this->getQueueService()->get($queueName);
-      while ($item = $queue->claimItem()) {
-        $worker->processItem($item->data);
-        $queue->deleteItem($item);
-      }
-    }
   }
 
   private function countTables() {


### PR DESCRIPTION
Approximately 958723498502834759230485723094587 of our tests have their own copypasted definition of a `runQueues()` method.

Let's turn that into a trait which is then reused.