### PR TITLE
Refactor datastore events to use DataResource with the event instead of id and version

### DIFF
--- a/modules/datastore/src/Events/DatastoreEventBase.php
+++ b/modules/datastore/src/Events/DatastoreEventBase.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\datastore\Events;
 
+use Drupal\common\DataResource;
 use Drupal\Component\EventDispatcher\Event;
 
 /**
@@ -10,44 +11,27 @@ use Drupal\Component\EventDispatcher\Event;
 class DatastoreEventBase extends Event implements DatastoreEventInterface {
 
   /**
-   * The datastore identifier.
+   * The DataResource object for the event.
    *
-   * @var string
+   * @var \Drupal\common\DataResource
    */
-  private string $identifier;
-
-  /**
-   * The datastore version.
-   *
-   * @var string|null
-   */
-  private ?string $version;
+  protected DataResource $dataResource;
 
   /**
    * Constructor.
    *
-   * @param string $identifier
-   *   The datastore identifier.
-   * @param string|null $version
-   *   (Optional) The datastore version.
+   * @param \Drupal\common\DataResource $data_resource
+   *   The DataResource object for the event.
    */
-  public function __construct(string $identifier, ?string $version) {
-    $this->identifier = $identifier;
-    $this->version = $version;
+  public function __construct(DataResource $data_resource) {
+    $this->dataResource = $data_resource;
   }
 
   /**
    * {@inheritDoc}
    */
-  public function getIdentifier(): string {
-    return $this->identifier;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  public function getVersion(): ?string {
-    return $this->version;
+  public function getDataResource(): DataResource {
+    return $this->dataResource;
   }
 
 }

--- a/modules/datastore/src/Events/DatastoreEventInterface.php
+++ b/modules/datastore/src/Events/DatastoreEventInterface.php
@@ -2,25 +2,19 @@
 
 namespace Drupal\datastore\Events;
 
+use Drupal\common\DataResource;
+
 /**
  * Event base class for the datastore module.
  */
 interface DatastoreEventInterface {
 
   /**
-   * Get the datastore identifier.
+   * Get the DataResource object for the event.
    *
-   * @return string
-   *   The datastore identifier.
+   * @return \Drupal\common\DataResource
+   *   DataResource object related to the datastore in question.
    */
-  public function getIdentifier(): string;
-
-  /**
-   * Get the datastore version.
-   *
-   * @return string|null
-   *   The datastore version, or NULL if none was provided.
-   */
-  public function getVersion(): ?string;
+  public function getDataResource(): DataResource;
 
 }

--- a/modules/datastore/src/Service/ImportService.php
+++ b/modules/datastore/src/Service/ImportService.php
@@ -162,7 +162,7 @@ class ImportService {
     elseif ($result->getStatus() === Result::DONE) {
       // Dispatch the import event.
       $this->eventDispatcher->dispatch(
-        new DatastoreImportedEvent($data_resource->getIdentifier(), $data_resource->getVersion()),
+        new DatastoreImportedEvent($data_resource),
         self::EVENT_DATASTORE_IMPORTED
       );
       // Queue the imported resource for post-import processing.

--- a/modules/datastore/tests/src/Kernel/DatastoreServiceEventsTest.php
+++ b/modules/datastore/tests/src/Kernel/DatastoreServiceEventsTest.php
@@ -154,12 +154,12 @@ class DatastoreServiceEventsTest extends KernelTestBase implements EventSubscrib
       array_keys($this->events)
     );
 
-    // Both events will be DatastoreEventInterface, so we can use getters for
-    // our values.
+    // Assert that all of our events can return a DataResource object. We
+    // can't assert against the id or version because our datastore doesn't
+    // exist, so the mapper can't find it.
     /** @var \Drupal\datastore\Events\DatastoreEventInterface $event */
     foreach ($this->events as $event) {
-      $this->assertEquals('id', $event->getIdentifier());
-      $this->assertEquals('ver', $event->getVersion());
+      $this->assertInstanceOf(DataResource::class, $event->getDataResource());
     }
   }
 

--- a/modules/datastore/tests/src/Kernel/DatastoreServiceEventsTest.php
+++ b/modules/datastore/tests/src/Kernel/DatastoreServiceEventsTest.php
@@ -17,7 +17,6 @@ use Drupal\datastore\Storage\ImportJobStoreFactory;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * @covers \Drupal\datastore\DatastoreService
  * @coversDefaultClass \Drupal\datastore\DatastoreService
  *
  * @group dkan
@@ -79,9 +78,6 @@ class DatastoreServiceEventsTest extends KernelTestBase implements EventSubscrib
     $container->set('testing.datastore_drop_subscriber', $this);
   }
 
-  /**
-   * @covers ::drop
-   */
   public function testEvents() {
     // Mock a data resource.
     $data_resource = $this->getMockBuilder(DataResource::class)

--- a/modules/datastore/tests/src/Kernel/Service/ImportServiceEventsTest.php
+++ b/modules/datastore/tests/src/Kernel/Service/ImportServiceEventsTest.php
@@ -14,7 +14,6 @@ use Procrastinator\Result;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * @covers \Drupal\datastore\Service\ImportService
  * @coversDefaultClass \Drupal\datastore\Service\ImportService
  *
  * @group dkan
@@ -63,9 +62,6 @@ class ImportServiceEventsTest extends KernelTestBase implements EventSubscriberI
     $container->set('testing.datastore_imported_subscriber', $this);
   }
 
-  /**
-   * @covers ::import
-   */
   public function testEvents() {
     // Our result will be DONE.
     $result = new Result();

--- a/modules/datastore/tests/src/Kernel/Service/ImportServiceEventsTest.php
+++ b/modules/datastore/tests/src/Kernel/Service/ImportServiceEventsTest.php
@@ -108,8 +108,12 @@ class ImportServiceEventsTest extends KernelTestBase implements EventSubscriberI
     $this->assertCount(1, $this->events);
     /** @var \Drupal\datastore\Events\DatastoreImportedEvent $event */
     $event = reset($this->events);
-    $this->assertNotEmpty($event->getIdentifier());
-    $this->assertNotEmpty($event->getVersion());
+    $this->assertInstanceOf(
+      DataResource::class,
+      $data_resource = $event->getDataResource()
+    );
+    $this->assertNotEmpty($data_resource->getIdentifier());
+    $this->assertNotEmpty($data_resource->getVersion());
   }
 
 }


### PR DESCRIPTION
Fixes [issue#]

## Describe your changes

Fast-follow on https://github.com/GetDKAN/dkan/pull/4312

Changes our datastore pre-drop, drop, and import events to use a DataResource object instead of requiring the consumer to rebuild one anyway.

## QA Steps

- [x] Automated tests exists to support maintenance.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
