### PR TITLE
#4273: Datastore MySQL Import handles empty file incorrect

### DIFF
--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -72,6 +72,11 @@ class MysqlImport extends ImportJob {
       return $this->setResultError(sprintf('Unable to resolve file name "%s" for resource with identifier "%s".', $this->resource->getFilePath(), $this->resource->getId()));
     }
 
+    $size = @filesize($file_path);
+    if (!$size) {
+      return $this->setResultError("Can't get size from file {$file_path}");
+    }
+
     // Read the columns and EOL character sequence from the CSV file.
     $delimiter = $this->resource->getMimeType() == 'text/tab-separated-values' ? "\t" : ',';
     try {


### PR DESCRIPTION
Fixes #4273 

## Describe your changes

taking empty file handling from CSV Parser Import Job to MysqlImport Job.

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
