### PR TITLE
Cache tag invalidation on datastore drop

### DIFF
--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -9,6 +9,7 @@ services:
       - '@dkan.datastore.service.resource_processor.dictionary_enforcer'
       - '@dkan.metastore.resource_mapper'
       - '@event_dispatcher'
+      - '@dkan.metastore.reference_lookup'
 
   dkan.datastore.service.post_import:
     class: \Drupal\datastore\Service\PostImport

--- a/modules/datastore/tests/src/Kernel/DatastoreServiceEventsTest.php
+++ b/modules/datastore/tests/src/Kernel/DatastoreServiceEventsTest.php
@@ -25,10 +25,17 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class DatastoreServiceEventsTest extends KernelTestBase implements EventSubscriberInterface {
 
+  protected $strictConfigSchema = FALSE;
+
   protected static $modules = [
     'common',
     'datastore',
     'metastore',
+    'node',
+    'user',
+    'field',
+    'text',
+    'system',
   ];
 
   /**
@@ -79,6 +86,9 @@ class DatastoreServiceEventsTest extends KernelTestBase implements EventSubscrib
   }
 
   public function testEvents() {
+    $this->installEntitySchema('node');
+    $this->installConfig(['node']);
+    $this->installConfig(['metastore']);
     // Mock a data resource.
     $data_resource = $this->getMockBuilder(DataResource::class)
       ->disableOriginalConstructor()
@@ -130,6 +140,7 @@ class DatastoreServiceEventsTest extends KernelTestBase implements EventSubscrib
         $this->container->get('dkan.datastore.service.resource_processor.dictionary_enforcer'),
         $this->container->get('dkan.metastore.resource_mapper'),
         $this->container->get('event_dispatcher'),
+        $this->container->get('dkan.metastore.reference_lookup'),
       ])
       ->onlyMethods(['getStorage'])
       ->getMock();

--- a/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/ImportQueueWorkerTest.php
+++ b/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/ImportQueueWorkerTest.php
@@ -48,6 +48,7 @@ class ImportQueueWorkerTest extends KernelTestBase {
         $this->container->get('dkan.datastore.service.resource_processor.dictionary_enforcer'),
         $this->container->get('dkan.metastore.resource_mapper'),
         $this->container->get('event_dispatcher'),
+        $this->container->get('dkan.metastore.reference_lookup'),
       ])
       ->onlyMethods(['import'])
       ->getMock();
@@ -95,6 +96,7 @@ class ImportQueueWorkerTest extends KernelTestBase {
         $this->container->get('dkan.datastore.service.resource_processor.dictionary_enforcer'),
         $this->container->get('dkan.metastore.resource_mapper'),
         $this->container->get('event_dispatcher'),
+        $this->container->get('dkan.metastore.reference_lookup'),
       ])
       ->onlyMethods(['import'])
       ->getMock();
@@ -228,6 +230,7 @@ class ImportQueueWorkerTest extends KernelTestBase {
         $this->container->get('dkan.datastore.service.resource_processor.dictionary_enforcer'),
         $this->container->get('dkan.metastore.resource_mapper'),
         $this->container->get('event_dispatcher'),
+        $this->container->get('dkan.metastore.reference_lookup'),
       ])
       ->onlyMethods(['getStorage'])
       ->getMock();

--- a/modules/datastore/tests/src/Unit/DatastoreServiceTest.php
+++ b/modules/datastore/tests/src/Unit/DatastoreServiceTest.php
@@ -15,6 +15,7 @@ use Drupal\datastore\Service\Factory\ImportServiceFactory;
 use Drupal\datastore\Service\ImportService;
 use Drupal\datastore\Service\Info\ImportInfoList;
 use Drupal\datastore\Service\ResourceLocalizer;
+use Drupal\metastore\Reference\ReferenceLookup;
 use Drupal\datastore\Service\ResourceProcessor\DictionaryEnforcer;
 use Drupal\datastore\Storage\DatabaseTable;
 use Drupal\metastore\ResourceMapper;
@@ -69,8 +70,10 @@ class DatastoreServiceTest extends TestCase {
       ->add(ResourceLocalizer::class, 'get', $resource)
       ->add(ResourceMapper::class, 'get', $resource)
       ->add(JobStoreFactory::class, 'getInstance', JobStore::class)
+      ->add(JobStore::class, 'remove', TRUE)
       ->add(ImportJobStoreFactory::class, 'getInstance', JobStore::class)
-      ->add(JobStore::class, 'remove', TRUE);
+      ->add(ReferenceLookup::class, 'getReferencers', [$resource->getIdentifier()])
+      ->add(ReferenceLookup::class, 'invalidateReferencerCacheTags');
 
     $service = DatastoreService::create($mockChain->getMock());
     // These are all valid ways to call drop().
@@ -106,6 +109,7 @@ class DatastoreServiceTest extends TestCase {
       ->add('dkan.datastore.import_job_store_factory', ImportJobStoreFactory::class)
       ->add('dkan.datastore.import_info_list', ImportInfoList::class)
       ->add('dkan.datastore.service.resource_processor.dictionary_enforcer', DictionaryEnforcer::class)
+      ->add('dkan.metastore.reference_lookup', ReferenceLookup::class)
       ->index(0);
 
     return (new Chain($this))

--- a/modules/datastore/tests/src/Unit/Service/DatastoreQueryTest.php
+++ b/modules/datastore/tests/src/Unit/Service/DatastoreQueryTest.php
@@ -28,6 +28,7 @@ use Drupal\metastore\Storage\Data;
 use Drupal\metastore\Storage\DataFactory;
 use Drupal\Tests\common\Unit\Storage\QueryDataProvider as QueryData;
 use Drupal\datastore\Service\ResourceProcessor\DictionaryEnforcer;
+use Drupal\metastore\Reference\ReferenceLookup;
 
 /**
  * @group dkan
@@ -204,6 +205,7 @@ class DatastoreQueryTest extends TestCase {
       ->add('dkan.metastore.storage', DataFactory::class)
       ->add('dkan.datastore.import_info_list', ImportInfoList::class)
       ->add('dkan.datastore.service.resource_processor.dictionary_enforcer', DictionaryEnforcer::class)
+      ->add('dkan.metastore.reference_lookup', ReferenceLookup::class)
       ->index(0);
 
     $resource_metadata = '{"data":{"%Ref:downloadURL":[{"data":{"identifier":"qwerty","version":"uiop"}}]}}';
@@ -223,7 +225,9 @@ class DatastoreQueryTest extends TestCase {
       ->add(DatabaseTable::class, "query", $queryResult, 'DatabaseTableQuery')
       ->add(DatabaseTable::class, "getSchema", ["fields" => ["a" => "a", "b" => "b"]])
       ->add(DatabaseTable::class, "getTableName", "table2")
-      ->add(DatabaseTable::class, "primaryKey", "record_number");
+      ->add(DatabaseTable::class, "primaryKey", "record_number")
+      ->add(ReferenceLookup::class, 'getReferencers', [$resource->getIdentifier()])
+      ->add(ReferenceLookup::class, 'invalidateReferencerCacheTags');
 
   }
 


### PR DESCRIPTION
Fixes [issue#]

## QA Steps

### Test 2.x branch to witness that a drop does not invalidate cache immediately. 

- [ ] Set up vanilla site with 2.x
- [ ] run ddev dkan-sample-content
- [ ] run ddev drush dkan:datastore:import 3a187a87dc6cd47c48b6b4c4785224b7
- [ ] Confirm datastore results: curl https://test1.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0
- [ ] run ddev drush dkan:datastore:drop 3a187a87dc6cd47c48b6b4c4785224b7
- [ ] Confirm that results still appear even though we just dropped it: curl https://test1.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0

### Test this branch to witness that a drop does invalidate cache immediately. 
- [ ] check out this branch.
- [ ] Set up vanilla site
- [ ] run ddev dkan-sample-content
- [ ] run ddev drush dkan:datastore:import 3a187a87dc6cd47c48b6b4c4785224b7
- [ ] Confirm datastore results: curl https://test1.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0
- [ ] run ddev drush dkan:datastore:drop 3a187a87dc6cd47c48b6b4c4785224b7
- [ ] Confirm no datastore results: curl https://test1.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
