### PR TITLE
Tests for dropping datastore with missing resources

### DIFF
--- a/modules/datastore/src/DatastoreService.php
+++ b/modules/datastore/src/DatastoreService.php
@@ -312,8 +312,7 @@ class DatastoreService implements ContainerInjectionInterface {
     }
 
     // Invalidate cache tag.
-    $uid = $resource->getIdentifier() . '__' . $resource->getVersion();
-    $this->invalidateCacheTags($uid . '__source');
+    $this->invalidateCacheTags($identifier . '__' . $version . '__source');
   }
 
   /**

--- a/modules/datastore/tests/src/Kernel/DatastoreServiceTest.php
+++ b/modules/datastore/tests/src/Kernel/DatastoreServiceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\datastore\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\common\Storage\DatabaseTableInterface;
+use Drupal\datastore\DatastoreService;
+use Drupal\datastore\Service\ResourceLocalizer;
+
+/**
+ * @coversDefaultClass \Drupal\datastore\DatastoreService
+ *
+ * @group dkan
+ * @group datastore
+ * @group kernel
+ */
+class DatastoreServiceTest extends KernelTestBase {
+
+  protected $strictConfigSchema = FALSE;
+
+  protected static $modules = [
+    'common',
+    'datastore',
+    'metastore',
+  ];
+
+  /**
+   * @covers ::drop
+   *
+   * It's possible for drop() to receive an id and version that yield a null
+   * resource object from the resource localizer, even though there is a valid
+   * storage object. Therefore, we have to test that drop() can deal with that
+   * scenario.
+   */
+  public function testNullResource() {
+    $this->installEntitySchema('resource_mapping');
+
+    // Mock the resource localizer service so it returns NULL.
+    $resource_localizer = $this->getMockBuilder(ResourceLocalizer::class)
+      ->setConstructorArgs([
+        $this->container->get('dkan.metastore.resource_mapper'),
+        $this->container->get('dkan.common.file_fetcher'),
+        $this->container->get('dkan.common.drupal_files'),
+        $this->container->get('dkan.common.filefetcher_job_store_factory'),
+        $this->container->get('queue'),
+      ])
+      ->onlyMethods(['get'])
+      ->getMock();
+    $resource_localizer->expects($this->any())
+      ->method('get')
+      // We always return NULL.
+      ->willReturn(NULL);
+
+    $this->container->set('dkan.datastore.service.resource_localizer', $resource_localizer);
+
+    // Mock the datastore service so we can create a stub storage object.
+    $datastore_service = $this->getMockBuilder(DatastoreService::class)
+      ->setConstructorArgs([
+        $this->container->get('dkan.datastore.service.resource_localizer'),
+        $this->container->get('dkan.datastore.service.factory.import'),
+        $this->container->get('queue'),
+        $this->container->get('dkan.datastore.import_job_store_factory'),
+        $this->container->get('dkan.datastore.service.resource_processor.dictionary_enforcer'),
+        $this->container->get('dkan.metastore.resource_mapper'),
+        $this->container->get('event_dispatcher'),
+        $this->container->get('dkan.metastore.reference_lookup'),
+      ])
+      ->onlyMethods(['getStorage', 'invalidateCacheTags'])
+      ->getMock();
+    $datastore_service->expects($this->once())
+      ->method('getStorage')
+      ->willReturn($this->createStub(DatabaseTableInterface::class));
+    // Mock invalidateCacheTags() to reduce dependencies.
+    $datastore_service->expects($this->once())
+      ->method('invalidateCacheTags');
+
+    $datastore_service->drop('id', 'version');
+  }
+
+}

--- a/modules/datastore/tests/src/Kernel/DatastoreServiceTest.php
+++ b/modules/datastore/tests/src/Kernel/DatastoreServiceTest.php
@@ -32,7 +32,7 @@ class DatastoreServiceTest extends KernelTestBase {
    * It's possible for drop() to receive an id and version that yield a null
    * resource object from the resource localizer, even though there is a valid
    * storage object. Therefore, we have to test that drop() can deal with that
-   * scenario.
+   * situation.
    */
   public function testNullResource() {
     $this->installEntitySchema('resource_mapping');


### PR DESCRIPTION


Fixes #4340 

## Describe your changes

Doesn't use `$resource` in code where it's not safety-checked.

Adds a test.

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
