### PR TITLE
Validate pattern matching in StringHelper.

### DIFF
--- a/modules/json_form_widget/src/StringHelper.php
+++ b/modules/json_form_widget/src/StringHelper.php
@@ -6,6 +6,7 @@ use Drupal\Component\Utility\EmailValidator;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element\FormElement;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -86,6 +87,10 @@ class StringHelper implements ContainerInjectionInterface {
 
     if ($element['#type'] == 'textfield') {
       $element['#maxlength'] = $property->maxLength ?? self::TEXTFIELD_MAXLENGTH;
+      if (!empty($definition['schema']->pattern)) {
+        $element['#pattern'] = $definition['schema']->pattern;
+        $element['#element_validate'][] = [$this, 'validatePattern'];
+      }
     }
 
     // Add extra validate if element type is email.
@@ -163,6 +168,13 @@ class StringHelper implements ContainerInjectionInterface {
     if ($value !== '' && !$this->emailValidator->isValid($value) || !filter_var($value, FILTER_VALIDATE_EMAIL)) {
       $form_state->setError($element, $this->t('The email address %mail is not valid.', ['%mail' => $value]));
     }
+  }
+
+  /**
+   * Validate string pattern.
+   */
+  public function validatePattern(&$element, FormStateInterface $form_state, &$complete_form) {
+    FormElement::validatePattern($element, $form_state, $complete_form);
   }
 
 }

--- a/modules/json_form_widget/src/StringHelper.php
+++ b/modules/json_form_widget/src/StringHelper.php
@@ -86,11 +86,7 @@ class StringHelper implements ContainerInjectionInterface {
     }
 
     if ($element['#type'] == 'textfield') {
-      $element['#maxlength'] = $property->maxLength ?? self::TEXTFIELD_MAXLENGTH;
-      if (!empty($definition['schema']->pattern)) {
-        $element['#pattern'] = $definition['schema']->pattern;
-        $element['#element_validate'][] = [$this, 'validatePattern'];
-      }
+      $this->addTextFieldAttributes($element, $property);
     }
 
     // Add extra validate if element type is email.
@@ -175,6 +171,17 @@ class StringHelper implements ContainerInjectionInterface {
    */
   public function validatePattern(&$element, FormStateInterface $form_state, &$complete_form) {
     FormElement::validatePattern($element, $form_state, $complete_form);
+  }
+
+  /**
+   * Add maxlength and regex pattern, if any, to text field.
+   */
+  public function addTextFieldAttributes(array &$element, \stdClass $property) {
+    $element['#maxlength'] = $property->maxLength ?? self::TEXTFIELD_MAXLENGTH;
+    if (!empty($property->pattern)) {
+      $element['#pattern'] = $property->pattern;
+      $element['#element_validate'][] = [$this, 'validatePattern'];
+    }
   }
 
 }


### PR DESCRIPTION
8766

## Describe your changes
Added pattern validation to StringHelper.php, so that error is displayed only on the relevant field

## QA Steps

- [ ] Edit a dataset with a distribution
- [ ] Enter a 'Data Dictionary Type' value with a number or capital letter and save the dataset.
- [ ] Verify that the resulting error message is associated with the Data Dictionary Type field


## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
