### PR TITLE
Add events for datastore pre-drop, drop, and import

### DIFF
--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -8,6 +8,7 @@ services:
       - '@dkan.datastore.import_job_store_factory'
       - '@dkan.datastore.service.resource_processor.dictionary_enforcer'
       - '@dkan.metastore.resource_mapper'
+      - '@event_dispatcher'
 
   dkan.datastore.service.post_import:
     class: \Drupal\datastore\Service\PostImport
@@ -58,6 +59,7 @@ services:
       - '@dkan.datastore.import_job_store_factory'
       - '@dkan.datastore.database_table_factory'
       - '@dkan.datastore.logger_channel'
+      - '@event_dispatcher'
 
   dkan.datastore.logger_channel:
     parent: logger.channel_base

--- a/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.services.yml
+++ b/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.services.yml
@@ -6,6 +6,7 @@ services:
       - '@dkan.datastore.import_job_store_factory'
       - '@dkan.datastore_mysql_import.database_table_factory'
       - '@dkan.datastore.logger_channel'
+      - '@event_dispatcher'
 
   dkan.datastore_mysql_import.database_table_factory:
     class: \Drupal\datastore_mysql_import\Storage\MySqlDatabaseTableFactory

--- a/modules/datastore/modules/datastore_mysql_import/src/Factory/MysqlImportFactory.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Factory/MysqlImportFactory.php
@@ -8,6 +8,7 @@ use Drupal\datastore\Storage\ImportJobStoreFactory;
 use Drupal\datastore_mysql_import\Service\MysqlImport;
 use Drupal\datastore_mysql_import\Storage\MySqlDatabaseTableFactory;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Mysql importer factory.
@@ -36,22 +37,29 @@ class MysqlImportFactory implements ImportFactoryInterface {
   private LoggerInterface $logger;
 
   /**
+   * Event dispatcher service.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  private EventDispatcherInterface $eventDispatcher;
+
+  /**
    * Constructor.
    */
   public function __construct(
     ImportJobStoreFactory $importJobStoreFactory,
     MySqlDatabaseTableFactory $databaseTableFactory,
-    LoggerInterface $loggerChannel
+    LoggerInterface $loggerChannel,
+    EventDispatcherInterface $eventDispatcher,
   ) {
     $this->importJobStoreFactory = $importJobStoreFactory;
     $this->databaseTableFactory = $databaseTableFactory;
     $this->logger = $loggerChannel;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
-   * Inherited.
-   *
-   * @inheritdoc
+   * {@inheritDoc}
    */
   public function getInstance(string $identifier, array $config = []) {
     $resource = $config['resource'] ?? FALSE;
@@ -63,7 +71,8 @@ class MysqlImportFactory implements ImportFactoryInterface {
       $resource,
       $this->importJobStoreFactory,
       $this->databaseTableFactory,
-      $this->logger
+      $this->logger,
+      $this->eventDispatcher
     );
     $importer->setImporterClass(MysqlImport::class);
     return $importer;

--- a/modules/datastore/src/DatastoreService.php
+++ b/modules/datastore/src/DatastoreService.php
@@ -246,7 +246,7 @@ class DatastoreService implements ContainerInjectionInterface {
   /**
    * Returns the Data Dictionary fields.
    *
-   * @param string $identifier
+   * @param string|null $identifier
    *   A resource's identifier. Used when in reference mode.
    *
    * @return array|null

--- a/modules/datastore/src/DatastoreService.php
+++ b/modules/datastore/src/DatastoreService.php
@@ -2,10 +2,11 @@
 
 namespace Drupal\datastore;
 
-use Drupal\common\DataResource;
-use Drupal\common\EventDispatcherTrait;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Queue\QueueFactory;
+use Drupal\common\DataResource;
+use Drupal\datastore\Events\DatastoreDroppedEvent;
+use Drupal\datastore\Events\DatastorePreDropEvent;
 use Drupal\datastore\Service\Factory\ImportFactoryInterface;
 use Drupal\datastore\Service\ImportService;
 use Drupal\datastore\Service\ResourceLocalizer;
@@ -13,13 +14,12 @@ use Drupal\datastore\Service\ResourceProcessor\DictionaryEnforcer;
 use Drupal\datastore\Storage\ImportJobStoreFactory;
 use Drupal\metastore\ResourceMapper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Main services for the datastore.
  */
 class DatastoreService implements ContainerInjectionInterface {
-
-  use EventDispatcherTrait;
 
   /**
    * This event is triggered when the datastore is about to be dropped.
@@ -78,6 +78,13 @@ class DatastoreService implements ContainerInjectionInterface {
   private ImportJobStoreFactory $importJobStoreFactory;
 
   /**
+   * Event dispatcher service.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  private EventDispatcherInterface $eventDispatcher;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
@@ -87,7 +94,8 @@ class DatastoreService implements ContainerInjectionInterface {
       $container->get('queue'),
       $container->get('dkan.datastore.import_job_store_factory'),
       $container->get('dkan.datastore.service.resource_processor.dictionary_enforcer'),
-      $container->get('dkan.metastore.resource_mapper')
+      $container->get('dkan.metastore.resource_mapper'),
+      $container->get('event_dispatcher')
     );
   }
 
@@ -106,6 +114,8 @@ class DatastoreService implements ContainerInjectionInterface {
    *   Dictionary Enforcer object.
    * @param \Drupal\metastore\ResourceMapper $resourceMapper
    *   Resource mapper service.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *   Event dispatcher service.
    */
   public function __construct(
     ResourceLocalizer $resourceLocalizer,
@@ -113,7 +123,8 @@ class DatastoreService implements ContainerInjectionInterface {
     QueueFactory $queue,
     ImportJobStoreFactory $importJobStoreFactory,
     DictionaryEnforcer $dictionaryEnforcer,
-    ResourceMapper $resourceMapper
+    ResourceMapper $resourceMapper,
+    EventDispatcherInterface $eventDispatcher,
   ) {
     $this->resourceLocalizer = $resourceLocalizer;
     $this->importServiceFactory = $importServiceFactory;
@@ -121,6 +132,7 @@ class DatastoreService implements ContainerInjectionInterface {
     $this->importJobStoreFactory = $importJobStoreFactory;
     $this->dictionaryEnforcer = $dictionaryEnforcer;
     $this->resourceMapper = $resourceMapper;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
@@ -240,7 +252,7 @@ class DatastoreService implements ContainerInjectionInterface {
    * @return array|null
    *   An array of dictionary fields or null if no dictionary is in use.
    */
-  public function getDataDictionaryFields(string $identifier = NULL): ?array {
+  public function getDataDictionaryFields(?string $identifier = NULL): ?array {
     return $this->dictionaryEnforcer->returnDataDictionaryFields($identifier);
   }
 
@@ -259,15 +271,17 @@ class DatastoreService implements ContainerInjectionInterface {
     $resource = $this->resourceLocalizer->get($identifier, $version);
 
     if ($storage = $this->getStorage($identifier, $version)) {
-      $data = [
-        'identifier' => $identifier,
-        'version' => $version,
-      ];
-      $this->dispatchEvent(self::EVENT_DATASTORE_PRE_DROP, $data);
+      $this->eventDispatcher->dispatch(
+        new DatastorePreDropEvent($identifier, $version),
+        self::EVENT_DATASTORE_PRE_DROP
+      );
       $storage->destruct();
       $this->importJobStoreFactory->getInstance()
         ->remove(md5($resource->getUniqueIdentifier()));
-      $this->dispatchEvent(self::EVENT_DATASTORE_DROPPED, $data);
+      $this->eventDispatcher->dispatch(
+        new DatastoreDroppedEvent($identifier, $version),
+        self::EVENT_DATASTORE_DROPPED
+      );
     }
 
     if ($remove_local_resource) {

--- a/modules/datastore/src/EventSubscriber/DatastoreSubscriber.php
+++ b/modules/datastore/src/EventSubscriber/DatastoreSubscriber.php
@@ -167,6 +167,8 @@ class DatastoreSubscriber implements EventSubscriberInterface {
     $resource = $event->getData();
     $id = md5(str_replace(DataResource::DEFAULT_SOURCE_PERSPECTIVE, ResourceLocalizer::LOCAL_FILE_PERSPECTIVE, $resource->getUniqueIdentifier()));
     try {
+      // @todo Check if the datastore exists before dropping. Don't log an
+      //   error if it wasn't there to begin with.
       $this->datastoreService->drop($resource->getIdentifier(), $resource->getVersion());
       $this->logger->notice('Dropping datastore for @id', ['@id' => $id]);
     }

--- a/modules/datastore/src/Events/DatastoreDroppedEvent.php
+++ b/modules/datastore/src/Events/DatastoreDroppedEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drupal\datastore\Events;
+
+/**
+ * Event object for after we've dropped a datastore.
+ *
+ * @see \Drupal\datastore\DatastoreService::EVENT_DATASTORE_DROPPED
+ */
+class DatastoreDroppedEvent extends DatastoreEventBase {
+
+}

--- a/modules/datastore/src/Events/DatastoreEventBase.php
+++ b/modules/datastore/src/Events/DatastoreEventBase.php
@@ -7,7 +7,7 @@ use Drupal\Component\EventDispatcher\Event;
 /**
  * Event base class for the datastore module.
  */
-class DatastoreEventBase extends Event {
+class DatastoreEventBase extends Event implements DatastoreEventInterface {
 
   /**
    * The datastore identifier.
@@ -37,20 +37,14 @@ class DatastoreEventBase extends Event {
   }
 
   /**
-   * Get the datastore identifier.
-   *
-   * @return string
-   *   The datastore identifier.
+   * {@inheritDoc}
    */
   public function getIdentifier(): string {
     return $this->identifier;
   }
 
   /**
-   * Get the datastore version.
-   *
-   * @return string|null
-   *   The datastore version, or NULL if none was provided.
+   * {@inheritDoc}
    */
   public function getVersion(): ?string {
     return $this->version;

--- a/modules/datastore/src/Events/DatastoreEventBase.php
+++ b/modules/datastore/src/Events/DatastoreEventBase.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\datastore\Events;
+
+use Drupal\Component\EventDispatcher\Event;
+
+/**
+ * Event base class for the datastore module.
+ */
+class DatastoreEventBase extends Event {
+
+  /**
+   * The datastore identifier.
+   *
+   * @var string
+   */
+  private string $identifier;
+
+  /**
+   * The datastore version.
+   *
+   * @var string|null
+   */
+  private ?string $version;
+
+  /**
+   * Constructor.
+   *
+   * @param string $identifier
+   *   The datastore identifier.
+   * @param string|null $version
+   *   (Optional) The datastore version.
+   */
+  public function __construct(string $identifier, ?string $version) {
+    $this->identifier = $identifier;
+    $this->version = $version;
+  }
+
+  /**
+   * Get the datastore identifier.
+   *
+   * @return string
+   *   The datastore identifier.
+   */
+  public function getIdentifier(): string {
+    return $this->identifier;
+  }
+
+  /**
+   * Get the datastore version.
+   *
+   * @return string|null
+   *   The datastore version, or NULL if none was provided.
+   */
+  public function getVersion(): ?string {
+    return $this->version;
+  }
+
+}

--- a/modules/datastore/src/Events/DatastoreEventInterface.php
+++ b/modules/datastore/src/Events/DatastoreEventInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\datastore\Events;
+
+/**
+ * Event base class for the datastore module.
+ */
+interface DatastoreEventInterface {
+
+  /**
+   * Get the datastore identifier.
+   *
+   * @return string
+   *   The datastore identifier.
+   */
+  public function getIdentifier(): string;
+
+  /**
+   * Get the datastore version.
+   *
+   * @return string|null
+   *   The datastore version, or NULL if none was provided.
+   */
+  public function getVersion(): ?string;
+
+}

--- a/modules/datastore/src/Events/DatastoreImportedEvent.php
+++ b/modules/datastore/src/Events/DatastoreImportedEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drupal\datastore\Events;
+
+/**
+ * Event object for when a datastore has finished importing.
+ *
+ * @see \Drupal\datastore\Service\ImportService::EVENT_DATASTORE_IMPORTED
+ */
+class DatastoreImportedEvent extends DatastoreEventBase {
+
+}

--- a/modules/datastore/src/Events/DatastorePreDropEvent.php
+++ b/modules/datastore/src/Events/DatastorePreDropEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drupal\datastore\Events;
+
+/**
+ * Event object for when we're about to drop a datastore.
+ *
+ * @see \Drupal\datastore\DatastoreService::EVENT_DATASTORE_PRE_DROP
+ */
+class DatastorePreDropEvent extends DatastoreEventBase {
+
+}

--- a/modules/datastore/src/Plugin/QueueWorker/ImportQueueWorker.php
+++ b/modules/datastore/src/Plugin/QueueWorker/ImportQueueWorker.php
@@ -28,13 +28,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ImportQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
 
   /**
-   * This event is when the datastore has successfully been imported.
-   *
-   * @todo This also happens in ImportJob. We should consolidate.
-   */
-  const EVENT_DATASTORE_IMPORTED = 'dkan_datastore_imported';
-
-  /**
    * This queue worker's corresponding database queue instance.
    *
    * @var \Drupal\Core\Queue\DatabaseQueue

--- a/modules/datastore/src/Plugin/QueueWorker/ImportQueueWorker.php
+++ b/modules/datastore/src/Plugin/QueueWorker/ImportQueueWorker.php
@@ -5,7 +5,6 @@ namespace Drupal\datastore\Plugin\QueueWorker;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
-use Drupal\common\EventDispatcherTrait;
 use Drupal\common\Storage\DatabaseConnectionFactoryInterface;
 use Drupal\common\Storage\ImportedItemInterface;
 use Drupal\datastore\DatastoreService;
@@ -27,8 +26,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * )
  */
 class ImportQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
-
-  use EventDispatcherTrait;
 
   /**
    * This event is when the datastore has successfully been imported.
@@ -254,9 +251,6 @@ class ImportQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
 
       case Result::DONE:
         $this->logger->notice($label . ' for ' . $uid . ' completed.');
-        // @todo This is not the best place to dispatch the event. It can be
-        //   sent twice, once after localization and once after import.
-        $this->dispatchEvent(self::EVENT_DATASTORE_IMPORTED, ['identifier' => $data['identifier'], 'version' => $data['version']]);
         $this->invalidateCacheTags($uid . '__source');
         break;
     }

--- a/modules/datastore/src/Service/Factory/ImportServiceFactory.php
+++ b/modules/datastore/src/Service/Factory/ImportServiceFactory.php
@@ -6,6 +6,7 @@ use Drupal\datastore\Service\ImportService;
 use Drupal\datastore\Storage\DatabaseTableFactory;
 use Drupal\datastore\Storage\ImportJobStoreFactory;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Create an importer object for a given resource.
@@ -34,22 +35,29 @@ class ImportServiceFactory implements ImportFactoryInterface {
   private LoggerInterface $logger;
 
   /**
+   * Event dispatcher service.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  private EventDispatcherInterface $eventDispatcher;
+
+  /**
    * Constructor.
    */
   public function __construct(
     ImportJobStoreFactory $importJobStoreFactory,
     DatabaseTableFactory $databaseTableFactory,
-    LoggerInterface $loggerChannel
+    LoggerInterface $loggerChannel,
+    EventDispatcherInterface $eventDispatcher,
   ) {
     $this->importJobStoreFactory = $importJobStoreFactory;
     $this->databaseTableFactory = $databaseTableFactory;
     $this->logger = $loggerChannel;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
-   * Inherited.
-   *
-   * @inheritdoc
+   * {@inheritDoc}
    */
   public function getInstance(string $identifier, array $config = []) {
     if ($resource = $config['resource'] ?? FALSE) {
@@ -57,7 +65,8 @@ class ImportServiceFactory implements ImportFactoryInterface {
         $resource,
         $this->importJobStoreFactory,
         $this->databaseTableFactory,
-        $this->logger
+        $this->logger,
+        $this->eventDispatcher,
       );
     }
     throw new \Exception("config['resource'] is required");

--- a/modules/datastore/tests/src/Kernel/DatastoreServiceEventsTest.php
+++ b/modules/datastore/tests/src/Kernel/DatastoreServiceEventsTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\datastore\Kernel;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\common\DataResource;
+use Drupal\common\Events\Event;
+use Drupal\common\Storage\DatabaseTableInterface;
+use Drupal\datastore\DatastoreService;
+use Drupal\datastore\Service\ResourceLocalizer;
+use Drupal\datastore\Storage\DatabaseTable;
+use Drupal\datastore\Storage\ImportJobStoreFactory;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @covers \Drupal\datastore\DatastoreService
+ * @coversDefaultClass \Drupal\datastore\DatastoreService
+ *
+ * @group dkan
+ * @group datastore
+ * @group kernel
+ */
+class DatastoreServiceEventsTest extends KernelTestBase implements EventSubscriberInterface {
+
+  protected static $modules = [
+    'common',
+    'datastore',
+    'metastore',
+  ];
+
+  /**
+   * Store the events we receive.
+   *
+   * @var array
+   */
+  protected array $events = [];
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      DatastoreService::EVENT_DATASTORE_PRE_DROP => 'catchPreDropEvent',
+      DatastoreService::EVENT_DATASTORE_DROPPED => 'catchDroppedEvent',
+    ];
+  }
+
+  /**
+   * Event handler.
+   *
+   * @param \Drupal\common\Events\Event $event
+   *   The event.
+   */
+  public function catchPreDropEvent(Event $event) {
+    $this->events[DatastoreService::EVENT_DATASTORE_PRE_DROP] = $event;
+  }
+
+  /**
+   * Event handler.
+   *
+   * @param \Drupal\common\Events\Event $event
+   *   The event.
+   */
+  public function catchDroppedEvent(Event $event) {
+    $this->events[DatastoreService::EVENT_DATASTORE_DROPPED] = $event;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function register(ContainerBuilder $container) {
+    parent::register($container);
+    $container->register('testing.datastore_drop_subscriber', self::class)
+      ->addTag('event_subscriber');
+    $container->set('testing.datastore_drop_subscriber', $this);
+  }
+
+  /**
+   * @covers ::drop
+   */
+  public function testEvents() {
+    // Mock a data resource.
+    $data_resource = $this->getMockBuilder(DataResource::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['getUniqueIdentifier'])
+      ->getMock();
+
+    // Mock the resource localizer.
+    $resource_localizer = $this->getMockBuilder(ResourceLocalizer::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get'])
+      ->getMock();
+    $resource_localizer->expects($this->once())
+      ->method('get')
+      ->willReturn($data_resource);
+
+    // Mock the storage.
+    $storage = $this->getMockBuilder(DatabaseTable::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['destruct'])
+      ->getMock();
+    $storage->expects($this->once())
+      ->method('destruct');
+
+    // Mock a database table so we don't need one.
+    $database_table = $this->getMockBuilder(DatabaseTableInterface::class)
+      ->onlyMethods(['remove'])
+      ->getMockForAbstractClass();
+    $database_table->expects($this->once())
+      ->method('remove');
+
+    // Mock a job store factory so we can avoid actually trying to drop an
+    // actual table.
+    $job_store_factory = $this->getMockBuilder(ImportJobStoreFactory::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['getInstance'])
+      ->getMock();
+    $job_store_factory->expects($this->once())
+      ->method('getInstance')
+      ->willReturn($database_table);
+
+    // Mock the datastore service so we can isolate the dispatched events.
+    $datastore_service = $this->getMockBuilder(DatastoreService::class)
+      // We only want to mock a few of the services.
+      ->setConstructorArgs([
+        $resource_localizer,
+        $this->container->get('dkan.datastore.service.factory.import'),
+        $this->container->get('queue'),
+        $job_store_factory,
+        $this->container->get('dkan.datastore.service.resource_processor.dictionary_enforcer'),
+        $this->container->get('dkan.metastore.resource_mapper'),
+      ])
+      ->onlyMethods(['getStorage'])
+      ->getMock();
+    $datastore_service->expects($this->once())
+      ->method('getStorage')
+      ->willReturn($storage);
+
+    // This test class, being an event subscriber, will load up $this->events
+    // with the events we generated.
+    $this->assertCount(0, $this->events);
+    $datastore_service->drop('id', 'ver', FALSE);
+    // 2 events happened because of drop().
+    $this->assertCount(2, $this->events);
+
+    // Pre-drop happened first.
+    $this->assertEquals(
+      ['dkan_datastore_pre_drop', 'dkan_datastore_dropped'],
+      array_keys($this->events)
+    );
+
+    foreach ($this->events as $event) {
+      $this->assertIsArray($data = $event->getData());
+      // We don't know what the identifier or version actually will be, so we
+      // check that the data has the correct keys.
+      $this->assertEquals('id', $data['identifier']);
+      $this->assertEquals('ver', $data['version']);
+    }
+  }
+
+}

--- a/modules/datastore/tests/src/Kernel/DatastoreServiceEventsTest.php
+++ b/modules/datastore/tests/src/Kernel/DatastoreServiceEventsTest.php
@@ -154,8 +154,6 @@ class DatastoreServiceEventsTest extends KernelTestBase implements EventSubscrib
 
     foreach ($this->events as $event) {
       $this->assertIsArray($data = $event->getData());
-      // We don't know what the identifier or version actually will be, so we
-      // check that the data has the correct keys.
       $this->assertEquals('id', $data['identifier']);
       $this->assertEquals('ver', $data['version']);
     }

--- a/modules/datastore/tests/src/Kernel/DatastoreServiceEventsTest.php
+++ b/modules/datastore/tests/src/Kernel/DatastoreServiceEventsTest.php
@@ -154,9 +154,9 @@ class DatastoreServiceEventsTest extends KernelTestBase implements EventSubscrib
       array_keys($this->events)
     );
 
-    // Both events will be DatastoreEventBase, so we can use getters for our
-    // values.
-    /** @var \Drupal\datastore\Events\DatastoreEventBase $event */
+    // Both events will be DatastoreEventInterface, so we can use getters for
+    // our values.
+    /** @var \Drupal\datastore\Events\DatastoreEventInterface $event */
     foreach ($this->events as $event) {
       $this->assertEquals('id', $event->getIdentifier());
       $this->assertEquals('ver', $event->getVersion());

--- a/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/ImportQueueWorkerTest.php
+++ b/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/ImportQueueWorkerTest.php
@@ -47,6 +47,7 @@ class ImportQueueWorkerTest extends KernelTestBase {
         $this->container->get('dkan.datastore.import_job_store_factory'),
         $this->container->get('dkan.datastore.service.resource_processor.dictionary_enforcer'),
         $this->container->get('dkan.metastore.resource_mapper'),
+        $this->container->get('event_dispatcher'),
       ])
       ->onlyMethods(['import'])
       ->getMock();
@@ -93,6 +94,7 @@ class ImportQueueWorkerTest extends KernelTestBase {
         $this->container->get('dkan.datastore.import_job_store_factory'),
         $this->container->get('dkan.datastore.service.resource_processor.dictionary_enforcer'),
         $this->container->get('dkan.metastore.resource_mapper'),
+        $this->container->get('event_dispatcher'),
       ])
       ->onlyMethods(['import'])
       ->getMock();
@@ -225,6 +227,7 @@ class ImportQueueWorkerTest extends KernelTestBase {
         $this->container->get('dkan.datastore.import_job_store_factory'),
         $this->container->get('dkan.datastore.service.resource_processor.dictionary_enforcer'),
         $this->container->get('dkan.metastore.resource_mapper'),
+        $this->container->get('event_dispatcher'),
       ])
       ->onlyMethods(['getStorage'])
       ->getMock();

--- a/modules/datastore/tests/src/Kernel/Service/ImportServiceEventsTest.php
+++ b/modules/datastore/tests/src/Kernel/Service/ImportServiceEventsTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\datastore\Kernel\Service;
+
+use Drupal\common\DataResource;
+use Drupal\common\Events\Event;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\datastore\Plugin\QueueWorker\ImportJob;
+use Drupal\datastore\Service\ImportService;
+use Drupal\KernelTests\KernelTestBase;
+use Procrastinator\Result;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @covers \Drupal\datastore\Service\ImportService
+ * @coversDefaultClass \Drupal\datastore\Service\ImportService
+ *
+ * @group dkan
+ * @group datastore
+ * @group kernel
+ */
+class ImportServiceEventsTest extends KernelTestBase implements EventSubscriberInterface {
+
+  /**
+   * Store the events we receive.
+   *
+   * @var array
+   */
+  protected array $events = [];
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function getSubscribedEvents() {
+    return [ImportService::EVENT_DATASTORE_IMPORTED => 'catchImportEvent'];
+  }
+
+  /**
+   * Our event handler.
+   *
+   * @param \Drupal\common\Events\Event $event
+   *   The event.
+   */
+  public function catchImportEvent(Event $event) {
+    $this->events[] = $event;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function register(ContainerBuilder $container) {
+    parent::register($container);
+    $container->register('testing.datastore_imported_subscriber', self::class)
+      ->addTag('event_subscriber');
+    $container->set('testing.datastore_imported_subscriber', $this);
+  }
+
+  /**
+   * @covers ::import
+   */
+  public function testEvents() {
+    // Our result will be DONE.
+    $result = new Result();
+    $result->setStatus(Result::DONE);
+
+    // Our import job will return our result.
+    $import_job = $this->getMockBuilder(ImportJob::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['run'])
+      ->getMock();
+    $import_job->expects($this->once())
+      ->method('run')
+      ->willReturn($result);
+
+    // Mock an ImportService object to test. We'll mock a number of methods
+    // so that we can isolate the event dispatch.
+    $import_service = $this->getMockBuilder(ImportService::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['getImporter', 'getResource'])
+      ->getMock();
+    // getImporter returns the import job and thus the result.
+    $import_service->expects($this->once())
+      ->method('getImporter')
+      ->willReturn($import_job);
+    // getResource will return a known data resource.
+    $import_service->expects($this->once())
+      ->method('getResource')
+      ->willReturn(new DataResource('path', 'text/csv', 'local_file'));
+
+    // This test class, being an event subscriber, will load up $this->events
+    // with the events we generated.
+    $this->assertCount(0, $this->events);
+    $import_service->import();
+    $this->assertCount(1, $this->events);
+    /** @var \Drupal\common\Events\Event $event */
+    $event = reset($this->events);
+    $this->assertIsArray($data = $event->getData());
+    // We don't know what the identifier or version actually will be, so we
+    // check that the data has the correct keys.
+    $this->assertArrayHasKey('identifier', $data);
+    $this->assertArrayHasKey('version', $data);
+  }
+
+}

--- a/modules/datastore/tests/src/Kernel/Service/ImportServiceTest.php
+++ b/modules/datastore/tests/src/Kernel/Service/ImportServiceTest.php
@@ -52,7 +52,8 @@ class ImportServiceTest extends KernelTestBase {
         new DataResource('abc.txt', 'text/csv'),
         $this->container->get('dkan.datastore.import_job_store_factory'),
         $this->container->get('dkan.datastore.database_table_factory'),
-        $this->container->get('dkan.datastore.logger_channel')
+        $this->container->get('dkan.datastore.logger_channel'),
+        $this->container->get('event_dispatcher'),
       ])
       ->getMock();
     $import_service->method('getImporter')

--- a/modules/datastore/tests/src/Unit/DatastoreServiceTest.php
+++ b/modules/datastore/tests/src/Unit/DatastoreServiceTest.php
@@ -72,7 +72,10 @@ class DatastoreServiceTest extends TestCase {
       ->add(ImportJobStoreFactory::class, 'getInstance', JobStore::class)
       ->add(JobStore::class, 'remove', TRUE);
 
-    $service = DatastoreService::create($mockChain->getMock());
+    // Workaround for DatastoreService using EventDispatcherTrait.
+    \Drupal::setContainer($container = $mockChain->getMock());
+
+    $service = DatastoreService::create($container);
     // These are all valid ways to call drop().
     $this->assertNull($service->drop('foo'));
     $this->assertNull($service->drop('foo', '123152'));
@@ -97,6 +100,7 @@ class DatastoreServiceTest extends TestCase {
 
   private function getCommonChain() {
     $options = (new Options())
+      ->add('event_dispatcher', ContainerAwareEventDispatcher::class)
       ->add('dkan.metastore.resource_mapper', ResourceMapper::class)
       ->add('dkan.datastore.service.resource_localizer', ResourceLocalizer::class)
       ->add('dkan.datastore.service.factory.import', ImportServiceFactory::class)

--- a/modules/datastore/tests/src/Unit/DatastoreServiceTest.php
+++ b/modules/datastore/tests/src/Unit/DatastoreServiceTest.php
@@ -72,10 +72,7 @@ class DatastoreServiceTest extends TestCase {
       ->add(ImportJobStoreFactory::class, 'getInstance', JobStore::class)
       ->add(JobStore::class, 'remove', TRUE);
 
-    // Workaround for DatastoreService using EventDispatcherTrait.
-    \Drupal::setContainer($container = $mockChain->getMock());
-
-    $service = DatastoreService::create($container);
+    $service = DatastoreService::create($mockChain->getMock());
     // These are all valid ways to call drop().
     $this->assertNull($service->drop('foo'));
     $this->assertNull($service->drop('foo', '123152'));

--- a/modules/datastore/tests/src/Unit/Service/DatastoreQueryTest.php
+++ b/modules/datastore/tests/src/Unit/Service/DatastoreQueryTest.php
@@ -15,6 +15,7 @@ use Drupal\datastore\DatastoreService;
 use Drupal\datastore\Service\Factory\ImportServiceFactory;
 use Drupal\datastore\Service\ResourceLocalizer;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Drupal\datastore\Service\DatastoreQuery;
@@ -190,6 +191,7 @@ class DatastoreQueryTest extends TestCase {
   public function getCommonMockChain() {
 
     $options = (new Options())
+      ->add('event_dispatcher', EventDispatcherInterface::class)
       ->add('dkan.metastore.resource_mapper', ResourceMapper::class)
       ->add("dkan.datastore.query", Query::class)
       ->add("dkan.datastore.service", DatastoreService::class)

--- a/modules/datastore/tests/src/Unit/Service/Factory/ImportServiceFactoryTest.php
+++ b/modules/datastore/tests/src/Unit/Service/Factory/ImportServiceFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\Tests\datastore\Unit\Service\Factory;
 
 use Drupal\datastore\Service\Factory\ImportServiceFactory;
@@ -7,6 +9,7 @@ use Drupal\datastore\Storage\DatabaseTableFactory;
 use Drupal\datastore\Storage\ImportJobStoreFactory;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @covers \Drupal\datastore\Service\Factory\ImportServiceFactory
@@ -29,7 +32,8 @@ class ImportServiceFactoryTest extends TestCase {
       $this->getMockBuilder(DatabaseTableFactory::class)
         ->disableOriginalConstructor()
         ->getMock(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
 
     $this->expectException(\Exception::class);


### PR DESCRIPTION
Re: 22964 and 22872

## Describe your changes

Adds these events:

- `DatastoreService::EVENT_DATASTORE_PRE_DROP`
- `DatastoreService::EVENT_DATASTORE_DROPPED`
- `ImportService::EVENT_DATASTORE_IMPORTED`

This way other services can respond to these events.

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
