### PR TITLE
Add tests for ResourceImporter and sample_content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
         type: string
       addon_branch:
         description: 'Repo branch name for the dkan-ddev-addon you want to test against.'
-        default: 'main'
+        default: 'whither-file-public-base-url'
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
         default: '8.2'
         type: string
       addon_branch:
-        description: 'Repo branch name for the dkan-ddev-addon you want to test against.'
+        description: 'Repo branch name for the DKAN DDev add-on you want to test against.'
         default: 'whither-file-public-base-url'
         type: string
       dkan_recommended_branch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
         type: string
       addon_branch:
         description: 'Repo branch name for the DKAN DDev add-on you want to test against.'
-        default: 'whither-file-public-base-url'
+        default: 'main'
         type: string
       dkan_recommended_branch:
         description: 'Branch of getdkan/recommended-project to use.'

--- a/modules/common/src/Util/DrupalFiles.php
+++ b/modules/common/src/Util/DrupalFiles.php
@@ -53,7 +53,10 @@ class DrupalFiles implements ContainerInjectionInterface {
   }
 
   /**
-   * Getter.
+   * Get the Drupal file_system service.
+   *
+   * @returns FileSystemInterface
+   *   The file_system service.
    */
   public function getFilesystem(): FileSystemInterface {
     return $this->filesystem;
@@ -84,6 +87,7 @@ class DrupalFiles implements ContainerInjectionInterface {
       throw new \Exception("Only moving files to Drupal's public directory (public://) is supported");
     }
 
+    // Handle file:// URIs.
     if (substr_count($url, "file://") > 0) {
 
       $src = str_replace("file://", "", $url);
@@ -93,15 +97,17 @@ class DrupalFiles implements ContainerInjectionInterface {
 
       return $this->fileCreateUrl("{$destination}/{$filename}");
     }
-    else {
-      return system_retrieve_file($url, $destination, FALSE, FileSystemInterface::EXISTS_REPLACE);
-    }
+    // Handle http(s):// URIs.
+    return system_retrieve_file($url, $destination, FALSE, FileSystemInterface::EXISTS_REPLACE);
   }
 
   /**
-   * Given a URI like public:// retrieve the URL.
+   * Given a URI like public://, retrieve the http URL.
+   *
+   * @returns string
+   *   The URL.
    */
-  public function fileCreateUrl($uri) {
+  public function fileCreateUrl($uri) : string {
     if (substr_count($uri, 'http') > 0) {
       return $uri;
     }

--- a/modules/harvest/harvest.info.yml
+++ b/modules/harvest/harvest.info.yml
@@ -5,4 +5,5 @@ core_version_requirement: ^10
 package: DKAN
 dependencies:
   - dkan:common
+  - dkan:datastore
   - dkan:metastore

--- a/modules/harvest/harvest.info.yml
+++ b/modules/harvest/harvest.info.yml
@@ -5,5 +5,4 @@ core_version_requirement: ^10
 package: DKAN
 dependencies:
   - dkan:common
-  - dkan:datastore
   - dkan:metastore

--- a/modules/harvest/src/Transform/ResourceImporter.php
+++ b/modules/harvest/src/Transform/ResourceImporter.php
@@ -17,7 +17,7 @@ use Harvest\ETL\Transform\Transform;
 class ResourceImporter extends Transform {
 
   /**
-   * Drupal files.
+   * DKAN's Drupal files service.
    *
    * @var \Drupal\common\Util\DrupalFiles
    */
@@ -31,12 +31,20 @@ class ResourceImporter extends Transform {
   private FileUrlGeneratorInterface $fileUrlGenerator;
 
   /**
+   * Drupal's file system service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  private FileSystemInterface $fileSystem;
+
+  /**
    * Constructor.
    */
   public function __construct($harvest_plan) {
     parent::__construct($harvest_plan);
     $this->drupalFiles = \Drupal::service('dkan.common.drupal_files');
     $this->fileUrlGenerator = \Drupal::service('file_url_generator');
+    $this->fileSystem = \Drupal::service('file_system');
   }
 
   /**
@@ -122,12 +130,10 @@ class ResourceImporter extends Transform {
    * @return string|bool
    *   The URL for the newly created file, or FALSE if failure occurs.
    */
-  public function saveFile($url, $dataset_id) {
-
+  public function saveFile(string $url, string $dataset_id) {
     $targetDir = 'public://distribution/' . $dataset_id;
 
-    $this->drupalFiles
-      ->getFilesystem()
+    $this->fileSystem
       ->prepareDirectory($targetDir, FileSystemInterface::CREATE_DIRECTORY);
 
     // Abort if file can't be saved locally.
@@ -138,9 +144,7 @@ class ResourceImporter extends Transform {
     if (is_object($path)) {
       return $this->fileUrlGenerator->generateAbsoluteString($path->uri->value);
     }
-    else {
-      return $this->drupalFiles->fileCreateUrl($path);
-    }
+    return $this->drupalFiles->fileCreateUrl($path);
   }
 
 }

--- a/modules/harvest/src/Transform/ResourceImporter.php
+++ b/modules/harvest/src/Transform/ResourceImporter.php
@@ -3,11 +3,16 @@
 namespace Drupal\harvest\Transform;
 
 use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\common\Util\DrupalFiles;
 use Harvest\ETL\Transform\Transform;
 
 /**
  * Moves local files to public:// and alters the downloadUrl field.
+ *
+ * Used by the sample_content harvest.
+ *
+ * @see modules/sample_content/harvest_plan.json
  */
 class ResourceImporter extends Transform {
 
@@ -19,11 +24,19 @@ class ResourceImporter extends Transform {
   private DrupalFiles $drupalFiles;
 
   /**
+   * File URL generator service.
+   *
+   * @var \Drupal\Core\File\FileUrlGeneratorInterface
+   */
+  private FileUrlGeneratorInterface $fileUrlGenerator;
+
+  /**
    * Constructor.
    */
   public function __construct($harvest_plan) {
     parent::__construct($harvest_plan);
     $this->drupalFiles = \Drupal::service('dkan.common.drupal_files');
+    $this->fileUrlGenerator = \Drupal::service('file_url_generator');
   }
 
   /**
@@ -99,6 +112,8 @@ class ResourceImporter extends Transform {
    * `$settings['file_public_base_url']` must be configured in `settings.php`,
    * otherwise 'default' will be used as the hostname in the new URL.
    *
+   * @todo Is the above comment true?
+   *
    * @param string $url
    *   External file URL.
    * @param string $dataset_id
@@ -121,7 +136,7 @@ class ResourceImporter extends Transform {
     }
 
     if (is_object($path)) {
-      return \Drupal::service('file_url_generator')->generateAbsoluteString($path->uri->value);
+      return $this->fileUrlGenerator->generateAbsoluteString($path->uri->value);
     }
     else {
       return $this->drupalFiles->fileCreateUrl($path);

--- a/modules/harvest/src/Transform/ResourceImporter.php
+++ b/modules/harvest/src/Transform/ResourceImporter.php
@@ -3,12 +3,11 @@
 namespace Drupal\harvest\Transform;
 
 use Drupal\Core\File\FileSystemInterface;
+use Drupal\common\Util\DrupalFiles;
 use Harvest\ETL\Transform\Transform;
 
 /**
  * Moves local files to public:// and alters the downloadUrl field.
- *
- * @codeCoverageIgnore
  */
 class ResourceImporter extends Transform {
 
@@ -17,7 +16,7 @@ class ResourceImporter extends Transform {
    *
    * @var \Drupal\common\Util\DrupalFiles
    */
-  private $drupalFiles;
+  private DrupalFiles $drupalFiles;
 
   /**
    * Constructor.

--- a/modules/harvest/src/Transform/ResourceImporter.php
+++ b/modules/harvest/src/Transform/ResourceImporter.php
@@ -116,12 +116,6 @@ class ResourceImporter extends Transform {
   /**
    * Pulls down external file and saves it locally.
    *
-   * If this method is called when PHP is running on the CLI (e.g. via drush),
-   * `$settings['file_public_base_url']` must be configured in `settings.php`,
-   * otherwise 'default' will be used as the hostname in the new URL.
-   *
-   * @todo Is the above comment true?
-   *
    * @param string $url
    *   External file URL.
    * @param string $dataset_id

--- a/modules/harvest/tests/src/Functional/Transform/ResourceImporterTest.php
+++ b/modules/harvest/tests/src/Functional/Transform/ResourceImporterTest.php
@@ -20,6 +20,7 @@ use Drupal\Tests\BrowserTestBase;
 class ResourceImporterTest extends BrowserTestBase {
 
   protected static $modules = [
+    'datastore',
     'metastore',
   ];
 

--- a/modules/harvest/tests/src/Functional/Transform/ResourceImporterTest.php
+++ b/modules/harvest/tests/src/Functional/Transform/ResourceImporterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\Tests\harvest\Functional\Transform;
+
+use Drupal\harvest\Transform\ResourceImporter;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * @covers \Drupal\harvest\Transform\ResourceImporter
+ * @coversDefaultClass \Drupal\harvest\Transform\ResourceImporter
+ *
+ * @group dkan
+ * @group harvest
+ * @group functional
+ * @group btb
+ *
+ * @todo Turn this into a kernel test when we have refactored
+ *   DrupalFiles::retrieveFile to allow for vfsStream.
+ */
+class ResourceImporterTest extends BrowserTestBase {
+
+  protected static $modules = [
+    'metastore',
+  ];
+
+  protected $defaultTheme = 'stark';
+
+  /**
+   * @covers ::saveFile
+   */
+  public function testSaveFileHappyPath() {
+    $sample_content_module_path = $this->container->get('extension.list.module')
+      ->getPath('sample_content');
+
+    $importer = new ResourceImporter('harvest_plan_id');
+
+    $this->assertStringContainsString(
+      'distribution/dataset/Bike_Lane.csv',
+      $importer->saveFile(
+        'file://' . $sample_content_module_path . '/files/Bike_Lane.csv',
+        'dataset'
+      )
+    );
+  }
+
+}

--- a/modules/harvest/tests/src/Kernel/Transform/ResourceImporterTest.php
+++ b/modules/harvest/tests/src/Kernel/Transform/ResourceImporterTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\harvest\Kernel\Transform;
 
+use Drupal\common\Util\DrupalFiles;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\harvest\Transform\ResourceImporter;
 
@@ -73,6 +74,28 @@ class ResourceImporterTest extends KernelTestBase {
       'my_url_saved',
       $result->distribution[0]->downloadURL ?? 'nope'
     );
+  }
+
+  /**
+   * @covers ::saveFile
+   */
+  public function testSaveFile() {
+    // When DrupalFiles::retrieveFile fails, saveFile will return FALSE.
+    $drupal_files = $this->getMockBuilder(DrupalFiles::class)
+      ->setConstructorArgs([
+        $this->container->get('file_system'),
+        $this->container->get('stream_wrapper_manager'),
+      ])
+      ->onlyMethods(['retrieveFile'])
+      ->getMock();
+    $drupal_files->expects($this->once())
+      ->method('retrieveFile')
+      ->willReturn(FALSE);
+
+    $this->container->set('dkan.common.drupal_files', $drupal_files);
+
+    $importer = new ResourceImporter('harvest_plan_id');
+    $this->assertFalse($importer->saveFile('any_url', 'any_dataset'));
   }
 
 }

--- a/modules/harvest/tests/src/Kernel/Transform/ResourceImporterTest.php
+++ b/modules/harvest/tests/src/Kernel/Transform/ResourceImporterTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\Tests\harvest\Kernel\Transform;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\harvest\Transform\ResourceImporter;
+
+/**
+ * @covers \Drupal\harvest\Transform\ResourceImporter
+ * @coversDefaultClass \Drupal\harvest\Transform\ResourceImporter
+ *
+ * @group dkan
+ * @group harvest
+ * @group kernel
+ */
+class ResourceImporterTest extends KernelTestBase {
+
+  protected static $modules = [
+    'common',
+  ];
+
+  /**
+   * @covers ::updateDistributions
+   */
+  public function testUpdateDistributions() {
+    // Calling with an empty dataset should result in the same empty dataset.
+    $dataset = (object) [];
+    $importer = new ResourceImporter('harvest_plan_id');
+    $this->assertIsObject($result = $importer->run($dataset));
+    $this->assertEquals($dataset, $result);
+
+    // Calling with a distribution with no download url should result in the
+    // same object being returned.
+    $dataset = (object) [
+      'distribution' => [
+        (object) [
+          'title' => 'my title',
+        ],
+      ],
+    ];
+    $this->assertIsObject($result = $importer->run($dataset));
+    $this->assertEquals($dataset, $result);
+  }
+
+  /**
+   * @covers ::updateDownloadUrl
+   */
+  public function testUpdateDownloadUrl() {
+    // Mock saveFile so we don't actually have to worry about the file system.
+    $importer = $this->getMockBuilder(ResourceImporter::class)
+      ->setConstructorArgs(['harvest_plan_id'])
+      ->onlyMethods(['saveFile'])
+      ->getMock();
+    $importer->expects($this->any())
+      ->method('saveFile')
+      // Adds '_saved' to whatever URL was passed in.
+      ->willReturnCallback(function ($url, $dataset_id): string {
+        return $url . '_saved';
+      });
+
+    // Prepare a dataset with a downloadURL.
+    $dataset = (object) [
+      'identifier' => 'identifier',
+      'distribution' => [
+        (object) [
+          'downloadURL' => 'my_url',
+          'title' => 'my title',
+        ],
+      ],
+    ];
+    $this->assertIsObject($result = $importer->run($dataset));
+    $this->assertEquals(
+      'my_url_saved',
+      $result->distribution[0]->downloadURL ?? 'nope'
+    );
+  }
+
+}

--- a/modules/metastore/metastore.info.yml
+++ b/modules/metastore/metastore.info.yml
@@ -7,3 +7,4 @@ dependencies:
   - dkan:common
   - drupal:basic_auth
   - drupal:content_moderation
+  - drupal:node

--- a/modules/sample_content/src/SampleContentService.php
+++ b/modules/sample_content/src/SampleContentService.php
@@ -21,7 +21,7 @@ class SampleContentService {
   private string $modulePath;
 
   /**
-   * Constructor for the Sample Content commands.
+   * Constructor for the Sample Content service.
    *
    * @param \Drupal\Core\Extension\ModuleExtensionList $moduleExtensionList
    *   Extension list.

--- a/modules/sample_content/tests/src/Functional/SampleContentCommandsTest.php
+++ b/modules/sample_content/tests/src/Functional/SampleContentCommandsTest.php
@@ -132,7 +132,7 @@ class SampleContentCommandsTest extends BrowserTestBase {
       $download_url = $payload->distribution[0]->downloadURL ?? ''
     );
     // Ensure the server is not 'default'.
-    $this->assertStringNotContainsString('default', $download_url);
+    $this->assertStringNotContainsString('default', parse_url($download_url, PHP_URL_HOST));
 
     // We can reach the download URL. Roll our own Guzzle client since we don't
     // want a base URL option.

--- a/modules/sample_content/tests/src/Functional/SampleContentCommandsTest.php
+++ b/modules/sample_content/tests/src/Functional/SampleContentCommandsTest.php
@@ -102,9 +102,20 @@ class SampleContentCommandsTest extends BrowserTestBase {
     $this->assertEquals(200, $response->getStatusCode());
     $this->assertCount(10, json_decode($response->getBody()->getContents()));
 
+    // Do the import.
+    $this->drush('queue:run localize_import');
+    $this->assertStringContainsString(
+      'Processed 10 items from the localize_import queue',
+      $this->getSimplifiedErrorOutput()
+    );
+    $this->drush('queue:run datastore_import');
+    $this->assertStringContainsString(
+      'Processed 10 items from the datastore_import queue',
+      $this->getSimplifiedErrorOutput()
+    );
+
     // Run the remove command.
     $this->drush('dkan:sample-content:remove');
-
     // Logged output counts as an error, even if it's not an error.
     $output = $this->getErrorOutput();
     // Assert the output.

--- a/modules/sample_content/tests/src/Functional/SampleContentCommandsTest.php
+++ b/modules/sample_content/tests/src/Functional/SampleContentCommandsTest.php
@@ -73,7 +73,7 @@ class SampleContentCommandsTest extends BrowserTestBase {
     $this->drush('dkan:sample-content:create');
     $output = $this->getOutput();
 
-    // Start asserting. Admittedly, not the best set of assertions.
+    // Start asserting.
     foreach ([
       'run_id',
       'processed',


### PR DESCRIPTION
Fixes [#4205] Be sure and see the notes there.

## NOTE:

This PR adds tests to support a change to the DKAN DDev add-on. See https://github.com/GetDKAN/ddev-dkan/pull/52

## Describe your changes

- Adds tests for `ResourceImporter`, kernel and functional.
- Performs minor refactoring of `ResourceImporter`:
  - Short-circuits unneeded else statements.
  - Injects services explicitly.
- Adds steps to `SampleContentCommandsTest` to prove that the Drush commands work without setting `file_public_base_url`.

## Discoveries

- `Drupal\common\Util\DrupalFiles` uses the deprecated `system_retrieve_file()` function, which goes away in Drupal 11.
- `DrupalFiles` also does not handle file wrappers properly, leading to an inability to write a kernel test. (Kernel tests use in-memory vfsStream file wrappers.)

Follow-up recommendations:

- Refactor `DrupalFiles` to play nice with vfsStream and also to not use `system_retrieve_file()`.
- Turn `Drupal\Tests\harvest\Functional\Transform\ResourceImporterTest` into a kernel test.
- Investigate whether we actually need `DrupalFiles`, since it's only used in `Drupal\harvest\Transform\ResourceImporter` and `ResourceLocalizer` service.

## QA Steps

- [ ] Stand up a local build with the special settings config
- [ ] Create sample content
- [ ] Remove the config
- [ ] Remove sample content
- [ ] Create sample content again

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
