### PR TITLE
Fixes misalignment of import dashboard

### DIFF
--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -17,10 +17,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Datastore Import Dashboard form.
- *
- * @package Drupal\datastore
  */
-class  DashboardForm extends FormBase {
+class DashboardForm extends FormBase {
   use StringTranslationTrait;
 
   /**

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @package Drupal\datastore
  */
-class DashboardForm extends FormBase {
+class  DashboardForm extends FormBase {
   use StringTranslationTrait;
 
   /**
@@ -414,7 +414,7 @@ class DashboardForm extends FormBase {
     // here.
     $moderation_class = $rev['moderation_state'];
     if ($moderation_class == 'hidden') {
-      $moderation_class = 'registered';
+      $moderation_class = 'published-hidden';
     }
     return [
       [
@@ -428,12 +428,12 @@ class DashboardForm extends FormBase {
       ],
       [
         'rowspan' => $resourceCount,
-        'class' => $rev['moderation_state'],
+        'class' => $moderation_class,
         'data' => [
           '#theme' => 'datastore_dashboard_revision_cell',
           '#revision_id' => $rev['revision_id'],
           '#modified' => $this->dateFormatter->format(strtotime($rev['modified_date_dkan']), 'short'),
-          '#moderation_state' => $moderation_class,
+          '#moderation_state' => $rev['moderation_state'],
         ],
       ],
       [

--- a/modules/harvest/css/style.css
+++ b/modules/harvest/css/style.css
@@ -10,6 +10,15 @@ table.dashboard-datasets td.done
 }
 
 /**
+ * Hidden.
+ */
+table.dashboard-datasets td.published-hidden
+{
+  color: #325e1c;
+  background-color: #edf3e8;
+}
+
+/**
  * Waiting.
  */
 table.dashboard-harvests td.registered


### PR DESCRIPTION
Fixes [issue#]

## Describe your changes

The import status dashboard has suffered from misalignment issues because datastore nodes can have the publish status of 'hidden.'
This gets set in CSS as class=hidden, which just hides the table cell.

The fix is to change the class used to style the table cell.

## QA Steps

- Set up a sample content site:
```
ddev dkan-site-install
ddev drush pm-enable sample_content
ddev drush dkan:sample-content:create
ddev drush cron
ddev drush cron
```
- Log in: `ddev drush uli`
- Visit the import status page at `admin/dkan/datastore/status`
- Pick a dataset. I suggest Florida Bike Lanes.
- Visit it's edit page... DKAN -> Datasets -> find bike lanes -> click Edit.
- Change its published status to 'Published (hidden)'
- Revisit the import status page (`admin/dkan/datastore/status`). The table will not be misaligned.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
