### PR TITLE
Factor out DatastoreResource class

### DIFF
--- a/modules/common/src/DataResource.php
+++ b/modules/common/src/DataResource.php
@@ -235,6 +235,8 @@ class DataResource implements \JsonSerializable {
    *
    * @return \Drupal\datastore\DatastoreResource
    *   Datastore Resource.
+   *
+   * @deprecated
    */
   public function getDatastoreResource(): DatastoreResource {
     return new DatastoreResource(
@@ -329,6 +331,8 @@ class DataResource implements \JsonSerializable {
 
   /**
    * Retrieve datastore table name for resource.
+   *
+   * @deprecated
    */
   public function getTableName() {
     return 'datastore_' . md5($this->getUniqueIdentifier());

--- a/modules/common/src/DataResource.php
+++ b/modules/common/src/DataResource.php
@@ -135,9 +135,8 @@ class DataResource implements \JsonSerializable {
    * @return \Drupal\common\DataResource
    *   DataResource object.
    *
-   * @deprecated Use DataResource::createFromEntity() instead.
-   *
-   * @see self::createFromEntity()
+   * @deprecated in dkan:2.17.1 and is removed from dkan:2.20.0. Use DataResource::createFromEntity() instead.
+   * @see https://github.com/GetDKAN/dkan/pull/4027
    */
   public static function createFromRecord(object $record): DataResource {
     $resource = new static($record->filePath, $record->mimeType, $record->perspective);
@@ -253,10 +252,16 @@ class DataResource implements \JsonSerializable {
   }
 
   /**
-   * Getter.
+   * Get the resource's filepath.
+   *
+   * @param bool|null $resolve
+   *   Whether to resolve the URL host tokens in the file path.
+   *
+   * @return string
+   *   The file path.
    */
-  public function getFilePath() {
-    return $this->filePath;
+  public function getFilePath(?bool $resolve = FALSE):string {
+    return $resolve ? UrlHostTokenResolver::resolve($this->getFilePath()) : $this->filePath;
   }
 
   /**
@@ -333,7 +338,7 @@ class DataResource implements \JsonSerializable {
    * {@inheritDoc}
    */
   #[\ReturnTypeWillChange]
-  public function jsonSerialize() {
+  public function jsonSerialize(): mixed {
     return $this->serialize();
   }
 

--- a/modules/common/src/DataResource.php
+++ b/modules/common/src/DataResource.php
@@ -135,7 +135,8 @@ class DataResource implements \JsonSerializable {
    * @return \Drupal\common\DataResource
    *   DataResource object.
    *
-   * @deprecated in dkan:2.17.1 and is removed from dkan:2.20.0. Use DataResource::createFromEntity() instead.
+   * @deprecated in dkan:8.x-2.17 and is removed from dkan:8.x-2.21. Use
+   *   DataResource::createFromEntity() instead.
    * @see https://github.com/GetDKAN/dkan/pull/4027
    */
   public static function createFromRecord(object $record): DataResource {
@@ -236,7 +237,10 @@ class DataResource implements \JsonSerializable {
    * @return \Drupal\datastore\DatastoreResource
    *   Datastore Resource.
    *
-   * @deprecated
+   * @deprecated in dkan:8.x-2.20 and is removed from dkan:8.x-2.21. Use storage
+   *   classes like DatabaseTable::getTableName() to determine correct table
+   *   names, and pass true to ::getFilePath to get the resolved URL.
+   * @see https://github.com/GetDKAN/dkan/pull/4372
    */
   public function getDatastoreResource(): DatastoreResource {
     return new DatastoreResource(
@@ -332,7 +336,10 @@ class DataResource implements \JsonSerializable {
   /**
    * Retrieve datastore table name for resource.
    *
-   * @deprecated
+   * @deprecated in dkan:8.x-2.20 and is removed from dkan:8.x-2.21. Use storage
+   *  classes like DatabaseTable::getTableName() to determine correct table
+   *  names.
+   * @see https://github.com/GetDKAN/dkan/pull/4372
    */
   public function getTableName() {
     return 'datastore_' . md5($this->getUniqueIdentifier());

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -21,11 +21,6 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   const EVENT_TABLE_CREATE = 'dkan_common_table_create';
 
   /**
-   * Real table name.
-   */
-  protected string $tableName;
-
-  /**
    * A schema. Should be a drupal schema array.
    *
    * @var array
@@ -45,7 +40,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    * Transform the string data given into what should be use by the insert
    * query.
    */
-  abstract protected function prepareData(string $data, string $id = NULL): array;
+  abstract protected function prepareData(string $data, ?string $id = NULL): array;
 
   /**
    * Get the primary key used in the table.
@@ -110,7 +105,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   /**
    * Store data.
    */
-  public function store($data, string $id = NULL): string {
+  public function store($data, ?string $id = NULL): string {
     $this->setTable();
 
     $existing = (isset($id)) ? $this->retrieve($id) : NULL;

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -263,7 +263,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    * @throws \Exception
    *   Throws an exception if the schema was not already set.
    */
-  protected function setTable() {
+  public function setTable() {
     if (!$this->tableExist($table_name = $this->getTableName())) {
       if ($schema = $this->schema) {
         try {

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -21,6 +21,11 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   const EVENT_TABLE_CREATE = 'dkan_common_table_create';
 
   /**
+   * Real table name.
+   */
+  protected string $tableName;
+
+  /**
    * A schema. Should be a drupal schema array.
    *
    * @var array
@@ -40,7 +45,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    * @return string
    *   Table name.
    */
-  abstract protected function getTableName();
+  abstract public function getTableName();
 
   /**
    * Prepare data.
@@ -68,6 +73,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
 
     if ($this->tableExist($this->getTableName())) {
       $this->setSchemaFromTable();
+      $this->tableName = $this->getTableName();
     }
   }
 
@@ -268,6 +274,7 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
       if ($schema = $this->schema) {
         try {
           $this->tableCreate($table_name, $schema);
+          $this->tableName = $table_name;
         }
         catch (SchemaObjectExistsException) {
           // Table already exists, which is totally OK. Other throwables find

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -40,14 +40,6 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   protected $connection;
 
   /**
-   * Get the full name of datastore db table.
-   *
-   * @return string
-   *   Table name.
-   */
-  abstract public function getTableName();
-
-  /**
    * Prepare data.
    *
    * Transform the string data given into what should be use by the insert
@@ -73,7 +65,6 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
 
     if ($this->tableExist($this->getTableName())) {
       $this->setSchemaFromTable();
-      $this->tableName = $this->getTableName();
     }
   }
 
@@ -274,7 +265,6 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
       if ($schema = $this->schema) {
         try {
           $this->tableCreate($table_name, $schema);
-          $this->tableName = $table_name;
         }
         catch (SchemaObjectExistsException) {
           // Table already exists, which is totally OK. Other throwables find

--- a/modules/common/tests/src/Unit/DataResourceTest.php
+++ b/modules/common/tests/src/Unit/DataResourceTest.php
@@ -19,6 +19,21 @@ use PHPUnit\Framework\TestCase;
 class DataResourceTest extends TestCase {
 
   /**
+   * Test getTableName().
+   */
+  public function testGetTableName() {
+
+    $resource = new DataResource(
+      '/foo/bar',
+      'txt',
+      DataResource::DEFAULT_SOURCE_PERSPECTIVE
+    );
+    $tableName = $resource->getTableName();
+
+    $this->assertStringStartsWith('datastore_', $tableName);
+  }
+
+  /**
    * Test getFolder().
    */
   public function testGetFolder() {

--- a/modules/common/tests/src/Unit/DataResourceTest.php
+++ b/modules/common/tests/src/Unit/DataResourceTest.php
@@ -19,21 +19,6 @@ use PHPUnit\Framework\TestCase;
 class DataResourceTest extends TestCase {
 
   /**
-   * Test getTableName().
-   */
-  public function testGetTableName() {
-
-    $resource = new DataResource(
-      '/foo/bar',
-      'txt',
-      DataResource::DEFAULT_SOURCE_PERSPECTIVE
-    );
-    $tableName = $resource->getTableName();
-
-    $this->assertStringStartsWith('datastore_', $tableName);
-  }
-
-  /**
    * Test getFolder().
    */
   public function testGetFolder() {

--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -42,6 +42,7 @@ services:
       - '@dkan.datastore.data_dictionary.alter_table_query_builder.mysql'
       - '@dkan.metastore.service'
       - '@dkan.metastore.data_dictionary_discovery'
+      - '@dkan.datastore.database_table_factory'
     tags:
       - { name: resource_processor, priority: 25 }
 

--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -68,8 +68,12 @@ class MysqlImport extends ImportJob {
     }
 
     // Attempt to resolve resource file name from file path.
-    if (($file_path = \Drupal::service('file_system')->realpath($this->resource->getFilePath())) === FALSE) {
-      return $this->setResultError(sprintf('Unable to resolve file name "%s" for resource with identifier "%s".', $this->resource->getFilePath(), $this->resource->getId()));
+    if (($file_path = \Drupal::service('file_system')->realpath($this->resource->getFilePath(TRUE))) === FALSE) {
+      return $this->setResultError(sprintf(
+        'Unable to resolve file name "%s" for resource with identifier "%s".',
+        $this->resource->getFilePath(TRUE),
+        $this->resource->getUniqueIdentifier())
+      );
     }
 
     $size = @filesize($file_path);

--- a/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Storage/MySqlDatabaseTableFactoryTest.php
+++ b/modules/datastore/modules/datastore_mysql_import/tests/src/Kernel/Storage/MySqlDatabaseTableFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\Tests\datastore_mysql_import\Kernel\Storage;
 
-use Drupal\datastore\DatastoreResource;
+use Drupal\common\DataResource;
 use Drupal\datastore_mysql_import\Storage\MySqlDatabaseTable;
 use Drupal\KernelTests\KernelTestBase;
 
@@ -11,6 +11,7 @@ use Drupal\KernelTests\KernelTestBase;
  * @coversDefaultClass \Drupal\datastore_mysql_import\Storage\MySqlDatabaseTableFactory
  *
  * @group datastore_mysql_import
+ * @group kernel
  */
 class MySqlDatabaseTableFactoryTest extends KernelTestBase {
 
@@ -33,10 +34,8 @@ class MySqlDatabaseTableFactoryTest extends KernelTestBase {
   }
 
   public function testFactoryService() {
-    $identifier = 'identifier';
     $file_path = dirname(__FILE__, 4) . '/data/columnspaces.csv';
-    $datastore_resource = new DatastoreResource(
-      $identifier,
+    $datastore_resource = new DataResource(
       $file_path,
       'text/csv'
     );

--- a/modules/datastore/src/DatastoreResource.php
+++ b/modules/datastore/src/DatastoreResource.php
@@ -43,6 +43,8 @@ class DatastoreResource implements \JsonSerializable {
 
   /**
    * Get the resource ID.
+   *
+   * Note: duplicates Drupal\common\DataResource::getUniqueIdentifier().
    */
   public function getId(): string {
     return $this->id;
@@ -50,6 +52,8 @@ class DatastoreResource implements \JsonSerializable {
 
   /**
    * Get the file path.
+   *
+   * Note: duplicates Drupal\common\DataResource::getFilePath(TRUE).
    */
   public function getFilePath(): string {
     return $this->filePath;
@@ -57,6 +61,8 @@ class DatastoreResource implements \JsonSerializable {
 
   /**
    * Get the mimeType.
+   *
+   * Note: duplicates Drupal\common\DataResource::getMimeType().
    */
   public function getMimeType(): string {
     return $this->mimeType;
@@ -65,8 +71,7 @@ class DatastoreResource implements \JsonSerializable {
   /**
    * {@inheritdoc}
    */
-  #[\ReturnTypeWillChange]
-  public function jsonSerialize() {
+  public function jsonSerialize(): mixed {
     return (object) [
       'filePath' => $this->getFilePath(),
       'id' => $this->getId(),

--- a/modules/datastore/src/DatastoreResource.php
+++ b/modules/datastore/src/DatastoreResource.php
@@ -5,9 +5,9 @@ namespace Drupal\datastore;
 /**
  * Basic datastore resource class.
  *
- * Always generate this object using DataResource::getDatastoreResource().
- *
- * @see \Drupal\common\DataResource::getDatastoreResource()
+ * @deprecated in dkan:8.x-2.20 and is removed from dkan:8.x-2.21. Use
+ *   \Drupal\common\DataResource instead.
+ * @see https://github.com/GetDKAN/dkan/pull/4372
  */
 class DatastoreResource implements \JsonSerializable {
 

--- a/modules/datastore/src/DatastoreResource.php
+++ b/modules/datastore/src/DatastoreResource.php
@@ -44,7 +44,9 @@ class DatastoreResource implements \JsonSerializable {
   /**
    * Get the resource ID.
    *
-   * Note: duplicates Drupal\common\DataResource::getUniqueIdentifier().
+   * @deprecated in dkan:8.x-2.20 and is removed from dkan:8.x-2.21. Use
+   *   \Drupal\common\DataResource::getUniqueIdentifier() instead.
+   * @see https://github.com/GetDKAN/dkan/pull/4372
    */
   public function getId(): string {
     return $this->id;
@@ -53,7 +55,12 @@ class DatastoreResource implements \JsonSerializable {
   /**
    * Get the file path.
    *
-   * Note: duplicates Drupal\common\DataResource::getFilePath(TRUE).
+   * @return string
+   *   The file path.
+   *
+   * @deprecated in dkan:8.x-2.20 and is removed from dkan:8.x-2.21. Use
+   *   \Drupal\common\DataResource::getUniqueIdentifier() instead.
+   * @see https://github.com/GetDKAN/dkan/pull/4372
    */
   public function getFilePath(): string {
     return $this->filePath;
@@ -62,7 +69,12 @@ class DatastoreResource implements \JsonSerializable {
   /**
    * Get the mimeType.
    *
-   * Note: duplicates Drupal\common\DataResource::getMimeType().
+   * @return string
+   *   The mimeType.
+   *
+   * @deprecated in dkan:8.x-2.20 and is removed from dkan:8.x-2.21. Use
+   *   \Drupal\common\DataResource::getMimeType() instead.
+   * @see https://github.com/GetDKAN/dkan/pull/4372
    */
   public function getMimeType(): string {
     return $this->mimeType;

--- a/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
+++ b/modules/datastore/src/Plugin/QueueWorker/ImportJob.php
@@ -89,7 +89,7 @@ class ImportJob extends AbstractPersistentJob {
   /**
    * Datastore resource.
    *
-   * @var \Drupal\datastore\DatastoreResource
+   * @var \Drupal\common\DataResource
    */
   protected $resource;
 
@@ -105,7 +105,7 @@ class ImportJob extends AbstractPersistentJob {
    * @param array|null $config
    *   Configuration options.
    */
-  protected function __construct(string $identifier, $storage, array $config = NULL) {
+  protected function __construct(string $identifier, $storage, ?array $config = NULL) {
     parent::__construct($identifier, $storage, $config);
 
     $this->dataStorage = $config['storage'];
@@ -195,7 +195,7 @@ class ImportJob extends AbstractPersistentJob {
    * {@inheritdoc}
    */
   protected function runIt() {
-    $filename = $this->resource->getFilePath();
+    $filename = $this->resource->getFilePath(TRUE);
     $size = @filesize($filename);
     if (!$size) {
       return $this->setResultError("Can't get size from file {$filename}");

--- a/modules/datastore/src/Service/ImportService.php
+++ b/modules/datastore/src/Service/ImportService.php
@@ -151,10 +151,9 @@ class ImportService {
     $data_resource = $this->getResource();
 
     if ($result->getStatus() === Result::ERROR) {
-      $datastore_resource = $data_resource->getDatastoreResource();
       $this->logger->error('Error importing resource id:%id path:%path message:%message', [
-        '%id' => $datastore_resource->getId(),
-        '%path' => $datastore_resource->getFilePath(),
+        '%id' => $data_resource->getUniqueIdentifier(),
+        '%path' => $data_resource->getFilePath(TRUE),
         '%message' => $result->getError(),
       ]);
     }
@@ -188,20 +187,20 @@ class ImportService {
     if ($this->importJob ?? FALSE) {
       return $this->importJob;
     }
-    $datastore_resource = $this->getResource()->getDatastoreResource();
+    $data_resource = $this->getResource();
 
     $delimiter = ",";
-    if ($datastore_resource->getMimeType() == 'text/tab-separated-values') {
+    if ($data_resource->getMimeType() == 'text/tab-separated-values') {
       $delimiter = "\t";
     }
 
     $this->importJob = call_user_func([$this->importerClass, 'get'],
-      $datastore_resource->getId(),
+      $data_resource->getUniqueIdentifier(),
       $this->importJobStoreFactory->getInstance(),
       [
         "storage" => $this->getStorage(),
         "parser" => $this->getNonRecordingParser($delimiter),
-        "resource" => $datastore_resource,
+        "resource" => $data_resource,
       ]
     );
 
@@ -245,8 +244,8 @@ class ImportService {
    *   DatabaseTable storage object.
    */
   public function getStorage(): DatabaseTable {
-    $datastore_resource = $this->getResource()->getDatastoreResource();
-    return $this->databaseTableFactory->getInstance($datastore_resource->getId(), ['resource' => $datastore_resource]);
+    $data_resource = $this->getResource();
+    return $this->databaseTableFactory->getInstance($data_resource->getUniqueIdentifier(), ['resource' => $data_resource]);
   }
 
   /**

--- a/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
+++ b/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
@@ -5,6 +5,7 @@ namespace Drupal\datastore\Service\ResourceProcessor;
 use Drupal\common\DataResource;
 use Drupal\datastore\DataDictionary\AlterTableQueryBuilderInterface;
 use Drupal\datastore\Service\ResourceProcessorInterface;
+use Drupal\datastore\Storage\DatabaseTableFactory;
 use Drupal\metastore\MetastoreService;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscoveryInterface;
 
@@ -44,6 +45,13 @@ class DictionaryEnforcer implements ResourceProcessorInterface {
   protected $resourceMapper;
 
   /**
+   * Database table factory service.
+   *
+   * @var \Drupal\datastore\Storage\DatabaseTableFactory
+   */
+  protected $databaseTableFactory;
+
+  /**
    * Constructs a \Drupal\Component\Plugin\PluginBase object.
    *
    * @param \Drupal\datastore\DataDictionary\AlterTableQueryBuilderInterface $alter_table_query_builder
@@ -56,11 +64,13 @@ class DictionaryEnforcer implements ResourceProcessorInterface {
   public function __construct(
     AlterTableQueryBuilderInterface $alter_table_query_builder,
     MetastoreService $metastore,
-    DataDictionaryDiscoveryInterface $data_dictionary_discovery
+    DataDictionaryDiscoveryInterface $data_dictionary_discovery,
+    DatabaseTableFactory $table_factory,
   ) {
     $this->metastore = $metastore;
     $this->dataDictionaryDiscovery = $data_dictionary_discovery;
     $this->alterTableQueryBuilder = $alter_table_query_builder;
+    $this->databaseTableFactory = $table_factory;
   }
 
   /**
@@ -78,7 +88,8 @@ class DictionaryEnforcer implements ResourceProcessorInterface {
     // Get data-dictionary for the given resource.
     $dictionary = $this->getDataDictionaryForResource($resource);
     // Retrieve name of datastore table for resource.
-    $datastore_table = $resource->getTableName();
+    $table = $this->databaseTableFactory->getInstance('', ['resource' => $resource]);
+    $datastore_table = $table->getTableName();
 
     $this->applyDictionary($dictionary, $datastore_table);
   }

--- a/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
+++ b/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
@@ -60,6 +60,8 @@ class DictionaryEnforcer implements ResourceProcessorInterface {
    *   The metastore service.
    * @param \Drupal\metastore\DataDictionary\DataDictionaryDiscoveryInterface $data_dictionary_discovery
    *   The data-dictionary discovery service.
+   * @param \Drupal\datastore\Storage\DatabaseTableFactory $table_factory
+   *   The datastore database table factory service.
    */
   public function __construct(
     AlterTableQueryBuilderInterface $alter_table_query_builder,
@@ -142,7 +144,7 @@ class DictionaryEnforcer implements ResourceProcessorInterface {
    * @return array|null
    *   An array of dictionary fields or null if no dictionary is in use.
    */
-  public function returnDataDictionaryFields(string $identifier = NULL): ?array {
+  public function returnDataDictionaryFields(?string $identifier = NULL): ?array {
     // Get data dictionary mode.
     $dd_mode = $this->dataDictionaryDiscovery->getDataDictionaryMode();
     // Get data dictionary info.

--- a/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
+++ b/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
@@ -138,7 +138,7 @@ class DictionaryEnforcer implements ResourceProcessorInterface {
   /**
    * Returning data dictionary fields from schema.
    *
-   * @param string $identifier
+   * @param string|null $identifier
    *   A resource's identifier. Used when in reference mode.
    *
    * @return array|null

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -88,7 +88,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    */
   public function getTableName() {
     if ($this->resource) {
-      return $this->resource->getTableName();
+      return 'datastore_' . md5($this->resource->getUniqueIdentifier());
     }
     return 'datastore_does_not_exist';
   }

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -72,8 +72,6 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
   }
 
   /**
-   * Inherited.
-   *
    * {@inheritdoc}
    */
   #[\ReturnTypeWillChange]
@@ -97,7 +95,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
   /**
    * Protected.
    */
-  protected function prepareData(string $data, string $id = NULL): array {
+  protected function prepareData(string $data, ?string $id = NULL): array {
     $decoded = json_decode($data);
     if ($decoded === NULL) {
       $this->logger->error('Error decoding id:@id, data: @data.', [

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -49,7 +49,6 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
 
     if ($this->tableExist($this->getTableName())) {
       $this->setSchemaFromTable();
-      $this->tableName = $this->getTableName();
     }
   }
 

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -3,8 +3,8 @@
 namespace Drupal\datastore\Storage;
 
 use Drupal\Core\Database\Connection;
+use Drupal\common\DataResource;
 use Drupal\common\Storage\AbstractDatabaseTable;
-use Drupal\datastore\DatastoreResource;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -17,7 +17,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
   /**
    * Datastore resource object.
    *
-   * @var \Drupal\datastore\DatastoreResource
+   * @var \Drupal\common\DataResource
    */
   private $resource;
 
@@ -31,15 +31,15 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    *
    * @param \Drupal\Core\Database\Connection $connection
    *   Drupal database connection object.
-   * @param \Drupal\datastore\DatastoreResource $resource
+   * @param \Drupal\common\DataResource $resource
    *   A resource.
    * @param \Psr\Log\LoggerInterface $loggerChannel
    *   DKAN logger channel service.
    */
   public function __construct(
     Connection $connection,
-    DatastoreResource $resource,
-    LoggerInterface $loggerChannel
+    DataResource $resource,
+    LoggerInterface $loggerChannel,
   ) {
     // Set resource before calling the parent constructor. The parent calls
     // getTableName which we implement and needs the resource to operate.
@@ -76,7 +76,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    * {@inheritdoc}
    */
   #[\ReturnTypeWillChange]
-  public function jsonSerialize() {
+  public function jsonSerialize(): mixed {
     return (object) ['resource' => $this->resource];
   }
 
@@ -88,7 +88,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    */
   public function getTableName() {
     if ($this->resource) {
-      return 'datastore_' . $this->resource->getId();
+      return 'datastore_' . $this->resource->getUniqueIdentifier();
     }
     return 'datastore_does_not_exist';
   }

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -88,7 +88,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    */
   public function getTableName() {
     if ($this->resource) {
-      return 'datastore_' . $this->resource->getUniqueIdentifier();
+      return $this->resource->getTableName();
     }
     return 'datastore_does_not_exist';
   }

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -19,12 +19,12 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    *
    * @var \Drupal\common\DataResource
    */
-  private $resource;
+  protected $resource;
 
   /**
    * DKAN logger channel service.
    */
-  private LoggerInterface $logger;
+  protected LoggerInterface $logger;
 
   /**
    * Constructor method.
@@ -49,6 +49,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
 
     if ($this->tableExist($this->getTableName())) {
       $this->setSchemaFromTable();
+      $this->tableName = $this->getTableName();
     }
   }
 

--- a/modules/datastore/src/Storage/DatabaseTableFactory.php
+++ b/modules/datastore/src/Storage/DatabaseTableFactory.php
@@ -28,7 +28,7 @@ class DatabaseTableFactory implements FactoryInterface {
    */
   public function __construct(
     Connection $connection,
-    LoggerInterface $loggerChannel
+    LoggerInterface $loggerChannel,
   ) {
     $this->connection = $connection;
     $this->logger = $loggerChannel;

--- a/modules/datastore/src/Storage/DatabaseTableFactory.php
+++ b/modules/datastore/src/Storage/DatabaseTableFactory.php
@@ -35,9 +35,15 @@ class DatabaseTableFactory implements FactoryInterface {
   }
 
   /**
-   * Inherited.
+   * Get a DatabaseTable instance.
    *
-   * @inheritdoc
+   * @param string $identifier
+   *   Some way to discern between different instances of a class.
+   * @param array $config
+   *   Must contain a 'resource' key, which is a DataResource object.
+   *
+   * @return \Drupal\datastore\Storage\DatabaseTable
+   *   A DatabaseTable object.
    */
   public function getInstance(string $identifier, array $config = []) {
     if (!isset($config['resource'])) {
@@ -50,7 +56,13 @@ class DatabaseTableFactory implements FactoryInterface {
   }
 
   /**
-   * Protected.
+   * Get a DatabaseTable object from a DataResource object.
+   *
+   * @param \Drupal\common\DataResource $resource
+   *   A resource.
+   *
+   * @return \Drupal\datastore\Storage\DatabaseTable
+   *   A DatabaseTable object.
    */
   protected function getDatabaseTable($resource) {
     return new DatabaseTable($this->connection, $resource, $this->logger);

--- a/modules/datastore/src/Storage/DatabaseTableFactory.php
+++ b/modules/datastore/src/Storage/DatabaseTableFactory.php
@@ -3,6 +3,7 @@
 namespace Drupal\datastore\Storage;
 
 use Contracts\FactoryInterface;
+use Drupal\common\DataResource;
 use Drupal\Core\Database\Connection;
 use Psr\Log\LoggerInterface;
 
@@ -64,7 +65,7 @@ class DatabaseTableFactory implements FactoryInterface {
    * @return \Drupal\datastore\Storage\DatabaseTable
    *   A DatabaseTable object.
    */
-  protected function getDatabaseTable($resource) {
+  protected function getDatabaseTable(DataResource $resource) {
     return new DatabaseTable($this->connection, $resource, $this->logger);
   }
 

--- a/modules/datastore/src/Storage/QueryFactory.php
+++ b/modules/datastore/src/Storage/QueryFactory.php
@@ -40,7 +40,7 @@ class QueryFactory {
   /**
    * Static factory create method.
    *
-   * @param Drupal\datastore\Service\DatastoreQuery $datastoreQuery
+   * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
    *   Datastore query request object.
    * @param array $storageMap
    *   Storage map array.

--- a/modules/datastore/tests/data/states_with_dupes_link.csv
+++ b/modules/datastore/tests/data/states_with_dupes_link.csv
@@ -1,0 +1,1 @@
+states_with_dupes.csv

--- a/modules/datastore/tests/src/Kernel/Service/ResourceProcessor/DictionaryEnforcerTest.php
+++ b/modules/datastore/tests/src/Kernel/Service/ResourceProcessor/DictionaryEnforcerTest.php
@@ -66,6 +66,7 @@ class DictionaryEnforcerTest extends KernelTestBase {
         $this->container->get('dkan.datastore.data_dictionary.alter_table_query_builder.mysql'),
         $this->container->get('dkan.metastore.service'),
         $this->container->get('dkan.metastore.data_dictionary_discovery'),
+        $this->container->get('dkan.datastore.database_table_factory'),
       ])
       ->onlyMethods(['getDataDictionaryForResource', 'applyDictionary'])
       ->getMock();

--- a/modules/datastore/tests/src/Kernel/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Kernel/Storage/DatabaseTableTest.php
@@ -9,6 +9,7 @@ use Drupal\datastore\DatastoreResource;
 use Drupal\datastore\Plugin\QueueWorker\ImportJob;
 use Drupal\datastore\Service\Factory\ImportServiceFactory;
 use Drupal\datastore\Storage\DatabaseTable;
+use Drupal\datastore\Storage\DatabaseTableFactory;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\common\Unit\Connection;
 use Procrastinator\Result;
@@ -95,8 +96,9 @@ class DatabaseTableTest extends KernelTestBase {
       ->onlyMethods(['tableExist'])
       ->setConstructorArgs([
         $this->createStub(Connection::class),
-        $this->createStub(DatastoreResource::class),
+        $this->createStub(DataResource::class),
         $logger,
+        $this->createStub(DatabaseTableFactory::class),
       ])
       ->getMock();
     $database_table->expects($this->any())

--- a/modules/datastore/tests/src/Kernel/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Kernel/Storage/DatabaseTableTest.php
@@ -5,7 +5,6 @@ namespace Drupal\Tests\datastore\Kernel\Storage;
 use ColinODell\PsrTestLogger\TestLogger;
 use Drupal\common\DataResource;
 use Drupal\common\Storage\ImportedItemInterface;
-use Drupal\datastore\DatastoreResource;
 use Drupal\datastore\Plugin\QueueWorker\ImportJob;
 use Drupal\datastore\Service\Factory\ImportServiceFactory;
 use Drupal\datastore\Storage\DatabaseTable;

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -9,7 +9,6 @@ use Drupal\Core\Config\ImmutableConfig;
 use Drupal\common\DatasetInfo;
 use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Drupal\datastore\Controller\QueryController;
-use Drupal\datastore\DatastoreResource;
 use Drupal\datastore\DatastoreService;
 use Drupal\datastore\Service\Query;
 use Drupal\datastore\Storage\SqliteDatabaseTable;

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -2,10 +2,12 @@
 
 namespace Drupal\Tests\datastore\Unit\Controller;
 
+use Drupal\common\DataResource;
 use Drupal\Core\Cache\Context\CacheContextsManager;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
 use Drupal\common\DatasetInfo;
+use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Drupal\datastore\Controller\QueryController;
 use Drupal\datastore\DatastoreResource;
 use Drupal\datastore\DatastoreService;
@@ -33,23 +35,33 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class QueryControllerTest extends TestCase {
 
+  const FILE_DIR = __DIR__ . "/../../../data/";
+
+  /**
+   * Resources to be used in tests.
+   */
+  private DataResource $resource;
+
   protected function setUp(): void {
     parent::setUp();
     // Set cache services.
     $options = (new Options)
       ->add('cache_contexts_manager', CacheContextsManager::class)
+      ->add('event_dispatcher', ContainerAwareEventDispatcher::class)
       ->index(0);
     $chain = (new Chain($this))
       ->add(ContainerInterface::class, 'get', $options)
       ->add(CacheContextsManager::class, 'assertValidTokens', TRUE);
     \Drupal::setContainer($chain->getMock());
+
+    $this->resource = new DataResource(self::FILE_DIR . 'states_with_dupes.csv', 'text/csv');
   }
 
   public function testQueryJson() {
     $data = json_encode([
       "resources" => [
         [
-          "id" => "2",
+          "id" => $this->resource->getIdentifier(),
           "alias" => "t",
         ],
       ],
@@ -98,7 +110,7 @@ class QueryControllerTest extends TestCase {
     // Try simple string properties:
     $data = json_encode(["properties" => ["record_number", "state"]]);
 
-    $result = $this->getQueryResult($data, "2");
+    $result = $this->getQueryResult($data, $this->resource->getIdentifier());
 
     $this->assertEquals(400, $result->getStatusCode());
     $this->assertStringContainsString('The record_number property is for internal use', $result->getContent());
@@ -106,7 +118,7 @@ class QueryControllerTest extends TestCase {
     // Now try with rowIds plus an arbitrary property:
     $data = json_encode(["properties" => ["state"], "rowIds" => TRUE]);
 
-    $result = $this->getQueryResult($data, "2");
+    $result = $this->getQueryResult($data, $this->resource->getIdentifier());
 
     $this->assertEquals(400, $result->getStatusCode());
     $this->assertStringContainsString('The rowIds property cannot be set to true', $result->getContent());
@@ -125,7 +137,7 @@ class QueryControllerTest extends TestCase {
       ],
     ]);
 
-    $result = $this->getQueryResult($data, "2");
+    $result = $this->getQueryResult($data, $this->resource->getIdentifier());
 
     $this->assertEquals(400, $result->getStatusCode());
     $this->assertStringContainsString('The record_number property is for internal use', $result->getContent());
@@ -147,7 +159,7 @@ class QueryControllerTest extends TestCase {
       ],
     ]);
 
-    $result = $this->getQueryResult($data, "2");
+    $result = $this->getQueryResult($data, $this->resource->getIdentifier());
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(200, $result->getStatusCode());
@@ -195,7 +207,7 @@ class QueryControllerTest extends TestCase {
     $data = json_encode([
       "conditions" => "nope",
     ]);
-    $result = $this->getQueryResult($data, "2");
+    $result = $this->getQueryResult($data, $this->resource->getIdentifier());
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(400, $result->getStatusCode());
@@ -208,7 +220,7 @@ class QueryControllerTest extends TestCase {
         "condition" => "t.field1 = s.field1",
       ],
     ]);
-    $result = $this->getQueryResult($data, "2");
+    $result = $this->getQueryResult($data, $this->resource->getIdentifier());
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(400, $result->getStatusCode());
@@ -221,7 +233,7 @@ class QueryControllerTest extends TestCase {
     $data = json_encode([
       "results" => TRUE,
     ]);
-    $result = $this->getQueryResult($data, "2");
+    $result = $this->getQueryResult($data, $this->resource->getIdentifier());
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(200, $result->getStatusCode());
@@ -274,7 +286,7 @@ class QueryControllerTest extends TestCase {
         ],
       ],
     ]);
-    $result = $this->getQueryResult($data, "2");
+    $result = $this->getQueryResult($data, $this->resource->getIdentifier());
 
     $this->assertTrue($result instanceof JsonResponse);
     $this->assertEquals(400, $result->getStatusCode());
@@ -288,7 +300,7 @@ class QueryControllerTest extends TestCase {
     $data = json_encode([
       "resources" => [
         [
-          "id" => "2",
+          "id" => $this->resource->getIdentifier(),
           "alias" => "t",
         ],
       ],
@@ -330,7 +342,7 @@ class QueryControllerTest extends TestCase {
       "results" => TRUE,
       "format" => "csv",
     ]);
-    $result = $this->getQueryResult($data, "2");
+    $result = $this->getQueryResult($data, $this->resource->getIdentifier());
     $this->assertTrue($result instanceof CsvResponse);
     $csv = explode("\n", $result->getContent());
     $this->assertEquals('State', $csv[0]);
@@ -358,7 +370,7 @@ class QueryControllerTest extends TestCase {
       "results" => TRUE,
       "format" => "csv",
     ]);
-    $result = $this->getQueryResult($data, "2");
+    $result = $this->getQueryResult($data, $this->resource->getIdentifier());
     $this->assertTrue($result instanceof CsvResponse);
 
     $csv = explode("\n", $result->getContent());
@@ -428,7 +440,7 @@ class QueryControllerTest extends TestCase {
     $data = json_encode([
       "resources" => [
         [
-          "id" => "2",
+          "id" => $this->resource->getIdentifier(),
           "alias" => "t",
         ],
       ],
@@ -524,20 +536,10 @@ class QueryControllerTest extends TestCase {
    */
   public function mockDatastoreTable() {
     $connection = new SqliteConnection(new \PDO('sqlite::memory:'), []);
-    $connection->query('CREATE TABLE `datastore_2` (`record_number` INTEGER NOT NULL, state TEXT, year INT);');
-
-    $sampleData = [];
-    $fp = fopen(__DIR__ . '/../../../data/states_with_dupes.csv', 'rb');
-    while (!feof($fp)) {
-      $sampleData[] = fgetcsv($fp);
-    }
-    foreach ($sampleData as $row) {
-      $connection->query("INSERT INTO `datastore_2` VALUES ($row[0], '$row[1]', $row[2]);");
-    }
-
+    // $connection->query('CREATE TABLE `datastore_2` (`record_number` INTEGER NOT NULL, state TEXT, year INT);');
     $storage = new SqliteDatabaseTable(
       $connection,
-      new DatastoreResource("2", "data.csv", "text/csv"),
+      $this->resource,
       $this->createStub(LoggerInterface::class)
     );
     $storage->setSchema([
@@ -547,6 +549,20 @@ class QueryControllerTest extends TestCase {
         'year' => ['type' => 'int', 'description' => 'Year'],
       ],
     ]);
+    $storage->setTable();
+
+    $fp = fopen($this->resource->getFilePath(), 'rb');
+    $sampleData = [];
+    while (!feof($fp)) {
+      $sampleData[] = fgetcsv($fp);
+    }
+    fclose($fp);
+
+    $table_name = $storage->getTableName();
+    foreach ($sampleData as $row) {
+      $connection->query("INSERT INTO `$table_name` VALUES ($row[0], '$row[1]', $row[2]);");
+    }
+
     return $storage;
   }
 

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -34,7 +34,16 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class QueryDownloadControllerTest extends TestCase {
 
+  const FILE_DIR = __DIR__ . "/../../../data/";
+
   private $buffer;
+
+  /**
+   * Resources to be used in tests.
+   *
+   * @var \Drupal\common\DataResource[]
+   */
+  private array $resources;
 
   protected function setUp(): void {
     parent::setUp();
@@ -47,6 +56,11 @@ class QueryDownloadControllerTest extends TestCase {
       ->add(ContainerInterface::class, 'get', $options)
       ->add(CacheContextsManager::class, 'assertValidTokens', TRUE);
     \Drupal::setContainer($chain->getMock());
+
+    $this->resources = [
+      '2' => new DataResource(self::FILE_DIR . 'states_with_dupes.csv', 'text/csv'),
+      '3' => new DataResource(self::FILE_DIR . 'years_colors.csv', 'text/csv'),
+    ];
   }
 
   protected function tearDown(): void {
@@ -61,13 +75,13 @@ class QueryDownloadControllerTest extends TestCase {
     $request = $this->mockRequest($data);
     $qController = QueryController::create($this->getQueryContainer(500));
     $response = $resource ? $qController->queryResource($resource, $request) : $qController->query($request);
-    $csv = $response->getContent();
+    $csv = $response->getContent() ?? '';
 
     $dController = QueryDownloadController::create($this->getQueryContainer(25));
     ob_start([self::class, 'getBuffer']);
     $streamResponse = $resource ? $dController->queryResource($resource, $request) : $dController->query($request);
     $streamResponse->sendContent();
-    $streamedCsv = $this->buffer;
+    $streamedCsv = $this->buffer ?? '';
     ob_get_clean();
 
     $this->assertEquals(count(explode("\n", $csv)), count(explode("\n", $streamedCsv)));
@@ -81,7 +95,7 @@ class QueryDownloadControllerTest extends TestCase {
     $data = [
       "resources" => [
         [
-          "id" => "2",
+          "id" => $this->resources[2]->getIdentifier(),
           "alias" => "t",
         ],
       ],
@@ -109,7 +123,7 @@ class QueryDownloadControllerTest extends TestCase {
     $data = [
       "resources" => [
         [
-          "id" => "2",
+          "id" => $this->resources[2]->getIdentifier(),
           "alias" => "t",
         ],
       ],
@@ -139,11 +153,11 @@ class QueryDownloadControllerTest extends TestCase {
       "schema" => TRUE,
       "resources" => [
         [
-          "id" => "2",
+          "id" => $this->resources[2]->getIdentifier(),
           "alias" => "t",
         ],
         [
-          "id" => "3",
+          "id" => $this->resources[3]->getIdentifier(),
           "alias" => "j",
         ],
       ],
@@ -201,7 +215,7 @@ class QueryDownloadControllerTest extends TestCase {
     $data = json_encode([
       "resources" => [
         [
-          "id" => "2",
+          "id" => $this->resources[2]->getIdentifier(),
           "alias" => "t",
         ],
       ],
@@ -224,7 +238,7 @@ class QueryDownloadControllerTest extends TestCase {
     $data = json_encode([
       "resources" => [
         [
-          "id" => "2",
+          "id" => $this->resources[2]->getIdentifier(),
           "alias" => "t",
         ],
       ],
@@ -259,7 +273,7 @@ class QueryDownloadControllerTest extends TestCase {
     $data = [
       "resources" => [
         [
-          "id" => "2",
+          "id" => $this->resources[2]->getIdentifier(),
           "alias" => "t",
         ],
       ],
@@ -276,7 +290,7 @@ class QueryDownloadControllerTest extends TestCase {
     $data = [
       "resources" => [
         [
-          "id" => "2",
+          "id" => $this->resources[2]->getIdentifier(),
           "alias" => "t",
         ],
       ],
@@ -304,7 +318,7 @@ class QueryDownloadControllerTest extends TestCase {
     $data = [
       "resources" => [
         [
-          "id" => "2",
+          "id" => $this->resources[2]->getIdentifier(),
           "alias" => "t",
         ],
       ],
@@ -322,7 +336,7 @@ class QueryDownloadControllerTest extends TestCase {
     $data = [
       "resources" => [
         [
-          "id" => "2",
+          "id" => $this->resources[2]->getIdentifier(),
           "alias" => "tx",
         ],
       ],
@@ -394,13 +408,13 @@ class QueryDownloadControllerTest extends TestCase {
       ],
     ];
 
-    $storage2 = $this->mockDatastoreTable($connection, "2", 'states_with_dupes.csv', $schema2);
+    $storage2 = $this->mockDatastoreTable($connection, $this->resources[2], $schema2);
     $storage2x = clone($storage2);
     $storage2x->setSchema(['fields' => []]);
     $storageMap = [
       't' => $storage2,
       'tx' => $storage2x,
-      'j' => $this->mockDatastoreTable($connection, "3", 'years_colors.csv', $schema3
+      'j' => $this->mockDatastoreTable($connection, $this->resources[3], $schema3
       ),
     ];
 
@@ -415,7 +429,7 @@ class QueryDownloadControllerTest extends TestCase {
       ->add(Data::class, 'getCacheMaxAge', 0)
       ->add(ConfigFactoryInterface::class, 'get', ImmutableConfig::class)
       ->add(Query::class, "getQueryStorageMap", $storageMap)
-      ->add(Query::class, 'getDatastoreService',  DatastoreService::class)
+      ->add(Query::class, 'getDatastoreService', DatastoreService::class)
       ->add(DatastoreService::class, 'getDataDictionaryFields', NULL)
       // @todo Use an Options or Sequence return here; this will only work for one arg at a time.
       ->add(ImmutableConfig::class, 'get', $rowLimit)
@@ -451,37 +465,38 @@ class QueryDownloadControllerTest extends TestCase {
    * @return \Drupal\common\Storage\DatabaseTableInterface
    *   A database table storage class useable for datastore queries.
    */
-  public function mockDatastoreTable($connection, $id, $csvFile, $fields) {
-    foreach ($fields as $name => $field) {
-      $types[] = $field['type'];
-      $notNull = $field['not null'] ?? FALSE;
-      $createFields[] = "`$name` " . strtoupper($field['type']) . (($notNull) ? ' NOT NULL' : '');
-    }
-    $createFieldsStr = implode(", ", $createFields);
-    $connection->query("CREATE TABLE `datastore_$id` ($createFieldsStr);");
+  public function mockDatastoreTable($connection, DataResource $resource, $fields) {
+    $storage = new SqliteDatabaseTable(
+      $connection,
+      $resource,
+      $this->createStub(LoggerInterface::class)
+    );
+    $storage->setSchema([
+      'fields' => $fields,
+    ]);
+    $storage->setTable();
 
+    foreach ($fields as $field) {
+      $types[] = $field['type'];
+    }
+    
+    $fp = fopen($resource->getFilePath(), 'rb');
     $sampleData = [];
-    $fp = fopen(__DIR__ . "/../../../data/$csvFile", 'rb');
     while (!feof($fp)) {
       $sampleData[] = fgetcsv($fp);
     }
+    fclose($fp);
+
+    $table_name = $storage->getTableName();
     foreach ($sampleData as $row) {
       $values = [];
       foreach ($row as $key => $value) {
         $values[] = $types[$key] == "int" ? $value : "'$value'";
         $valuesStr = implode(", ", $values);
       }
-      $connection->query("INSERT INTO `datastore_$id` VALUES ($valuesStr);");
+      $connection->query("INSERT INTO `$table_name` VALUES ($valuesStr);");
     }
 
-    $storage = new SqliteDatabaseTable(
-      $connection,
-      new DataResource("data-$id.csv", "text/csv"),
-      $this->createStub(LoggerInterface::class)
-    );
-    $storage->setSchema([
-      'fields' => $fields,
-    ]);
     return $storage;
   }
 

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -10,7 +10,6 @@ use Drupal\Core\Config\ImmutableConfig;
 use Drupal\common\DatasetInfo;
 use Drupal\datastore\Controller\QueryController;
 use Drupal\datastore\Controller\QueryDownloadController;
-use Drupal\datastore\DatastoreResource;
 use Drupal\datastore\DatastoreService;
 use Drupal\datastore\Service\Query;
 use Drupal\datastore\Storage\SqliteDatabaseTable;
@@ -65,12 +64,15 @@ class QueryDownloadControllerTest extends TestCase {
     $this->resources = [
       '2' => new DataResource(self::FILE_DIR . 'states_with_dupes.csv', 'text/csv'),
       '3' => new DataResource(self::FILE_DIR . 'years_colors.csv', 'text/csv'),
+      '4' => new DataResource(self::FILE_DIR . 'states_with_dupes_link.csv', 'text/csv'),
     ];
+
+    $this->buffer = '';
   }
 
   protected function tearDown(): void {
     parent::tearDown();
-    $this->buffer = NULL;
+    $this->buffer = '';
   }
 
   /**
@@ -362,14 +364,15 @@ class QueryDownloadControllerTest extends TestCase {
    * Create a mock object for the main container passed to the controller.
    *
    * @param int $rowLimit
-   *    The row limit for a query.
+   *   The row limit for a query.
    * @param int|null $responseStreamMaxAge
-   *    The max age for the response stream in cache, or NULL to use the default.
+   *   The max age for the response stream in cache, or NULL to use the default.
    *
    * @return \PHPUnit\Framework\MockObject\MockObject
    *   MockChain mock object.
    */
   private function getQueryContainer(int $rowLimit, ?int $responseStreamMaxAge = NULL) {
+    $connection = new SqliteConnection(new \PDO('sqlite::memory:'), []);
     $options = (new Options())
       ->add("dkan.metastore.storage", DataFactory::class)
       ->add("dkan.datastore.service", DatastoreService::class)
@@ -411,14 +414,14 @@ class QueryDownloadControllerTest extends TestCase {
       ],
     ];
 
-    $storage2 = $this->mockDatastoreTable($this->resources[2], $schema2);
-    $storage2x = clone($storage2);
+    $storage2 = $this->mockDatastoreTable($this->resources[2], $schema2, $connection);
+    $storage2x = $this->mockDatastoreTable($this->resources[4], $schema2, $connection);
     $storage2x->setSchema(['fields' => []]);
+    $storage3 = $this->mockDatastoreTable($this->resources[3], $schema3, $connection);
     $storageMap = [
       't' => $storage2,
       'tx' => $storage2x,
-      'j' => $this->mockDatastoreTable($this->resources[3], $schema3
-      ),
+      'j' => $storage3,
     ];
 
     $chain = (new Chain($this))
@@ -468,9 +471,8 @@ class QueryDownloadControllerTest extends TestCase {
    * @return \Drupal\common\Storage\DatabaseTableInterface
    *   A database table storage class useable for datastore queries.
    */
-  public function mockDatastoreTable(DataResource $resource, $fields) {
-    $connection = new SqliteConnection(new \PDO('sqlite::memory:'), []);
-
+  public function mockDatastoreTable(DataResource $resource, $fields, $connection) {
+    
     $storage = new SqliteDatabaseTable(
       $connection,
       $resource,

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -36,7 +36,12 @@ class QueryDownloadControllerTest extends TestCase {
 
   const FILE_DIR = __DIR__ . "/../../../data/";
 
-  private $buffer;
+  /**
+   * Output buffer.
+   *
+   * @var string
+   */
+  private string $buffer;
 
   /**
    * Resources to be used in tests.
@@ -375,8 +380,6 @@ class QueryDownloadControllerTest extends TestCase {
       ->add('dkan.metastore.api_response', MetastoreApiResponse::class)
       ->index(0);
 
-    $connection = new SqliteConnection(new \PDO('sqlite::memory:'), []);
-
     $schema2 = [
       'record_number' => [
         'type' => 'int',
@@ -408,13 +411,13 @@ class QueryDownloadControllerTest extends TestCase {
       ],
     ];
 
-    $storage2 = $this->mockDatastoreTable($connection, $this->resources[2], $schema2);
+    $storage2 = $this->mockDatastoreTable($this->resources[2], $schema2);
     $storage2x = clone($storage2);
     $storage2x->setSchema(['fields' => []]);
     $storageMap = [
       't' => $storage2,
       'tx' => $storage2x,
-      'j' => $this->mockDatastoreTable($connection, $this->resources[3], $schema3
+      'j' => $this->mockDatastoreTable($this->resources[3], $schema3
       ),
     ];
 
@@ -465,7 +468,9 @@ class QueryDownloadControllerTest extends TestCase {
    * @return \Drupal\common\Storage\DatabaseTableInterface
    *   A database table storage class useable for datastore queries.
    */
-  public function mockDatastoreTable($connection, DataResource $resource, $fields) {
+  public function mockDatastoreTable(DataResource $resource, $fields) {
+    $connection = new SqliteConnection(new \PDO('sqlite::memory:'), []);
+
     $storage = new SqliteDatabaseTable(
       $connection,
       $resource,
@@ -503,9 +508,10 @@ class QueryDownloadControllerTest extends TestCase {
   /**
    * Callback to get output buffer.
    *
-   * @param $buffer
+   * @param string $buffer
+   *   A buffer to be appended to existing buffer in memory.
    */
-  protected function getBuffer($buffer) {
+  protected function getBuffer(string $buffer) {
     $this->buffer .= $buffer;
   }
 

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\datastore\Unit\Controller;
 
+use Drupal\common\DataResource;
 use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Drupal\Core\Cache\Context\CacheContextsManager;
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -475,7 +476,7 @@ class QueryDownloadControllerTest extends TestCase {
 
     $storage = new SqliteDatabaseTable(
       $connection,
-      new DatastoreResource($id, "data-$id.csv", "text/csv"),
+      new DataResource("data-$id.csv", "text/csv"),
       $this->createStub(LoggerInterface::class)
     );
     $storage->setSchema([

--- a/modules/datastore/tests/src/Unit/Service/Info/ImportInfoTest.php
+++ b/modules/datastore/tests/src/Unit/Service/Info/ImportInfoTest.php
@@ -4,7 +4,7 @@ namespace Drupal\Tests\datastore\Unit\Service\Info;
 
 use Contracts\Mock\Storage\Memory;
 use CsvParser\Parser\Csv;
-use Drupal\datastore\DatastoreResource;
+use Drupal\common\DataResource;
 use Drupal\datastore\Plugin\QueueWorker\ImportJob;
 use Drupal\datastore\Service\Info\ImportInfo;
 use Drupal\Tests\datastore\Unit\Plugin\QueueWorker\TestMemStorage;
@@ -56,7 +56,7 @@ class ImportInfoTest extends TestCase {
     // Make a FileFetcher object.
     $storage = new Memory();
     $config = [
-      "resource" => (new DatastoreResource('id', 'path', 'mime')),
+      "resource" => (new DataResource('path', 'mime')),
       "storage" => new TestMemStorage(),
       "parser" => Csv::getParser(),
       "filePath" => 'test',
@@ -87,7 +87,7 @@ class ImportInfoTest extends TestCase {
     // Make an ImportJob object.
     $storage = new Memory();
     $config = [
-      "resource" => (new DatastoreResource('id', 'path', 'mime')),
+      "resource" => (new DataResource('path', 'mime')),
       "storage" => new TestMemStorage(),
       "parser" => Csv::getParser(),
     ];

--- a/modules/datastore/tests/src/Unit/Service/ResourceProcessor/DictionaryEnforcerTest.php
+++ b/modules/datastore/tests/src/Unit/Service/ResourceProcessor/DictionaryEnforcerTest.php
@@ -14,6 +14,9 @@ use Drupal\datastore\DatastoreService;
 use Drupal\datastore\Service\PostImport;
 use Drupal\datastore\Service\ResourceProcessorCollector;
 use Drupal\datastore\Service\ResourceProcessor\DictionaryEnforcer;
+use Drupal\datastore\Storage\DatabaseTable;
+use Drupal\datastore\Storage\DatabaseTableFactory;
+use Drupal\jsonapi\JsonApiResource\Data;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscovery;
 use Drupal\metastore\DataDictionary\DataDictionaryDiscoveryInterface;
 use Drupal\metastore\MetastoreService;
@@ -59,7 +62,17 @@ class DictionaryEnforcerTest extends TestCase {
     $dictionary_discovery_service = (new Chain($this))
       ->add(DataDictionaryDiscoveryInterface::class, 'dictionaryIdFromResource', 'dictionary-id')
       ->getMock();
-    $dictionary_enforcer = new DictionaryEnforcer($alter_table_query_builder, $metastore_service, $dictionary_discovery_service);
+    $database_table_factory = (new Chain($this))
+      ->add(DatabaseTableFactory::class, 'getInstance', DatabaseTable::class)
+      ->add(DatabaseTable::class, 'getTableName', 'datastore_table')
+      ->getMock();
+
+    $dictionary_enforcer = new DictionaryEnforcer(
+      $alter_table_query_builder,
+      $metastore_service,
+      $dictionary_discovery_service,
+      $database_table_factory
+    );
 
     $container_chain = $this->getContainerChain($resource->getVersion())
       ->add(AlterTableQueryInterface::class, 'execute')
@@ -96,7 +109,16 @@ class DictionaryEnforcerTest extends TestCase {
     $dictionary_discovery_service = (new Chain($this))
       ->add(DataDictionaryDiscoveryInterface::class, 'dictionaryIdFromResource', 'data-dictionary')
       ->getMock();
-    $dictionary_enforcer = new DictionaryEnforcer($alter_table_query_builder, $metastore_service, $dictionary_discovery_service);
+    $database_table_factory = (new Chain($this))
+      ->add(DatabaseTableFactory::class, 'getInstance', DatabaseTable::class)
+      ->add(DatabaseTable::class, 'getTableName', 'datastore_table')
+      ->getMock();
+    $dictionary_enforcer = new DictionaryEnforcer(
+      $alter_table_query_builder,
+      $metastore_service,
+      $dictionary_discovery_service,
+      $database_table_factory
+    );
 
     $container_chain = $this->getContainerChain($resource->getVersion())
       ->add(AlterTableQueryInterface::class, 'execute')
@@ -133,7 +155,17 @@ class DictionaryEnforcerTest extends TestCase {
       ->add(DataDictionaryDiscoveryInterface::class, 'getDataDictionaryMode', DataDictionaryDiscoveryInterface::MODE_SITEWIDE)
       ->add(DataDictionaryDiscoveryInterface::class, 'getSitewideDictionaryId','2')
       ->getMock();
-    $dictionary_enforcer = new DictionaryEnforcer($alter_table_query_builder, $metastore_service, $dictionary_discovery_service);
+    $database_table_factory = (new Chain($this))
+      ->add(DatabaseTableFactory::class, 'getInstance', DatabaseTable::class)
+      ->add(DatabaseTable::class, 'getTableName', 'datastore_table')
+      ->getMock();
+
+    $dictionary_enforcer = new DictionaryEnforcer(
+      $alter_table_query_builder,
+      $metastore_service,
+      $dictionary_discovery_service,
+      $database_table_factory
+    );
 
     $container_chain = $this->getContainerChain($resource->getVersion())
       ->add(AlterTableQueryInterface::class, 'execute')

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableFactoryTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableFactoryTest.php
@@ -3,7 +3,7 @@
 namespace Drupal\Tests\datastore\Unit\Storage;
 
 use Drupal\Core\Database\Connection;
-use Drupal\datastore\DatastoreResource;
+use Drupal\common\DataResource;
 use Drupal\datastore\Storage\DatabaseTable;
 use Drupal\datastore\Storage\DatabaseTableFactory;
 use MockChain\Chain;
@@ -39,8 +39,8 @@ class DatabaseTableFactoryTest extends TestCase {
 
     $factory->method("getDatabaseTable")->willReturn($databaseTable);
 
-    $resource = new DatastoreResource("blah", "", "text/csv");
-    $object = $factory->getInstance($resource->getId(), ['resource' => $resource]);
+    $resource = new DataResource("", "text/csv");
+    $object = $factory->getInstance($resource->getUniqueIdentifier(), ['resource' => $resource]);
     $this->assertTrue($object instanceof DatabaseTable);
   }
 

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -9,7 +9,6 @@ use Drupal\Core\Database\Query\Insert;
 use Drupal\Core\Database\Query\Select;
 use Drupal\Core\Database\StatementWrapper;
 use Drupal\common\Storage\Query;
-use Drupal\datastore\DatastoreResource;
 use Drupal\datastore\Storage\DatabaseTable;
 use Drupal\mysql\Driver\Database\mysql\Schema;
 use MockChain\Chain;

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\datastore\Storage;
 
+use Drupal\common\DataResource;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\DatabaseExceptionWrapper;
 use Drupal\Core\Database\Query\Insert;
@@ -476,7 +477,7 @@ class DatabaseTableTest extends TestCase {
    * Private.
    */
   private function getResource() {
-    return new DatastoreResource("people", "", "text/csv");
+    return new DataResource("", "text/csv");
   }
 
 }

--- a/modules/json_form_widget/tests/src/Unit/StringHelperTest.php
+++ b/modules/json_form_widget/tests/src/Unit/StringHelperTest.php
@@ -102,7 +102,6 @@ class StringHelperTest extends TestCase {
     $data = 'mailto:john@doe.com';
 
     $result = $string_helper->handleStringElement($definition, $data);
-    print_r($result['#default_value']);
     $this->assertEquals('john@doe.com', $result['#default_value']);
   }
 


### PR DESCRIPTION
Fixes #4359

## Describe your changes

Remove DatastoreResource class, use DataResource for everything. Note that any class or function that expected a DatastoreResource object now expects a DataResource object. So any custom code that, for instance, builds a datastore `DatabaseTable` object will need to be slightly refactored. 

Other changes to note:

* `AbstractDatabaseTable::setTable()` is now public. We should use this directly instead of calling `::count()` (as we do currently in some places) to indirectly create a database table.
* `DictionaryEnforcer` now requires the `dkan.datastore.database_table_factory` service

Please override the CC warnings when reviewing, they are due to CC getting confused by the ReturnTypeMayChange attribute. May be an issue with CC config.

## QA Steps

Nothing to QA, everything should still work as it did before from user's perspective.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [x] I have updated or added documentation
