### PR TITLE
Allow unpublished items in form

### DIFF
--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -219,7 +219,7 @@ class WidgetRouter implements ContainerInjectionInterface {
    */
   public function getOptionsFromMetastore(mixed $source, mixed $titleProperty = FALSE) {
     $options = [];
-    $metastore_items = $this->metastore->getAll($source->metastoreSchema, NULL, NULL TRUE);
+    $metastore_items = $this->metastore->getAll($source->metastoreSchema, NULL, NULL, TRUE);
     foreach ($metastore_items as $item) {
       $item = json_decode($item);
       $title = $this->metastoreOptionTitle($item, $titleProperty);

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -219,7 +219,7 @@ class WidgetRouter implements ContainerInjectionInterface {
    */
   public function getOptionsFromMetastore(mixed $source, mixed $titleProperty = FALSE) {
     $options = [];
-    $metastore_items = $this->metastore->getAll($source->metastoreSchema);
+    $metastore_items = $this->metastore->getAll($source->metastoreSchema, NULL, NULL TRUE);
     foreach ($metastore_items as $item) {
       $item = json_decode($item);
       $title = $this->metastoreOptionTitle($item, $titleProperty);


### PR DESCRIPTION
## Describe your changes

Currently, if a keyword or other child item is unpublished, it will be invisible to the json_form_widget's autocomplete. This means if you create a dataset that is unpublished, then edit it again, the keywords will be missing from the form, and when you save will be removed.

## QA Steps

- [ ] Set default workflow state to "draft".
- [ ] Create a dataset, add new keywords that were not previously in the autocomplete
- [ ] Edit the dataset again, confirm that the keywords are still populated in the form.

## Notes

This becomes unnecessary after the second save, when all child items are published. That workflow doesn't make a lot of sense though, and there is a [todo](https://github.com/GetDKAN/dkan/blob/2.19.8/modules/metastore/src/Reference/Referencer.php#L449) to change that as well.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
