### PR TITLE
Add config for which column header to use on filtered csv downloads

### DIFF
--- a/docs/source/user-guide/guide_data_dictionaries.rst
+++ b/docs/source/user-guide/guide_data_dictionaries.rst
@@ -31,7 +31,7 @@ The structure of your data dictionary should follow `Frictionless Standards tabl
 
     {
       "data": {
-       "title": "A human readable label",
+       "title": "A human readable label for the dictionary",
        "fields": [
         {
           "name": "(REQUIRED) machine name of the field that matches the datastore column header.",
@@ -50,7 +50,7 @@ The "name" should match the datastore column name. These are derived from the co
 
 title
 ^^^^^
-This is usually the column header from the data file, but if the data file uses abbreviated column headings, this is where you can supply a more human readable and clear display title. This value will also be used for column headings when users export a filtered subset of results as a csv file.
+This is usually the column header from the data file, but if the data file uses abbreviated column headings, this is where you can supply a more human readable and clear display title. Depending on your :ref:`configuration <guide_data_dictionary_config>`, this value may also be used for column headings when users export a filtered subset of results as a csv file.
 
 type
 ^^^^
@@ -209,7 +209,7 @@ Adding indexes
 Data dictionaries can be used to describe indexes that should be applied when importing to a database.
 Learn more about this on :doc:`guide_indexes`
 
-How to set the data dictionary mode
+How to set the Dictionary Mode
 -----------------------------------
 
 In the section above we created a data dictionary
@@ -303,3 +303,20 @@ request the dataset back from the API, it would show us the absolute URL as well
   If you have set the dictionary mode to *distribution reference*, any time you update the data file in the distribution, the datastore will be dropped, re-imported, and any data typing defined in the data dictionary will be applied to the table.
 
   If you have set the dictionary mode to *sitewide*, when any dataset is updated, and the machine name of the column header from the source data matches the name value in the sitewide data dictionary, the data typing will also be applied to the datastore table.
+
+
+.. _guide_data_dictionary_config:
+
+How to set the CSV Headers Mode
+-------------------------------
+
+Users can run queries against the datastore API and download the results to a CSV file. The **CSV Headers Mode** will determine what values to use for the column headers when the CSV file is generated. The default setting will simply use the same column headings that exist in the original resource file. If your site is using data dictionaries, you could change this setting to use the titles defined in the data dictionary. And there is a third option to use the converted machine name headers that are used in the datastore table.
+
+Visit `/admin/dkan/data-dictionary/settings` to make a selection.
+
+- Use the column names from the resource file
+- Use data dictionary titles
+- Use the datastore machine names
+
+.. NOTE::
+  If you are changing this setting after data has been imported, you will need to re-import the data for the change to take effect.

--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -72,6 +72,7 @@ services:
       - '@dkan.datastore.database_connection_factory'
       - '@pdlt.converter.strptime_to_mysql'
       - '@uuid'
+      - '@config.factory'
 
   dkan.datastore.database:
     class: \Drupal\Core\Database\Connection

--- a/modules/datastore/src/Controller/AbstractQueryController.php
+++ b/modules/datastore/src/Controller/AbstractQueryController.php
@@ -352,6 +352,7 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
    *   Array of strings for a CSV header row.
    */
   protected function getHeaderRow(DatastoreQuery $datastoreQuery, RootedJsonData &$result) {
+    $config = $this->configFactory->get('metastore.settings')->get('csv_headers_mode');
     $schema_fields = $result->{'$.schema..fields'}[0] ?? [];
     if (empty($schema_fields)) {
       throw new \DomainException("Could not generate header for CSV.");
@@ -363,7 +364,12 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     $header_row = [];
     foreach ($datastoreQuery->{'$.properties'} ?? [] as $property) {
       $normalized_prop = $this->propToString($property, $datastoreQuery);
-      $header_row[] = $schema_fields[$normalized_prop]['description'] ?? $normalized_prop;
+      if ($config == "machine_names") {
+        $header_row[] = $normalized_prop ?? ($schema_fields[$normalized_prop]['description'] ?? FALSE);
+      }
+      else {
+        $header_row[] = $schema_fields[$normalized_prop]['description'] ?? $normalized_prop;
+      }
     }
 
     return $header_row;

--- a/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQuery.php
+++ b/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQuery.php
@@ -102,7 +102,7 @@ class MySQLQuery extends AlterTableQueryBase implements AlterTableQueryInterface
    * Assign the csvHeaderMode based on the config setting.
    */
   public function setCsvHeaderMode($mode) {
-    $this->csvHeadersMode = $mode;
+    $this->csvHeadersMode = $mode ?? 'resource_headers';
   }
 
   /**

--- a/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQuery.php
+++ b/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQuery.php
@@ -460,7 +460,6 @@ class MySQLQuery extends AlterTableQueryBase implements AlterTableQueryInterface
    */
   protected function buildModifyColumnOptions(array $fields, array $type_map, string $table): array {
     $modify_column_options = [];
-    $table_cols = $this->getTableColsAndComments($table);
 
     foreach ($fields as ['name' => $field, 'title' => $title]) {
       $column_type = $type_map[$field];
@@ -473,6 +472,7 @@ class MySQLQuery extends AlterTableQueryBase implements AlterTableQueryInterface
         $modify_column_options[] = "MODIFY COLUMN {$field} {$column_type} COMMENT '{$comment}'";
       }
       else {
+        $table_cols = $this->getTableColsAndComments($table);
         $modify_column_options[] = "MODIFY COLUMN {$field} {$column_type} COMMENT '{$table_cols[$field]}'";
       }
     }

--- a/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQueryBuilder.php
+++ b/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQueryBuilder.php
@@ -16,13 +16,17 @@ class MySQLQueryBuilder extends AlterTableQueryBuilderBase implements AlterTable
    * {@inheritdoc}
    */
   public function getQuery(): AlterTableQueryInterface {
-    return new MySQLQuery(
+
+    $query = new MySQLQuery(
       $this->databaseConnectionFactory->getConnection(),
       $this->dateFormatConverter,
       $this->table,
       $this->fields,
       $this->indexes,
     );
+
+    $query->setCsvHeaderMode($this->configFactory->get('metastore.settings')->get('csv_headers_mode'));
+    return $query;
   }
 
 }

--- a/modules/datastore/src/DataDictionary/AlterTableQueryBuilderBase.php
+++ b/modules/datastore/src/DataDictionary/AlterTableQueryBuilderBase.php
@@ -5,6 +5,7 @@ namespace Drupal\datastore\DataDictionary;
 use Drupal\Component\Uuid\UuidInterface;
 
 use Drupal\common\Storage\DatabaseConnectionFactoryInterface;
+use Drupal\Core\Config\ConfigFactory;
 use Drupal\datastore\DataDictionary\AlterTableQueryInterface;
 
 use PDLT\ConverterInterface;
@@ -97,6 +98,13 @@ abstract class AlterTableQueryBuilderBase implements AlterTableQueryBuilderInter
   protected array $indexes = [];
 
   /**
+   * ConfigFactory object.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
    * Create an alter table query factory.
    *
    * @param \Drupal\common\Storage\DatabaseConnectionFactoryInterface $database_connection_factory
@@ -105,15 +113,19 @@ abstract class AlterTableQueryBuilderBase implements AlterTableQueryBuilderInter
    *   PHP Date Language Tool Converter.
    * @param \Drupal\Component\Uuid\UuidInterface $uuid
    *   Uuid generator service.
+   * @param \Drupal\Core\Config\ConfigFactory $configFactory
+   *   ConfigFactory service.
    */
   public function __construct(
     DatabaseConnectionFactoryInterface $database_connection_factory,
     ConverterInterface $date_format_converter,
-    UuidInterface $uuid
+    UuidInterface $uuid,
+    ConfigFactory $configFactory
   ) {
     $this->databaseConnectionFactory = $database_connection_factory;
     $this->dateFormatConverter = $date_format_converter;
     $this->uuid = $uuid;
+    $this->configFactory = $configFactory;
   }
 
   /**

--- a/modules/datastore/tests/src/Functional/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Functional/Controller/QueryDownloadControllerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Drupal\Tests\datastore\Functional\Controller;
+
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\common\Traits\GetDataTrait;
+use Drupal\Tests\common\Traits\QueueRunnerTrait;
+use RootedData\RootedJsonData;
+
+/**
+ * @coversDefaultClass \Drupal\datastore\Controller\QueryDownloadController
+ *
+ * @group dkan
+ * @group datastore
+ * @group functional
+ * @group btb
+ */
+class QueryDownloadControllerTest extends BrowserTestBase {
+
+  use GetDataTrait, QueueRunnerTrait;
+
+  /**
+   * Uploaded resource file destination.
+   *
+   * @var string
+   */
+  protected const UPLOAD_LOCATION = 'public://uploaded_resources/';
+
+  /**
+   * Test data file path.
+   *
+   * @var string
+   */
+  protected const TEST_DATA_PATH = __DIR__ . '/../../../data/';
+
+  /**
+   * Resource file name.
+   *
+   * @var string
+   */
+  protected const RESOURCE_FILE = 'longcolumn.csv';
+
+
+  protected static $modules = [
+    'datastore',
+    'node',
+  ];
+
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Test application of data dictionary schema to CSV generated for download.
+   */
+  public function testDownloadWithMachineName() {
+    // Dependencies.
+    $uuid = $this->container->get('uuid');
+    /** @var \Drupal\metastore\ValidMetadataFactory $validMetadataFactory */
+    $validMetadataFactory = $this->container->get('dkan.metastore.valid_metadata');
+    /** @var \Drupal\metastore\MetastoreService $metastoreService */
+    $metastoreService = $this->container->get('dkan.metastore.service');
+    // Copy resource file to uploads directory.
+    /** @var \Drupal\Core\File\FileSystemInterface $file_system */
+    $file_system = $this->container->get('file_system');
+    $upload_path = $file_system->realpath(self::UPLOAD_LOCATION);
+    $file_system->prepareDirectory($upload_path, FileSystemInterface::CREATE_DIRECTORY);
+    $file_system->copy(self::TEST_DATA_PATH . self::RESOURCE_FILE, $upload_path, FileSystemInterface::EXISTS_REPLACE);
+    $resourceUrl = $this->container->get('stream_wrapper_manager')
+      ->getViaUri(self::UPLOAD_LOCATION . self::RESOURCE_FILE)
+      ->getExternalUrl();
+
+    // Set up dataset.
+    $dataset_id = $uuid->generate();
+    $this->assertInstanceOf(
+      RootedJsonData::class,
+      $dataset = $validMetadataFactory->get(
+        $this->getDataset(
+          $dataset_id,
+          'Test ' . $dataset_id,
+          [$resourceUrl],
+          TRUE
+        ),
+        'dataset'
+      )
+    );
+    // Create dataset.
+    $this->assertEquals(
+      $dataset_id,
+      $metastoreService->post('dataset', $dataset)
+    );
+    // Publish should return FALSE, because the node was already published.
+    $this->assertFalse($metastoreService->publish('dataset', $dataset_id));
+
+    // Retrieve dataset.
+    $this->assertInstanceOf(
+      RootedJsonData::class,
+      $dataset = $metastoreService->get('dataset', $dataset_id)
+    );
+
+    // Run queue items to perform the import.
+    $this->runQueues(['localize_import', 'datastore_import', 'post_import']);
+
+    // Explicitly configure for the CSV's headers.
+    $this->config('metastore.settings')
+      ->set('csv_headers_mode', 'resource_headers')
+      ->save();
+
+    // Query for the dataset, as a streaming CSV.
+    $client = $this->getHttpClient();
+    $response = $client->request(
+      'GET',
+      $this->baseUrl . '/api/1/datastore/query/' . $dataset_id . '/0/download',
+      ['query' => ['format' => 'csv']]
+    );
+
+    $lines = explode("\n", $response->getBody()->getContents());
+    $this->assertEquals(
+      'id,name,extra_long_column_name_with_tons_of_characters_that_will_need_to_be_truncated_in_order_to_work,extra_long_column_name_with_tons_of_characters_that_will_need_to_be_truncated_in_order_to_work2',
+      $lines[0]
+    );
+
+    // Re-request, but with machine name headers.
+    $this->config('metastore.settings')
+      ->set('csv_headers_mode', 'machine_names')
+      ->save();
+
+    $client = $this->getHttpClient();
+    $response = $client->request(
+      'GET',
+      $this->baseUrl . '/api/1/datastore/query/' . $dataset_id . '/0/download',
+      ['query' => ['format' => 'csv']]
+    );
+
+    $lines = explode("\n", $response->getBody()->getContents());
+    // Truncated headers from the datastore.
+    $this->assertEquals(
+      'id,name,extra_long_column_name_with_tons_of_characters_that_will_ne_e872,extra_long_column_name_with_tons_of_characters_that_will_ne_5127',
+      $lines[0]
+    );
+  }
+
+}

--- a/modules/datastore/tests/src/Functional/DictionaryEnforcerTest.php
+++ b/modules/datastore/tests/src/Functional/DictionaryEnforcerTest.php
@@ -186,6 +186,7 @@ class DictionaryEnforcerTest extends BrowserTestBase {
     $metastore_config = $this->config('metastore.settings');
     $metastore_config->set('data_dictionary_mode', DataDictionaryDiscovery::MODE_SITEWIDE)
       ->set('data_dictionary_sitewide', $dict_id)
+      ->set('csv_headers_mode', 'dictionary_titles')
       ->save();
 
     // Build dataset.

--- a/modules/datastore/tests/src/Unit/DataDictionary/AlterTableQuery/BuilderTest.php
+++ b/modules/datastore/tests/src/Unit/DataDictionary/AlterTableQuery/BuilderTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\datastore\Unit\DataDictionary\AlterTableQuery;
 use Drupal\Core\Database\Connection;
 use Drupal\common\Storage\DatabaseConnectionFactoryInterface;
 use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Config\ConfigFactory;
 use Drupal\datastore\DataDictionary\AlterTableQueryBase;
 use Drupal\datastore\DataDictionary\AlterTableQueryBuilderBase;
 use Drupal\datastore\DataDictionary\AlterTableQueryBuilderInterface;
@@ -70,8 +71,11 @@ class BuilderTest extends TestCase {
     $uuid = (new Chain($this))
       ->add(UuidInterface::class)
       ->getMock();
+    $configFactory = (new Chain($this))
+      ->add(ConfigFactory::class)
+      ->getMock();
 
-    $builder = new TestBuilder($connection, $converter, $uuid);
+    $builder = new TestBuilder($connection, $converter, $uuid, $configFactory);
 
     // Test Builder's setConnectionTimeout() returns what's expected.
     $result = $builder->setConnectionTimeout(1);

--- a/modules/metastore/config/install/metastore.settings.yml
+++ b/modules/metastore/config/install/metastore.settings.yml
@@ -1,3 +1,4 @@
+csv_headers_mode: resource_headers
 property_list:
   'theme': 'theme'
   'keyword': 'keyword'

--- a/modules/metastore/config/schema/metastore.schema.yml
+++ b/modules/metastore/config/schema/metastore.schema.yml
@@ -8,6 +8,9 @@ metastore.settings:
     data_dictionary_sitewide:
       type: string
       label: 'Sitewide Dictionary ID'
+    csv_headers_mode:
+      type: string
+      label: 'CSV Headers Mode'
     property_list:
       type: sequence
       label: 'Property List'

--- a/modules/metastore/src/Form/DataDictionarySettingsForm.php
+++ b/modules/metastore/src/Form/DataDictionarySettingsForm.php
@@ -119,6 +119,21 @@ class DataDictionarySettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('data_dictionary_sitewide'),
     ];
 
+    $form['csv_headers_mode'] = [
+      '#type' => 'select',
+      '#title' => $this->t('CSV Headers Mode'),
+      '#options' => [
+        'resource_headers' => $this->t('Use the column names from the resource file'),
+        'dictionary_titles' => $this->t('Use data dictionary titles'),
+        'machine_names' => $this->t('Use the datastore machine names'),
+      ],
+      '#default_value' => $config->get('csv_headers_mode'),
+      '#description' => $this->t("Choose the column header values to be used for datastore query CSV downloads."),
+      '#attributes' => [
+        'name' => 'csv_headers_mode',
+      ],
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -150,6 +165,7 @@ class DataDictionarySettingsForm extends ConfigFormBase {
       // Set the submitted configuration setting.
       ->set('data_dictionary_mode', $form_state->getValue('dictionary_mode'))
       ->set('data_dictionary_sitewide', $form_state->getValue('sitewide_dictionary_id'))
+      ->set('csv_headers_mode', $form_state->getValue('csv_headers_mode'))
       ->save();
 
     parent::submitForm($form, $form_state);


### PR DESCRIPTION
re: 21838

## Describe your changes
To allow flexibility on the column headings being used for datastore query csv downloads when a data dictionary is in use, this new global configuration setting will determine between the original column headings or the title values saved to the data dictionary in case these two values differ from each other.

## QA Steps

- [x] details in 21838.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [x] I have updated or added documentation
