### PR TITLE
Added Indexes edit unit tests

### DIFF
--- a/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildIndexesTest.php
+++ b/modules/data_dictionary_widget/tests/src/Unit/DataDictionaryWidgetBuildIndexesTest.php
@@ -9,7 +9,9 @@ use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\data_dictionary_widget\Indexes\IndexFieldAddCreation;
 use Drupal\data_dictionary_widget\Indexes\IndexFieldCallbacks;
+use Drupal\data_dictionary_widget\Indexes\IndexFieldEditCreation;
 use Drupal\data_dictionary_widget\Indexes\IndexFieldOperations;
+use Drupal\data_dictionary_widget\Indexes\IndexValidation;
 use Drupal\data_dictionary_widget\Plugin\Field\FieldWidget\DataDictionaryWidget;
 use PHPUnit\Framework\TestCase;
 
@@ -341,7 +343,7 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
   }
 
   /**
-   * Test edit a data dictionary index field and save it.
+   * Test edit a data dictionary index and save it.
    */
   public function testEditDataDictionaryIndexDictionaryWidget() {
     $formState = $this->createMock(FormStateInterface::class);
@@ -517,6 +519,261 @@ class DataDictionaryWidgetBuildIndexesTest extends TestCase {
     $this->assertNotNull($element);
     $this->assertEquals($updated_index[0]["description"], $element["indexes"]["data"]["#rows"][0]["description"]);
     $this->assertEquals($updated_index[0]["type"], $element["indexes"]["data"]["#rows"][0]["type"]);
+  }
+
+  /**
+   * Test edit index for indexes.
+   */
+  public function testEditDataDictionaryIndexEdit() {
+    // Arrange
+    $indexKey = 'index_key_0';
+    $current_index = [
+      [
+        'description' => 'test',
+        'type' => 'index',
+        'fields' => [
+          [
+            'name' => 'test',
+            'length' => 20
+          ]
+        ]
+      ]
+    ];
+    $index_being_modified = $current_index;
+    $formState = $this->createMock(FormStateInterface::class);
+    $formState->expects($this->any())
+      ->method('get')
+      ->willReturnOnConsecutiveCalls(FALSE);
+
+    // Act
+    $edit_index = IndexFieldEditCreation::editIndex($indexKey, $current_index, $index_being_modified, $formState);
+
+    // Assert
+    $this->assertNotNull($edit_index);
+    $this->assertEquals('field_json_metadata[0][indexes][edit_index][index_key_0][description]', $edit_index['description']['#name']);
+    $this->assertEquals($current_index[0]['description'], $edit_index['description']['#value']);
+    $this->assertEquals('field_json_metadata[0][indexes][edit_index][index_key_0][type]', $edit_index['type']['#name']);
+    $this->assertEquals($current_index[0]['type'], $edit_index['type']['#value']);
+    $this->assertEquals($current_index[0]['fields'][0]['name'], $edit_index['group']['fields']['data']['#rows'][0]['name']);
+    $this->assertEquals($current_index[0]['fields'][0]['length'], $edit_index['group']['fields']['data']['#rows'][0]['length']);
+  }
+
+  /**
+   * Test edit index fields for indexes.
+   */
+  public function testEditDataDictionaryIndexEditFields() {
+    // Arrange
+    $indexKey = 'index_field_key_0';
+    $current_index_fields = [
+      [
+        'name' => 'test',
+        'length' => 20
+      ]
+    ];
+
+    // Act
+    $edit_index_fields = IndexFieldEditCreation::editIndexFields($indexKey, $current_index_fields, null);
+
+    // Assert
+    $this->assertNotNull($edit_index_fields);
+    $this->assertEquals('field_json_metadata[0][indexes][fields][edit_index_fields][0][name]', $edit_index_fields['name']['#name']);
+    $this->assertEquals($current_index_fields[0]['name'], $edit_index_fields['name']['#value']);
+    $this->assertEquals('field_json_metadata[0][indexes][fields][edit_index_fields][0][length]', $edit_index_fields['length']['#name']);
+    $this->assertEquals($current_index_fields[0]['length'], $edit_index_fields['length']['#value']);
+  }
+
+  /**
+   * Test editing data dictionary index fields and save it.
+   */
+  public function testEditDataDictionaryIndexFieldsDictionaryWidget() {
+    $formState = $this->createMock(FormStateInterface::class);
+    $formObject = $this->createMock(EntityFormInterface::class);
+    $entity = $this->createMock(FieldableEntityInterface::class);
+    $fieldItemList = $this->createMock(FieldItemListInterface::class);
+    $field_definition = $this->createMock(FieldDefinitionInterface::class);
+    $settings = [];
+    $third_party_settings = [];
+    $form = [];
+    $plugin_id = '';
+    $plugin_definition = [];
+
+    $current_index_field = [
+      [
+        'name' => 'test',
+        'length' => 20,
+      ]
+    ];
+
+    $updated_index_field = [
+      [
+        'name' => 'test_update',
+        'length' => 25,
+      ]
+    ];
+
+    $user_input = [
+      'field_json_metadata' => [
+        0 => [
+          'identifier' => 'test_identifier',
+          'title' => 'test_title',
+          'indexes' => [
+            'edit_index' => [
+              'index_key_0' => [
+                'description' => 'test_edit',
+                'type' => 'fulltext',
+              ]
+            ],
+            'fields' => [
+              'edit_index_fields' => [
+                [
+                  'name' => 'test',
+                  'length' => 20,
+                ]
+              ]
+            ]
+          ],
+        ],
+      ],
+    ];
+
+    $form["field_json_metadata"]["widget"][0] = [
+      "dictionary_fields" => [
+        "data" => [
+          "#rows" => [
+            0 => [],
+          ],
+        ],
+      ],
+      'indexes' => [
+        'data' => [
+          "#rows" => [
+            [
+              'description' => 'test',
+              'type' => 'index',
+              'fields' => [
+                'name' => 'test',
+                'length' => 20,
+              ],
+            ],
+          ],
+        ],
+        'fields' => [
+          'data' => [
+            "#rows" => [
+              0 => [
+                'name' => 'test',
+                'length' => 20,
+              ],
+            ],
+          ],
+        ]
+      ],
+    ];
+
+    $formState->expects($this->exactly(2))
+      ->method('getFormObject')
+      ->willReturn($formObject);
+
+    $formObject->expects($this->exactly(2))
+      ->method('getEntity')
+      ->willReturn($entity);
+
+    $entity->expects($this->exactly(2))
+      ->method('set')
+      ->with('field_data_type', 'data-dictionary');
+
+    // The gets are happening in indexEditCallback and formElement and function calls in it that use the formState variable.
+    // Set the value for various $form_state calls that use the current index and then are updated when we pass the updated index value.
+    $formState->expects($this->any())
+      ->method('get')
+      ->willReturnOnConsecutiveCalls(
+        $current_index_field,
+        $current_index_field,
+        [],
+        [],
+        $current_index_field,
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        $current_index_field,
+        $current_index_field,
+        [],
+        $current_index_field,
+        [],
+        [],
+        TRUE,
+        $current_index_field,
+        $current_index_field,
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        $updated_index_field,
+        $updated_index_field,
+        [],
+        $updated_index_field,
+      );
+
+    $formState->expects($this->any())
+      ->method('getTriggeringElement')
+      ->willReturnOnConsecutiveCalls(
+        ['#op' => 'edit_index_field_key_0'], ['#op' => 'edit_index_field_key_0'],
+        ['#op' => 'update_index_field_key_0'], ['#op' => 'update_index_field_key_0'],
+      );
+
+    $formState->expects($this->any())
+      ->method('getUserInput')
+      ->willReturn($user_input);
+
+    $dataDictionaryWidget = new DataDictionaryWidget(
+      $plugin_id,
+      $plugin_definition,
+      $field_definition,
+      $settings,
+      $third_party_settings
+    );
+
+    // Trigger callback function to edit fields.
+    IndexFieldCallbacks::indexEditSubformCallback($form, $formState);
+
+    // First call to re-create data dictionary form with the editable fields.
+    $element = $dataDictionaryWidget->formElement(
+      $fieldItemList,
+      0,
+      [],
+      $form,
+      $formState
+    );
+
+    // Assert edit feature loads form with the current field values.
+    $this->assertNotNull($element);
+    $this->assertEquals($current_index_field[0]["name"], $element["indexes"]["fields"]["data"]["#rows"][0]["name"]);
+    $this->assertEquals($current_index_field[0]["length"], $element["indexes"]["fields"]["data"]["#rows"][0]["length"]);
+
+    // Trigger callback function to save the edited fields.
+    IndexFieldCallbacks::indexEditSubformCallback($form, $formState);
+
+    // Second call to re-create data dictionary and apply the edits made to the fields.
+    $element = $dataDictionaryWidget->formElement(
+      $fieldItemList,
+      0,
+      [],
+      $form,
+      $formState
+    );
+
+    // Assert update feature loads form with the edited field values.
+    $this->assertNotNull($element);
+    $this->assertEquals($updated_index_field[0]["name"], $element["indexes"]["fields"]["data"]["#rows"][0]["name"]);
+    $this->assertEquals($updated_index_field[0]["length"], $element["indexes"]["fields"]["data"]["#rows"][0]["length"]);
   }
 
 }


### PR DESCRIPTION
re: 22002

## Describe your changes

Tests for #4185

## QA Steps

- [ ] Tests are passing in the pipeline and locally with the following command:

```
ddev dkan-phpunit \                                                                                                                 
                    --coverage-clover /var/www/html/docroot/modules/contrib/dkan/clover.xml \
                    --coverage-html /var/www/html/docroot/modules/contrib/dkan/coverage-html \
                    --log-junit /var/www/html/docroot/modules/contrib/dkan/junit/junit.xml --filter DataDictionaryWidgetBuildIndexesTest
```