### PR TITLE
Convert SearchTest to BTB

### DIFF
--- a/modules/metastore/modules/metastore_search/src/Controller/SearchController.php
+++ b/modules/metastore/modules/metastore_search/src/Controller/SearchController.php
@@ -25,13 +25,6 @@ class SearchController implements ContainerInjectionInterface {
   private $service;
 
   /**
-   * Request stack.
-   *
-   * @var \Symfony\Component\HttpFoundation\RequestStack
-   */
-  private $requestStack;
-
-  /**
    * Metastore API response service.
    *
    * @var \Drupal\metastore\MetastoreApiResponse


### PR DESCRIPTION
- Converts `SearchTest` to BTB.
- Removes unneeded references to the request stack service.