### PR TITLE
Upgrade select_or_other to 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "drupal/moderated_content_bulk_publish": "~2.0.20",
         "drupal/search_api": "^1.15",
         "drupal/select2": "^1.13",
-        "drupal/select_or_other": "^4.1.0",
+        "drupal/select_or_other": "^4.2.0",
         "drupal/views_bulk_operations": "^4.0",
         "ezyang/htmlpurifier": "^4.11",
         "fmizzell/maquina": "^1.1.1",


### PR DESCRIPTION
See 23561

## Describe your changes
https://www.drupal.org/project/select_or_other
4.1.x version no longer supported.

## QA Steps

- [ ] Check status report and confirm no warnings about unsupported modules

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
