### PR TITLE
Remove 'Other' option from File Format select list for Dataset Distributions.

### DIFF
--- a/modules/json_form_widget/tests/src/Functional/AdminDatasetFileUploadTest.php
+++ b/modules/json_form_widget/tests/src/Functional/AdminDatasetFileUploadTest.php
@@ -94,7 +94,7 @@ class AdminDatasetFileUploadTest extends BrowserTestBase {
       'edit-field-json-metadata-0-value-keyword-keyword-0' => $keyword_data,
       'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-title' => 'distribution title test',
       'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-description' => 'distribution description test',
-      'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-format-select' => 'csv',
+      'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-format' => 'csv',
       'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-downloadurl-file-url-type-remote' => 'remote',
       'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-downloadurl-file-url-remote' => $file_url,
     ], 'Save');
@@ -192,7 +192,7 @@ class AdminDatasetFileUploadTest extends BrowserTestBase {
       'edit-field-json-metadata-0-value-keyword-keyword-0' => $keyword_data,
       'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-title' => 'distribution title test',
       'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-description' => 'distribution description test',
-      'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-format-select' => 'csv',
+      'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-format' => 'csv',
       'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-downloadurl-file-url-type-upload' => 'upload',
     ], 'Save');
     $assert->statusCodeEquals(200);

--- a/modules/json_form_widget/tests/src/Functional/AdminDatasetJsonFormTest.php
+++ b/modules/json_form_widget/tests/src/Functional/AdminDatasetJsonFormTest.php
@@ -62,12 +62,11 @@ class AdminDatasetJsonFormTest extends BrowserTestBase {
       );
     }
 
-    // 07_admin_dataset_json_form.spec.js : License and format fields are
+    // 07_admin_dataset_json_form.spec.js : License field is
     // select_or_other elements in dataset form.
     // These select elements have an '- Other -' option.
     foreach ([
       "#edit-field-json-metadata-0-value-license-select option[value='select_or_other']",
-      "#edit-field-json-metadata-0-value-distribution-distribution-0-distribution-format-select option[value='select_or_other']",
     ] as $locator) {
       $item = $page->find('css', $locator);
       $this->assertEquals('select_or_other', $item->getValue());
@@ -76,9 +75,24 @@ class AdminDatasetJsonFormTest extends BrowserTestBase {
     // fields.
     foreach ([
       '#edit-field-json-metadata-0-value-license-other.form-url',
-      '#edit-field-json-metadata-0-value-distribution-distribution-0-distribution-format-other.form-text',
     ] as $locator) {
       $this->assertNotNull($page->find('css', $locator));
+    }
+
+    // 07_admin_dataset_json_form.spec.js : format field is select elements in dataset form.
+    // These select elements have options, but do not have an '- Other -' option.
+    foreach ([
+      "#edit-field-json-metadata-0-value-distribution-distribution-0-distribution-format option",
+    ] as $locator) {
+      $item = $page->find('css', $locator);
+      $this->assertNotEquals('select', $item->getValue());
+    }
+    // Assert the nonexistence of the 'other' text element for select_or_other
+    // fields.
+    foreach ([
+      '#edit-field-json-metadata-0-value-distribution-distribution-0-distribution-format.form-text',
+    ] as $locator) {
+      $this->assertNull($page->find('css', $locator));
     }
 
     // 07_admin_dataset_json_form.spec.js : User can create and edit a dataset
@@ -145,7 +159,7 @@ class AdminDatasetJsonFormTest extends BrowserTestBase {
       'edit-field-json-metadata-0-value-accrualperiodicity' => 'R/P1Y',
       'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-title' => 'DKANTEST distribution title text',
       'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-description' => 'DKANTEST distribution description text',
-      'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-format-select' => 'csv',
+      'edit-field-json-metadata-0-value-distribution-distribution-0-distribution-format' => 'csv',
     ], 'Save');
     $assert->statusCodeEquals(200);
     $assert->pageTextContains('Data ' . $dataset_new_title . ' has been updated.');

--- a/schema/collections/dataset.ui.json
+++ b/schema/collections/dataset.ui.json
@@ -143,7 +143,7 @@
         "ui:options": {
           "title": "File Format",
           "widget": "list",
-          "type": "select_other",
+          "type": "select",
           "other_type": "textfield",
           "description": "CSV files must be encoded in UTF-8 format to be imported correctly. UTF-8 encoding is an established standard that provides optimal compatibility between applications and operating systems. Note that Excel provides a <strong>CSV UTF-8</strong> option when saving data files.",
           "source": {

--- a/schema/collections/dataset.ui.json
+++ b/schema/collections/dataset.ui.json
@@ -148,6 +148,7 @@
           "description": "CSV files must be encoded in UTF-8 format to be imported correctly. UTF-8 encoding is an established standard that provides optimal compatibility between applications and operating systems. Note that Excel provides a <strong>CSV UTF-8</strong> option when saving data files.",
           "source": {
             "enum": [
+              "",
               "arcgis",
               "csv",
               "esri rest",

--- a/schema/collections/distribution.json
+++ b/schema/collections/distribution.json
@@ -39,6 +39,7 @@
           "description": "A human-readable description of the file format of a distribution (i.e. csv, pdf, xml, kml, etc.).",
           "type": "string",
           "examples": [
+            "",
             "arcgis",
             "csv",
             "esri rest",


### PR DESCRIPTION
(15468)
Distribution File Format select list should not allow publishers to upload ANY file format, the allowed types should be set in the schema by the site maintainer. 

## Describe your changes
Changed Distribution Format list type from 'select_other' to select.

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
