### PR TITLE
Add logging information when a dataset has already been imported

### DIFF
--- a/modules/datastore/src/Plugin/QueueWorker/ImportQueueWorker.php
+++ b/modules/datastore/src/Plugin/QueueWorker/ImportQueueWorker.php
@@ -129,6 +129,7 @@ class ImportQueueWorker extends QueueWorkerBase implements ContainerFactoryPlugi
 
     // Can we short-circuit this task?
     if ($this->alreadyImported($data)) {
+      $this->logger->notice('Dataset with identifier ' . $data['identifier'] . ' and version ' . $data['version'] . ' already exists and will not be re-imported.');
       return;
     }
 

--- a/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/ImportQueueWorkerTest.php
+++ b/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/ImportQueueWorkerTest.php
@@ -131,6 +131,18 @@ class ImportQueueWorkerTest extends KernelTestBase {
    * @covers ::processItem
    */
   public function testProcessItemAlreadyImported() {
+    $this->installEntitySchema('resource_mapping');
+
+    // Mock the logger so we can tell the notice occurs.
+    $logger = $this->getMockForAbstractClass(LoggerInterface::class);
+    // We expect a notice to be logged.
+    $logger->expects($this->once())
+      ->method('notice');
+    // We don't expect an error to be logged.
+    $logger->expects($this->never())
+      ->method('error');
+    $this->container->set('dkan.datastore.logger_channel', $logger);
+
     $queue_worker = $this->createPartialMock(
       ImportQueueWorker::class,
       ['alreadyImported', 'importData']

--- a/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/ImportQueueWorkerTest.php
+++ b/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/ImportQueueWorkerTest.php
@@ -133,7 +133,7 @@ class ImportQueueWorkerTest extends KernelTestBase {
   public function testProcessItemAlreadyImported() {
     $this->installEntitySchema('resource_mapping');
 
-    // Mock the logger so we can tell the notice occurs.
+    // Mock the logger so we can tell when the notice occurs.
     $logger = $this->getMockForAbstractClass(LoggerInterface::class);
     // We expect a notice to be logged.
     $logger->expects($this->once())


### PR DESCRIPTION
Fixes #4334 

## Describe your changes

Add logging facilities to Drupal\datastore\Plugin\QueueWorker\ImportQueueWorker::processItem() such that it informs the user that the dataset already exists and will not be imported.

## QA Steps

- [ ] Import a dataset
- [ ] Attempt to re-import the same dataset
- [ ] Confirm log message notifying that the dataset was not re-mported

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [N/A] I have updated or added tests to cover my code
- [N/A] I have updated or added documentation
