### PR TITLE
Update matrix to target PHP 8.3, Drupal 10.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,24 +230,24 @@ workflows:
     jobs:
       - cypress:
           name: install_test_cypress
-          dkan_recommended_branch: '10.2.x-dev'
+          dkan_recommended_branch: '10.3.x-dev'
       - phpunit:
-          name: 'Install target (Drupal 10.2, PHP 8.3)'
+          name: 'Install target (Drupal 10.3, PHP 8.3)'
           report_coverage: true
           matrix:
             parameters:
-              dkan_recommended_branch: ['10.2.x-dev']
+              dkan_recommended_branch: ['10.3.x-dev']
               php_version: [ '8.3' ]
       - phpunit:
           matrix:
             parameters:
               dkan_recommended_branch: [ '10.3.x-dev']
-              php_version: [ '8.3' ]
+              php_version: [ '8.1', '8.2' ]
       - phpunit:
           matrix:
             parameters:
               dkan_recommended_branch: [ '10.2.x-dev']
-              php_version: [ '8.1', '8.2' ]
+              php_version: [ '8.2' ]
       - phpunit:
           matrix:
             parameters:
@@ -260,9 +260,9 @@ workflows:
           upgrade: true
           dkan_recommended_branch: '10.2.x-dev'
       - phpunit:
-          name: 'Upgrade target (Drupal 10.2, PHP 8.2)'
+          name: 'Upgrade target (Drupal 10.3, PHP 8.3)'
           upgrade: true
           matrix:
             parameters:
-              dkan_recommended_branch: [ '10.2.x-dev']
-              php_version: [ '8.2' ]
+              dkan_recommended_branch: [ '10.3.x-dev']
+              php_version: [ '8.3' ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
 
   cypress:
     machine:
-      image: default
+      image: ubuntu-2204:current
     parallelism: 4
     parameters:
       php_version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,12 +247,7 @@ workflows:
           matrix:
             parameters:
               dkan_recommended_branch: [ '10.2.x-dev']
-              php_version: [ '8.2' ]
-      - phpunit:
-          matrix:
-            parameters:
-              dkan_recommended_branch: [ '10.1.x-dev']
-              php_version: [ '8.2' ]
+              php_version: [ '8.2', '8.3' ]
   upgrade_and_test:
     jobs:
       - cypress:


### PR DESCRIPTION
The target and matrix are a bit out of date. We now target 10.3/8.3, and the matrix tests Drupal 10.3 against PHP 8.2 and 8.1, then Drupal 10.2 and 10.1 against 8.2 only.

~Note: Not sure we should even be testing 10.1 anymore?~ Update: testing for 10.1 removed from pipeline matrix.