### PR TITLE
Fixes some HarvestCommand logging

### DIFF
--- a/modules/harvest/drush.services.yml
+++ b/modules/harvest/drush.services.yml
@@ -3,7 +3,6 @@ services:
     class: \Drupal\harvest\Commands\HarvestCommands
     arguments:
       - '@dkan.harvest.service'
-      - '@dkan.harvest.logger_channel'
       - '@dkan.harvest.utility'
     tags:
       - { name: drush.command }

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -137,20 +137,23 @@ class HarvestCommands extends DrushCommands {
   /**
    * Deregister a harvest.
    *
+   * @param string $plan_id
+   *   Harvest plan identifier.
+   *
    * @command dkan:harvest:deregister
    */
-  public function deregister($id) {
+  public function deregister($plan_id) {
     $this->logger()->warning('If you deregister a harvest with published datasets, you will not be able to bulk revert the datasets connected to this harvest.');
-    if ($this->io()->confirm('Deregister harvest ' . $id)) {
-      if ($this->harvestService->deregisterHarvest($id)) {
-        $this->logger()->notice('Successfully deregistered the ' . $id . ' harvest.');
+    if ($this->io()->confirm('Deregister harvest ' . $plan_id)) {
+      if ($this->harvestService->deregisterHarvest($plan_id)) {
+        $this->logger()->notice('Successfully deregistered the ' . $plan_id . ' harvest.');
         return DrushCommands::EXIT_SUCCESS;
       }
     }
     else {
       throw new UserAbortException();
     }
-    $this->logger()->error('Could not deregister the ' . $id . ' harvest.');
+    $this->logger()->error('Could not deregister the ' . $plan_id . ' harvest.');
     return DrushCommands::EXIT_FAILURE;
   }
 

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -275,24 +275,24 @@ class HarvestCommands extends DrushCommands {
   /**
    * Perform the act of archiving or publishing a harvest plan.
    *
-   * @param $harvestId
+   * @param string $plan_id
    *   The harvest id.
-   * @param $operation
+   * @param string $operation
    *   (optional) The operation to perform. Either 'archive' or 'publish.'
    *   Defaults to 'archive'.
    */
-  protected function archiveOrPublish($harvestId, $operation = 'archive') {
+  protected function archiveOrPublish($plan_id, $operation = 'archive') {
     $verb = 'Archived';
     if ($operation === 'publish') {
       $verb = 'Published';
     }
-    $this->validateHarvestPlan($harvestId);
-    $result = $this->harvestService->$operation($harvestId);
+    $this->validateHarvestPlan($plan_id);
+    $result = $this->harvestService->$operation($plan_id);
     if (empty($result)) {
-      $this->logger()->notice('No items available to ' . $operation . ' for the \'' . $harvestId . '\' harvest plan.');
+      $this->logger()->notice('No items available to ' . $operation . ' for the \'' . $plan_id . '\' harvest plan.');
     }
     foreach ($result as $id) {
-      $this->logger()->notice($verb . ' dataset ' . $id . ' from harvest \'' . $harvestId . '\'.');
+      $this->logger()->notice($verb . ' dataset ' . $id . ' from harvest \'' . $plan_id . '\'.');
     }
   }
 

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -254,14 +254,7 @@ class HarvestCommands extends DrushCommands {
    *   Archives harvested entities.
    */
   public function archive($harvestId) {
-    $this->validateHarvestPlan($harvestId);
-    $result = $this->harvestService->archive($harvestId);
-    if (empty($result)) {
-      $this->logger()->notice('No items available to archive for the \'' . $harvestId . '\' harvest plan.');
-    }
-    foreach ($result as $id) {
-      $this->logger()->notice('Archived dataset ' . $id . " from harvest '" . $harvestId . "'.");
-    }
+    $this->archiveOrPublish($harvestId, 'archive');
   }
 
   /**
@@ -276,13 +269,30 @@ class HarvestCommands extends DrushCommands {
    *   Publishes harvested entities.
    */
   public function publish($harvestId) {
+    $this->archiveOrPublish($harvestId, 'publish');
+  }
+
+  /**
+   * Perform the act of archiving or publishing a harvest plan.
+   *
+   * @param $harvestId
+   *   The harvest id.
+   * @param $operation
+   *   (optional) The operation to perform. Either 'archive' or 'publish.'
+   *   Defaults to 'archive'.
+   */
+  protected function archiveOrPublish($harvestId, $operation = 'archive') {
+    $verb = 'Archived';
+    if ($operation === 'publish') {
+      $verb = 'Published';
+    }
     $this->validateHarvestPlan($harvestId);
-    $result = $this->harvestService->publish($harvestId);
+    $result = $this->harvestService->$operation($harvestId);
     if (empty($result)) {
-      $this->logger()->notice("No items available to publish for the '" . $harvestId . "' harvest plan.");
+      $this->logger()->notice('No items available to ' . $operation . ' for the \'' . $harvestId . '\' harvest plan.');
     }
     foreach ($result as $id) {
-      $this->logger()->notice('Published dataset ' . $id . " from harvest '" . $harvestId . "'.");
+      $this->logger()->notice($verb . ' dataset ' . $id . ' from harvest \'' . $harvestId . '\'.');
     }
   }
 

--- a/modules/harvest/tests/src/Functional/Commands/HarvestCommandsTest.php
+++ b/modules/harvest/tests/src/Functional/Commands/HarvestCommandsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\Tests\harvest\Functional\Commands;
+
+use Drupal\Tests\BrowserTestBase;
+use Drush\TestTraits\DrushTestTrait;
+
+/**
+ * @coversDefaultClass \Drupal\harvest\Commands\HarvestCommands
+ *
+ * @group dkan
+ * @group harvest
+ * @group btb
+ * @group functional
+ */
+class HarvestCommandsTest extends BrowserTestBase {
+
+  use DrushTestTrait;
+
+  protected static $modules = [
+    'harvest',
+    'metastore',
+    'node',
+  ];
+
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Minimally run all the commands.
+   */
+  public function testCommands() {
+    // Run the commands with --help to ensure there are no fundamental errors.
+    foreach ([
+      'dkan:harvest:list',
+      'dkan:harvest:register',
+      'dkan:harvest:deregister',
+      'dkan:harvest:run',
+      'dkan:harvest:run-all',
+      'dkan:harvest:info',
+      'dkan:harvest:revert',
+      'dkan:harvest:archive',
+      'dkan:harvest:publish',
+      'dkan:harvest:status',
+      'dkan:harvest:orphan-datasets',
+      'dkan:harvest:cleanup',
+      'dkan:harvest:update',
+    ] as $command) {
+      $this->drush($command, ['--help']);
+      $this->assertErrorOutputEquals('');
+    }
+
+    // Run the commands with no arguments, assert the response code.
+    foreach ([
+      'dkan:harvest:list' => 0,
+      'dkan:harvest:register' => 0,
+      'dkan:harvest:deregister' => 1,
+      'dkan:harvest:run' => 1,
+      'dkan:harvest:run-all' => 0,
+      'dkan:harvest:info' => 1,
+      'dkan:harvest:revert' => 1,
+      'dkan:harvest:archive' => 1,
+      'dkan:harvest:publish' => 1,
+      'dkan:harvest:status' => 1,
+      'dkan:harvest:orphan-datasets' => 1,
+      'dkan:harvest:cleanup' => 0,
+      'dkan:harvest:update' => 0,
+    ] as $command => $expected_return) {
+      $this->drush($command, [], [], NULL, NULL, $expected_return);
+      // Exceptions will tell you which PHP file.
+      $this->assertStringNotContainsString(
+        '.php',
+        $this->getSimplifiedErrorOutput()
+      );
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes [issue#]

## Describe your changes

- Removes logger as an injected dependency from `HarvestCommands`.
- Converts all commands in `HarvestCommands` to use `$this->logger()` instead of alternatives.
- Converts all message strings to use concatenation rather than interpolation.
- Adds minimal automated test of commands.

## QA Steps

Use sample_content module to create a harvest.

Try out the commands.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
