### PR TITLE
Index UI unit tests

### DIFF
--- a/modules/data_dictionary_widget/src/Plugin/Field/FieldWidget/DataDictionaryWidget.php
+++ b/modules/data_dictionary_widget/src/Plugin/Field/FieldWidget/DataDictionaryWidget.php
@@ -85,7 +85,7 @@ class DataDictionaryWidget extends WidgetBase implements TrustedCallbackInterfac
     // Create dictionary fields/buttons for editing.
     $element['dictionary_fields'] = FieldOperations::createDictionaryFieldOptions($op_index, $data_results, $dictionary_fields_being_modified, $element['dictionary_fields']);
     $element['dictionary_fields']['add_row_button']['#access'] = $dictionary_fields_being_modified == NULL ? TRUE : FALSE;
-
+    
     // Create index fields/buttons for editing.
     $element['indexes'] = IndexFieldOperations::createIndexOptions($op_index, $index_data_results, $index_being_modified, $index_fields_being_modified, $element['indexes'], $form_state);
     //$element['indexes'] = IndexFieldOperations::createIndexOptions($op_index, $index_data_results, $index_fields_being_modified, $element['indexes'], $form_state);
@@ -140,11 +140,10 @@ class DataDictionaryWidget extends WidgetBase implements TrustedCallbackInterfac
     $current_dictionary_fields = $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["data"]["#rows"] ?? [];
     $current_indexes = $form["field_json_metadata"]["widget"][0]["indexes"]["data"]["#rows"] ?? [];
     $field_collection = $values[0]['dictionary_fields']["field_collection"]["group"] ?? [];
-    $indexes_collection =  $values[0]["indexes"]["field_collection"]["group"] ?? [];
-    $indexes_fields_collection = $values[0]["indexes"]["fields"]["field_collection"]["group"] ?? [];
+    $indexes_collection = $values[0]["indexes"]["fields"]["field_collection"]["group"] ?? [];
 
-    if (!empty($indexes_fields_collection) && !empty($indexes_fields_collection["indexes"]["fields"])) {
-      $index_fields = $indexes_fields_collection["indexes"]["fields"];
+    if (!empty($indexes_collection) && !empty($indexes_collection["indexes"]["fields"])) {
+      $index_fields = $indexes_collection["indexes"]["fields"];
     }
 
     $dictionary_fields_input = !empty($field_collection) ? [
@@ -157,30 +156,22 @@ class DataDictionaryWidget extends WidgetBase implements TrustedCallbackInterfac
       ],
     ] : [];
 
-    $index_fields_inputs = !empty($indexes_fields_collection) ? [
+    $index_inputs = !empty($indexes_collection) ? [
       [
         "name" => $index_fields["name"] ?? '',
         "length" => isset($index_fields["length"]) ? (int)$index_fields["length"] : 0,
       ],
     ] : [];
-    $indexes = array_merge($current_indexes ?? [], $index_fields_inputs);
-
-    $index_inputs = !empty($indexes_collection) ? [
-      [
-        "description" => $indexes_collection["index"]["description"] ?? '',
-        "type" => $indexes_collection["index"]["type"] ?? '',
-        "fields" => $indexes,
-      ],
-    ] : [];
 
     $dictionary_fields = array_merge($current_dictionary_fields ?? [], $dictionary_fields_input);
+    $indexes = array_merge($current_indexes ?? [], $index_inputs);
 
     $json_data = [
       'identifier' => $values[0]['identifier'] ?? '',
       'data' => [
         'title' => $values[0]['title'] ?? '',
         'fields' => $dictionary_fields,
-        'indexes' => $index_inputs,
+        'indexes' => $indexes,
       ],
     ];
 

--- a/modules/data_dictionary_widget/src/Plugin/Field/FieldWidget/DataDictionaryWidget.php
+++ b/modules/data_dictionary_widget/src/Plugin/Field/FieldWidget/DataDictionaryWidget.php
@@ -85,7 +85,7 @@ class DataDictionaryWidget extends WidgetBase implements TrustedCallbackInterfac
     // Create dictionary fields/buttons for editing.
     $element['dictionary_fields'] = FieldOperations::createDictionaryFieldOptions($op_index, $data_results, $dictionary_fields_being_modified, $element['dictionary_fields']);
     $element['dictionary_fields']['add_row_button']['#access'] = $dictionary_fields_being_modified == NULL ? TRUE : FALSE;
-    
+
     // Create index fields/buttons for editing.
     $element['indexes'] = IndexFieldOperations::createIndexOptions($op_index, $index_data_results, $index_being_modified, $index_fields_being_modified, $element['indexes'], $form_state);
     //$element['indexes'] = IndexFieldOperations::createIndexOptions($op_index, $index_data_results, $index_fields_being_modified, $element['indexes'], $form_state);
@@ -140,10 +140,11 @@ class DataDictionaryWidget extends WidgetBase implements TrustedCallbackInterfac
     $current_dictionary_fields = $form["field_json_metadata"]["widget"][0]["dictionary_fields"]["data"]["#rows"] ?? [];
     $current_indexes = $form["field_json_metadata"]["widget"][0]["indexes"]["data"]["#rows"] ?? [];
     $field_collection = $values[0]['dictionary_fields']["field_collection"]["group"] ?? [];
-    $indexes_collection = $values[0]["indexes"]["fields"]["field_collection"]["group"] ?? [];
+    $indexes_collection =  $values[0]["indexes"]["field_collection"]["group"] ?? [];
+    $indexes_fields_collection = $values[0]["indexes"]["fields"]["field_collection"]["group"] ?? [];
 
-    if (!empty($indexes_collection) && !empty($indexes_collection["indexes"]["fields"])) {
-      $index_fields = $indexes_collection["indexes"]["fields"];
+    if (!empty($indexes_fields_collection) && !empty($indexes_fields_collection["indexes"]["fields"])) {
+      $index_fields = $indexes_fields_collection["indexes"]["fields"];
     }
 
     $dictionary_fields_input = !empty($field_collection) ? [
@@ -156,22 +157,30 @@ class DataDictionaryWidget extends WidgetBase implements TrustedCallbackInterfac
       ],
     ] : [];
 
-    $index_inputs = !empty($indexes_collection) ? [
+    $index_fields_inputs = !empty($indexes_fields_collection) ? [
       [
         "name" => $index_fields["name"] ?? '',
         "length" => isset($index_fields["length"]) ? (int)$index_fields["length"] : 0,
       ],
     ] : [];
+    $indexes = array_merge($current_indexes ?? [], $index_fields_inputs);
+
+    $index_inputs = !empty($indexes_collection) ? [
+      [
+        "description" => $indexes_collection["index"]["description"] ?? '',
+        "type" => $indexes_collection["index"]["type"] ?? '',
+        "fields" => $indexes,
+      ],
+    ] : [];
 
     $dictionary_fields = array_merge($current_dictionary_fields ?? [], $dictionary_fields_input);
-    $indexes = array_merge($current_indexes ?? [], $index_inputs);
 
     $json_data = [
       'identifier' => $values[0]['identifier'] ?? '',
       'data' => [
         'title' => $values[0]['title'] ?? '',
         'fields' => $dictionary_fields,
-        'indexes' => $indexes,
+        'indexes' => $index_inputs,
       ],
     ];
 

--- a/modules/data_dictionary_widget/tests/src/Functional/DataDictionaryWidgetTest.php
+++ b/modules/data_dictionary_widget/tests/src/Functional/DataDictionaryWidgetTest.php
@@ -51,6 +51,7 @@ class DataDictionaryWidgetTest extends BrowserTestBase {
     $session->elementExists('css', '#edit-field-json-metadata-0-identifier');
     $session->elementExists('css', '#edit-field-json-metadata-0-title');
     $session->elementExists('css', '#edit-field-json-metadata-0-dictionary-fields-add-row-button');
+    $session->elementExists('css', '#edit-field-json-metadata-0-indexes-add-row-button');
 
   }
 

--- a/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildIndexesTest.php
+++ b/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildIndexesTest.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\Tests\data_dictionary_widget\Unit;
 
+use Drupal\Core\Entity\EntityFormInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -24,7 +26,6 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
    * Test collecting indexes field information.
    */
   public function testIndexesFieldCollectionDictionaryWidget() {
-
     // Create mock objects.
     $formState = $this->createMock(FormStateInterface::class);
     $fieldItemList = $this->createMock(FieldItemListInterface::class);
@@ -35,7 +36,7 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
     $plugin_id = '';
     $plugin_definition = [];
 
-    $dataDictionaryWidget = new DataDictionaryWidget (
+    $dataDictionaryWidget = new DataDictionaryWidget(
       $plugin_id,
       $plugin_definition,
       $field_definition,
@@ -79,90 +80,142 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
   }
 
   /**
-   * Test creating a new dictionary field with indexes and adding it to the dictionary table.
+   * Test creating a new dictionary with indexes and adding it to the dictionary table.
    */
-  public function testAddNewFieldWithIndexDictionaryWidget() {
-
+  public function testAddNewIndexesDictionaryWidget() {
     // Create mock objects.
     $formState = $this->createMock(FormStateInterface::class);
+    $formObject = $this->createMock(EntityFormInterface::class);
+    $entity = $this->createMock(FieldableEntityInterface::class);
+    $fieldItemList = $this->createMock(FieldItemListInterface::class);
     $field_definition = $this->createMock(FieldDefinitionInterface::class);
     $settings = [];
     $third_party_settings = [];
+    $form = [];
     $plugin_id = '';
     $plugin_definition = [];
 
-    $form = [
+    $new_index = [
       'field_json_metadata' => [
-        'widget' => [
-          0 => [
-            'dictionary_fields' => [
-              'data' => [
-                '#rows' => null
-              ]
-            ],
-            'indexes' => [
-              'data' => [
-                '#rows' => null
-              ]
-            ]
-          ]
-        ]
-      ]
-    ];
-
-    $user_input = [
-      'field_json_metadata' => [
-        'identifier' => 'test',
-        'title' => 'test',
-        'indexes' => [
-          'field_collection' => [
-            'group' => [
-              'index' => [
-                'description' => 'test',
-                'type' => 'index',
-                'fields' => [
-                  'field_collection' => [
-                    'group' => [
-                      'index' => [
-                        'fields' => [
-                          'name' => 'test',
-                          'length' => 20,
-                        ]
-                      ]
-                    ]
-                  ]
-                ],
-                'data' => null,
-                'edit_buttons' => [],
-              ]
-            ]
-          ]
-        ]
-      ]
-    ];
-
-    $values = [
-      [
-        'identifier' => 'test',
-        'title' => 'test',
-        'indexes' => [
-          'data' => '',
-          'add_row_button' => 'Add index',
-          'field_collection' => [
-            'group' => [
-              'index' => [
-                'description' => 'test',
-                'type' => 'index',
-              ]
-            ]
-          ],
-          'fields' => [
+        [
+          'indexes' => [
             'field_collection' => [
               'group' => [
-                'indexes' => [
-                  'fields' => [
-                    'name' => 'test',
-                    'length' => 20,
+                'index' => [
+                  'description' => 'test',
+                  'type' => 'index',
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ];
+
+    $formState->expects($this->once())
+      ->method('getFormObject')
+      ->willReturn($formObject);
+
+    $formObject->expects($this->once())
+      ->method('getEntity')
+      ->willReturn($entity);
+
+    $entity->expects($this->once())
+      ->method('set')
+      ->with('field_data_type', 'data-dictionary');
+
+    $formState->expects($this->exactly(14))
+      ->method('get')
+      ->willReturnOnConsecutiveCalls(
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        $new_index,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+      );
+
+    // Set up a triggering element with '#op' set to 'add_index'.
+    $trigger = ['#op' => 'add_index'];
+    // Expect that getTriggeringElement will be called once and return the add.
+    $formState->expects($this->any())
+      ->method('getTriggeringElement')
+      ->willReturn($trigger);
+
+    $dataDictionaryWidget = new DataDictionaryWidget(
+      $plugin_id,
+      $plugin_definition,
+      $field_definition,
+      $settings,
+      $third_party_settings
+    );
+
+    // Call the method under test.
+    $element = $dataDictionaryWidget->formElement(
+      $fieldItemList,
+      0,
+      [],
+      $form,
+      $formState
+    );
+
+    $this->assertEquals('test', $element['indexes']['data']['#rows'][0]['description']);
+    $this->assertEquals('index', $element['indexes']['data']['#rows'][0]['type']);
+  }
+
+  /**
+   * Test creating a new dictionary with indexes with index fields and adding it to the dictionary table.
+   */
+  public function testAddNewIndexesWithFieldsDictionaryWidget() {
+    // Create mock objects.
+    $formState = $this->createMock(FormStateInterface::class);
+    $formObject = $this->createMock(EntityFormInterface::class);
+    $entity = $this->createMock(FieldableEntityInterface::class);
+    $fieldItemList = $this->createMock(FieldItemListInterface::class);
+    $field_definition = $this->createMock(FieldDefinitionInterface::class);
+    $settings = [];
+    $third_party_settings = [];
+    $form = [];
+    $plugin_id = '';
+    $plugin_definition = [];
+
+    $new_index = [
+      'field_json_metadata' => [
+        [
+          'indexes' => [
+            'field_collection' => [
+              'group' => [
+                'index' => [
+                  'description' => 'test',
+                  'type' => 'index',
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ];
+
+    $new_index_fields = [
+      'field_json_metadata' => [
+        [
+          'indexes' => [
+            'fields' => [
+              'field_collection' => [
+                'group' => [
+                  'index' => [
+                    'fields' => [
+                      'name' => 'test',
+                      'length' => 20,
+                    ]
                   ]
                 ]
               ]
@@ -172,7 +225,45 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
       ]
     ];
 
-    $dataDictionaryWidget = new DataDictionaryWidget (
+    $formState->expects($this->once())
+      ->method('getFormObject')
+      ->willReturn($formObject);
+
+    $formObject->expects($this->once())
+      ->method('getEntity')
+      ->willReturn($entity);
+
+    $entity->expects($this->once())
+      ->method('set')
+      ->with('field_data_type', 'data-dictionary');
+
+    $formState->expects($this->exactly(15))
+      ->method('get')
+      ->willReturnOnConsecutiveCalls(
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        $new_index_fields,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+      );
+
+    // Set up a triggering element with '#op' set to 'add_index'.
+    $trigger = ['#op' => 'add_index_field'];
+    // Expect that getTriggeringElement will be called once and return the add.
+    $formState->expects($this->any())
+      ->method('getTriggeringElement')
+      ->willReturn($trigger);
+
+    $dataDictionaryWidget = new DataDictionaryWidget(
       $plugin_id,
       $plugin_definition,
       $field_definition,
@@ -180,43 +271,289 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
       $third_party_settings
     );
 
-    // Set up a triggering element with '#op' set to 'add_index'.
-    $trigger = ['#op' => 'add_index'];
-
-    // Expect that getTriggeringElement will be called once and return the add.
-    $formState->expects($this->any())
-      ->method('getTriggeringElement')
-      ->willReturn($trigger);
-
-    $formState->expects($this->exactly(12))
-      ->method('set')
-      ->willReturnOnConsecutiveCalls (
-        '',
-        $this->equalTo($user_input),
-        TRUE,
-        FALSE,
-        '',
-        ''
-      );
-
-    IndexFieldCallbacks::indexAddCallback($form, $formState);
-
     // Call the method under test.
-    $json_data = $dataDictionaryWidget->massageFormValues(
-      $values,
+    $element = $dataDictionaryWidget->formElement(
+      $fieldItemList,
+      0,
+      [],
       $form,
       $formState
     );
 
-    // Convert JSON to array
-    $data = json_decode($json_data, true);
+    $this->assertEquals('test', $element['indexes']['fields']['data']['#rows'][0]['name']);
+    $this->assertEquals(20, $element['indexes']['fields']['data']['#rows'][0]['length']);
+  }
 
-    $this->assertEquals($data['identifier'], $user_input['field_json_metadata']['identifier']);
-    $this->assertEquals($data['data']['title'], $user_input['field_json_metadata']['title']);
-    $this->assertEquals($data['data']['indexes'][0]['description'], $user_input['field_json_metadata']['indexes']['field_collection']['group']['index']['description']);
-    $this->assertEquals($data['data']['indexes'][0]['type'], $user_input['field_json_metadata']['indexes']['field_collection']['group']['index']['type']);
-    $this->assertEquals($data['data']['indexes'][0]['fields'][0]['name'], $user_input['field_json_metadata']['indexes']['field_collection']['group']['index']['fields']['field_collection']['group']['index']['fields']['name']);
-    $this->assertEquals($data['data']['indexes'][0]['fields'][0]['length'], $user_input['field_json_metadata']['indexes']['field_collection']['group']['index']['fields']['field_collection']['group']['index']['fields']['length']);
+  /**
+   * Test the creation of the edit buttons for a data dictionary indexes field.
+   */
+  public function testEditIndexesButtonsCreationDictionaryWidget() {
+    // Create mock objects.
+    $formState = $this->createMock(FormStateInterface::class);
+    $formObject = $this->createMock(EntityFormInterface::class);
+    $entity = $this->createMock(FieldableEntityInterface::class);
+    $fieldItemList = $this->createMock(FieldItemListInterface::class);
+    $field_definition = $this->createMock(FieldDefinitionInterface::class);
+    $settings = [];
+    $third_party_settings = [];
+    $form = [];
+    $plugin_id = '';
+    $plugin_definition = [];
+
+    $current_fields = [
+      [
+        'description' => 'test',
+        'type' => 'index',
+      ]
+    ];
+
+    $formState->expects($this->once())
+      ->method('getFormObject')
+      ->willReturn($formObject);
+
+    $formObject->expects($this->once())
+      ->method('getEntity')
+      ->willReturn($entity);
+
+    $entity->expects($this->once())
+      ->method('set')
+      ->with('field_data_type', 'data-dictionary');
+
+    $formState->expects($this->exactly(14))
+      ->method('get')
+      ->willReturnOnConsecutiveCalls(
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        $current_fields,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+      );
+
+    $dataDictionaryWidget = new DataDictionaryWidget(
+      $plugin_id,
+      $plugin_definition,
+      $field_definition,
+      $settings,
+      $third_party_settings
+    );
+
+    $element = $dataDictionaryWidget->formElement(
+      $fieldItemList,
+      0,
+      [],
+      $form,
+      $formState
+    );
+
+    $this->assertNotNull($element["indexes"]["edit_index_buttons"]);
+    $this->assertArrayHasKey('#name', $element["indexes"]["edit_index_buttons"]['index_key_0']["edit_index_button"]);
+    $this->assertArrayHasKey('#id', $element["indexes"]["edit_index_buttons"]['index_key_0']["edit_index_button"]);
+    $this->assertArrayHasKey('#op', $element["indexes"]["edit_index_buttons"]['index_key_0']["edit_index_button"]);
+  }
+
+  /**
+   * Test edit a data dictionary index field and save it.
+   */
+  public function testEditDataDictionaryIndexDictionaryWidget() {
+
+    // Create mock objects.
+    $formState = $this->createMock(FormStateInterface::class);
+    $formObject = $this->createMock(EntityFormInterface::class);
+    $entity = $this->createMock(FieldableEntityInterface::class);
+    $fieldItemList = $this->createMock(FieldItemListInterface::class);
+    $field_definition = $this->createMock(FieldDefinitionInterface::class);
+    $settings = [];
+    $third_party_settings = [];
+    $form = [];
+    $plugin_id = '';
+    $plugin_definition = [];
+
+    $current_index = [
+      [
+        'description' => 'test',
+        'type' => 'index',
+      ]
+    ];
+
+    $updated_index = [
+      [
+        'description' => 'test_edit',
+        'type' => 'fulltext',
+      ]
+    ];
+
+    $op = "edit_index_key_0";
+
+    $user_input = [
+      'field_json_metadata' => [
+        0 => [
+          'identifier' => 'test_identifier',
+          'title' => 'test_title',
+          'dictionary_fields' => [
+            'field_collection' => [
+              'group' => [
+                'name' => 'test_edit',
+                'title' => 'test_edit',
+                'type' => 'string',
+                'format' => 'default',
+                'format_other' => '',
+                'description' => 'test_edit',
+              ]
+            ],
+            'data' => [
+              [
+                'field_collection' => [
+                  'name' => 'test_edit',
+                  'title' => 'test_edit',
+                  'type' => 'string',
+                  'format' => 'default',
+                  'format_other' => '',
+                  'description' => 'test_edit',
+                ],
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    $form["field_json_metadata"]["widget"][0] = [
+      "dictionary_fields" => [
+        "data" => [
+          "#rows" => [
+            0 => [],
+          ],
+        ],
+      ],
+      'indexes' => [
+        'data' => [
+          "#rows" => [
+            [
+              'description' => 'test',
+              'type' => 'index',
+            ],
+          ],
+        ],
+        'fields' => [
+          'data' => [
+            "#rows" => [
+              0 => [],
+            ],
+          ],
+        ]
+      ],
+    ];
+
+    $formState->expects($this->exactly(2))
+      ->method('getFormObject')
+      ->willReturn($formObject);
+
+    $formObject->expects($this->exactly(2))
+      ->method('getEntity')
+      ->willReturn($entity);
+
+    $entity->expects($this->exactly(2))
+      ->method('set')
+      ->with('field_data_type', 'data-dictionary');
+
+    $formState->expects($this->any())
+      ->method('get')
+      ->willReturnOnConsecutiveCalls(
+        [],
+        $current_index,
+        $current_index,
+        [],
+        [],
+        [],
+        [],
+        [],
+        $current_index,
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        TRUE,
+        [],
+        $current_index,
+        $current_index,
+        [],
+        [],
+        [],
+        [],
+        [],
+        $updated_index,
+        [],
+        [],
+        [],
+        [],
+        []
+      );
+
+    $formState->expects($this->any())
+      ->method('getTriggeringElement')
+      ->willReturnOnConsecutiveCalls(
+        ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op],
+        ['#op' => 'update'], ['#op' => 'update'], ['#op' => 'update'], ['#op' => 'update'], ['#op' => 'update'],
+      );
+
+    $formState->expects($this->any())
+      ->method('getUserInput')
+      ->willReturn($user_input);
+
+    $dataDictionaryWidget = new DataDictionaryWidget(
+      $plugin_id,
+      $plugin_definition,
+      $field_definition,
+      $settings,
+      $third_party_settings
+    );
+
+    // Trigger callback function to edit fields.
+    IndexFieldCallbacks::indexEditCallback($form, $formState);
+
+    // First call to re-create data dictionary form with the editable fields.
+    $element = $dataDictionaryWidget->formElement(
+      $fieldItemList,
+      0,
+      [],
+      $form,
+      $formState
+    );
+
+    // Assert edit feature loads form with the current field values.
+    $this->assertNotNull($element);
+    $this->assertEquals($element["indexes"]["data"]["#rows"][0]["description"], $current_index[0]["description"]);
+    $this->assertEquals($element["indexes"]["data"]["#rows"][0]["type"], $current_index[0]["type"]);
+
+    // Trigger callback function to save the edited fields.
+    IndexFieldCallbacks::indexEditCallback($form, $formState);
+
+    // Second call to re-create data dictionary and apply the edits made to the fields.
+    $element = $dataDictionaryWidget->formElement(
+      $fieldItemList,
+      0,
+      [],
+      $form,
+      $formState
+    );
+
+    // Assert update feature loads form with the edited field values.
+    $this->assertNotNull($element);
+    $this->assertEquals($element["indexes"]["data"]["#rows"][0]["description"], $updated_index[0]["description"]);
+    $this->assertEquals($element["indexes"]["data"]["#rows"][0]["type"], $updated_index[0]["type"]);
   }
 
 }

--- a/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildIndexesTest.php
+++ b/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildIndexesTest.php
@@ -26,7 +26,6 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
    * Test collecting indexes field information.
    */
   public function testIndexesFieldCollectionDictionaryWidget() {
-    // Create mock objects.
     $formState = $this->createMock(FormStateInterface::class);
     $fieldItemList = $this->createMock(FieldItemListInterface::class);
     $field_definition = $this->createMock(FieldDefinitionInterface::class);
@@ -44,7 +43,6 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
       $third_party_settings
     );
 
-    // Call the method under test.
     $element = $dataDictionaryWidget->formElement(
       $fieldItemList,
       0,
@@ -53,12 +51,10 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
       $formState
     );
 
+    // After creating the widget and building it call the index functions to update $element with the index fields.
     $add_fields = IndexFieldAddCreation::addIndex();
-
     $element = IndexFieldOperations::setAddIndexFormState($add_fields, $element);
-
     $add_index_fields = IndexFieldAddCreation::addIndexFields(null);
-
     $element = IndexFieldOperations::setAddIndexFieldFormState($add_index_fields, $element);
 
     $this->assertNotNull($element);
@@ -83,7 +79,6 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
    * Test creating a new dictionary with indexes and adding it to the dictionary table.
    */
   public function testAddNewIndexesDictionaryWidget() {
-    // Create mock objects.
     $formState = $this->createMock(FormStateInterface::class);
     $formObject = $this->createMock(EntityFormInterface::class);
     $entity = $this->createMock(FieldableEntityInterface::class);
@@ -124,6 +119,8 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
       ->method('set')
       ->with('field_data_type', 'data-dictionary');
 
+    // The gets are happening in formElement and function calls in it that use the formState variable.
+    // Set the value for $form_state->get("new_index").
     $formState->expects($this->exactly(14))
       ->method('get')
       ->willReturnOnConsecutiveCalls(
@@ -158,7 +155,6 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
       $third_party_settings
     );
 
-    // Call the method under test.
     $element = $dataDictionaryWidget->formElement(
       $fieldItemList,
       0,
@@ -175,7 +171,6 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
    * Test creating a new dictionary with indexes with index fields and adding it to the dictionary table.
    */
   public function testAddNewIndexesWithFieldsDictionaryWidget() {
-    // Create mock objects.
     $formState = $this->createMock(FormStateInterface::class);
     $formObject = $this->createMock(EntityFormInterface::class);
     $entity = $this->createMock(FieldableEntityInterface::class);
@@ -220,6 +215,8 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
       ->method('set')
       ->with('field_data_type', 'data-dictionary');
 
+    // The gets are happening in formElement and function calls in it that use the formState variable.
+    // Set the value for $form_state->get("new_index_fields").
     $formState->expects($this->exactly(15))
       ->method('get')
       ->willReturnOnConsecutiveCalls(
@@ -254,7 +251,6 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
       $third_party_settings
     );
 
-    // Call the method under test.
     $element = $dataDictionaryWidget->formElement(
       $fieldItemList,
       0,
@@ -271,7 +267,6 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
    * Test the creation of the edit buttons for a data dictionary indexes field.
    */
   public function testEditIndexesButtonsCreationDictionaryWidget() {
-    // Create mock objects.
     $formState = $this->createMock(FormStateInterface::class);
     $formObject = $this->createMock(EntityFormInterface::class);
     $entity = $this->createMock(FieldableEntityInterface::class);
@@ -283,7 +278,7 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
     $plugin_id = '';
     $plugin_definition = [];
 
-    $current_fields = [
+    $current_index = [
       [
         'description' => 'test',
         'type' => 'index',
@@ -302,6 +297,8 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
       ->method('set')
       ->with('field_data_type', 'data-dictionary');
 
+    // The gets are happening in formElement and function calls in it that use the formState variable.
+    // Set the value for $form_state->get("current_index").
     $formState->expects($this->exactly(14))
       ->method('get')
       ->willReturnOnConsecutiveCalls(
@@ -309,7 +306,7 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
         NULL,
         NULL,
         NULL,
-        $current_fields,
+        $current_index,
         NULL,
         NULL,
         NULL,
@@ -347,8 +344,6 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
    * Test edit a data dictionary index field and save it.
    */
   public function testEditDataDictionaryIndexDictionaryWidget() {
-
-    // Create mock objects.
     $formState = $this->createMock(FormStateInterface::class);
     $formObject = $this->createMock(EntityFormInterface::class);
     $entity = $this->createMock(FieldableEntityInterface::class);
@@ -373,8 +368,6 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
         'type' => 'fulltext',
       ]
     ];
-
-    $op = "edit_index_key_0";
 
     $user_input = [
       'field_json_metadata' => [
@@ -433,6 +426,8 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
       ->method('set')
       ->with('field_data_type', 'data-dictionary');
 
+    // The gets are happening in indexEditCallback and formElement and function calls in it that use the formState variable.
+    // Set the value for various $form_state calls that use the current index and then are updated when we pass the updated index value.
     $formState->expects($this->any())
       ->method('get')
       ->willReturnOnConsecutiveCalls(
@@ -473,7 +468,7 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
     $formState->expects($this->any())
       ->method('getTriggeringElement')
       ->willReturnOnConsecutiveCalls(
-        ['#op' => $op], ['#op' => $op],
+        ['#op' => 'edit_index_key_0'], ['#op' => 'edit_index_key_0'],
         ['#op' => 'update_index_key_0'], ['#op' => 'update_index_key_0'],
       );
 

--- a/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildIndexesTest.php
+++ b/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildIndexesTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Drupal\Tests\data_dictionary_widget\Unit;
+
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\data_dictionary_widget\Indexes\IndexFieldAddCreation;
+use Drupal\data_dictionary_widget\Indexes\IndexFieldCallbacks;
+use Drupal\data_dictionary_widget\Indexes\IndexFieldOperations;
+use Drupal\data_dictionary_widget\Plugin\Field\FieldWidget\DataDictionaryWidget;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for DataDictionaryWidget focus on Indexes.
+ *
+ * @group dkan
+ * @group data_dictionary_widget
+ * @group unit
+ */
+class DataDictionaryWidgetBuildIndexesTest extends TestCase {
+
+  /**
+   * Test collecting indexes field information.
+   */
+  public function testIndexesFieldCollectionDictionaryWidget() {
+
+    // Create mock objects.
+    $formState = $this->createMock(FormStateInterface::class);
+    $fieldItemList = $this->createMock(FieldItemListInterface::class);
+    $field_definition = $this->createMock(FieldDefinitionInterface::class);
+    $settings = [];
+    $third_party_settings = [];
+    $form = [];
+    $plugin_id = '';
+    $plugin_definition = [];
+
+    $dataDictionaryWidget = new DataDictionaryWidget (
+      $plugin_id,
+      $plugin_definition,
+      $field_definition,
+      $settings,
+      $third_party_settings
+    );
+
+    // Call the method under test.
+    $element = $dataDictionaryWidget->formElement(
+      $fieldItemList,
+      0,
+      [],
+      $form,
+      $formState
+    );
+
+    $add_fields = IndexFieldAddCreation::addIndex();
+
+    $element = IndexFieldOperations::setAddIndexFormState($add_fields, $element);
+
+    $add_index_fields = IndexFieldAddCreation::addIndexFields(null);
+
+    $element = IndexFieldOperations::setAddIndexFieldFormState($add_index_fields, $element);
+
+    $this->assertNotNull($element);
+    $this->assertNotNull($element["indexes"]["field_collection"]);
+    $this->assertArrayHasKey('group', $element["indexes"]["field_collection"], 'Indexes Group Does Not Exist On The Data Dictionary Form');
+    $this->assertArrayHasKey('description', $element["indexes"]["field_collection"]["group"]["index"], 'Indexes Name Field Does Not Exist On The Data Dictionary Form');
+    $this->assertArrayHasKey('type', $element["indexes"]["field_collection"]["group"]["index"], 'Indexes Type Field Does Not Exist On The Data Dictionary Form');
+    $this->assertArrayHasKey('fields', $element["indexes"]["field_collection"]["group"]["index"], 'Indexes Fields Does Not Exist On The Data Dictionary Form');
+
+    $this->assertNotNull($element["indexes"]["fields"]["field_collection"]);
+    $this->assertArrayHasKey('group', $element["indexes"]["fields"]["field_collection"], 'Indexes Fields Group Does Not Exist On The Data Dictionary Form');
+    $this->assertArrayHasKey('name', $element["indexes"]["fields"]["field_collection"]["group"]["index"]["fields"], 'Indexes Fields Name Does Not Exist On The Data Dictionary Form');
+    $this->assertArrayHasKey('length', $element["indexes"]["fields"]["field_collection"]["group"]["index"]["fields"], 'Indexes Fields Length Does Not Exist On The Data Dictionary Form');
+    $this->assertArrayHasKey('save_index_settings', $element["indexes"]["fields"]["field_collection"]["group"]["index"]["fields"]["actions"], 'Add button Does Not Exist On The Data Dictionary Form');
+    $this->assertArrayHasKey('cancel_index_settings', $element["indexes"]["fields"]["field_collection"]["group"]["index"]["fields"]["actions"], 'Cancel button Does Not Exist On The Data Dictionary Form');
+
+    $this->assertArrayHasKey('save_index', $element["indexes"]["field_collection"]["group"]["index"], 'Submit Index button Does Not Exist On The Data Dictionary Form');
+    $this->assertArrayHasKey('cancel_index', $element["indexes"]["field_collection"]["group"]["index"], 'Cancel Index button Does Not Exist On The Data Dictionary Form');
+  }
+
+  /**
+   * Test creating a new dictionary field with indexes and adding it to the dictionary table.
+   */
+  public function testAddNewFieldWithIndexDictionaryWidget() {
+
+    // Create mock objects.
+    $formState = $this->createMock(FormStateInterface::class);
+    $field_definition = $this->createMock(FieldDefinitionInterface::class);
+    $settings = [];
+    $third_party_settings = [];
+    $plugin_id = '';
+    $plugin_definition = [];
+
+    $form = [
+      'field_json_metadata' => [
+        'widget' => [
+          0 => [
+            'dictionary_fields' => [
+              'data' => [
+                '#rows' => null
+              ]
+            ],
+            'indexes' => [
+              'data' => [
+                '#rows' => null
+              ]
+            ]
+          ]
+        ]
+      ]
+    ];
+
+    $user_input = [
+      'field_json_metadata' => [
+        'identifier' => 'test',
+        'title' => 'test',
+        'indexes' => [
+          'field_collection' => [
+            'group' => [
+              'index' => [
+                'description' => 'test',
+                'type' => 'index',
+                'fields' => [
+                  'field_collection' => [
+                    'group' => [
+                      'index' => [
+                        'fields' => [
+                          'name' => 'test',
+                          'length' => 20,
+                        ]
+                      ]
+                    ]
+                  ]
+                ],
+                'data' => null,
+                'edit_buttons' => [],
+              ]
+            ]
+          ]
+        ]
+      ]
+    ];
+
+    $values = [
+      [
+        'identifier' => 'test',
+        'title' => 'test',
+        'indexes' => [
+          'data' => '',
+          'add_row_button' => 'Add index',
+          'field_collection' => [
+            'group' => [
+              'index' => [
+                'description' => 'test',
+                'type' => 'index',
+              ]
+            ]
+          ],
+          'fields' => [
+            'field_collection' => [
+              'group' => [
+                'indexes' => [
+                  'fields' => [
+                    'name' => 'test',
+                    'length' => 20,
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ];
+
+    $dataDictionaryWidget = new DataDictionaryWidget (
+      $plugin_id,
+      $plugin_definition,
+      $field_definition,
+      $settings,
+      $third_party_settings
+    );
+
+    // Set up a triggering element with '#op' set to 'add_index'.
+    $trigger = ['#op' => 'add_index'];
+
+    // Expect that getTriggeringElement will be called once and return the add.
+    $formState->expects($this->any())
+      ->method('getTriggeringElement')
+      ->willReturn($trigger);
+
+    $formState->expects($this->exactly(12))
+      ->method('set')
+      ->willReturnOnConsecutiveCalls (
+        '',
+        $this->equalTo($user_input),
+        TRUE,
+        FALSE,
+        '',
+        ''
+      );
+
+    IndexFieldCallbacks::indexAddCallback($form, $formState);
+
+    // Call the method under test.
+    $json_data = $dataDictionaryWidget->massageFormValues(
+      $values,
+      $form,
+      $formState
+    );
+
+    // Convert JSON to array
+    $data = json_decode($json_data, true);
+
+    $this->assertEquals($data['identifier'], $user_input['field_json_metadata']['identifier']);
+    $this->assertEquals($data['data']['title'], $user_input['field_json_metadata']['title']);
+    $this->assertEquals($data['data']['indexes'][0]['description'], $user_input['field_json_metadata']['indexes']['field_collection']['group']['index']['description']);
+    $this->assertEquals($data['data']['indexes'][0]['type'], $user_input['field_json_metadata']['indexes']['field_collection']['group']['index']['type']);
+    $this->assertEquals($data['data']['indexes'][0]['fields'][0]['name'], $user_input['field_json_metadata']['indexes']['field_collection']['group']['index']['fields']['field_collection']['group']['index']['fields']['name']);
+    $this->assertEquals($data['data']['indexes'][0]['fields'][0]['length'], $user_input['field_json_metadata']['indexes']['field_collection']['group']['index']['fields']['field_collection']['group']['index']['fields']['length']);
+  }
+
+}

--- a/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildIndexesTest.php
+++ b/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildIndexesTest.php
@@ -187,23 +187,6 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
     $plugin_id = '';
     $plugin_definition = [];
 
-    $new_index = [
-      'field_json_metadata' => [
-        [
-          'indexes' => [
-            'field_collection' => [
-              'group' => [
-                'index' => [
-                  'description' => 'test',
-                  'type' => 'index',
-                ]
-              ]
-            ]
-          ]
-        ]
-      ]
-    ];
-
     $new_index_fields = [
       'field_json_metadata' => [
         [
@@ -398,29 +381,13 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
         0 => [
           'identifier' => 'test_identifier',
           'title' => 'test_title',
-          'dictionary_fields' => [
-            'field_collection' => [
-              'group' => [
-                'name' => 'test_edit',
-                'title' => 'test_edit',
-                'type' => 'string',
-                'format' => 'default',
-                'format_other' => '',
+          'indexes' => [
+            'edit_index' => [
+              'index_key_0' => [
                 'description' => 'test_edit',
+                'type' => 'fulltext',
               ]
-            ],
-            'data' => [
-              [
-                'field_collection' => [
-                  'name' => 'test_edit',
-                  'title' => 'test_edit',
-                  'type' => 'string',
-                  'format' => 'default',
-                  'format_other' => '',
-                  'description' => 'test_edit',
-                ],
-              ],
-            ],
+            ]
           ],
         ],
       ],
@@ -440,6 +407,7 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
             [
               'description' => 'test',
               'type' => 'index',
+              'fields' => [],
             ],
           ],
         ],
@@ -505,8 +473,8 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
     $formState->expects($this->any())
       ->method('getTriggeringElement')
       ->willReturnOnConsecutiveCalls(
-        ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op], ['#op' => $op],
-        ['#op' => 'update'], ['#op' => 'update'], ['#op' => 'update'], ['#op' => 'update'], ['#op' => 'update'],
+        ['#op' => $op], ['#op' => $op],
+        ['#op' => 'update_index_key_0'], ['#op' => 'update_index_key_0'],
       );
 
     $formState->expects($this->any())
@@ -535,8 +503,8 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
 
     // Assert edit feature loads form with the current field values.
     $this->assertNotNull($element);
-    $this->assertEquals($element["indexes"]["data"]["#rows"][0]["description"], $current_index[0]["description"]);
-    $this->assertEquals($element["indexes"]["data"]["#rows"][0]["type"], $current_index[0]["type"]);
+    $this->assertEquals($current_index[0]["description"], $element["indexes"]["data"]["#rows"][0]["description"]);
+    $this->assertEquals($current_index[0]["type"], $element["indexes"]["data"]["#rows"][0]["type"]);
 
     // Trigger callback function to save the edited fields.
     IndexFieldCallbacks::indexEditCallback($form, $formState);
@@ -552,8 +520,8 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
 
     // Assert update feature loads form with the edited field values.
     $this->assertNotNull($element);
-    $this->assertEquals($element["indexes"]["data"]["#rows"][0]["description"], $updated_index[0]["description"]);
-    $this->assertEquals($element["indexes"]["data"]["#rows"][0]["type"], $updated_index[0]["type"]);
+    $this->assertEquals($updated_index[0]["description"], $element["indexes"]["data"]["#rows"][0]["description"]);
+    $this->assertEquals($updated_index[0]["type"], $element["indexes"]["data"]["#rows"][0]["type"]);
   }
 
 }

--- a/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildTest.php
+++ b/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildTest.php
@@ -15,7 +15,7 @@ use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\data_dictionary_widget\Plugin\Field\FieldWidget\DataDictionaryWidget;
 
 /**
- * Test class for DataDictionaryWidget.
+ * Test class for DataDictionaryWidget focus on Data Dictionary Fields.
  *
  * @group dkan
  * @group data_dictionary_widget
@@ -76,6 +76,7 @@ class DataDictionaryWidgetBuildTest extends TestCase {
     $this->assertArrayHasKey('identifier', $element, 'Identifier Field Does Not Exist On The Data Dictionary Form');
     $this->assertArrayHasKey('title', $element, 'Identifier Field Does Not Exist On The Data Dictionary Form');
     $this->assertArrayHasKey('dictionary_fields', $element, 'Identifier Field Does Not Exist On The Data Dictionary Form');
+    $this->assertArrayHasKey('indexes', $element, 'Identifier Field Does Not Exist On The Data Dictionary Form');
   }
 
   /**
@@ -261,7 +262,7 @@ class DataDictionaryWidgetBuildTest extends TestCase {
 
     FieldCallbacks::addSubformCallback($form, $formState);
     $element['dictionary_fields']['data'] = FieldCreation::createDictionaryDataRows([], $data_results, $formState);
-    
+
     // Call the method under test.
     $json_data = $dataDictionaryWidget->massageFormValues(
       $values,
@@ -349,7 +350,7 @@ class DataDictionaryWidgetBuildTest extends TestCase {
     $this->assertArrayHasKey('#op', $element["dictionary_fields"]["edit_buttons"][0]["edit_button"]);
   }
 
-    /**
+  /**
    * Test edit a data dictionary field and save it.
    */
   public function testEditDataDictionaryField() {
@@ -472,33 +473,33 @@ class DataDictionaryWidgetBuildTest extends TestCase {
     $formState->expects($this->any())
       ->method('get')
       ->willReturnOnConsecutiveCalls(
-        [], 
-        $current_dictionary_fields, 
-        [], 
-        [], 
-        [], 
-        $current_dictionary_fields, 
-        [], 
-        [], 
-        [], 
-        [], 
-        [], 
-        [], 
         [],
-        [], 
-        [], 
-        $user_input, 
+        $current_dictionary_fields,
         [],
-        $current_dictionary_fields, 
-        [], 
-        [], 
-        [], 
-        [], 
-        $updated_dictionary_fields, 
-        [], 
-        [], 
-        [], 
-        [], 
+        [],
+        [],
+        $current_dictionary_fields,
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        $user_input,
+        [],
+        $current_dictionary_fields,
+        [],
+        [],
+        [],
+        [],
+        $updated_dictionary_fields,
+        [],
+        [],
+        [],
+        [],
         []
       );
 
@@ -521,9 +522,9 @@ class DataDictionaryWidgetBuildTest extends TestCase {
       $third_party_settings
     );
 
-    // Trigger callback function to edit fields. 
+    // Trigger callback function to edit fields.
     FieldCallbacks::editSubformCallback($form, $formState);
-    
+
     // First call to re-create data dictionary form with the editable fields.
     $element = $dataDictionaryWidget->formElement(
       $fieldItemList,
@@ -542,7 +543,7 @@ class DataDictionaryWidgetBuildTest extends TestCase {
     $this->assertEquals($element["dictionary_fields"]["data"]["#rows"][0]["description"], $current_dictionary_fields[0]["description"]);
 
 
-    // Trigger callback function to save the edited fields. 
+    // Trigger callback function to save the edited fields.
     FieldCallbacks::editSubformCallback($form, $formState);
 
     // Second call to re-create data dictionary and apply the edits made to the fields.


### PR DESCRIPTION
re: 17377

## Describe your changes

Tests for #4185

## QA Steps

- [ ] Tests are passing in the pipeline and locally with the following command:

```
ddev dkan-phpunit \                                                                                                                 
                    --coverage-clover /var/www/html/docroot/modules/contrib/dkan/clover.xml \
                    --coverage-html /var/www/html/docroot/modules/contrib/dkan/coverage-html \
                    --log-junit /var/www/html/docroot/modules/contrib/dkan/junit/junit.xml --filter DataDictionaryWidgetBuildIndexesTest
```

- [ ] Code coverage for `/var/www/html/dkan/modules -> data_dictionary_widget -> src -> Indexes` is > 50%

