### PR TITLE
Handle missing resource when dropping a datastore 

### DIFF
--- a/modules/datastore/src/DatastoreService.php
+++ b/modules/datastore/src/DatastoreService.php
@@ -269,22 +269,29 @@ class DatastoreService implements ContainerInjectionInterface {
    */
   public function drop(string $identifier, ?string $version = NULL, bool $remove_local_resource = TRUE) {
     if ($storage = $this->getStorage($identifier, $version)) {
-      $resource = $this->resourceLocalizer->get($identifier, $version);
-      // Dispatch the pre-drop event.
-      $this->eventDispatcher->dispatch(
-        new DatastorePreDropEvent($resource),
-        self::EVENT_DATASTORE_PRE_DROP
-      );
+      $resource = NULL;
+      // If there is no resource from the localizer, we can't send this event.
+      if ($resource = $this->resourceLocalizer->get($identifier, $version)) {
+        // Dispatch the pre-drop event.
+        $this->eventDispatcher->dispatch(
+          new DatastorePreDropEvent($resource),
+          self::EVENT_DATASTORE_PRE_DROP
+        );
+      }
       // Drop.
       $storage->destruct();
-      // Remove the info from the job store.
-      $this->importJobStoreFactory->getInstance()
-        ->remove(md5($resource->getUniqueIdentifier()));
-      // Dispatch the dropped event.
-      $this->eventDispatcher->dispatch(
-        new DatastoreDroppedEvent($resource),
-        self::EVENT_DATASTORE_DROPPED
-      );
+      // If there is no resource we can't remove the jobstore or send the
+      // event.
+      if ($resource) {
+        // Remove the info from the job store.
+        $this->importJobStoreFactory->getInstance()
+          ->remove(md5($resource->getUniqueIdentifier()));
+        // Dispatch the dropped event.
+        $this->eventDispatcher->dispatch(
+          new DatastoreDroppedEvent($resource),
+          self::EVENT_DATASTORE_DROPPED
+        );
+      }
     }
 
     if ($remove_local_resource) {

--- a/modules/datastore/src/DatastoreService.php
+++ b/modules/datastore/src/DatastoreService.php
@@ -270,7 +270,7 @@ class DatastoreService implements ContainerInjectionInterface {
   public function drop(string $identifier, ?string $version = NULL, bool $remove_local_resource = TRUE) {
     if ($storage = $this->getStorage($identifier, $version)) {
       $resource = NULL;
-      // If there is no resource from the localizer, we can't send this event.
+      // Check for the resource before sending the pre-drop event.
       if ($resource = $this->resourceLocalizer->get($identifier, $version)) {
         // Dispatch the pre-drop event.
         $this->eventDispatcher->dispatch(
@@ -280,8 +280,8 @@ class DatastoreService implements ContainerInjectionInterface {
       }
       // Drop.
       $storage->destruct();
-      // If there is no resource we can't remove the jobstore or send the
-      // event.
+      // Check for the resource before removing the job store or sending the
+      // dropped event.
       if ($resource) {
         // Remove the info from the job store.
         $this->importJobStoreFactory->getInstance()


### PR DESCRIPTION
Fixes https://github.com/GetDKAN/dkan/issues/4340

## Describe your changes

Checks whether the resource could be loaded before sending it as an event.

This probably speaks to a larger issue where our resource mapper and the resources they map get out of sync.

There might also be a better way to generate a DataResource object to add to the event than to use the localizer.

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
