### PR TITLE
Provide text_format render element in JSON Form Widget

### DIFF
--- a/modules/json_form_widget/README.md
+++ b/modules/json_form_widget/README.md
@@ -154,7 +154,7 @@ UI options:
         "widget": "textarea",
         "rows": 5,
         "description": "Description (e.g., an abstract) with sufficient detail to enable a user to quickly understand whether the asset is of interest.",
-        "textFormat": "html
+        "textFormat": "html"
       }
     },
 

--- a/modules/json_form_widget/README.md
+++ b/modules/json_form_widget/README.md
@@ -162,7 +162,9 @@ UI options:
 - textFormat: html
   - This can be the machine name of any Drupal text format you have configured in your system
 
-Note that using the `textFormat` property will not affect how the field is rendered; you must handle this in your decoupled frontend or by overriding the node--data twig template or `metastore_preprocess_node__data()` method in metastore.theme.inc. See the [Theming Drupal](https://www.drupal.org/docs/develop/theming-drupal) guide for more information.
+You can use `textFormat` to add a WYSIWYG or other Drupal text editor plugin to your dataset form. Just enable the modules you need and assign the editor to your text format in Drupal at /admin/config/content/formats.
+
+ Note that using the `textFormat` property will not affect how the field is rendered; you must handle this in your decoupled frontend or by overriding the node--data twig template or `metastore_preprocess_node__data()` method in metastore.theme.inc. See the [Theming Drupal](https://www.drupal.org/docs/develop/theming-drupal) guide for more information.
 
 **Form Element:**
 

--- a/modules/json_form_widget/README.md
+++ b/modules/json_form_widget/README.md
@@ -136,6 +136,34 @@ UI options:
   - The text area has a height of 5 rows
 - description
 
+### Formatted Text Area
+
+**Schema File Example:**
+
+    "description": {
+      "title": "Description",
+      "description": "Human-readable description (e.g., an abstract) with sufficient detail to enable a user to quickly understand whether the asset is of interest.",
+      "type": "string",
+      "minLength": 1
+    },
+
+**UI Schema File Example:**
+
+    "description": {
+      "ui:options": {
+        "widget": "textarea",
+        "rows": 5,
+        "description": "Description (e.g., an abstract) with sufficient detail to enable a user to quickly understand whether the asset is of interest.",
+        "textFormat": "html
+      }
+    },
+
+UI options:
+- textFormat: html
+  - This can be the machine name of any Drupal text format you have configured in your system
+
+Note that using the `textFormat` property will not affect how the field is rendered; you must handle this in your decoupled frontend or by overriding the node--data twig template or `metastore_preprocess_node__data()` method in metastore.theme.inc. See the [Theming Drupal](https://www.drupal.org/docs/develop/theming-drupal) guide for more information.
+
 **Form Element:**
 
 ![Screenshot of a "Description" Drupal form field with a description of "Description (e.g., an abstract) with sufficient detail to enable a user to quickly understand whether the asset is of interest." used to show how a "textarea" field can be created using the JSON Form Widget module.](https://dkan-documentation-files.s3.us-east-2.amazonaws.com/dkan2/json_form_widget/string-textarea.png)

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -51,7 +51,7 @@ class ValueHandler {
     if (isset($formValues[$property]['select'])) {
       return $formValues[$property][0] ?? NULL;
     }
-    // Handle text_format
+    // Handle text_format.
     if (isset($formValues[$property]['value'])) {
       return $formValues[$property]['value'];
     }

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -51,6 +51,10 @@ class ValueHandler {
     if (isset($formValues[$property]['select'])) {
       return $formValues[$property][0] ?? NULL;
     }
+    // Handle text_format
+    if (isset($formValues[$property]['value'])) {
+      return $formValues[$property]['value'];
+    }
     return !empty($formValues[$property]) && is_string($formValues[$property]) ? $this->cleanSelectId($formValues[$property]) : FALSE;
   }
 

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -41,21 +41,25 @@ class ValueHandler {
    * Flatten values for string properties.
    */
   public function handleStringValues($formValues, $property) {
+    $return = FALSE;
     if (isset($formValues[$property]) && $formValues[$property] instanceof DrupalDateTime) {
-      return $formValues[$property]->format('c', ['timezone' => 'UTC']);
+      $return = $formValues[$property]->format('c', ['timezone' => 'UTC']);
     }
-    if (!empty($formValues[$property]) && isset($formValues[$property]['date_range'])) {
-      return $formValues[$property]['date_range'];
+    elseif (!empty($formValues[$property]) && isset($formValues[$property]['date_range'])) {
+      $return = $formValues[$property]['date_range'];
     }
     // Handle select_or_other_select.
-    if (isset($formValues[$property]['select'])) {
-      return $formValues[$property][0] ?? NULL;
+    elseif (isset($formValues[$property]['select'])) {
+      $return = $formValues[$property][0] ?? NULL;
     }
     // Handle text_format.
-    if (isset($formValues[$property]['value'])) {
-      return $formValues[$property]['value'];
+    elseif (isset($formValues[$property]['value'])) {
+      $return = $formValues[$property]['value'];
     }
-    return !empty($formValues[$property]) && is_string($formValues[$property]) ? $this->cleanSelectId($formValues[$property]) : FALSE;
+    elseif (!empty($formValues[$property]) && is_string($formValues[$property])) {
+      $return = $this->cleanSelectId($formValues[$property]);
+    }
+    return $return;
   }
 
   /**

--- a/modules/json_form_widget/src/ValueHandler.php
+++ b/modules/json_form_widget/src/ValueHandler.php
@@ -41,25 +41,20 @@ class ValueHandler {
    * Flatten values for string properties.
    */
   public function handleStringValues($formValues, $property) {
-    $return = FALSE;
-    if (isset($formValues[$property]) && $formValues[$property] instanceof DrupalDateTime) {
-      $return = $formValues[$property]->format('c', ['timezone' => 'UTC']);
+
+    if (!isset($formValues[$property])) {
+      return FALSE;
     }
-    elseif (!empty($formValues[$property]) && isset($formValues[$property]['date_range'])) {
-      $return = $formValues[$property]['date_range'];
-    }
-    // Handle select_or_other_select.
-    elseif (isset($formValues[$property]['select'])) {
-      $return = $formValues[$property][0] ?? NULL;
-    }
-    // Handle text_format.
-    elseif (isset($formValues[$property]['value'])) {
-      $return = $formValues[$property]['value'];
-    }
-    elseif (!empty($formValues[$property]) && is_string($formValues[$property])) {
-      $return = $this->cleanSelectId($formValues[$property]);
-    }
-    return $return;
+
+    return match (TRUE) {
+      $formValues[$property] instanceof DrupalDateTime => $formValues[$property]->format('c', ['timezone' => 'UTC']),
+      isset($formValues[$property]['date_range']) => $formValues[$property]['date_range'],
+      isset($formValues[$property]['select']) => $formValues[$property][0] ?? NULL,
+      isset($formValues[$property]['value']) => $formValues[$property]['value'],
+      is_string($formValues[$property] ?? NULL) => $this->cleanSelectId($formValues[$property]),
+      default => FALSE,
+    };
+
   }
 
   /**

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -321,6 +321,7 @@ class WidgetRouter implements ContainerInjectionInterface {
    */
   public function handleTextareaElement(mixed $spec, array $element) {
     $element['#type'] = 'textarea';
+    unset($element['#maxlength']);
     if (isset($spec->text_format)) {
       $element['#type'] = 'text_format';
       $element['#format'] = $spec->text_format;

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -321,7 +321,13 @@ class WidgetRouter implements ContainerInjectionInterface {
    */
   public function handleTextareaElement(mixed $spec, array $element) {
     $element['#type'] = 'textarea';
-    unset($element['#maxlength']);
+    if ($spec->text_format) {
+      $element['#type'] = 'text_format';
+      $element['#format'] = $spec->text_format;
+      $element['#allowed_formats'] = [
+        $spec->text_format
+      ];
+    }
     if (isset($spec->rows)) {
       $element['#rows'] = $spec->rows;
     }

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -322,11 +322,11 @@ class WidgetRouter implements ContainerInjectionInterface {
   public function handleTextareaElement(mixed $spec, array $element) {
     $element['#type'] = 'textarea';
     unset($element['#maxlength']);
-    if (isset($spec->text_format)) {
+    if (isset($spec->textFormat)) {
       $element['#type'] = 'text_format';
-      $element['#format'] = $spec->text_format;
+      $element['#format'] = $spec->textFormat;
       $element['#allowed_formats'] = [
-        $spec->text_format,
+        $spec->textFormat,
       ];
     }
     if (isset($spec->rows)) {

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -321,7 +321,7 @@ class WidgetRouter implements ContainerInjectionInterface {
    */
   public function handleTextareaElement(mixed $spec, array $element) {
     $element['#type'] = 'textarea';
-    if ($spec->text_format) {
+    if (isset($spec->text_format)) {
       $element['#type'] = 'text_format';
       $element['#format'] = $spec->text_format;
       $element['#allowed_formats'] = [

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -325,7 +325,7 @@ class WidgetRouter implements ContainerInjectionInterface {
       $element['#type'] = 'text_format';
       $element['#format'] = $spec->text_format;
       $element['#allowed_formats'] = [
-        $spec->text_format
+        $spec->text_format,
       ];
     }
     if (isset($spec->rows)) {

--- a/modules/json_form_widget/tests/src/Unit/StringHelperTest.php
+++ b/modules/json_form_widget/tests/src/Unit/StringHelperTest.php
@@ -89,16 +89,7 @@ class StringHelperTest extends TestCase {
       'name' => 'hasEmail',
     ];
 
-    $options = (new Options())
-      ->add('string_translation', TranslationManager::class)
-      ->add('email.validator', EmailValidator::class)
-      ->index(0);
-
-    $container_chain = (new Chain($this))
-      ->add(Container::class, 'get', $options)
-      ->add(EmailValidator::class, 'isValid', TRUE);
-
-    $string_helper = StringHelper::create($container_chain->getMock());
+    $string_helper = new StringHelper(new EmailValidator());
     $field_type_router = $this->createMock(FieldTypeRouter::class);
     $field_type_router->method('getSchema')->willReturn((object) [
       'type' => 'object',

--- a/modules/json_form_widget/tests/src/Unit/StringHelperTest.php
+++ b/modules/json_form_widget/tests/src/Unit/StringHelperTest.php
@@ -8,6 +8,8 @@ use Drupal\Component\DependencyInjection\Container;
 use Drupal\Component\Utility\EmailValidator;
 use Drupal\Core\Form\FormState;
 use Drupal\Core\StringTranslation\TranslationManager;
+use Drupal\field\Plugin\migrate\source\d6\Field;
+use Drupal\json_form_widget\FieldTypeRouter;
 use Drupal\json_form_widget\StringHelper;
 use MockChain\Options;
 
@@ -71,6 +73,46 @@ class StringHelperTest extends TestCase {
     $element["#value"] = "test@test.com";
     $string_helper->validateEmail($element, $form_state, $form);
     $this->assertEmpty($form_state->getErrors());
+  }
+
+  /**
+   * Test that StringHelper::handleStringElement correctly reemoves mailto:.
+   */
+  public function testHandleStringElement() {
+    $definition = [
+      'schema' => (object) [
+        'title' => 'Email',
+        'description' => 'Email address for the contact name.',
+        'type' => 'string',
+        "pattern" => "^mailto:[\\w\\_\\~\\!\\$\\&\\'\\(\\)\\*\\+\\,\\;\\=\\:.-]+@[\\w.-]+\\.[\\w.-]+?$|[\\w\\_\\~\\!\\$\\&\\'\\(\\)\\*\\+\\,\\;\\=\\:.-]+@[\\w.-]+\\.[\\w.-]+?$",
+      ],
+      'name' => 'hasEmail',
+    ];
+
+    $options = (new Options())
+      ->add('string_translation', TranslationManager::class)
+      ->add('email.validator', EmailValidator::class)
+      ->index(0);
+
+    $container_chain = (new Chain($this))
+      ->add(Container::class, 'get', $options)
+      ->add(EmailValidator::class, 'isValid', TRUE);
+
+    $string_helper = StringHelper::create($container_chain->getMock());
+    $field_type_router = $this->createMock(FieldTypeRouter::class);
+    $field_type_router->method('getSchema')->willReturn((object) [
+      'type' => 'object',
+      'properties' => [
+        'hasEmail' => $definition['schema'],
+      ],
+    ]);
+    $string_helper->setBuilder($field_type_router);
+
+    $data = 'mailto:john@doe.com';
+
+    $result = $string_helper->handleStringElement($definition, $data);
+    print_r($result['#default_value']);
+    $this->assertEquals('john@doe.com', $result['#default_value']);
   }
 
 }

--- a/modules/json_form_widget/tests/src/Unit/ValueHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/ValueHandlerTest.php
@@ -204,6 +204,20 @@ class ValueHandlerTest extends TestCase {
   }
 
   /**
+   * Test mailto: fix.
+   */
+  public function testFlattenValuesMailto() {
+    $value_handler = new ValueHandler();
+
+    $schema = json_decode('{"type":"string"}');
+    $formValues = [
+      'hasEmail' => 'john@doe.com',
+    ];
+    $result = $value_handler->flattenValues($formValues, "hasEmail", $schema);
+    $this->assertEquals('mailto:john@doe.com', $result);
+  }
+
+  /**
    * Test values for datetime elements.
    */
   public function testDatetimeValues() {
@@ -226,7 +240,7 @@ class ValueHandlerTest extends TestCase {
     ];
     $expected = $date->format('c', ['timezone' => 'UTC']);
     $result = $value_handler->handleStringValues($formValues, 'modified');
-    $this->assertEquals($result, $expected);
+    $this->assertEquals($expected, $result);
 
     // Test date_range.
     $date = new DrupalDateTime('2020-05-11T15:06:39.000Z');
@@ -240,7 +254,38 @@ class ValueHandlerTest extends TestCase {
     ];
     $expected = '2020-05-11T15:06:39.000Z/2020-05-15T15:00:00.000Z';
     $result = $value_handler->handleStringValues($formValues, 'temporal');
-    $this->assertEquals($result, $expected);
+    $this->assertEquals($expected, $result);
+  }
+
+  /**
+   * Test textFormat handling.
+   */
+  public function testTextFormat() {
+    $value_handler = new ValueHandler();
+
+    // Test textFormat.
+    $formValues = [
+      'description' => [
+        'value' => 'This is a description',
+        'format' => 'basic_html',
+      ],
+    ];
+    $expected = 'This is a description';
+    $result = $value_handler->handleStringValues($formValues, 'description');
+    $this->assertEquals($expected, $result);
+  }
+
+  public function testIntegerValues() {
+    $value_handler = new ValueHandler();
+
+    // Test integer.
+    $formValues = [
+      'integer' => "1",
+    ];
+    $expected = 1;
+    $result = $value_handler->handleIntegerValues($formValues, 'integer');
+    $this->assertIsInt($result);
+    $this->assertEquals($expected, $result);
   }
 
   /**

--- a/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
+++ b/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
@@ -85,6 +85,23 @@ class WidgetRouterTest extends TestCase {
           '#title' => 'textArea',
         ],
       ],
+      // A textformat property converts it to a text_format element.
+      'textFormat' => [
+        (object) [
+          'widget' => 'textarea',
+          'textFormat' => 'html',
+        ],
+        [
+          '#type' => 'textfield',
+          '#title' => 'textFormat',
+        ],
+        [
+          '#type' => 'text_format',
+          '#title' => 'textFormat',
+          '#format' => 'html',
+          '#allowed_formats' => ['html'],
+        ],
+      ],
       'tagField' => [
         (object) [
           'widget' => 'list',


### PR DESCRIPTION
Fixes #4132 
Re-roll of #4133 by @stefan-korn 

This provides an option in the UI Schema to define a Drupal text format for a textarea property. It only affects JSON Form widget forms, not any rendering or API response. We may do a follow-up to reflect this in the twig template or accompanying theme preprocess function. For now, what this achieves is replacing the bare textarea element on a form with a text_format element.

It does not allow a selection of all text formats available in Drupal, but locks a particular property in to a particular text format (as this is only about presentation and there is nowhere to store entity-specific format information).

I also added some test coverage to the `mailto:` fix as we kept getting dinged on that in coverage reports (even though that code needs to be replaced at some point).

## QA Steps

- [ ] Add a basic HTML text format to Drupal (/admin/config/content/formats)
- [ ] Edit your dataset.ui.json so that the description property includes `"textFormat": "html"
- [ ] Add a new dataset. Confirm that you get the help text under the textarea that you would expect for the selected text format
- [ ] Now, enable the ckeditor module.
- [ ] Add another text format that uses ckeditor. Call it "ckeditor."
- [ ] Change the "textFormat" property in dataset.ui.json description to "ckeditor"
- [ ] Confirm that the dataset form now displays ckeditor for the description field

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [x] I have updated or added documentation
