### PR TITLE
Stop passing empty values to retrieveDownloadUrlFromResourceMapper

### DIFF
--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -189,11 +189,10 @@ class LifeCycle {
 
     $downloadUrl = $metadata->data->downloadURL;
 
-    if (!empty($downloadUrl) && !filter_var($downloadUrl, FILTER_VALIDATE_URL)) {
-      $resourceIdentifier = $downloadUrl;
+    if (!empty($downloadUrl) && filter_var($downloadUrl, FILTER_VALIDATE_URL) === FALSE) {
       $ref = NULL;
       $original = NULL;
-      [$ref, $original] = $this->retrieveDownloadUrlFromResourceMapper($resourceIdentifier);
+      [$ref, $original] = $this->retrieveDownloadUrlFromResourceMapper($downloadUrl);
 
       $downloadUrl = $original ?? "";
 

--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -189,7 +189,7 @@ class LifeCycle {
 
     $downloadUrl = $metadata->data->downloadURL;
 
-    if (isset($downloadUrl) && !filter_var($downloadUrl, FILTER_VALIDATE_URL)) {
+    if (!empty($downloadUrl) && !filter_var($downloadUrl, FILTER_VALIDATE_URL)) {
       $resourceIdentifier = $downloadUrl;
       $ref = NULL;
       $original = NULL;


### PR DESCRIPTION
This is annoying
<img width="387" alt="Screenshot 2024-11-14 at 7 53 43 PM" src="https://github.com/user-attachments/assets/c3816180-21c6-40bf-a6bf-11cb16115b11">

When removing old revisions, many nodes without downloadUrls were getting passed to LifeCycle::distributionLoad
which then calls retrieveDownloadUrlFromResourceMapper on non-existent $resourceIdentifier values.

## Describe your changes
Changing the check from `isset` to `!empty` avoids sending non-distribution nodes through the process

## Steps to reproduce

- [ ] Add a logger in `distributionLoad` to confirm empty $resourceIdentifier values are being sent through retrieveDownloadUrlFromResourceMapper
<img width="961" alt="Screenshot 2024-11-14 at 8 01 33 PM" src="https://github.com/user-attachments/assets/30f91a9e-1a2f-4741-bbdb-65191bbb5a3a">
 

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
