### PR TITLE
Split sanitize and normalize to be separate operations

### DIFF
--- a/modules/common/src/Storage/SelectFactory.php
+++ b/modules/common/src/Storage/SelectFactory.php
@@ -104,10 +104,8 @@ class SelectFactory {
   private function addDateExpressions($db_query, $fields, $meta_data) {
     foreach ($meta_data as $definition) {
       // Confirm definition name is in the fields list.
-      $name = $this->dbQuery->escapeField($definition['name']);
-      $sanitizedName = $fields[$name]['field'];
-      if ($sanitizedName && $definition['type'] == 'date') {
-        $db_query->addExpression("DATE_FORMAT(" . $sanitizedName . ", '" . $definition['format'] . "')", $sanitizedName);
+      if ($fields[$definition['name']]['field'] && $definition['type'] == 'date') {
+        $db_query->addExpression("DATE_FORMAT(" . $definition['name'] . ", '" . $definition['format'] . "')", $definition['name']);
       }
     }
   }
@@ -143,7 +141,7 @@ class SelectFactory {
     if (is_string($property) && self::safeProperty($property)) {
       return (object) [
         "collection" => $this->alias,
-        "property" => $this->dbQuery->escapeField($property),
+        "property" => $property,
         "alias" => NULL,
       ];
     }
@@ -152,6 +150,10 @@ class SelectFactory {
     }
     // Throw exception if obviously unsafe property name.
     self::safeProperty($property->property);
+    return $property;
+  }
+
+  private function sanitizeProperty(object $property) {
     // Sanitize the property name.
     $property->property = $this->dbQuery->escapeField($property->property);
     $property->alias = isset($property->alias) ? $this->connection->escapeAlias($property->alias) : NULL;
@@ -254,6 +256,7 @@ class SelectFactory {
    */
   private function propertyToString(mixed $property) {
     $property = $this->normalizeProperty($property);
+    $property = $this->sanitizeProperty($property);
     return "{$property->collection}.{$property->property}";
   }
 

--- a/modules/datastore/tests/src/Functional/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Functional/Controller/QueryDownloadControllerTest.php
@@ -242,7 +242,7 @@ class QueryDownloadControllerTest extends BrowserTestBase {
     // Header should be using the dictionary title.
     $this->assertEquals('a,b_title,c,d,e', $lines[0]);
 
-    // Set the machine name CSV header mode.
+    // Set the machine name CSV header mode before the import.
     $this->config('metastore.settings')
       ->set('csv_headers_mode', 'machine_names')
       ->save();


### PR DESCRIPTION
21640

WIP: Fixes applying date formats when using data dictionaries and the streamed CSV download API

## Describe your changes
We only want to sanitize expressions, not when adding fields to the query.

## QA Steps

- [ ] TBD

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
