### PR TITLE
#4273: Datastore MySQL Import handles empty file incorrect (with a test)

### DIFF
--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -72,6 +72,11 @@ class MysqlImport extends ImportJob {
       return $this->setResultError(sprintf('Unable to resolve file name "%s" for resource with identifier "%s".', $this->resource->getFilePath(), $this->resource->getId()));
     }
 
+    $size = @filesize($file_path);
+    if (!$size) {
+      return $this->setResultError("Can't get size from file {$file_path}");
+    }
+
     // Read the columns and EOL character sequence from the CSV file.
     $delimiter = $this->resource->getMimeType() == 'text/tab-separated-values' ? "\t" : ',';
     try {

--- a/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Service/MysqlImportTest.php
+++ b/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Service/MysqlImportTest.php
@@ -174,6 +174,33 @@ class MysqlImportTest extends KernelTestBase {
     $this->assertEquals(Result::DONE, $result->getStatus(), $result->getError());
   }
 
+  /**
+   * Test MysqlImport importer with an empty CSV file.
+   */
+  public function testMysqlImporterWithEmptyCSVFile() {
+    $identifier = 'my_id';
+    $file_path = dirname(__FILE__, 7) . '/tests/data/empty.csv';
+    $data_resource = new DataResource($file_path, 'text/csv');
+
+    $import_factory = $this->container->get('dkan.datastore.service.factory.import');
+    $this->assertInstanceOf(MysqlImportFactory::class, $import_factory);
+
+    $import_service = $import_factory->getInstance(
+      $identifier,
+      ['resource' => $data_resource]
+    );
+    $this->assertInstanceOf(ImportService::class, $import_service);
+    $import_service->setImporterClass(MockQueryVisibilityImport::class);
+    $mysql_import = $import_service->getImporter();
+    $this->assertInstanceOf(MockQueryVisibilityImport::class, $mysql_import);
+    $this->assertInstanceOf(MySqlDatabaseTable::class, $mysql_import->getStorage());
+
+    // Run the import and confirm result is valid albeit an error.
+    $result = $mysql_import->run();
+    $this->assertEquals(Result::ERROR, $result->getStatus());
+    $this->assertStringStartsWith("Can't get size from file", $result->getError());
+  }
+
 }
 
 class MockQueryVisibilityImport extends MysqlImport {


### PR DESCRIPTION
Fixes #4273 

## Describe your changes

Adds a test to the solution from #4274 (thank you @stefan-korn)

## QA Steps

- Upload an empty CSV file to a distribution
- enable the datastore_mysql_import submodule
- Start the import to the datastore (via cron)
- Run cron again.
- Cron should not fail with an error and instead you should see an import error on the datastore 'error (Can't get size from file ...'

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
