### PR TITLE
Run fulltext index alters one at at time

### DIFF
--- a/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQuery.php
+++ b/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQuery.php
@@ -514,7 +514,15 @@ class MySQLQuery extends AlterTableQueryBase implements AlterTableQueryInterface
       $comment = addslashes($description);
 
       // Build add index option list.
-      $add_index_options[] = "ADD {$mysql_index_type} INDEX {$name} ({$formatted_field_options}) COMMENT '{$comment}'";
+      if ($index_type == 'index') {
+        $add_index_options[] = "ADD {$mysql_index_type} INDEX {$name} ({$formatted_field_options}) COMMENT '{$comment}'";
+      }
+      if ($index_type == 'fulltext') {
+        // Innodb only allows adding one fulltext index at a time.
+        $command = $this->connection->prepareStatement("ALTER TABLE {$table} ADD {$mysql_index_type} INDEX {$name} ({$formatted_field_options}) COMMENT '{$comment}';", []);
+        // Execute alter command.
+        $command->execute();
+      }
     }
 
     return $add_index_options;

--- a/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQuery.php
+++ b/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQuery.php
@@ -538,15 +538,10 @@ class MySQLQuery extends AlterTableQueryBase implements AlterTableQueryInterface
    *   Description of the index.
    */
   protected function executeFulltextAlter(string $table, string $name, string $formatted_field_options, string $comment): void {
-    try {
-      // Innodb only allows adding one fulltext index at a time.
-      $command = $this->connection->prepareStatement("ALTER TABLE {{$table}} ADD FULLTEXT INDEX {$name} ({$formatted_field_options}) COMMENT '{$comment}';", []);
-      // Execute alter command.
-      $command->execute();
-    }
-    catch (\Throwable $e) {
-      throw $e;
-    }
+    // Innodb only allows adding one fulltext index at a time.
+    $command = $this->connection->prepareStatement("ALTER TABLE {{$table}} ADD FULLTEXT INDEX {$name} ({$formatted_field_options}) COMMENT '{$comment}';", []);
+    // Execute alter command.
+    $command->execute();
   }
 
   /**

--- a/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQuery.php
+++ b/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQuery.php
@@ -518,14 +518,35 @@ class MySQLQuery extends AlterTableQueryBase implements AlterTableQueryInterface
         $add_index_options[] = "ADD {$mysql_index_type} INDEX {$name} ({$formatted_field_options}) COMMENT '{$comment}'";
       }
       if ($index_type == 'fulltext') {
-        // Innodb only allows adding one fulltext index at a time.
-        $command = $this->connection->prepareStatement("ALTER TABLE {$table} ADD {$mysql_index_type} INDEX {$name} ({$formatted_field_options}) COMMENT '{$comment}';", []);
-        // Execute alter command.
-        $command->execute();
+        $this->executeFulltextAlter($table, $name, $formatted_field_options, $comment);
       }
     }
 
     return $add_index_options;
+  }
+
+  /**
+   * Execute fulltext index table alters.
+   *
+   * @param string $table
+   *   Table name.
+   * @param string $name
+   *   Index name.
+   * @param string $formatted_field_options
+   *   Fields to be indexed.
+   * @param string $comment
+   *   Description of the index.
+   */
+  protected function executeFulltextAlter(string $table, string $name, string $formatted_field_options, string $comment): void {
+    try {
+      // Innodb only allows adding one fulltext index at a time.
+      $command = $this->connection->prepareStatement("ALTER TABLE {$table} ADD FULLTEXT INDEX {$name} ({$formatted_field_options}) COMMENT '{$comment}';", []);
+      // Execute alter command.
+      $command->execute();
+    }
+    catch (\Throwable $e) {
+      throw $e;
+    }
   }
 
   /**

--- a/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQuery.php
+++ b/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQuery.php
@@ -538,10 +538,15 @@ class MySQLQuery extends AlterTableQueryBase implements AlterTableQueryInterface
    *   Description of the index.
    */
   protected function executeFulltextAlter(string $table, string $name, string $formatted_field_options, string $comment): void {
-    // Innodb only allows adding one fulltext index at a time.
-    $command = $this->connection->prepareStatement("ALTER TABLE {{$table}} ADD FULLTEXT INDEX {$name} ({$formatted_field_options}) COMMENT '{$comment}';", []);
-    // Execute alter command.
-    $command->execute();
+    try {
+      // Innodb only allows adding one fulltext index at a time.
+      $command = $this->connection->prepareStatement("ALTER TABLE {{$table}} ADD FULLTEXT INDEX {$name} ({$formatted_field_options}) COMMENT '{$comment}';", []);
+      // Execute alter command.
+      $command->execute();
+    }
+    catch (\Exception) {
+      \Drupal::logger('Data Dictionary')->error("Error applying fulltext index to dataset {$comment}");
+    }
   }
 
   /**

--- a/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQuery.php
+++ b/modules/datastore/src/DataDictionary/AlterTableQuery/MySQLQuery.php
@@ -540,7 +540,7 @@ class MySQLQuery extends AlterTableQueryBase implements AlterTableQueryInterface
   protected function executeFulltextAlter(string $table, string $name, string $formatted_field_options, string $comment): void {
     try {
       // Innodb only allows adding one fulltext index at a time.
-      $command = $this->connection->prepareStatement("ALTER TABLE {$table} ADD FULLTEXT INDEX {$name} ({$formatted_field_options}) COMMENT '{$comment}';", []);
+      $command = $this->connection->prepareStatement("ALTER TABLE {{$table}} ADD FULLTEXT INDEX {$name} ({$formatted_field_options}) COMMENT '{$comment}';", []);
       // Execute alter command.
       $command->execute();
     }

--- a/modules/datastore/tests/src/Kernel/DataDictionary/AlterTableQuery/MySQLQueryTest.php
+++ b/modules/datastore/tests/src/Kernel/DataDictionary/AlterTableQuery/MySQLQueryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\datastore\Kernel\DataDictionary\AlterTableQuery;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\datastore\DataDictionary\AlterTableQuery\MySQLQuery;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * @coversDefaultClass \Drupal\datastore\DataDictionary\AlterTableQuery\MySQLQuery
+ *
+ * @group dkan
+ * @group datastore
+ * @group kernel
+ */
+class MySQLQueryTest extends KernelTestBase {
+
+  protected static $modules = [
+    'common',
+    'datastore',
+    'metastore',
+  ];
+
+  /**
+   * @covers ::executeFulltextAlter
+   */
+  public function testExecuteFullTextAlterWithException(): void {
+    $exception_message = 'Test exception message.';
+    $comment_message = 'comment message';
+
+    // Throw an exception from the connection object.
+    $connection = $this->getMockBuilder(Connection::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['prepareStatement'])
+      ->getMockForAbstractClass();
+    $connection->expects($this->once())
+      ->method('prepareStatement')
+      ->willThrowException(new \Exception($exception_message));
+
+    $this->container->set('database', $connection);
+
+    // Set up a logger channel to expect our log message.
+    $logger = $this->getMockBuilder(LoggerChannelInterface::class)
+      ->onlyMethods(['error'])
+      ->getMockForAbstractClass();
+    // Error() must be called once, with our special message.
+    $logger->expects($this->once())
+      ->method('error')
+      ->with('Error applying fulltext index to dataset ' . $comment_message);
+
+    // Mock a logger factory to return our special mocked logger.
+    $logger_factory = $this->getMockBuilder(LoggerChannelFactory::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get'])
+      ->getMock();
+    $logger_factory->expects($this->once())
+      ->method('get')
+      ->willReturn($logger);
+
+    $this->container->set('logger.factory', $logger_factory);
+
+    // Get a MySQLQuery object to test.
+    $table = 'foo';
+    $mysql_query = new MySQLQuery(
+      $connection,
+      $this->container->get('pdlt.converter.strptime_to_mysql'),
+      $table,
+      [],
+      []
+    );
+
+    // Set executeFulltextAlter() to be public and run it.
+    $ref_full_text_alter = new \ReflectionMethod($mysql_query, 'executeFulltextAlter');
+    $ref_full_text_alter->setAccessible(TRUE);
+    $ref_full_text_alter->invokeArgs($mysql_query, ['', '', '', $comment_message]);
+  }
+
+}

--- a/modules/datastore/tests/src/Unit/DataDictionary/AlterTableQuery/MySQLQueryTest.php
+++ b/modules/datastore/tests/src/Unit/DataDictionary/AlterTableQuery/MySQLQueryTest.php
@@ -122,10 +122,8 @@ class MySQLQueryTest extends TestCase {
     $this->assertEquals("ALTER TABLE {" . $table . "} MODIFY COLUMN foo TEXT COMMENT 'Foo', " .
     "MODIFY COLUMN bar DECIMAL(10, 5) COMMENT 'Bar', " .
     "MODIFY COLUMN baz DATE COMMENT 'Baz', " .
-    "ADD  INDEX index1 (foo (12), bar, baz) COMMENT 'Fizz', " .
-    "ADD FULLTEXT INDEX index2 (foo (6), baz) COMMENT '';", $query);
+    "ADD  INDEX index1 (foo (12), bar, baz) COMMENT 'Fizz';", $query);
   }
-
 
   /**
    * Ensure alter fails when attempting to apply decimal type to large numbers.


### PR DESCRIPTION
```
[error]  SQLSTATE[HY000]: General error: 1795 InnoDB presently supports one FULLTEXT index creation at a time 
```
When defining multiple fulltext indexes in a data dictionary, user will get this error when running the post_import queue.

## Describe your changes
Updating the _buildAddIndexOptions_ method in the datastore/DataDictionary MySQLQuery class so that the fulltext indexes are split off for executing one at a time.

## QA Steps
details: 22521
- [ ] Create a dictionary with some standard indexes and some fulltext indexes.
- [ ] Use the data dictionary 'reference' mode
- [ ] Create/Edit a dataset to use the dictionary you just created.
- [ ] Run the queues
- [ ] Confirm the queues run without error.
- [ ] Confirm the import dashboard concurs.
- [ ] Confirm the indexes on the datastore table align with the data dictionary.
- [ ] Confirm the data typing also aligns with the data dictionary.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
