### PR TITLE
Filter by title on the dataset import status dashboard

### DIFF
--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -2,15 +2,18 @@
 
 namespace Drupal\datastore\Form;
 
-use Drupal\common\DataResource;
-use Drupal\Core\Pager\PagerManagerInterface;
-use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Datetime\DateFormatter;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\common\DatasetInfo;
-use Drupal\Core\Datetime\DateFormatter;
+use Drupal\Core\Pager\PagerManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
+use Drupal\common\DataResource;
+use Drupal\common\DatasetInfo;
 use Drupal\common\UrlHostTokenResolver;
+use Drupal\datastore\Service\PostImport;
 use Drupal\harvest\HarvestService;
 use Drupal\metastore\MetastoreService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -72,6 +75,13 @@ class DashboardForm extends FormBase {
   protected PostImportResultFactory $postImportResultFactory;
 
   /**
+   * Node storage service.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected EntityStorageInterface $nodeStorage;
+
+  /**
    * DashboardController constructor.
    *
    * @param \Drupal\harvest\HarvestService $harvestService
@@ -84,8 +94,10 @@ class DashboardForm extends FormBase {
    *   Pager manager service.
    * @param \Drupal\Core\Datetime\DateFormatter $dateFormatter
    *   Date formatter service.
-   * @param \Drupal\datastore\PostImportResultFactory $postImportResultFactory
-   *   The PostImportResultFactory service..
+   * @param \Drupal\datastore\Service\PostImport $post_import
+   *   The post import service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   Entity type manager service.
    */
   public function __construct(
     HarvestService $harvestService,
@@ -93,13 +105,16 @@ class DashboardForm extends FormBase {
     MetastoreService $metastoreService,
     PagerManagerInterface $pagerManager,
     DateFormatter $dateFormatter,
-    PostImportResultFactory $postImportResultFactory
+    PostImport $post_import,
+    EntityTypeManagerInterface $entityTypeManager,
   ) {
     $this->harvest = $harvestService;
     $this->datasetInfo = $datasetInfo;
     $this->metastore = $metastoreService;
     $this->pagerManager = $pagerManager;
     $this->dateFormatter = $dateFormatter;
+    $this->postImport = $post_import;
+    $this->nodeStorage = $entityTypeManager->getStorage('node');
     $this->itemsPerPage = 10;
     $this->postImportResultFactory = $postImportResultFactory;
   }
@@ -114,7 +129,8 @@ class DashboardForm extends FormBase {
       $container->get('dkan.metastore.service'),
       $container->get('pager.manager'),
       $container->get('date.formatter'),
-      $container->get('dkan.datastore.post_import_result_factory'),
+      $container->get('dkan.datastore.service.post_import'),
+      $container->get('entity_type.manager'),
     );
   }
 
@@ -190,6 +206,12 @@ class DashboardForm extends FormBase {
           '#title' => $this->t('Dataset ID'),
           '#default_value' => $filters['uuid'] ?? '',
         ],
+        'dataset_title' => [
+          '#type' => 'textfield',
+          '#weight' => 1,
+          '#title' => $this->t('Dataset Title'),
+          '#default_value' => $filters['dataset_title'] ?? '',
+        ],
         'harvest_id' => [
           '#type' => 'select',
           '#weight' => 1,
@@ -241,11 +263,20 @@ class DashboardForm extends FormBase {
   /**
    * Retrieve list of UUIDs for datasets matching the given filters.
    *
+   * Filters over-ride each other, in this order of priority:
+   * - UUID
+   * - Title search
+   * - Harvest plan ID
+   *
    * @param string[] $filters
-   *   Datasets filters.
+   *   Datasets filters. Keys determine the filter. Recognized keys:
+   *   - uuid - Dataset UUID.
+   *   - dataset_title - A CONTAINS search within the dataset title field.
+   *   - harvest_id - A harvest plan ID.
    *
    * @return string[]
-   *   Filtered list of dataset UUIDs.
+   *   Paged, filtered list of dataset UUIDs. If no filter was supplied, all
+   *   dataset UUIDs will be returned, paged.
    */
   protected function getDatasets(array $filters): array {
     $datasets = [];
@@ -255,8 +286,30 @@ class DashboardForm extends FormBase {
     if (isset($filters['uuid'])) {
       $datasets = [$filters['uuid']];
     }
+    // Is the user searching for a dataset title?
+    elseif (isset($filters['dataset_title'])) {
+      $datasets = [];
+      // Get the ids using an entity query, because our dataset title is in the
+      // node title field.
+      // @todo Unify different queries against Data nodes using a repository or
+      //   the NodeData wrapper.
+      $results = $this->nodeStorage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('type', 'data')
+        ->condition('field_data_type', 'dataset')
+        ->condition('title', $filters['dataset_title'], 'CONTAINS')
+        ->execute();
+      foreach ($this->nodeStorage->loadMultiple($results) as $node) {
+        $datasets[] = $node->uuid();
+      }
+      $total = count($datasets);
+      $currentPage = $this->pagerManager->createPager($total, $this->itemsPerPage)->getCurrentPage();
+
+      $chunks = array_chunk($datasets, $this->itemsPerPage) ?: [[]];
+      $datasets = $chunks[$currentPage];
+    }
     // If a value was supplied for the harvest ID filter, retrieve dataset UUIDs
-    // belonging to the specfied harvest.
+    // belonging to the specified harvest.
     elseif (isset($filters['harvest_id'])) {
       $harvestLoad = iterator_to_array($this->getHarvestLoadStatus($filters['harvest_id']));
       $datasets = array_keys($harvestLoad);

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -286,20 +286,8 @@ class DashboardForm extends FormBase {
     }
     // Is the user searching for a dataset title?
     elseif (isset($filters['dataset_title'])) {
-      // Get the ids using an entity query, because our dataset title is in the
-      // node title field.
-      // @todo Unify different queries against Data nodes using a repository or
-      // the NodeData wrapper.
-      $results = $this->nodeStorage->getQuery()
-        ->accessCheck(FALSE)
-        ->condition('type', 'data')
-        ->condition('field_data_type', 'dataset')
-        ->condition('title', $filters['dataset_title'], 'CONTAINS')
-        ->execute();
-      foreach ($this->nodeStorage->loadMultiple($results) as $node) {
-        $datasets[] = $node->uuid();
-      }
-      $datasets = $this->pagedFilteredList($datasets);
+      $results = $this->getDatasetsByTitle($filters);
+      $datasets = $this->pagedFilteredList($results);
     }
     // If a value was supplied for the harvest ID filter, retrieve dataset UUIDs
     // belonging to the specified harvest.
@@ -319,6 +307,33 @@ class DashboardForm extends FormBase {
         $this->itemsPerPage,
         TRUE
       );
+    }
+
+    return $datasets;
+  }
+
+  /**
+   * Entity query for nodes containing the dataset title.
+   *
+   * @param string[] $filters
+   *   Datasets filters.
+   *
+   * @return string[]
+   *   Dataset UUIDs .
+   */
+  protected function getDatasetsByTitle($filters): array {
+    // Get the ids using an entity query, because our dataset title is in the
+    // node title field.
+    // @todo Unify different queries against Data nodes using a repository or
+    // the NodeData wrapper.
+    $results = $this->nodeStorage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', 'data')
+      ->condition('field_data_type', 'dataset')
+      ->condition('title', $filters['dataset_title'], 'CONTAINS')
+      ->execute();
+    foreach ($this->nodeStorage->loadMultiple($results) as $node) {
+      $datasets[] = $node->uuid();
     }
 
     return $datasets;

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -13,7 +13,6 @@ use Drupal\Core\Url;
 use Drupal\common\DataResource;
 use Drupal\common\DatasetInfo;
 use Drupal\common\UrlHostTokenResolver;
-use Drupal\datastore\Service\PostImport;
 use Drupal\harvest\HarvestService;
 use Drupal\metastore\MetastoreService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -94,8 +93,8 @@ class DashboardForm extends FormBase {
    *   Pager manager service.
    * @param \Drupal\Core\Datetime\DateFormatter $dateFormatter
    *   Date formatter service.
-   * @param \Drupal\datastore\Service\PostImport $post_import
-   *   The post import service.
+   * @param \Drupal\datastore\PostImportResultFactory $postImportResultFactory
+   *   The PostImportResultFactory service..
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   Entity type manager service.
    */
@@ -105,7 +104,7 @@ class DashboardForm extends FormBase {
     MetastoreService $metastoreService,
     PagerManagerInterface $pagerManager,
     DateFormatter $dateFormatter,
-    PostImport $post_import,
+    PostImportResultFactory $postImportResultFactory,
     EntityTypeManagerInterface $entityTypeManager,
   ) {
     $this->harvest = $harvestService;
@@ -113,7 +112,6 @@ class DashboardForm extends FormBase {
     $this->metastore = $metastoreService;
     $this->pagerManager = $pagerManager;
     $this->dateFormatter = $dateFormatter;
-    $this->postImport = $post_import;
     $this->nodeStorage = $entityTypeManager->getStorage('node');
     $this->itemsPerPage = 10;
     $this->postImportResultFactory = $postImportResultFactory;
@@ -129,7 +127,7 @@ class DashboardForm extends FormBase {
       $container->get('dkan.metastore.service'),
       $container->get('pager.manager'),
       $container->get('date.formatter'),
-      $container->get('dkan.datastore.service.post_import'),
+      $container->get('dkan.datastore.post_import_result_factory'),
       $container->get('entity_type.manager'),
     );
   }
@@ -266,7 +264,7 @@ class DashboardForm extends FormBase {
    * Filters over-ride each other, in this order of priority:
    * - UUID
    * - Title search
-   * - Harvest plan ID
+   * - Harvest plan ID.
    *
    * @param string[] $filters
    *   Datasets filters. Keys determine the filter. Recognized keys:
@@ -288,11 +286,10 @@ class DashboardForm extends FormBase {
     }
     // Is the user searching for a dataset title?
     elseif (isset($filters['dataset_title'])) {
-      $datasets = [];
       // Get the ids using an entity query, because our dataset title is in the
       // node title field.
       // @todo Unify different queries against Data nodes using a repository or
-      //   the NodeData wrapper.
+      // the NodeData wrapper.
       $results = $this->nodeStorage->getQuery()
         ->accessCheck(FALSE)
         ->condition('type', 'data')
@@ -302,22 +299,14 @@ class DashboardForm extends FormBase {
       foreach ($this->nodeStorage->loadMultiple($results) as $node) {
         $datasets[] = $node->uuid();
       }
-      $total = count($datasets);
-      $currentPage = $this->pagerManager->createPager($total, $this->itemsPerPage)->getCurrentPage();
-
-      $chunks = array_chunk($datasets, $this->itemsPerPage) ?: [[]];
-      $datasets = $chunks[$currentPage];
+      $datasets = $this->pagedFilteredList($datasets);
     }
     // If a value was supplied for the harvest ID filter, retrieve dataset UUIDs
     // belonging to the specified harvest.
     elseif (isset($filters['harvest_id'])) {
       $harvestLoad = iterator_to_array($this->getHarvestLoadStatus($filters['harvest_id']));
       $datasets = array_keys($harvestLoad);
-      $total = count($datasets);
-      $currentPage = $this->pagerManager->createPager($total, $this->itemsPerPage)->getCurrentPage();
-
-      $chunks = array_chunk($datasets, $this->itemsPerPage) ?: [[]];
-      $datasets = $chunks[$currentPage];
+      $datasets = $this->pagedFilteredList($datasets);
     }
     // If no filter values were supplied, fetch from the list of all dataset
     // UUIDs.
@@ -333,6 +322,23 @@ class DashboardForm extends FormBase {
     }
 
     return $datasets;
+  }
+
+  /**
+   * Paged, filtered list of dataset UUIDs.
+   *
+   * @param string[] $datasets
+   *   Dataset UUIDs.
+   *
+   * @return string[]
+   *   Paged, filtered list of dataset UUIDs.
+   */
+  protected function pagedFilteredList(array $datasets): array {
+    $total = count($datasets);
+    $currentPage = $this->pagerManager->createPager($total, $this->itemsPerPage)->getCurrentPage();
+    $chunks = array_chunk($datasets, $this->itemsPerPage) ?: [[]];
+
+    return $chunks[$currentPage];
   }
 
   /**

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -321,7 +321,7 @@ class DashboardForm extends FormBase {
    * @return string[]
    *   Dataset UUIDs .
    */
-  protected function getDatasetsByTitle($filters): array {
+  protected function getDatasetsByTitle(array $filters): array {
     // Get the ids using an entity query, because our dataset title is in the
     // node title field.
     // @todo Unify different queries against Data nodes using a repository or

--- a/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
+++ b/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
@@ -189,7 +189,7 @@ class DashboardFormTest extends TestCase {
     $resourceMappermock = $this->createMock(ResourceMapper::class);
     $dataResourceMock = $this->createMock(DataResource::class);
     $postImportResultMock = $this->getMockBuilder(PostImportResult::class)
-      ->setConstructorArgs(['', '', $dataResourceMock, $connectionMock, $resourceMappermock])
+      ->setConstructorArgs(['', '', NULL, $dataResourceMock, $connectionMock, $resourceMappermock])
       ->onlyMethods(['retrieveJobStatus'])
       ->getMock();
 

--- a/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
+++ b/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
@@ -28,6 +28,10 @@ use Drupal\metastore\ResourceMapper;
 use Drupal\datastore\PostImportResult;
 use Drupal\datastore\PostImportResultFactory;
 use Drupal\common\DataResource;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * @group dkan
@@ -152,6 +156,72 @@ class DashboardFormTest extends TestCase {
   }
 
   /**
+   * Test building the dashboard table with a Dataset ID filter.
+   */
+  public function testBuildTableRowsWithDatasetTitleFilter() {
+    $info = [
+      'uuid' => 'dataset-1',
+      'title' => 'Dataset 1',
+      'revision_id' => '2',
+      'moderation_state' => 'published',
+      'modified_date_metadata' => '2020-01-15',
+      'modified_date_dkan' => '2021-02-11',
+    ];
+    $distribution = [
+      'distribution_uuid' => 'dist-1',
+      'resource_id' => '9ad17d45894f823c6a8e4f6d32b9535f',
+      'resource_version' => '1679508886',
+      'fetcher_status' => 'done',
+      'fetcher_percent_done' => 100,
+      'importer_status' => 'done',
+      'importer_percent_done' => 100,
+      'importer_error' => '',
+      'source_path' => 'http://example.com/file.csv',
+    ];
+
+    $postImportInfo = [
+      'resource_version' => '1679508886',
+      'post_import_status' => 'done',
+      'post_import_error' => NULL,
+    ];
+
+    $connectionMock = $this->createMock(Connection::class);
+    $resourceMappermock = $this->createMock(ResourceMapper::class);
+    $dataResourceMock = $this->createMock(DataResource::class);
+    $postImportResultMock = $this->getMockBuilder(PostImportResult::class)
+      ->setConstructorArgs(['', '', $dataResourceMock, $connectionMock, $resourceMappermock])
+      ->onlyMethods(['retrieveJobStatus'])
+      ->getMock();
+
+    $postImportResultMock->method('retrieveJobStatus')->willReturn($postImportInfo);
+
+    $nodeMock = (new Chain($this))
+      ->add(NodeInterface::class, 'uuid', 'dataset-1')
+      ->getMock();
+
+    $container = $this->buildContainerChain()
+      ->add(EntityTypeManagerInterface::class, 'getStorage', EntityStorageInterface::class)
+      ->add(RequestStack::class, 'getCurrentRequest', new Request(['dataset_title' => 'Dataset 1']))
+      ->add(EntityStorageInterface::class, 'getQuery', QueryInterface::class)
+      ->add(EntityStorageInterface::class, 'loadMultiple', [$nodeMock])
+      ->add(QueryInterface::class, 'accessCheck', QueryInterface::class)
+      ->add(QueryInterface::class, 'condition', QueryInterface::class)
+      ->add(QueryInterface::class, 'execute', [$nodeMock])
+      ->add(DatasetInfo::class, 'gather', ['latest_revision' => $info + ['distributions' => [$distribution]]])
+      ->add(PostImportResultFactory::class, 'initializeFromDistribution', $postImportResultMock)
+      ->getMock();
+    \Drupal::setContainer($container);
+    $form = DashboardForm::create($container)->buildForm([], new FormState());
+
+    $this->assertEquals(1, count($form['table']['#rows']));
+    $this->assertEquals('dataset-1', $form['table']['#rows'][0][0]['data']['#uuid']);
+    $this->assertEquals('Dataset 1', $form['table']['#rows'][0][0]['data']['#title']);
+    $this->assertEquals('NEW', $form['table']['#rows'][0][2]['data']);
+    $this->assertEquals('done', $form['table']['#rows'][0][6]['data']['#status']);
+    $this->assertEquals(NULL, $form['table']['#rows'][0][6]['data']['#error']);
+  }
+
+  /**
    * Test building the dashboard table with a UUID filter.
    */
   public function testBuildTableRowsWithUuidFilter() {
@@ -192,7 +262,7 @@ class DashboardFormTest extends TestCase {
     $postImportResultMock->method('retrieveJobStatus')->willReturn($postImportInfo);
 
     $container = $this->buildContainerChain()
-      ->add(RequestStack::class, 'getCurrentRequest', new Request(['uuid' => 'test']))
+      ->add(RequestStack::class, 'getCurrentRequest', new Request(['uuid' => 'test 1']))
       ->add(DatasetInfo::class, 'gather', ['latest_revision' => $info + ['distributions' => [$distribution]]])
       ->add(PostImportResultFactory::class, 'initializeFromDistribution', $postImportResultMock)
       ->getMock();
@@ -429,6 +499,8 @@ class DashboardFormTest extends TestCase {
       ->add('dkan.harvest.storage.harvest_run_repository', HarvestRunRepository::class)
       ->add('database', Connection::class)
       ->add('dkan.datastore.post_import_result_factory', PostImportResultFactory::class)
+      ->add('entity.storage.interface', EntityStorageInterface::class)
+      ->add('entity_type.manager', EntityTypeManagerInterface::class)
       ->index(0);
 
     $runStatus = [
@@ -459,6 +531,7 @@ class DashboardFormTest extends TestCase {
       ->add(PathValidator::class, 'getUrlIfValidWithoutAccessCheck', NULL)
       ->add(StreamWrapperManager::class, 'getViaUri', PublicStream::class)
       ->add(PublicStream::class, 'getExternalUrl', 'http://example.com')
-      ->add(Pager::class, 'getCurrentPage', 0);
+      ->add(Pager::class, 'getCurrentPage', 0)
+      ->add(EntityTypeManagerInterface::class, 'getStorage', EntityStorageInterface::class);
   }
 }

--- a/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
+++ b/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
@@ -156,7 +156,7 @@ class DashboardFormTest extends TestCase {
   }
 
   /**
-   * Test building the dashboard table with a Dataset ID filter.
+   * Test building the dashboard table with a Dataset Title filter.
    */
   public function testBuildTableRowsWithDatasetTitleFilter() {
     $info = [
@@ -262,7 +262,7 @@ class DashboardFormTest extends TestCase {
     $postImportResultMock->method('retrieveJobStatus')->willReturn($postImportInfo);
 
     $container = $this->buildContainerChain()
-      ->add(RequestStack::class, 'getCurrentRequest', new Request(['uuid' => 'test 1']))
+      ->add(RequestStack::class, 'getCurrentRequest', new Request(['uuid' => 'test']))
       ->add(DatasetInfo::class, 'gather', ['latest_revision' => $info + ['distributions' => [$distribution]]])
       ->add(PostImportResultFactory::class, 'initializeFromDistribution', $postImportResultMock)
       ->getMock();


### PR DESCRIPTION
Partially fixes [#3637]
JIRA: 23788

## Describe your changes

This PR adds a new filter to search the Datastore Import Status dashboard with the dataset title.

## QA Steps

- [ ] Checkout branch locally.
- [ ] run `ddev dkan-site-install`
- [ ] run `ddev dkan-sample-content`
- [ ] run `ddev drush cron` 2X
- [ ] run `ddev drush uli`
- [ ] navigate to the dashboard here: /admin/dkan/datastore/status
- [ ] Confirm you are able to search with Dataset ID, Dataset Title and Harvest ID.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
