### PR TITLE
DKAN-4291 add mysql empty row removal option

### DIFF
--- a/modules/datastore/modules/datastore_mysql_import/README.md
+++ b/modules/datastore/modules/datastore_mysql_import/README.md
@@ -7,6 +7,6 @@ To use, simply enable _datastore_mysql_import_ and clear your cache.
 
 ## Differences in behavior with the default DKAN importer.
 
-* Any "blank" rows in your data file, including carriage returns, will be imported into the datastore as empty rows. The default importer ignores any blank rows.  To have the Mysql Importer behave the same as default importer and ignore empty rows, enable the option on this page /admin/dkan/datastore/mysql_import
+* Any "blank" rows in your data file, including carriage returns, will be imported into the datastore as empty rows. The default importer ignores any blank rows.  To have the Mysql Importer behave the same as the default importer and ignore empty rows, enable the option on this page /admin/dkan/datastore/mysql_import
 * If you have column headings exceeding 64 characters in your data file, these headings will be truncated to a max of 64 characters with the last 4 characters containing a hash value to insure uniqueness. This is the same for both importers as the character limit is from MySQL. However, if you already have imported data with one importer, and switch to the other importer, the hash values will be different. This may disrupt established queries depending on the previous header values.
 * If your data includes a field containing the literal word NULL, it will be interpreted as empty unless you enclose it with quotes to be interpreted as a string.

--- a/modules/datastore/modules/datastore_mysql_import/README.md
+++ b/modules/datastore/modules/datastore_mysql_import/README.md
@@ -7,6 +7,6 @@ To use, simply enable _datastore_mysql_import_ and clear your cache.
 
 ## Differences in behavior with the default DKAN importer.
 
-* Any "blank" rows in your data file, including carriage returns, will be imported into the datastore as empty rows. The default importer will ignore these rows.
+* Any "blank" rows in your data file, including carriage returns, will be imported into the datastore as empty rows. The default importer ignores any blank rows.  To have the Mysql Importer behave the same as default importer and ignore empty rows, enable the option on this page /admin/dkan/datastore/mysql_import
 * If you have column headings exceeding 64 characters in your data file, these headings will be truncated to a max of 64 characters with the last 4 characters containing a hash value to insure uniqueness. This is the same for both importers as the character limit is from MySQL. However, if you already have imported data with one importer, and switch to the other importer, the hash values will be different. This may disrupt established queries depending on the previous header values.
 * If your data includes a field containing the literal word NULL, it will be interpreted as empty unless you enclose it with quotes to be interpreted as a string.

--- a/modules/datastore/modules/datastore_mysql_import/config/schema/datastore_mysql_import.schema.yml
+++ b/modules/datastore/modules/datastore_mysql_import/config/schema/datastore_mysql_import.schema.yml
@@ -4,4 +4,4 @@ datastore_mysql_import.settings:
   mapping:
     remove_empty_rows:
       type: boolean
-      label: 'Remove empty rows in dataset'
+      label: 'Remove empty rows from the datastore table'

--- a/modules/datastore/modules/datastore_mysql_import/config/schema/datastore_mysql_import.schema.yml
+++ b/modules/datastore/modules/datastore_mysql_import/config/schema/datastore_mysql_import.schema.yml
@@ -1,0 +1,7 @@
+datastore_mysql_import.settings:
+  type: config_object
+  label: 'Datastore Mysql Import settings'
+  mapping:
+    remove_empty_rows:
+      type: boolean
+      label: 'Remove empty rows in dataset'

--- a/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.info.yml
+++ b/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.info.yml
@@ -3,6 +3,7 @@ description: Provides a MySQL Importer class.
 type: module
 core_version_requirement: ^10
 package: DKAN
+configure: datastore.mysql_import.settings
 dependencies:
   - dkan:common
   - dkan:datastore

--- a/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.links.menu.yml
+++ b/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.links.menu.yml
@@ -1,5 +1,5 @@
 datastore_mysql_import.settings_form:
-  title: MySQl Import settings
+  title: MySQL Import settings
   description: Setting for the MySQL Importer.
   parent: system.admin_dkan
   route_name: datastore.mysql_import.settings

--- a/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.links.menu.yml
+++ b/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.links.menu.yml
@@ -1,0 +1,6 @@
+datastore_mysql_import.settings_form:
+  title: MySQl Import settings
+  description: Setting for the MySQL Importer.
+  parent: system.admin_dkan
+  route_name: datastore.mysql_import.settings
+  weight: 15

--- a/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.routing.yml
+++ b/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.routing.yml
@@ -1,0 +1,7 @@
+datastore.mysql_import.settings:
+  path: '/admin/dkan/datastore/mysql_import'
+  defaults:
+    _title: 'MySQL Import Settings'
+    _form: 'Drupal\datastore_mysql_import\Form\DatastoreMysqlImportSettingsForm'
+  requirements:
+    _permission: 'administer site configuration'

--- a/modules/datastore/modules/datastore_mysql_import/src/Form/DatastoreMysqlImportSettingsForm.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Form/DatastoreMysqlImportSettingsForm.php
@@ -2,10 +2,8 @@
 
 namespace Drupal\datastore_mysql_import\Form;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Datastore MySQL Import settings form.
@@ -14,26 +12,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @codeCoverageIgnore
  */
 class DatastoreMysqlImportSettingsForm extends ConfigFormBase {
-
-
-  /**
-   * Constructs form.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
-   *   The factory for configuration objects.
-   */
-  public function __construct(ConfigFactoryInterface $config_factory) {
-    parent::__construct($config_factory);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('config.factory'),
-    );
-  }
 
   /**
    * {@inheritdoc}
@@ -46,14 +24,14 @@ class DatastoreMysqlImportSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   protected function getEditableConfigNames() {
-    return ['datastore.mysql_import.settings'];
+    return ['datastore_mysql_import.settings'];
   }
 
   /**
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $config = $this->config('datastore.mysql_import.settings');
+    $config = $this->config('datastore_mysql_import.settings');
     $form['remove_empty_rows'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Enable removal of empty rows in dataset.'),
@@ -67,7 +45,7 @@ class DatastoreMysqlImportSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $this->config('datastore.mysql_import.settings')
+    $this->config('datastore_mysql_import.settings')
       ->set('remove_empty_rows', $form_state->getValue('remove_empty_rows'))
       ->save();
     parent::submitForm($form, $form_state);

--- a/modules/datastore/modules/datastore_mysql_import/src/Form/DatastoreMysqlImportSettingsForm.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Form/DatastoreMysqlImportSettingsForm.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\datastore_mysql_import\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Datastore MySQL Import settings form.
+ *
+ * @package Drupal\datastore\Form
+ * @codeCoverageIgnore
+ */
+class DatastoreMysqlImportSettingsForm extends ConfigFormBase {
+
+
+  /**
+   * Constructs form.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The factory for configuration objects.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    parent::__construct($config_factory);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'datastore_mysql_import_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['datastore.mysql_import.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('datastore.mysql_import.settings');
+    $form['remove_empty_rows'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable removal of empty rows in dataset.'),
+      '#description' => $this->t('Unlike the chunk harvester, which ignores empty rows in a CSV, the MySQL importer will import empty rows.'),
+      '#default_value' => $config->get('remove_empty_rows'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('datastore.mysql_import.settings')
+      ->set('remove_empty_rows', $form_state->getValue('remove_empty_rows'))
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/datastore/modules/datastore_mysql_import/tests/data/multiple_empty_rows.csv
+++ b/modules/datastore/modules/datastore_mysql_import/tests/data/multiple_empty_rows.csv
@@ -1,0 +1,6 @@
+"id","name","score"
+1,"Yessenia",67.1
+,,
+2,"Roberto",2.2
+"","",""
+,,


### PR DESCRIPTION
Fixes #4291

## Describe your changes

* adds a settings page for the datastore_mysql_importer to allow for automatic removal of empty rows after import.
* Adds two tests, one for the removal option enabled and one for it disabled.

## QA Steps

- [ ] Login as admin
- [ ] Visit /admin/dkan/datastore/mysql_import
- [ ] Validate wording and that changes to the one setting, are properly saved.
![image](https://github.com/user-attachments/assets/ebd7817c-b8a1-41f3-83bb-c8c9f07ee818)
- [ ] Validate the menu item placement for the settings page 
![image](https://github.com/user-attachments/assets/0afac4d3-c570-484c-a1f5-6800bd2fc8f3)
- in terminal run `ddev dkan-phpunit --group datastore_mysql_import`
- [ ] validate that tests pass.


## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
