### PR TITLE
Remove dependency on weitzman/drupal-test-traits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
         type: string
       addon_branch:
         description: 'Repo branch name for the dkan-ddev-addon you want to test against.'
-        default: 'main'
+        default: 'dev-21895-remove-dtt'
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
         type: string
       addon_branch:
         description: 'Repo branch name for the dkan-ddev-addon you want to test against.'
-        default: 'dev-21895-remove-dtt'
+        default: '21895-remove-dtt'
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ commands:
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'
-        default: '10.2.x-dev'
+        default: '21895-remove-dtt'
         type: string
     steps:
       - run:
@@ -236,18 +236,7 @@ workflows:
           report_coverage: true
           matrix:
             parameters:
-              dkan_recommended_branch: [ '10.2.x-dev']
               php_version: [ '8.3' ]
-      - phpunit:
-          matrix:
-            parameters:
-              dkan_recommended_branch: [ '10.2.x-dev']
-              php_version: [ '8.1', '8.2' ]
-      - phpunit:
-          matrix:
-            parameters:
-              dkan_recommended_branch: [ '10.1.x-dev']
-              php_version: [ '8.2' ]
   upgrade_and_test:
     jobs:
       - cypress:
@@ -259,5 +248,4 @@ workflows:
           upgrade: true
           matrix:
             parameters:
-              dkan_recommended_branch: [ '10.2.x-dev']
               php_version: [ '8.2' ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
         type: string
       addon_branch:
         description: 'Repo branch name for the dkan-ddev-addon you want to test against.'
-        default: '21895-remove-dtt'
+        default: 'main'
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ commands:
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'
-        default: '21895-remove-dtt'
+        default: '10.2.x-dev'
         type: string
     steps:
       - run:
@@ -236,7 +236,18 @@ workflows:
           report_coverage: true
           matrix:
             parameters:
+              dkan_recommended_branch: [ '10.2.x-dev']
               php_version: [ '8.3' ]
+      - phpunit:
+          matrix:
+            parameters:
+              dkan_recommended_branch: [ '10.2.x-dev']
+              php_version: [ '8.1', '8.2' ]
+      - phpunit:
+          matrix:
+            parameters:
+              dkan_recommended_branch: [ '10.1.x-dev']
+              php_version: [ '8.2' ]
   upgrade_and_test:
     jobs:
       - cypress:
@@ -248,4 +259,5 @@ workflows:
           upgrade: true
           matrix:
             parameters:
+              dkan_recommended_branch: [ '10.2.x-dev']
               php_version: [ '8.2' ]

--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,7 @@
         "drush/drush": "^12@stable",
         "getdkan/mock-chain": "^1.3.7",
         "osteel/openapi-httpfoundation-testing": "<1.0",
-        "phpunit/phpunit": "^8.5.14 || ^9",
-        "weitzman/drupal-test-traits": "^2.0.1"
+        "phpunit/phpunit": "^9.6"
     },
     "repositories": {
         "drupal": {

--- a/modules/common/tests/src/Traits/CleanUp.php
+++ b/modules/common/tests/src/Traits/CleanUp.php
@@ -6,7 +6,7 @@ use Drupal\node\Entity\Node;
 use FileFetcher\FileFetcher;
 
 /**
- *
+ * @deprecated Will be removed in a future version of DKAN.
  */
 trait CleanUp {
 

--- a/modules/datastore/tests/src/Functional/DictionaryEnforcerTest.php
+++ b/modules/datastore/tests/src/Functional/DictionaryEnforcerTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class DictionaryEnforcerTest extends BrowserTestBase {
 
-  use GetDataTrait, CleanUp, QueueRunnerTrait;
+  use GetDataTrait, QueueRunnerTrait;
 
   protected $defaultTheme = 'stark';
 

--- a/modules/datastore/tests/src/Functional/Service/ResourcePurgerTest.php
+++ b/modules/datastore/tests/src/Functional/Service/ResourcePurgerTest.php
@@ -20,7 +20,6 @@ use Drupal\Tests\metastore\Unit\MetastoreServiceTest;
  */
 class ResourcePurgerTest extends BrowserTestBase {
   use GetDataTrait;
-  use CleanUp;
   use QueueRunnerTrait;
 
   protected static $modules = [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
 <phpunit
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
-  bootstrap="/var/www/html/vendor/weitzman/drupal-test-traits/src/bootstrap.php"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
   colors="true"
   verbose="true">
   <coverage>


### PR DESCRIPTION
- Removes weitzman/drupal-test-traits from dependencies.
- Constraints PHPUnit to `^9.6` which fits our current requirements.
- Deprecates `Drupal\Tests\common\Traits\CleanUp` which should not be necessary in DKAN core.
- Requires a change to getdkan/ddev-dkan to allow for different test autoloaders. Merged and released: https://github.com/GetDKAN/ddev-dkan/releases/tag/1.2.0 ✅
- Follow-up with a change to getdkan/recommended-project which will remove DTT from its dev dependencies.