### PR TITLE
Moved cache tag invalidation from ImportQueueWorker to ImportService

### DIFF
--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -60,6 +60,7 @@ services:
       - '@dkan.datastore.database_table_factory'
       - '@dkan.datastore.logger_channel'
       - '@event_dispatcher'
+      - '@dkan.metastore.reference_lookup'
 
   dkan.datastore.logger_channel:
     parent: logger.channel_base

--- a/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.services.yml
+++ b/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.services.yml
@@ -7,6 +7,7 @@ services:
       - '@dkan.datastore_mysql_import.database_table_factory'
       - '@dkan.datastore.logger_channel'
       - '@event_dispatcher'
+      - '@dkan.metastore.reference_lookup'
 
   dkan.datastore_mysql_import.database_table_factory:
     class: \Drupal\datastore_mysql_import\Storage\MySqlDatabaseTableFactory

--- a/modules/datastore/modules/datastore_mysql_import/src/Factory/MysqlImportFactory.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Factory/MysqlImportFactory.php
@@ -7,6 +7,7 @@ use Drupal\datastore\Service\ImportService;
 use Drupal\datastore\Storage\ImportJobStoreFactory;
 use Drupal\datastore_mysql_import\Service\MysqlImport;
 use Drupal\datastore_mysql_import\Storage\MySqlDatabaseTableFactory;
+use Drupal\metastore\Reference\ReferenceLookup;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -44,6 +45,13 @@ class MysqlImportFactory implements ImportFactoryInterface {
   protected EventDispatcherInterface $eventDispatcher;
 
   /**
+   * Reference lookup service.
+   *
+   * @var \Drupal\metastore\Reference\ReferenceLookup
+   */
+  protected $referenceLookup;
+
+  /**
    * Constructor.
    */
   public function __construct(
@@ -51,11 +59,13 @@ class MysqlImportFactory implements ImportFactoryInterface {
     MySqlDatabaseTableFactory $databaseTableFactory,
     LoggerInterface $loggerChannel,
     EventDispatcherInterface $eventDispatcher,
+    ReferenceLookup $referenceLookup,
   ) {
     $this->importJobStoreFactory = $importJobStoreFactory;
     $this->databaseTableFactory = $databaseTableFactory;
     $this->logger = $loggerChannel;
     $this->eventDispatcher = $eventDispatcher;
+    $this->referenceLookup = $referenceLookup;
   }
 
   /**
@@ -72,7 +82,8 @@ class MysqlImportFactory implements ImportFactoryInterface {
       $this->importJobStoreFactory,
       $this->databaseTableFactory,
       $this->logger,
-      $this->eventDispatcher
+      $this->eventDispatcher,
+      $this->referenceLookup
     );
     $importer->setImporterClass(MysqlImport::class);
     return $importer;

--- a/modules/datastore/src/Service/Factory/ImportServiceFactory.php
+++ b/modules/datastore/src/Service/Factory/ImportServiceFactory.php
@@ -5,6 +5,7 @@ namespace Drupal\datastore\Service\Factory;
 use Drupal\datastore\Service\ImportService;
 use Drupal\datastore\Storage\DatabaseTableFactory;
 use Drupal\datastore\Storage\ImportJobStoreFactory;
+use Drupal\metastore\Reference\ReferenceLookup;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -42,6 +43,13 @@ class ImportServiceFactory implements ImportFactoryInterface {
   private EventDispatcherInterface $eventDispatcher;
 
   /**
+   * Reference lookup service.
+   *
+   * @var \Drupal\metastore\Reference\ReferenceLookup
+   */
+  protected $referenceLookup;
+
+  /**
    * Constructor.
    */
   public function __construct(
@@ -49,11 +57,13 @@ class ImportServiceFactory implements ImportFactoryInterface {
     DatabaseTableFactory $databaseTableFactory,
     LoggerInterface $loggerChannel,
     EventDispatcherInterface $eventDispatcher,
+    ReferenceLookup $referenceLookup,
   ) {
     $this->importJobStoreFactory = $importJobStoreFactory;
     $this->databaseTableFactory = $databaseTableFactory;
     $this->logger = $loggerChannel;
     $this->eventDispatcher = $eventDispatcher;
+    $this->referenceLookup = $referenceLookup;
   }
 
   /**
@@ -67,6 +77,7 @@ class ImportServiceFactory implements ImportFactoryInterface {
         $this->databaseTableFactory,
         $this->logger,
         $this->eventDispatcher,
+        $this->referenceLookup,
       );
     }
     throw new \Exception("config['resource'] is required");

--- a/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/ImportQueueWorkerTest.php
+++ b/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/ImportQueueWorkerTest.php
@@ -150,7 +150,6 @@ class ImportQueueWorkerTest extends KernelTestBase {
       $this->container->get('config.factory'),
       $this->container->get('dkan.datastore.service'),
       $this->container->get('dkan.datastore.logger_channel'),
-      $this->container->get('dkan.metastore.reference_lookup'),
       $this->container->get('dkan.common.database_connection_factory'),
       $this->container->get('dkan.datastore.database_connection_factory')
     );
@@ -192,7 +191,6 @@ class ImportQueueWorkerTest extends KernelTestBase {
       $this->container->get('config.factory'),
       $this->container->get('dkan.datastore.service'),
       $this->container->get('dkan.datastore.logger_channel'),
-      $this->container->get('dkan.metastore.reference_lookup'),
       $this->container->get('dkan.common.database_connection_factory'),
       $this->container->get('dkan.datastore.database_connection_factory')
     );

--- a/modules/datastore/tests/src/Kernel/Service/ImportServiceEventsTest.php
+++ b/modules/datastore/tests/src/Kernel/Service/ImportServiceEventsTest.php
@@ -22,10 +22,17 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class ImportServiceEventsTest extends KernelTestBase implements EventSubscriberInterface {
 
+  protected $strictConfigSchema = FALSE;
+
   protected static $modules = [
     'common',
     'datastore',
     'metastore',
+    'node',
+    'user',
+    'field',
+    'text',
+    'system',
   ];
 
   /**
@@ -63,6 +70,9 @@ class ImportServiceEventsTest extends KernelTestBase implements EventSubscriberI
   }
 
   public function testEvents() {
+    $this->installEntitySchema('node');
+    $this->installConfig(['node']);
+    $this->installConfig(['metastore']);
     // Our result will be DONE.
     $result = new Result();
     $result->setStatus(Result::DONE);
@@ -85,6 +95,7 @@ class ImportServiceEventsTest extends KernelTestBase implements EventSubscriberI
         $this->container->get('dkan.datastore.database_table_factory'),
         $this->container->get('dkan.datastore.logger_channel'),
         $this->container->get('event_dispatcher'),
+        $this->container->get('dkan.metastore.reference_lookup'),
       ])
       ->onlyMethods(['getImporter', 'getResource'])
       ->getMock();

--- a/modules/datastore/tests/src/Unit/Service/Factory/ImportServiceFactoryTest.php
+++ b/modules/datastore/tests/src/Unit/Service/Factory/ImportServiceFactoryTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\datastore\Unit\Service\Factory;
 use Drupal\datastore\Service\Factory\ImportServiceFactory;
 use Drupal\datastore\Storage\DatabaseTableFactory;
 use Drupal\datastore\Storage\ImportJobStoreFactory;
+use Drupal\metastore\Reference\ReferenceLookup;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -33,7 +34,8 @@ class ImportServiceFactoryTest extends TestCase {
         ->disableOriginalConstructor()
         ->getMock(),
       $this->createStub(LoggerInterface::class),
-      $this->createStub(EventDispatcherInterface::class)
+      $this->createStub(EventDispatcherInterface::class),
+      $this->createStub(ReferenceLookup::class)
     );
 
     $this->expectException(\Exception::class);


### PR DESCRIPTION
Fixes 19169

## Describe your changes

## QA Steps

### CRON
- [ ] Create a new dataset with a csv file containing the following data [Bike_Lane.csv](https://github.com/user-attachments/files/17836365/Bike_Lane.csv)
- [ ] Confirm the dataset is ready to be imported here /admin/dkan/datastore/status
- [ ] Run ddev drush cron to trigger import
- [ ] Confirm the import worked by navigating to the endpoints like this: example: https://dkan-project.ddev.site/api/1/datastore/query/[_dataset uuid_]/[_distribution index_]
- [ ] Be sure to select 'Last Updated' as a trigger here /admin/dkan/datastore
- [ ] Make a change to the original uploaded file "Bike_Lane" and the last updated date time on the dataset.
- [ ] Run cron twice
- [ ] Confirm the re-import and cache tag invalidation worked by navigating to the endpoints like this: example: https://dkan-project.ddev.site/api/1/datastore/query/[_dataset uuid_]/[_distribution index_] and confirm that the data changed.

### DRUSH
- [ ] Perform the same steps as above but instead of using the cron to import tasks, instead use the provided rush commands to drop and import the dataset.
- [ ] Update the datafile again and run `ddev drush dkan:datastore:drop` and `ddev drush dkan:datastore:import`
- [ ] Confirm the re-import and cache tag invalidation worked by navigating to the endpoints like this: example: https://dkan-project.ddev.site/api/1/datastore/query/[_dataset uuid_]/[_distribution index_] and confirm that the data changed.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
