### PR TITLE
Drush deregister improvements

### DIFF
--- a/docs/source/drush_commands.rst
+++ b/docs/source/drush_commands.rst
@@ -118,7 +118,13 @@ dkan:harvest:archive
 dkan:harvest:deregister
 -----------------------
 
-    Deregister a harvest.
+    Deregister a harvest. This action removes the harvest plan from the system,
+    but will leave the datasets in place. This is good if you are using harvest
+    to migrate content and you do not plan on using the harvest feature to
+    update the datasets.
+
+    If you want to remove the harvest plan AND the datasets associated with it,
+    use the --revert option.
 
     **Arguments**
 
@@ -192,7 +198,9 @@ dkan:harvest:register
 dkan:harvest:revert
 --------------------
 
-    Revert a harvest, i.e. remove harvested entities and unpublish orhpaned keywords, themes, and distributions.
+    Revert a harvest, i.e. remove harvested entities and unpublish orhpaned
+    keywords, themes, and distributions. The harvest plan will remain and can
+    be run again to generate the datasets after any issues have been resolved.
 
     **Arguments**
 

--- a/docs/source/drush_commands.rst
+++ b/docs/source/drush_commands.rst
@@ -123,6 +123,11 @@ dkan:harvest:deregister
     **Arguments**
 
     - **harvestId** The harvest id
+    - **revert** Perform a revert before deregistering.
+
+    **Usage**
+
+        ``drush dkan:harvest:deregister --revert myHarvestId``
 
 ~~~~~~
 

--- a/docs/source/drush_commands.rst
+++ b/docs/source/drush_commands.rst
@@ -118,10 +118,10 @@ dkan:harvest:archive
 dkan:harvest:deregister
 -----------------------
 
-    Deregister a harvest. This action removes the harvest plan from the system,
-    but will leave the datasets in place. This is good if you are using harvest
-    to migrate content and you do not plan on using the harvest feature to
-    update the datasets.
+    Deregister a harvest plan. This action removes the harvest plan from the
+    system, but will leave the datasets in place. This is good if you are using
+    harvest to migrate content and you do not plan on using the harvest feature
+    to update the datasets.
 
     If you want to remove the harvest plan AND the datasets associated with it,
     use the --revert option.
@@ -198,7 +198,7 @@ dkan:harvest:register
 dkan:harvest:revert
 --------------------
 
-    Revert a harvest, i.e. remove harvested entities and unpublish orhpaned
+    Revert a harvest. Removes harvested entities and unpublishes orhpaned
     keywords, themes, and distributions. The harvest plan will remain and can
     be run again to generate the datasets after any issues have been resolved.
 

--- a/modules/harvest/drush.services.yml
+++ b/modules/harvest/drush.services.yml
@@ -3,7 +3,6 @@ services:
     class: \Drupal\harvest\Commands\HarvestCommands
     arguments:
       - '@dkan.harvest.service'
-      - '@dkan.harvest.logger_channel'
       - '@dkan.harvest.utility'
     tags:
       - { name: drush.command }

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -2,12 +2,10 @@
 
 namespace Drupal\harvest\Commands;
 
-use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\harvest\HarvestService;
 use Drupal\harvest\HarvestUtility;
 use Drupal\harvest\Load\Dataset;
-use Drupal\harvest\HarvestService;
 use Drush\Commands\DrushCommands;
-use Drush\Exceptions\UserAbortException;
 use Harvest\ETL\Extract\DataJson;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -42,7 +40,6 @@ class HarvestCommands extends DrushCommands {
     HarvestUtility $harvestUtility
   ) {
     parent::__construct();
-    // @todo passing via arguments doesn't seem play well with drush.services.yml
     $this->harvestService = $service;
     $this->harvestUtility = $harvestUtility;
   }
@@ -147,9 +144,10 @@ class HarvestCommands extends DrushCommands {
    * @command dkan:harvest:deregister
    * @option revert Revert the harvest plan before deregistering it.
    * @usage dkan:harvest:deregister --revert PLAN_ID
-   *   Deregister the PLAN_ID plan, after reverting all the data resources associated with it.
+   *   Deregister the PLAN_ID plan, after reverting all the data resources
+   *   associated with it.
    */
-  public function deregister($plan_id, $options = ['revert' => FALSE]) {
+  public function deregister($plan_id, array $options = ['revert' => FALSE]) {
     // Short circuit if the plan doesn't exist.
     try {
       $this->validateHarvestPlan($plan_id);

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\harvest\Commands;
 
+use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\harvest\HarvestUtility;
 use Drupal\harvest\Load\Dataset;
 use Drupal\harvest\HarvestService;
@@ -66,7 +67,7 @@ class HarvestCommands extends DrushCommands {
       (new Table(new ConsoleOutput()))->setHeaders(['plan id'])->setRows($rows)->render();
       return;
     }
-    $this->logger()->notice('No harvests registered.');
+    $this->logger->notice('No harvests registered.');
   }
 
   /**
@@ -104,11 +105,11 @@ class HarvestCommands extends DrushCommands {
     try {
       $plan = $plan_json ? json_decode($plan_json) : $this->buildPlanFromOpts($opts);
       $identifier = $this->harvestService->registerHarvest($plan);
-      $this->logger()->notice('Successfully registered the ' . $identifier . ' harvest.');
+      $this->logger->notice('Successfully registered the ' . $identifier . ' harvest.');
     }
     catch (\Exception $e) {
-      $this->logger()->error($e->getMessage());
-      $this->logger()->debug($e->getTraceAsString());
+      $this->logger->error($e->getMessage());
+      $this->logger->debug($e->getTraceAsString());
     }
   }
 
@@ -254,19 +255,20 @@ class HarvestCommands extends DrushCommands {
   }
 
   /**
-   * Queue the removal of all entities for a harvest.
+   * Revert a harvest, i.e. remove all of its harvested entities.
    *
    * @param string $harvestId
-   *   The harvest plan to revert.
+   *   The source to revert.
    *
    * @command dkan:harvest:revert
    *
-   * @usage dkan:harvest:revert HARVEST_PLAN_ID
+   * @usage dkan:harvest:revert
+   *   Removes harvested entities.
    */
   public function revert($harvestId) {
     $this->validateHarvestPlan($harvestId);
     $result = $this->harvestService->revertHarvest($harvestId);
-    $this->logger()->success($result . ' items reverted for the \'' . $harvestId . '\' harvest plan.');
+    (new ConsoleOutput())->write("{$result} items reverted for the '{$harvestId}' harvest plan." . PHP_EOL);
   }
 
   /**
@@ -405,15 +407,16 @@ class HarvestCommands extends DrushCommands {
    * @bootstrap full
    */
   public function harvestCleanup(): int {
+    $logger = $this->logger();
     $orphaned = $this->harvestUtility->findOrphanedHarvestDataIds();
     if ($orphaned) {
-      $this->logger()->notice('Detected leftover harvest data for these plans: ' . implode(', ', $orphaned));
+      $logger->notice('Detected leftover harvest data for these plans: ' . implode(', ', $orphaned));
       if ($this->io()->confirm('Do you want to remove this data?', FALSE)) {
         $this->cleanupHarvestDataTables($orphaned);
       }
     }
     else {
-      $this->logger()->notice('No leftover harvest data detected.');
+      $logger->notice('No leftover harvest data detected.');
     }
     return DrushCommands::EXIT_SUCCESS;
   }

--- a/modules/harvest/src/Commands/HarvestCommands.php
+++ b/modules/harvest/src/Commands/HarvestCommands.php
@@ -167,11 +167,11 @@ class HarvestCommands extends DrushCommands {
     }
 
     // Try to revert if the user wants to.
-    if ($options['revert'] ?? FALSE) {
-      // If the revert command fails, fail here, too.
-      if ($this->revert($plan_id) === DrushCommands::EXIT_FAILURE) {
-        return DrushCommands::EXIT_FAILURE;
-      }
+    if (
+      ($options['revert'] ?? FALSE) &&
+      ($this->revert($plan_id) === DrushCommands::EXIT_FAILURE)
+    ) {
+      return DrushCommands::EXIT_FAILURE;
     }
 
     // Do the deregister.


### PR DESCRIPTION
Fixes [issue#]

## Describe your changes

Modifies `drush dkan:harvest:deregister`:
- Adds a confirmation step ('Are you sure?'). Can be bypassed with `-y`, `--yes`, or `--no-interaction`.
- Adds a flag to the command line, `--revert`. This will revert all datasets in the harvest before deregistering, and is the equivalent of `drush dkan:harvest:revert ID && drush dkan:harvest:deregister ID`

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
