### PR TITLE
Include only CSV and TSV resources in import status dashboard

### DIFF
--- a/modules/common/src/DataResource.php
+++ b/modules/common/src/DataResource.php
@@ -53,6 +53,14 @@ class DataResource implements \JsonSerializable {
   const DEFAULT_SOURCE_PERSPECTIVE = 'source';
 
   /**
+   * Mime types of files that contain importable data.
+   */
+  const IMPORTABLE_FILE_TYPES = [
+    'text/csv',
+    'text/tab-separated-values',
+  ];
+
+  /**
    * The file path or URL for the resource.
    *
    * @var string

--- a/modules/common/src/DatasetInfo.php
+++ b/modules/common/src/DatasetInfo.php
@@ -267,6 +267,7 @@ class DatasetInfo implements ContainerInjectionInterface {
       'fetcher_status' => $info->fileFetcherStatus,
       'fetcher_percent_done' => $info->fileFetcherPercentDone ?? 0,
       'file_path' => isset($fileMapper) ? $fileMapper->getFilePath() : 'not found',
+      'mime_type' => isset($source) ? $source->getMimeType() : '',
       'source_path' => isset($source) ? $source->getFilePath() : '',
       'importer_percent_done' => $info->importerPercentDone ?? 0,
       'importer_status' => $info->importerStatus,

--- a/modules/common/tests/src/Unit/DatasetInfoTest.php
+++ b/modules/common/tests/src/Unit/DatasetInfoTest.php
@@ -275,6 +275,7 @@ class DatasetInfoTest extends TestCase {
       'fetcher_status',
       'fetcher_percent_done',
       'file_path',
+      'mime_type',
       'source_path',
       'importer_percent_done',
       'importer_status',

--- a/modules/datastore/src/EventSubscriber/DatastoreSubscriber.php
+++ b/modules/datastore/src/EventSubscriber/DatastoreSubscriber.php
@@ -140,10 +140,7 @@ class DatastoreSubscriber implements EventSubscriberInterface {
    * Private.
    */
   private function isDataStorable(DataResource $resource) : bool {
-    return in_array($resource->getMimeType(), [
-      'text/csv',
-      'text/tab-separated-values',
-    ]);
+    return in_array($resource->getMimeType(), DataResource::IMPORTABLE_FILE_TYPES);
   }
 
   /**

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -302,6 +302,15 @@ class DashboardForm extends FormBase {
       if (empty($datasetInfo['latest_revision'])) {
         continue;
       }
+
+      $datasetInfo['latest_revision']['distributions'] = array_filter($datasetInfo['latest_revision']['distributions'], function ($v) {
+        return !isset($v['mime_type']) || in_array($v['mime_type'], ['text/csv', 'text/tab-separated-values']);
+      });
+
+      if (empty($datasetInfo['latest_revision']['distributions'])) {
+        continue;
+      }
+
       // Build a table row using its details and harvest status.
       $datasetRow = $this->buildRevisionRows($datasetInfo, $harvestLoad[$datasetId] ?? 'N/A');
       $rows = array_merge($rows, $datasetRow);

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -385,11 +385,13 @@ class DashboardForm extends FormBase {
         return !isset($v['mime_type']) || in_array($v['mime_type'], DataResource::IMPORTABLE_FILE_TYPES);
       });
 
-      // For first distribution, combine with revision information.
-      $rows[] = array_merge(
-        $this->buildRevisionRow($rev, count($distributions), $harvestStatus),
-        $this->buildResourcesRow(array_shift($distributions))
-      );
+      if (!empty($distributions)) {
+        // For first distribution, combine with revision information.
+        $rows[] = array_merge(
+          $this->buildRevisionRow($rev, count($distributions), $harvestStatus),
+          $this->buildResourcesRow(array_shift($distributions))
+        );
+      }
       // If there are more distributions, add additional rows for them.
       while (!empty($distributions)) {
         $rows[] = $this->buildResourcesRow(array_shift($distributions));

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\datastore\Form;
 
+use Drupal\common\DataResource;
 use Drupal\Core\Pager\PagerManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Form\FormBase;
@@ -303,10 +304,8 @@ class DashboardForm extends FormBase {
         continue;
       }
 
-      $datasetInfo['latest_revision']['distributions'] = array_filter($datasetInfo['latest_revision']['distributions'], function ($v) {
-        return !isset($v['mime_type']) || in_array($v['mime_type'], ['text/csv', 'text/tab-separated-values']);
-      });
-
+      // Remove distrubutions and datasets with only non-importable rescourcs.
+      $datasetInfo['latest_revision']['distributions'] = $this->filterDistributions($datasetInfo['latest_revision']['distributions']);
       if (empty($datasetInfo['latest_revision']['distributions'])) {
         continue;
       }
@@ -547,6 +546,21 @@ class DashboardForm extends FormBase {
       return $matches[1];
     }
     return $error;
+  }
+
+  /**
+   * Filter out distributions with resources that aren't importable.
+   *
+   * @param array $distributions
+   *   An array of distribution structures.
+   *
+   * @return array
+   *   The same array, with non-importable resource distributions removed.
+   */
+  protected function filterDistributions(array $distributions): array {
+    return $distributions = array_filter($distributions, function ($v) {
+      return !isset($v['mime_type']) || in_array($v['mime_type'], DataResource::IMPORTABLE_FILE_TYPES);
+    });
   }
 
 }


### PR DESCRIPTION
Fixes [issue#]
The Datastore Import Status page includes datastores with resources that can't be imported, e.g. PDF and zip files. These resources display with a status of "Waiting", which is inaccurate and confusing.

(19021)

## Describe your changes
Filter out distributions with resources that can't be imported, and datastores with only unimportable distributions  from the data used to create the Datastore Import Status page.

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
