### PR TITLE
Deprecate EventDispatcherTrait

### DIFF
--- a/modules/common/common.install
+++ b/modules/common/common.install
@@ -8,7 +8,10 @@ function common_requirements($phase): array {
   if ($phase == 'runtime') {
     // List all the jobstore tables.
     if ($connection = \Drupal::database()) {
-      $job_store_util = new JobStoreUtil($connection);
+      $job_store_util = new JobStoreUtil(
+        $connection,
+        \Drupal::service('event_dispatcher')
+      );
       if ($tables = $job_store_util->getUnknownJobstoreTables()) {
         $requirements['dkan unknown jobstore tables'] = [
           'title' => t('DKAN Unknown Jobstore Tables'),
@@ -68,7 +71,10 @@ function common_requirements($phase): array {
  */
 function common_update_90201() {
   $messages = [];
-  $job_store_util = new JobStoreUtil(Database::getConnection());
+  $job_store_util = new JobStoreUtil(
+    Database::getConnection(),
+    \Drupal::service('event_dispatcher')
+  );
   if ($renamed = $job_store_util->keyedToListDecorator(
     $job_store_util->renameDeprecatedJobstoreTables(), ' to '
   )) {

--- a/modules/common/common.services.yml
+++ b/modules/common/common.services.yml
@@ -12,6 +12,7 @@ services:
     class: \Drupal\common\Storage\JobStoreFactory
     arguments:
       - '@database'
+      - '@event_dispatcher'
 
   dkan.common.drupal_files:
     class: \Drupal\common\Util\DrupalFiles
@@ -36,6 +37,7 @@ services:
     class: \Drupal\common\Storage\FileFetcherJobStoreFactory
     arguments:
       - '@database'
+      - '@event_dispatcher'
 
   dkan.common.dataset_info:
     class: \Drupal\common\DatasetInfo

--- a/modules/common/src/EventDispatcherTrait.php
+++ b/modules/common/src/EventDispatcherTrait.php
@@ -6,6 +6,12 @@ use Drupal\common\Events\Event;
 
 /**
  * Event dispatcher trait.
+ *
+ * @deprecated DKAN 2.x - Many services use this trait because we needed a
+ * backwards-compatibility layer between Drupal 8 and 9, which is no longer
+ * needed. Classes should inject the 'event_dispatcher' service directly
+ * instead of using this trait. Modify those classes to use their own
+ * dispatcher instead of the one called in the trait.
  */
 trait EventDispatcherTrait {
 

--- a/modules/common/src/EventDispatcherTrait.php
+++ b/modules/common/src/EventDispatcherTrait.php
@@ -36,9 +36,9 @@ trait EventDispatcherTrait {
     if ($this->useLegacyDispatcher()) {
       return $this->legacyDispatchEvent($eventName, $data, $validator);
     }
-    $dispatcher = \Drupal::service('event_dispatcher');
+    $eventDispatcher = \Drupal::service('event_dispatcher');
 
-    if ($event = $dispatcher->dispatch(new Event($data, $validator), $eventName)) {
+    if ($event = $eventDispatcher->dispatch(new Event($data, $validator), $eventName)) {
       if ($e = $event->getException()) {
         throw $e;
       }
@@ -79,9 +79,9 @@ trait EventDispatcherTrait {
    *   If any of the subscribers registered and Exception it is thrown.
    */
   private function legacyDispatchEvent(mixed $eventName, mixed $data, mixed $validator = NULL) {
-    $dispatcher = \Drupal::service('event_dispatcher');
+    $eventDispatcher = \Drupal::service('event_dispatcher');
 
-    if ($event = $dispatcher->dispatch($eventName, new Event($data, $validator))) {
+    if ($event = $eventDispatcher->dispatch($eventName, new Event($data, $validator))) {
       if ($e = $event->getException()) {
         throw $e;
       }

--- a/modules/common/src/EventDispatcherTrait.php
+++ b/modules/common/src/EventDispatcherTrait.php
@@ -36,9 +36,9 @@ trait EventDispatcherTrait {
     if ($this->useLegacyDispatcher()) {
       return $this->legacyDispatchEvent($eventName, $data, $validator);
     }
-    $eventDispatcher = \Drupal::service('event_dispatcher');
+    $dispatcher = \Drupal::service('event_dispatcher');
 
-    if ($event = $eventDispatcher->dispatch(new Event($data, $validator), $eventName)) {
+    if ($event = $dispatcher->dispatch(new Event($data, $validator), $eventName)) {
       if ($e = $event->getException()) {
         throw $e;
       }
@@ -79,9 +79,9 @@ trait EventDispatcherTrait {
    *   If any of the subscribers registered and Exception it is thrown.
    */
   private function legacyDispatchEvent(mixed $eventName, mixed $data, mixed $validator = NULL) {
-    $eventDispatcher = \Drupal::service('event_dispatcher');
+    $dispatcher = \Drupal::service('event_dispatcher');
 
-    if ($event = $eventDispatcher->dispatch($eventName, new Event($data, $validator))) {
+    if ($event = $dispatcher->dispatch($eventName, new Event($data, $validator))) {
       if ($e = $event->getException()) {
         throw $e;
       }

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -2,16 +2,16 @@
 
 namespace Drupal\common\Storage;
 
+use Drupal\common\Events\Event;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\DatabaseExceptionWrapper;
-use Drupal\common\EventDispatcherTrait;
 use Drupal\Core\Database\SchemaObjectExistsException;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Base class for database storage methods.
  */
 abstract class AbstractDatabaseTable implements DatabaseTableInterface {
-  use EventDispatcherTrait;
 
   /**
    * The event name we send when we create a table.
@@ -35,6 +35,13 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
   protected $connection;
 
   /**
+   * Event dispatcher service.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  protected EventDispatcherInterface $eventDispatcher;
+
+  /**
    * Prepare data.
    *
    * Transform the string data given into what should be use by the insert
@@ -54,9 +61,15 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    *
    * @param \Drupal\Core\Database\Connection $connection
    *   Drupal database connection object.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *    Event dispatcher service.
    */
-  public function __construct(Connection $connection) {
+  public function __construct(
+    Connection $connection,
+    EventDispatcherInterface $eventDispatcher
+  ) {
     $this->connection = $connection;
+    $this->eventDispatcher = $eventDispatcher
 
     if ($this->tableExist($this->getTableName())) {
       $this->setSchemaFromTable();
@@ -297,12 +310,12 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    */
   protected function tableCreate($table_name, $schema) {
     // Opportunity to further alter the schema before table creation.
-    // @todo Give this event its own event class. Pass the schema array by
-    //   reference.
-    $schema = $this->dispatchEvent(self::EVENT_TABLE_CREATE, $schema);
+    $event = new Event($schema);
+    $this->eventDispatcher->dispatch($event, self::EVENT_TABLE_CREATE);
 
-    $this->connection->schema()->createTable($table_name, $schema);
+    $this->connection->schema()->createTable($table_name, $event->getData());
   }
+
 
   /**
    * Set the schema using the existing database table.

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -2,11 +2,11 @@
 
 namespace Drupal\common\Storage;
 
-use Drupal\common\Events\Event;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\DatabaseExceptionWrapper;
 use Drupal\Core\Database\SchemaObjectExistsException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Drupal\common\Events\Event;
 
 /**
  * Base class for database storage methods.

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -312,8 +312,9 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
     // Opportunity to further alter the schema before table creation.
     $event = new Event($schema);
     $this->eventDispatcher->dispatch($event, self::EVENT_TABLE_CREATE);
+    $modified_schema = $event->getData();
 
-    $this->connection->schema()->createTable($table_name, $event->getData());
+    $this->connection->schema()->createTable($table_name, $modified_schema);
   }
 
 

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -317,7 +317,6 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
     $this->connection->schema()->createTable($table_name, $modified_schema);
   }
 
-
   /**
    * Set the schema using the existing database table.
    */

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -62,14 +62,14 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    * @param \Drupal\Core\Database\Connection $connection
    *   Drupal database connection object.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
-   *    Event dispatcher service.
+   *   Event dispatcher service.
    */
   public function __construct(
     Connection $connection,
     EventDispatcherInterface $eventDispatcher
   ) {
     $this->connection = $connection;
-    $this->eventDispatcher = $eventDispatcher
+    $this->eventDispatcher = $eventDispatcher;
 
     if ($this->tableExist($this->getTableName())) {
       $this->setSchemaFromTable();

--- a/modules/common/src/Storage/AbstractJobStoreFactory.php
+++ b/modules/common/src/Storage/AbstractJobStoreFactory.php
@@ -3,6 +3,7 @@
 namespace Drupal\common\Storage;
 
 use Drupal\Core\Database\Connection;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * DKAN JobStore factory base class.
@@ -24,10 +25,16 @@ abstract class AbstractJobStoreFactory implements StorageFactoryInterface {
   protected Connection $connection;
 
   /**
+   * The event dispatcher.
+   */
+  protected EventDispatcherInterface $eventDispatcher;
+
+  /**
    * Constructor.
    */
-  public function __construct(Connection $connection) {
+  public function __construct(Connection $connection, EventDispatcherInterface $eventDispatcher) {
     $this->connection = $connection;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
@@ -59,7 +66,7 @@ abstract class AbstractJobStoreFactory implements StorageFactoryInterface {
     if ($table_name === $deprecated_table_name) {
       $deprecated_table_name = '';
     }
-    return new JobStore($table_name, $this->connection, $deprecated_table_name);
+    return new JobStore($table_name, $this->connection, $this->eventDispatcher, $deprecated_table_name);
   }
 
 }

--- a/modules/common/src/Storage/AbstractJobStoreFactory.php
+++ b/modules/common/src/Storage/AbstractJobStoreFactory.php
@@ -3,6 +3,7 @@
 namespace Drupal\common\Storage;
 
 use Drupal\Core\Database\Connection;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * DKAN JobStore factory base class.
@@ -24,10 +25,18 @@ abstract class AbstractJobStoreFactory implements StorageFactoryInterface {
   protected Connection $connection;
 
   /**
+   * Event dispatcher service.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  protected EventDispatcherInterface $eventDispatcher;
+
+  /**
    * Constructor.
    */
-  public function __construct(Connection $connection) {
+  public function __construct(Connection $connection, EventDispatcherInterface $eventDispatcher) {
     $this->connection = $connection;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
@@ -59,7 +68,7 @@ abstract class AbstractJobStoreFactory implements StorageFactoryInterface {
     if ($table_name === $deprecated_table_name) {
       $deprecated_table_name = '';
     }
-    return new JobStore($table_name, $this->connection, $deprecated_table_name);
+    return new JobStore($table_name, $this->connection, $this->eventDispatcher);
   }
 
 }

--- a/modules/common/src/Storage/AbstractJobStoreFactory.php
+++ b/modules/common/src/Storage/AbstractJobStoreFactory.php
@@ -3,7 +3,6 @@
 namespace Drupal\common\Storage;
 
 use Drupal\Core\Database\Connection;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * DKAN JobStore factory base class.
@@ -25,18 +24,10 @@ abstract class AbstractJobStoreFactory implements StorageFactoryInterface {
   protected Connection $connection;
 
   /**
-   * Event dispatcher service.
-   *
-   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
-   */
-  protected EventDispatcherInterface $eventDispatcher;
-
-  /**
    * Constructor.
    */
-  public function __construct(Connection $connection, EventDispatcherInterface $eventDispatcher) {
+  public function __construct(Connection $connection) {
     $this->connection = $connection;
-    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
@@ -68,7 +59,7 @@ abstract class AbstractJobStoreFactory implements StorageFactoryInterface {
     if ($table_name === $deprecated_table_name) {
       $deprecated_table_name = '';
     }
-    return new JobStore($table_name, $this->connection, $this->eventDispatcher);
+    return new JobStore($table_name, $this->connection, $deprecated_table_name);
   }
 
 }

--- a/modules/common/src/Storage/JobStore.php
+++ b/modules/common/src/Storage/JobStore.php
@@ -3,6 +3,7 @@
 namespace Drupal\common\Storage;
 
 use Drupal\Core\Database\Connection;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Retrieve a serialized job (datastore importer or harvest) from the database.
@@ -26,14 +27,21 @@ class JobStore extends AbstractDatabaseTable {
    *   Table name for this jobstore table.
    * @param \Drupal\Core\Database\Connection $connection
    *   Database connection.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *   The event dispatcher service.
    * @param string $deprecatedTableName
    *   (Optional) Deprecated table name, if there is one.
    */
-  public function __construct(string $tableName, Connection $connection, string $deprecatedTableName = '') {
+  public function __construct(
+    string $tableName,
+    Connection $connection,
+    EventDispatcherInterface $eventDispatcher,
+    string $deprecatedTableName = ''
+  ) {
     $this->tableName = $tableName;
     $this->deprecatedTableName = $deprecatedTableName;
     $this->setOurSchema();
-    parent::__construct($connection);
+    parent::__construct($connection, $eventDispatcher);
   }
 
   /**

--- a/modules/common/src/Storage/JobStore.php
+++ b/modules/common/src/Storage/JobStore.php
@@ -27,16 +27,16 @@ class JobStore extends AbstractDatabaseTable {
    *   Table name for this jobstore table.
    * @param \Drupal\Core\Database\Connection $connection
    *   Database connection.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *   The event dispatcher service.
    * @param string $deprecatedTableName
    *   (Optional) Deprecated table name, if there is one.
-   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
-   *    The event dispatcher service.
    */
   public function __construct(
     string $tableName,
     Connection $connection,
-    string $deprecatedTableName = '',
-    EventDispatcherInterface $eventDispatcher
+    EventDispatcherInterface $eventDispatcher,
+    string $deprecatedTableName = ''
   ) {
     $this->tableName = $tableName;
     $this->deprecatedTableName = $deprecatedTableName;

--- a/modules/common/src/Storage/JobStore.php
+++ b/modules/common/src/Storage/JobStore.php
@@ -3,6 +3,7 @@
 namespace Drupal\common\Storage;
 
 use Drupal\Core\Database\Connection;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Retrieve a serialized job (datastore importer or harvest) from the database.
@@ -29,11 +30,11 @@ class JobStore extends AbstractDatabaseTable {
    * @param string $deprecatedTableName
    *   (Optional) Deprecated table name, if there is one.
    */
-  public function __construct(string $tableName, Connection $connection, string $deprecatedTableName = '') {
+  public function __construct(string $tableName, Connection $connection, EventDispatcherInterface $eventDispatcher, string $deprecatedTableName = '') {
     $this->tableName = $tableName;
     $this->deprecatedTableName = $deprecatedTableName;
     $this->setOurSchema();
-    parent::__construct($connection);
+    parent::__construct($connection, $eventDispatcher);
   }
 
   /**

--- a/modules/common/src/Storage/JobStore.php
+++ b/modules/common/src/Storage/JobStore.php
@@ -27,16 +27,16 @@ class JobStore extends AbstractDatabaseTable {
    *   Table name for this jobstore table.
    * @param \Drupal\Core\Database\Connection $connection
    *   Database connection.
-   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
-   *   The event dispatcher service.
    * @param string $deprecatedTableName
    *   (Optional) Deprecated table name, if there is one.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *    The event dispatcher service.
    */
   public function __construct(
     string $tableName,
     Connection $connection,
-    EventDispatcherInterface $eventDispatcher,
-    string $deprecatedTableName = ''
+    string $deprecatedTableName = '',
+    EventDispatcherInterface $eventDispatcher
   ) {
     $this->tableName = $tableName;
     $this->deprecatedTableName = $deprecatedTableName;

--- a/modules/common/src/Storage/JobStore.php
+++ b/modules/common/src/Storage/JobStore.php
@@ -3,7 +3,6 @@
 namespace Drupal\common\Storage;
 
 use Drupal\Core\Database\Connection;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Retrieve a serialized job (datastore importer or harvest) from the database.
@@ -30,11 +29,11 @@ class JobStore extends AbstractDatabaseTable {
    * @param string $deprecatedTableName
    *   (Optional) Deprecated table name, if there is one.
    */
-  public function __construct(string $tableName, Connection $connection, EventDispatcherInterface $eventDispatcher, string $deprecatedTableName = '') {
+  public function __construct(string $tableName, Connection $connection, string $deprecatedTableName = '') {
     $this->tableName = $tableName;
     $this->deprecatedTableName = $deprecatedTableName;
     $this->setOurSchema();
-    parent::__construct($connection, $eventDispatcher);
+    parent::__construct($connection);
   }
 
   /**

--- a/modules/common/src/Storage/JobStoreFactory.php
+++ b/modules/common/src/Storage/JobStoreFactory.php
@@ -3,6 +3,7 @@
 namespace Drupal\common\Storage;
 
 use Drupal\Core\Database\Connection;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * DKAN JobStore Factory.
@@ -24,10 +25,16 @@ class JobStoreFactory implements StorageFactoryInterface {
   protected Connection $connection;
 
   /**
+   * The event dispatcher.
+   */
+  protected EventDispatcherInterface $eventDispatcher;
+
+  /**
    * Constructor.
    */
-  public function __construct(Connection $connection) {
+  public function __construct(Connection $connection, EventDispatcherInterface $eventDispatcher) {
     $this->connection = $connection;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
@@ -55,7 +62,7 @@ class JobStoreFactory implements StorageFactoryInterface {
     if ($table_name === $deprecated_table_name) {
       $deprecated_table_name = '';
     }
-    return new JobStore($table_name, $this->connection, $deprecated_table_name);
+    return new JobStore($table_name, $this->connection, $this->eventDispatcher, $deprecated_table_name);
   }
 
 }

--- a/modules/common/src/Util/JobStoreUtil.php
+++ b/modules/common/src/Util/JobStoreUtil.php
@@ -30,17 +30,19 @@ class JobStoreUtil {
    *
    * @var \Symfony\Contracts\EventDispatcher\EventDispatcherInterface
    */
-  protected EventDispatcherInterface $dispatcher;
+  protected EventDispatcherInterface $eventDispatcher;
 
   /**
    * Constructor.
    *
    * @param \Drupal\Core\Database\Connection $connection
    *   Database connection service.
+   * @param \Symfony\Contracts\EventDispatcher\EventDispatcherInterface $dispatcher
+   *    The event dispatcher instance.
    */
-  public function __construct(Connection $connection, EventDispatcherInterface $dispatcher) {
+  public function __construct(Connection $connection, EventDispatcherInterface $eventDispatcher) {
     $this->connection = $connection;
-    $this->dispatcher = $dispatcher;
+    $this->dispatcher = $eventDispatcher;
   }
 
   /**

--- a/modules/common/src/Util/JobStoreUtil.php
+++ b/modules/common/src/Util/JobStoreUtil.php
@@ -37,12 +37,12 @@ class JobStoreUtil {
    *
    * @param \Drupal\Core\Database\Connection $connection
    *   Database connection service.
-   * @param \Symfony\Contracts\EventDispatcher\EventDispatcherInterface $dispatcher
-   *    The event dispatcher instance.
+   * @param \Symfony\Contracts\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *   The event dispatcher instance.
    */
   public function __construct(Connection $connection, EventDispatcherInterface $eventDispatcher) {
     $this->connection = $connection;
-    $this->dispatcher = $eventDispatcher;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
@@ -107,7 +107,7 @@ class JobStoreUtil {
     if ($deprecated_table_names = $this->getAllDeprecatedJobstoreTableNames()) {
       $renamed = [];
       foreach ($deprecated_table_names as $class_name => $deprecated_table_name) {
-        $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->dispatcher);
+        $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->eventDispatcher);
         $table_name = $factory_accessor->accessTableName($class_name);
         $renamed[$deprecated_table_name] = $table_name;
         $this->connection->schema()->renameTable(
@@ -153,7 +153,7 @@ class JobStoreUtil {
    *   Class name identifier for the jobstore table to merge.
    */
   public function reconcileDuplicateJobstoreTable(string $class_name) {
-    $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->dispatcher);
+    $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->eventDispatcher);
     $deprecated_table_name = $factory_accessor->accessDeprecatedTableName($class_name);
     $table_name = $factory_accessor->accessTableName($class_name);
 
@@ -252,7 +252,7 @@ class JobStoreUtil {
    *   FALSE otherwise.
    */
   public function tableIsDeprecatedNameForClassname(string $class_name): bool {
-    $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->dispatcher);
+    $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->eventDispatcher);
     return $this->connection->schema()
       ->tableExists($factory_accessor->accessDeprecatedTableName($class_name)) &&
       !$this->connection->schema()
@@ -269,7 +269,7 @@ class JobStoreUtil {
    *   The deprecated table name.
    */
   public function getDeprecatedTableNameForClassname(string $className): string {
-    $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->dispatcher);
+    $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->eventDispatcher);
     return $factory_accessor->accessDeprecatedTableName($className);
   }
 
@@ -283,7 +283,7 @@ class JobStoreUtil {
    *   The non-deprecated table name.
    */
   public function getTableNameForClassname(string $className): string {
-    $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->dispatcher);
+    $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->eventDispatcher);
     return $factory_accessor->accessTableName($className);
   }
 

--- a/modules/common/src/Util/JobStoreUtil.php
+++ b/modules/common/src/Util/JobStoreUtil.php
@@ -3,6 +3,7 @@
 namespace Drupal\common\Util;
 
 use Drupal\Core\Database\Connection;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Utility class of methods for mitigating/updating legacy job store tables.
@@ -25,13 +26,21 @@ class JobStoreUtil {
   protected Connection $connection;
 
   /**
+   * Event dispatcher.
+   *
+   * @var \Symfony\Contracts\EventDispatcher\EventDispatcherInterface
+   */
+  protected EventDispatcherInterface $dispatcher;
+
+  /**
    * Constructor.
    *
    * @param \Drupal\Core\Database\Connection $connection
    *   Database connection service.
    */
-  public function __construct(Connection $connection) {
+  public function __construct(Connection $connection, EventDispatcherInterface $dispatcher) {
     $this->connection = $connection;
+    $this->dispatcher = $dispatcher;
   }
 
   /**
@@ -96,7 +105,7 @@ class JobStoreUtil {
     if ($deprecated_table_names = $this->getAllDeprecatedJobstoreTableNames()) {
       $renamed = [];
       foreach ($deprecated_table_names as $class_name => $deprecated_table_name) {
-        $factory_accessor = new JobStoreFactoryAccessor($this->connection);
+        $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->dispatcher);
         $table_name = $factory_accessor->accessTableName($class_name);
         $renamed[$deprecated_table_name] = $table_name;
         $this->connection->schema()->renameTable(
@@ -142,7 +151,7 @@ class JobStoreUtil {
    *   Class name identifier for the jobstore table to merge.
    */
   public function reconcileDuplicateJobstoreTable(string $class_name) {
-    $factory_accessor = new JobStoreFactoryAccessor($this->connection);
+    $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->dispatcher);
     $deprecated_table_name = $factory_accessor->accessDeprecatedTableName($class_name);
     $table_name = $factory_accessor->accessTableName($class_name);
 
@@ -241,7 +250,7 @@ class JobStoreUtil {
    *   FALSE otherwise.
    */
   public function tableIsDeprecatedNameForClassname(string $class_name): bool {
-    $factory_accessor = new JobStoreFactoryAccessor($this->connection);
+    $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->dispatcher);
     return $this->connection->schema()
       ->tableExists($factory_accessor->accessDeprecatedTableName($class_name)) &&
       !$this->connection->schema()
@@ -258,7 +267,7 @@ class JobStoreUtil {
    *   The deprecated table name.
    */
   public function getDeprecatedTableNameForClassname(string $className): string {
-    $factory_accessor = new JobStoreFactoryAccessor($this->connection);
+    $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->dispatcher);
     return $factory_accessor->accessDeprecatedTableName($className);
   }
 
@@ -272,7 +281,7 @@ class JobStoreUtil {
    *   The non-deprecated table name.
    */
   public function getTableNameForClassname(string $className): string {
-    $factory_accessor = new JobStoreFactoryAccessor($this->connection);
+    $factory_accessor = new JobStoreFactoryAccessor($this->connection, $this->dispatcher);
     return $factory_accessor->accessTableName($className);
   }
 

--- a/modules/common/src/Util/JobStoreUtil.php
+++ b/modules/common/src/Util/JobStoreUtil.php
@@ -3,7 +3,7 @@
 namespace Drupal\common\Util;
 
 use Drupal\Core\Database\Connection;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Utility class of methods for mitigating/updating legacy job store tables.

--- a/modules/common/tests/src/Kernel/Storage/AbstractJobStoreFactoryTest.php
+++ b/modules/common/tests/src/Kernel/Storage/AbstractJobStoreFactoryTest.php
@@ -27,9 +27,10 @@ namespace Drupal\Tests\common\Kernel\Storage {
 
     public function testDeprecatedClassnameTable() {
       $db = $this->container->get('database');
+      $dispatcher = $this->container->get('event_dispatcher');
       // Make a concrete AbstractJobStoreFactory object.
       /** @var \DkanTestConcreteAbstractJobStoreFactory $job_store_factory */
-      $job_store_factory = new \DkanTestConcreteAbstractJobStoreFactory($db);
+      $job_store_factory = new \DkanTestConcreteAbstractJobStoreFactory($db, $dispatcher);
       // Get a Job object by specifying an instance name.
       $job_store = $job_store_factory->getInstance(\DkanTestConcreteJobSubclass::class);
 

--- a/modules/common/tests/src/Kernel/Storage/AbstractJobStoreFactoryTest.php
+++ b/modules/common/tests/src/Kernel/Storage/AbstractJobStoreFactoryTest.php
@@ -27,10 +27,10 @@ namespace Drupal\Tests\common\Kernel\Storage {
 
     public function testDeprecatedClassnameTable() {
       $db = $this->container->get('database');
-      $dispatcher = $this->container->get('event_dispatcher');
+      $eventDispatcher = $this->container->get('event_dispatcher');
       // Make a concrete AbstractJobStoreFactory object.
       /** @var \DkanTestConcreteAbstractJobStoreFactory $job_store_factory */
-      $job_store_factory = new \DkanTestConcreteAbstractJobStoreFactory($db, $dispatcher);
+      $job_store_factory = new \DkanTestConcreteAbstractJobStoreFactory($db, $eventDispatcher);
       // Get a Job object by specifying an instance name.
       $job_store = $job_store_factory->getInstance(\DkanTestConcreteJobSubclass::class);
 

--- a/modules/common/tests/src/Kernel/Util/JobStoreUtilTest.php
+++ b/modules/common/tests/src/Kernel/Util/JobStoreUtilTest.php
@@ -35,8 +35,8 @@ namespace Drupal\Tests\common\Kernel\Util {
     protected function deprecatedJobStoreSetup(string $class_name = FileFetcher::class): void {
       /** @var \Drupal\Core\Database\Connection $db */
       $db = $this->container->get('database');
-      $dispatcher = $this->container->get('event_dispatcher');
-      $factory_accessor = new JobStoreFactoryAccessor($db, $dispatcher);
+      $eventDispatcher = $this->container->get('event_dispatcher');
+      $factory_accessor = new JobStoreFactoryAccessor($db, $eventDispatcher);
 
       // First, get the non-deprecated table name.
       $table_name = $factory_accessor->accessTableName($class_name);
@@ -47,7 +47,7 @@ namespace Drupal\Tests\common\Kernel\Util {
       // Make the deprecated table by creating a new jobstore object rather than
       // use the factory, so it does not recompute the table name.
       $this->assertFalse($db->schema()->tableExists($deprecated_table_name));
-      $job_store = new JobStore($deprecated_table_name, $db, $dispatcher);
+      $job_store = new JobStore($deprecated_table_name, $db, $eventDispatcher);
       // Count() will create the table.
       $this->assertEquals(0, $job_store->count());
 
@@ -98,22 +98,22 @@ namespace Drupal\Tests\common\Kernel\Util {
       // Create both deprecated and non-deprecated table for a jobstore.
       /** @var \Drupal\Core\Database\Connection $db */
       $db = $this->container->get('database');
-      $dispatcher = $this->container->get('event_dispatcher');
+      $eventDispatcher = $this->container->get('event_dispatcher');
 
-      $job_store_factory = new JobStoreFactoryAccessor($db, $dispatcher);
+      $job_store_factory = new JobStoreFactoryAccessor($db, $eventDispatcher);
       $identifier = \DkanTestUtilJobSubclass::class;
 
       // First, get the table name without deprecation.
       $table_name = $job_store_factory->accessTableName($identifier);
 
       // Make the non-deprecated table.
-      $table_store = new JobStore($table_name, $db, $dispatcher);
+      $table_store = new JobStore($table_name, $db, $eventDispatcher);
       $this->assertFalse($db->schema()->tableExists($table_name));
       $this->assertEquals(0, $table_store->count());
 
       // Make the deprecated table.
       $deprecated_table_name = $job_store_factory->accessDeprecatedTableName($identifier);
-      $deprecated_store = new JobStore($deprecated_table_name, $db, $dispatcher);
+      $deprecated_store = new JobStore($deprecated_table_name, $db, $eventDispatcher);
 
       $this->assertFalse($db->schema()->tableExists($deprecated_table_name));
       $this->assertEquals(0, $deprecated_store->count());
@@ -129,7 +129,7 @@ namespace Drupal\Tests\common\Kernel\Util {
       );
 
       // Now that we have both tables, our utility object should find them.
-      $job_store_util = new JobStoreUtil($db, $dispatcher);
+      $job_store_util = new JobStoreUtil($db, $eventDispatcher);
       $this->assertEquals(
         $deprecated_table_name,
         $job_store_util->getDeprecatedTableNameForClassname($identifier)
@@ -184,7 +184,7 @@ namespace Drupal\Tests\common\Kernel\Util {
     public function testReconcileDuplicateJobstoreTable() {
       /** @var \Drupal\Core\Database\Connection $db */
       $db = $this->container->get('database');
-      $dispatcher = $this->container->get('event_dispatcher');
+      $eventDispatcher = $this->container->get('event_dispatcher');
       $identifier = FileFetcher::class;
       // Key is identifier, value is value.
       $deprecated_data = [
@@ -195,18 +195,18 @@ namespace Drupal\Tests\common\Kernel\Util {
         'a' => '"new a"',
       ];
 
-      $job_store_factory = new JobStoreFactoryAccessor($db, $dispatcher);
+      $job_store_factory = new JobStoreFactoryAccessor($db, $eventDispatcher);
 
       // Store deprecated job data.
       $deprecated_table_name = $job_store_factory->accessDeprecatedTableName($identifier);
-      $deprecated_job = new JobStore($deprecated_table_name, $db, $dispatcher);
+      $deprecated_job = new JobStore($deprecated_table_name, $db, $eventDispatcher);
       foreach ($deprecated_data as $key => $value) {
         $deprecated_job->store($value, $key);
       }
 
       // Store non-deprecated job data.
       $table_name = $job_store_factory->accessTableName($identifier);
-      $table_job = new JobStore($table_name, $db, $dispatcher);
+      $table_job = new JobStore($table_name, $db, $eventDispatcher);
       foreach ($non_deprecated_data as $key => $value) {
         $table_job->store($value, $key);
       }
@@ -216,7 +216,7 @@ namespace Drupal\Tests\common\Kernel\Util {
       $this->assertTrue($db->schema()->tableExists($table_name));
 
       // Job store utility.
-      $job_store_util = new JobStoreUtil($db, $dispatcher);
+      $job_store_util = new JobStoreUtil($db, $eventDispatcher);
       // getDuplicateJobstoreTables() should find this becasue FileFetcher is
       // one of our fixable classes.
       $this->assertEquals(
@@ -243,7 +243,7 @@ namespace Drupal\Tests\common\Kernel\Util {
     public function testReconcileDuplicateJobstoreTableNoOverlap() {
       /** @var \Drupal\Core\Database\Connection $db */
       $db = $this->container->get('database');
-      $dispatcher = $this->container->get('event_dispatcher');
+      $eventDispatcher = $this->container->get('event_dispatcher');
       $identifier = FileFetcher::class;
       // Key is identifier, value is value.
       $deprecated_data = [
@@ -254,18 +254,18 @@ namespace Drupal\Tests\common\Kernel\Util {
         'c' => '"new c"',
       ];
 
-      $job_store_factory = new JobStoreFactoryAccessor($db, $dispatcher);
+      $job_store_factory = new JobStoreFactoryAccessor($db, $eventDispatcher);
 
       // Store deprecated job data.
       $deprecated_table_name = $job_store_factory->accessDeprecatedTableName($identifier);
-      $deprecated_job = new JobStore($deprecated_table_name, $db, $dispatcher);
+      $deprecated_job = new JobStore($deprecated_table_name, $db, $eventDispatcher);
       foreach ($deprecated_data as $key => $value) {
         $deprecated_job->store($value, $key);
       }
 
       // Store non-deprecated job data.
       $table_name = $job_store_factory->accessTableName($identifier);
-      $table_job = new JobStore($table_name, $db, $dispatcher);
+      $table_job = new JobStore($table_name, $db, $eventDispatcher);
       foreach ($non_deprecated_data as $key => $value) {
         $table_job->store($value, $key);
       }
@@ -275,7 +275,7 @@ namespace Drupal\Tests\common\Kernel\Util {
       $this->assertTrue($db->schema()->tableExists($table_name));
 
       // Job store utility.
-      $job_store_util = new JobStoreUtil($db, $dispatcher);
+      $job_store_util = new JobStoreUtil($db, $eventDispatcher);
       // getDuplicateJobstoreTables() should find this becasue FileFetcher is
       // one of our fixable classes.
       $this->assertEquals(

--- a/modules/common/tests/src/Kernel/Util/JobStoreUtilTest.php
+++ b/modules/common/tests/src/Kernel/Util/JobStoreUtilTest.php
@@ -35,7 +35,8 @@ namespace Drupal\Tests\common\Kernel\Util {
     protected function deprecatedJobStoreSetup(string $class_name = FileFetcher::class): void {
       /** @var \Drupal\Core\Database\Connection $db */
       $db = $this->container->get('database');
-      $factory_accessor = new JobStoreFactoryAccessor($db);
+      $dispatcher = $this->container->get('event_dispatcher');
+      $factory_accessor = new JobStoreFactoryAccessor($db, $dispatcher);
 
       // First, get the non-deprecated table name.
       $table_name = $factory_accessor->accessTableName($class_name);
@@ -46,7 +47,7 @@ namespace Drupal\Tests\common\Kernel\Util {
       // Make the deprecated table by creating a new jobstore object rather than
       // use the factory, so it does not recompute the table name.
       $this->assertFalse($db->schema()->tableExists($deprecated_table_name));
-      $job_store = new JobStore($deprecated_table_name, $db);
+      $job_store = new JobStore($deprecated_table_name, $db, $dispatcher);
       // Count() will create the table.
       $this->assertEquals(0, $job_store->count());
 
@@ -66,7 +67,7 @@ namespace Drupal\Tests\common\Kernel\Util {
      */
     public function testGetAllDeprecatedJobstoreTableNames() {
       $this->deprecatedJobStoreSetup();
-      $job_store_util = new JobStoreUtil($this->container->get('database'));
+      $job_store_util = new JobStoreUtil($this->container->get('database'), $this->container->get('event_dispatcher'));
       // Should get a list back of only the deprecated name and its class.
       $this->assertEquals(
         ['FileFetcher\FileFetcher' => 'jobstore_filefetcher_filefetcher'],
@@ -78,7 +79,7 @@ namespace Drupal\Tests\common\Kernel\Util {
      * @covers ::renameDeprecatedJobstoreTables
      */
     public function testRenameDeprecatedJobstoreTables() {
-      $job_store_util = new JobStoreUtil($this->container->get('database'));
+      $job_store_util = new JobStoreUtil($this->container->get('database'), $this->container->get('event_dispatcher'));
       // Before we set anything up, renaming should result in an empty array.
       $this->assertSame([], $job_store_util->renameDeprecatedJobstoreTables());
       // Set up the tables...
@@ -97,21 +98,22 @@ namespace Drupal\Tests\common\Kernel\Util {
       // Create both deprecated and non-deprecated table for a jobstore.
       /** @var \Drupal\Core\Database\Connection $db */
       $db = $this->container->get('database');
+      $dispatcher = $this->container->get('event_dispatcher');
 
-      $job_store_factory = new JobStoreFactoryAccessor($db);
+      $job_store_factory = new JobStoreFactoryAccessor($db, $dispatcher);
       $identifier = \DkanTestUtilJobSubclass::class;
 
       // First, get the table name without deprecation.
       $table_name = $job_store_factory->accessTableName($identifier);
 
       // Make the non-deprecated table.
-      $table_store = new JobStore($table_name, $db);
+      $table_store = new JobStore($table_name, $db, $dispatcher);
       $this->assertFalse($db->schema()->tableExists($table_name));
       $this->assertEquals(0, $table_store->count());
 
       // Make the deprecated table.
       $deprecated_table_name = $job_store_factory->accessDeprecatedTableName($identifier);
-      $deprecated_store = new JobStore($deprecated_table_name, $db);
+      $deprecated_store = new JobStore($deprecated_table_name, $db, $dispatcher);
 
       $this->assertFalse($db->schema()->tableExists($deprecated_table_name));
       $this->assertEquals(0, $deprecated_store->count());
@@ -127,7 +129,7 @@ namespace Drupal\Tests\common\Kernel\Util {
       );
 
       // Now that we have both tables, our utility object should find them.
-      $job_store_util = new JobStoreUtil($db);
+      $job_store_util = new JobStoreUtil($db, $dispatcher);
       $this->assertEquals(
         $deprecated_table_name,
         $job_store_util->getDeprecatedTableNameForClassname($identifier)
@@ -157,7 +159,7 @@ namespace Drupal\Tests\common\Kernel\Util {
       $this->assertEquals(0, $job_store->count());
       $this->assertEquals(0, $job_store_2->count());
       // Ask util if it found the tables.
-      $util = new JobStoreUtil($this->container->get('database'));
+      $util = new JobStoreUtil($this->container->get('database'), $this->container->get('event_dispatcher'));
       $tables = [
         'jobstore_1885897830_dkantestutiljobsubclass' => 'jobstore_1885897830_dkantestutiljobsubclass',
         'jobstore_3195278052_dkantestutiljobsubclass2' => 'jobstore_3195278052_dkantestutiljobsubclass2',
@@ -182,6 +184,7 @@ namespace Drupal\Tests\common\Kernel\Util {
     public function testReconcileDuplicateJobstoreTable() {
       /** @var \Drupal\Core\Database\Connection $db */
       $db = $this->container->get('database');
+      $dispatcher = $this->container->get('event_dispatcher');
       $identifier = FileFetcher::class;
       // Key is identifier, value is value.
       $deprecated_data = [
@@ -192,18 +195,18 @@ namespace Drupal\Tests\common\Kernel\Util {
         'a' => '"new a"',
       ];
 
-      $job_store_factory = new JobStoreFactoryAccessor($db);
+      $job_store_factory = new JobStoreFactoryAccessor($db, $dispatcher);
 
       // Store deprecated job data.
       $deprecated_table_name = $job_store_factory->accessDeprecatedTableName($identifier);
-      $deprecated_job = new JobStore($deprecated_table_name, $db);
+      $deprecated_job = new JobStore($deprecated_table_name, $db, $dispatcher);
       foreach ($deprecated_data as $key => $value) {
         $deprecated_job->store($value, $key);
       }
 
       // Store non-deprecated job data.
       $table_name = $job_store_factory->accessTableName($identifier);
-      $table_job = new JobStore($table_name, $db);
+      $table_job = new JobStore($table_name, $db, $dispatcher);
       foreach ($non_deprecated_data as $key => $value) {
         $table_job->store($value, $key);
       }
@@ -213,7 +216,7 @@ namespace Drupal\Tests\common\Kernel\Util {
       $this->assertTrue($db->schema()->tableExists($table_name));
 
       // Job store utility.
-      $job_store_util = new JobStoreUtil($db);
+      $job_store_util = new JobStoreUtil($db, $dispatcher);
       // getDuplicateJobstoreTables() should find this becasue FileFetcher is
       // one of our fixable classes.
       $this->assertEquals(
@@ -240,6 +243,7 @@ namespace Drupal\Tests\common\Kernel\Util {
     public function testReconcileDuplicateJobstoreTableNoOverlap() {
       /** @var \Drupal\Core\Database\Connection $db */
       $db = $this->container->get('database');
+      $dispatcher = $this->container->get('event_dispatcher');
       $identifier = FileFetcher::class;
       // Key is identifier, value is value.
       $deprecated_data = [
@@ -250,18 +254,18 @@ namespace Drupal\Tests\common\Kernel\Util {
         'c' => '"new c"',
       ];
 
-      $job_store_factory = new JobStoreFactoryAccessor($db);
+      $job_store_factory = new JobStoreFactoryAccessor($db, $dispatcher);
 
       // Store deprecated job data.
       $deprecated_table_name = $job_store_factory->accessDeprecatedTableName($identifier);
-      $deprecated_job = new JobStore($deprecated_table_name, $db);
+      $deprecated_job = new JobStore($deprecated_table_name, $db, $dispatcher);
       foreach ($deprecated_data as $key => $value) {
         $deprecated_job->store($value, $key);
       }
 
       // Store non-deprecated job data.
       $table_name = $job_store_factory->accessTableName($identifier);
-      $table_job = new JobStore($table_name, $db);
+      $table_job = new JobStore($table_name, $db, $dispatcher);
       foreach ($non_deprecated_data as $key => $value) {
         $table_job->store($value, $key);
       }
@@ -271,7 +275,7 @@ namespace Drupal\Tests\common\Kernel\Util {
       $this->assertTrue($db->schema()->tableExists($table_name));
 
       // Job store utility.
-      $job_store_util = new JobStoreUtil($db);
+      $job_store_util = new JobStoreUtil($db, $dispatcher);
       // getDuplicateJobstoreTables() should find this becasue FileFetcher is
       // one of our fixable classes.
       $this->assertEquals(
@@ -295,7 +299,7 @@ namespace Drupal\Tests\common\Kernel\Util {
      * @covers ::keyedToList
      */
     public function testKeyedToList() {
-      $job_store_util = new JobStoreUtil($this->container->get('database'));
+      $job_store_util = new JobStoreUtil($this->container->get('database'), $this->container->get('event_dispatcher'));
       $this->assertEquals(
         [['a', 'b']],
         $job_store_util->keyedToList(['a' => 'b'])
@@ -310,7 +314,7 @@ namespace Drupal\Tests\common\Kernel\Util {
      * @covers ::keyedToListDecorator
      */
     public function testKeyedToListDecorator() {
-      $job_store_util = new JobStoreUtil($this->container->get('database'));
+      $job_store_util = new JobStoreUtil($this->container->get('database'), $this->container->get('event_dispatcher'));
       $this->assertEquals(
         ['a > b'],
         $job_store_util->keyedToListDecorator(['a' => 'b'], ' > ')

--- a/modules/common/tests/src/Unit/Events/EventTest.php
+++ b/modules/common/tests/src/Unit/Events/EventTest.php
@@ -14,7 +14,7 @@ class EventTest extends TestCase
     $this->expectExceptionMessage("Invalid event data.");
 
     $eventDispatcher = new EventDispatcher();
-    $eventDispatcher->addListener('test_event', function (Event $event) {
+    $eventDispatcher->addListener('test_event', function(Event $event) {
       $event->setData(1);
     });
 

--- a/modules/common/tests/src/Unit/Events/EventTest.php
+++ b/modules/common/tests/src/Unit/Events/EventTest.php
@@ -10,8 +10,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class EventTest extends TestCase
 {
-  public function testDataIntegrityAcrossEventSubscribers()
-  {
+  public function testDataIntegrityAcrossEventSubscribers() {
     $this->expectExceptionMessage("Invalid event data.");
 
     $dispatcher = new EventDispatcher();

--- a/modules/common/tests/src/Unit/Events/EventTest.php
+++ b/modules/common/tests/src/Unit/Events/EventTest.php
@@ -24,12 +24,11 @@ class EventTest extends TestCase
 
     \Drupal::setContainer($container);
 
-    $event = new Event('hello');
-    $eventDispatcher->dispatch($event, 'test_event');
+    $event = new Event('hello', function ($data) {
+      return is_string($data);
+    });
 
-    if (!is_string($event->getData())) {
-      throw new \Exception("Invalid event data.");
-    }
+    $eventDispatcher->dispatch($event, 'test_event');
   }
 
 }

--- a/modules/common/tests/src/Unit/Events/EventTest.php
+++ b/modules/common/tests/src/Unit/Events/EventTest.php
@@ -13,19 +13,19 @@ class EventTest extends TestCase
   public function testDataIntegrityAcrossEventSubscribers() {
     $this->expectExceptionMessage("Invalid event data.");
 
-    $dispatcher = new EventDispatcher();
-    $dispatcher->addListener('test_event', function (Event $event) {
+    $eventDispatcher = new EventDispatcher();
+    $eventDispatcher->addListener('test_event', function (Event $event) {
       $event->setData(1);
     });
 
     $container = (new Chain($this))
-      ->add(Container::class, 'get', $dispatcher)
+      ->add(Container::class, 'get', $eventDispatcher)
       ->getMock();
 
     \Drupal::setContainer($container);
 
     $event = new Event('hello');
-    $dispatcher->dispatch($event, 'test_event');
+    $eventDispatcher->dispatch($event, 'test_event');
 
     if (!is_string($event->getData())) {
       throw new \Exception("Invalid event data.");

--- a/modules/common/tests/src/Unit/Events/EventTest.php
+++ b/modules/common/tests/src/Unit/Events/EventTest.php
@@ -7,15 +7,15 @@ use MockChain\Chain;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class EventTest extends TestCase
 {
-  public function testDataIntegrityAcrossEventSubscribers() {
+  public function testDataIntegrityAcrossEventSubscribers()
+  {
     $this->expectExceptionMessage("Invalid event data.");
 
     $dispatcher = new EventDispatcher();
-    $dispatcher->addListener('test_event', function(Event $event) {
+    $dispatcher->addListener('test_event', function (Event $event) {
       $event->setData(1);
     });
 
@@ -25,32 +25,12 @@ class EventTest extends TestCase
 
     \Drupal::setContainer($container);
 
-    $this->dispatchEvent('test_event', 'hello', function($data) {
-      return is_string($data);
-    });
-  }
+    $event = new Event('hello');
+    $dispatcher->dispatch($event, 'test_event');
 
-  /**
-   * Mimics the original dispatchEvent() method from the deprecated trait.
-   *
-   * @param string   $eventName
-   *   The event name.
-   * @param mixed    $data
-   *   The initial event data.
-   * @param callable $validator
-   *   A callback that validates the event data.
-   *
-   * @throws \Exception
-   *   If the validator returns FALSE.
-   */
-  private function dispatchEvent($eventName, $data, callable $validator) {
-    /** @var EventDispatcherInterface $dispatcher */
-    $dispatcher = \Drupal::getContainer()->get('event_dispatcher');
-    $event = new Event($data);
-    $dispatcher->dispatch($event, $eventName);
-
-    if (!$validator($event->getData())) {
+    if (!is_string($event->getData())) {
       throw new \Exception("Invalid event data.");
     }
   }
+
 }

--- a/modules/common/tests/src/Unit/Events/EventTest.php
+++ b/modules/common/tests/src/Unit/Events/EventTest.php
@@ -2,24 +2,19 @@
 
 namespace Drupal\Tests\common\Unit\Events;
 
-use Drupal\common\EventDispatcherTrait;
 use Drupal\common\Events\Event;
 use MockChain\Chain;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class EventTest extends TestCase
 {
-  use EventDispatcherTrait;
-
   public function testDataIntegrityAcrossEventSubscribers() {
     $this->expectExceptionMessage("Invalid event data.");
-    $containerx = (new Chain($this))
-      ->add(Container::class)
-      ->getMock();
 
-    $dispatcher = new EventDispatcher($containerx);
+    $dispatcher = new EventDispatcher();
     $dispatcher->addListener('test_event', function(Event $event) {
       $event->setData(1);
     });
@@ -35,4 +30,27 @@ class EventTest extends TestCase
     });
   }
 
+  /**
+   * Mimics the original dispatchEvent() method from the deprecated trait.
+   *
+   * @param string   $eventName
+   *   The event name.
+   * @param mixed    $data
+   *   The initial event data.
+   * @param callable $validator
+   *   A callback that validates the event data.
+   *
+   * @throws \Exception
+   *   If the validator returns FALSE.
+   */
+  private function dispatchEvent($eventName, $data, callable $validator) {
+    /** @var EventDispatcherInterface $dispatcher */
+    $dispatcher = \Drupal::getContainer()->get('event_dispatcher');
+    $event = new Event($data);
+    $dispatcher->dispatch($event, $eventName);
+
+    if (!$validator($event->getData())) {
+      throw new \Exception("Invalid event data.");
+    }
+  }
 }

--- a/modules/common/tests/src/Unit/Storage/JobStoreTest.php
+++ b/modules/common/tests/src/Unit/Storage/JobStoreTest.php
@@ -15,6 +15,7 @@ use FileFetcher\FileFetcher;
 use MockChain\Chain;
 use MockChain\Sequence;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @covers \Drupal\common\Storage\JobStore
@@ -34,7 +35,11 @@ class JobStoreTest extends TestCase {
       ->add(Connection::class, "schema", Schema::class)
       ->add(Schema::class, "tableExists", FALSE);
 
-    $jobStore = new JobStore(FileFetcher::class, $chain->getMock());
+    $jobStore = new JobStore(
+      FileFetcher::class,
+      $chain->getMock(),
+      $this->createStub(EventDispatcherInterface::class)
+    );
     $this->assertTrue(is_object($jobStore));
   }
 
@@ -67,7 +72,11 @@ class JobStoreTest extends TestCase {
       ->add(Connection::class, 'query', $statement_wrapper_class)
       ->add($statement_wrapper_class, 'fetchAll', $fieldInfo);
 
-    $jobStore = new JobStore(FileFetcher::class, $chain->getMock());
+    $jobStore = new JobStore(
+      FileFetcher::class,
+      $chain->getMock(),
+      $this->createStub(EventDispatcherInterface::class)
+    );
     $this->assertEquals($job_data, $jobStore->retrieve("1", FileFetcher::class));
   }
 
@@ -102,7 +111,11 @@ class JobStoreTest extends TestCase {
       ->add(Connection::class, 'query', $statement_wrapper_class)
       ->add($statement_wrapper_class, 'fetchAll', $sequence);
 
-    $jobStore = new JobStore(FileFetcher::class, $chain->getMock());
+    $jobStore = new JobStore(
+      FileFetcher::class,
+      $chain->getMock(),
+      $this->createStub(EventDispatcherInterface::class)
+    );
     $this->assertTrue(is_array($jobStore->retrieveAll()));
   }
 
@@ -143,7 +156,11 @@ class JobStoreTest extends TestCase {
       ->add($statement_wrapper_class, 'fetchAll', $fieldInfo)
       ->getMock();
 
-    $jobStore = new JobStore(FileFetcher::class, $connection);
+    $jobStore = new JobStore(
+      FileFetcher::class,
+      $connection,
+      $this->createStub(EventDispatcherInterface::class)
+    );
 
     $this->assertEquals("1", $jobStore->store(json_encode($jobObject), "1"));
   }
@@ -171,7 +188,11 @@ class JobStoreTest extends TestCase {
       ->add($statement_wrapper_class, 'fetchAll', $fieldInfo)
       ->getMock();
 
-    $jobStore = new JobStore(FileFetcher::class, $connection);
+    $jobStore = new JobStore(
+      FileFetcher::class,
+      $connection,
+      $this->createStub(EventDispatcherInterface::class)
+    );
 
     $this->assertEquals("", $jobStore->remove("1", FileFetcher::class));
   }

--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -99,6 +99,7 @@ services:
     arguments:
       - '@dkan.datastore.database'
       - '@dkan.datastore.logger_channel'
+      - '@event_dispatcher'
 
   dkan.datastore.sql_endpoint.service:
     class: \Drupal\datastore\SqlEndpoint\DatastoreSqlEndpointService

--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -40,6 +40,7 @@ services:
       - '@dkan.common.drupal_files'
       - '@dkan.common.filefetcher_job_store_factory'
       - '@queue'
+      - '@event_dispatcher'
 
   dkan.datastore.service.resource_processor_collector:
     class: \Drupal\datastore\Service\ResourceProcessorCollector

--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -136,6 +136,7 @@ services:
     class: \Drupal\datastore\Storage\ImportJobStoreFactory
     arguments:
       - '@database'
+      - '@event_dispatcher'
 
   pdlt.converter.strptime_to_mysql:
     class: \PDLT\Converter

--- a/modules/datastore/datastore.services.yml
+++ b/modules/datastore/datastore.services.yml
@@ -113,6 +113,7 @@ services:
       - '@dkan.datastore.service'
       - '@dkan.datastore.service.resource_purger'
       - '@dkan.datastore.import_job_store_factory'
+      - '@event_dispatcher'
     tags:
       - { name: event_subscriber }
 

--- a/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.services.yml
+++ b/modules/datastore/modules/datastore_mysql_import/datastore_mysql_import.services.yml
@@ -14,6 +14,7 @@ services:
     arguments:
       - '@dkan.datastore.database'
       - '@dkan.datastore.logger_channel'
+      - '@event_dispatcher'
 
   dkan.datastore_mysql_import.data_dictionary.alter_table_query_builder.mysql:
     class: \Drupal\datastore_mysql_import\DataDictionary\AlterTableQuery\StrictModeOffMySQLQueryBuilder

--- a/modules/datastore/modules/datastore_mysql_import/src/Storage/MySqlDatabaseTableFactory.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Storage/MySqlDatabaseTableFactory.php
@@ -13,7 +13,7 @@ class MySqlDatabaseTableFactory extends DatabaseTableFactory {
    * {@inheritDoc}
    */
   protected function getDatabaseTable($resource) {
-    return new MySqlDatabaseTable($this->connection, $resource, $this->logger);
+    return new MySqlDatabaseTable($this->connection, $resource, $this->logger, $this->eventDispatcher);
   }
 
 }

--- a/modules/datastore/src/EventSubscriber/DatastoreSubscriber.php
+++ b/modules/datastore/src/EventSubscriber/DatastoreSubscriber.php
@@ -85,8 +85,8 @@ class DatastoreSubscriber implements EventSubscriberInterface {
    *   The dkan.datastore.service.resource_purger service.
    * @param \Drupal\datastore\Storage\ImportJobStoreFactory $importJobStoreFactory
    *   The dkan.datastore.import_job_store_factory service.
-   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
-   *   The event dispatcher service
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *   The event dispatcher service.
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,

--- a/modules/datastore/src/EventSubscriber/DatastoreSubscriber.php
+++ b/modules/datastore/src/EventSubscriber/DatastoreSubscriber.php
@@ -15,6 +15,7 @@ use Drupal\metastore\ResourceMapper;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Subscriber.
@@ -49,6 +50,13 @@ class DatastoreSubscriber implements EventSubscriberInterface {
   private ImportJobStoreFactory $importJobStoreFactory;
 
   /**
+   * Event dispatcher service.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  protected EventDispatcherInterface $eventDispatcher;
+
+  /**
    * Inherited.
    *
    * @{inheritdocs}
@@ -59,7 +67,8 @@ class DatastoreSubscriber implements EventSubscriberInterface {
       $container->get('dkan.datastore.logger_channel'),
       $container->get('dkan.datastore.service'),
       $container->get('dkan.datastore.service.resource_purger'),
-      $container->get('dkan.datastore.import_job_store_factory')
+      $container->get('dkan.datastore.import_job_store_factory'),
+      $container->get('event_dispatcher')
     );
   }
 
@@ -76,6 +85,8 @@ class DatastoreSubscriber implements EventSubscriberInterface {
    *   The dkan.datastore.service.resource_purger service.
    * @param \Drupal\datastore\Storage\ImportJobStoreFactory $importJobStoreFactory
    *   The dkan.datastore.import_job_store_factory service.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
+   *   The event dispatcher service
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
@@ -83,12 +94,14 @@ class DatastoreSubscriber implements EventSubscriberInterface {
     DatastoreService $service,
     ResourcePurger $resourcePurger,
     ImportJobStoreFactory $importJobStoreFactory,
+    EventDispatcherInterface $eventDispatcher
   ) {
     $this->configFactory = $config_factory;
     $this->logger = $loggerChannel;
     $this->datastoreService = $service;
     $this->resourcePurger = $resourcePurger;
     $this->importJobStoreFactory = $importJobStoreFactory;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**

--- a/modules/datastore/src/Service/ImportService.php
+++ b/modules/datastore/src/Service/ImportService.php
@@ -4,7 +4,7 @@ namespace Drupal\datastore\Service;
 
 use CsvParser\Parser\Csv;
 use Drupal\common\DataResource;
-use \Drupal\common\Events\Event;
+use Drupal\common\Events\Event;
 use Drupal\datastore\Events\DatastoreImportedEvent;
 use Drupal\datastore\Plugin\QueueWorker\ImportJob;
 use Drupal\datastore\Storage\DatabaseTable;
@@ -215,8 +215,6 @@ class ImportService {
    *
    * @param string $delimiter
    *   Delimiter character.
-   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
-   *   Event dispatcher.
    *
    * @return \CsvParser\Parser\Csv
    *   A parser which does not keep track of every execution steps.

--- a/modules/datastore/src/Service/ImportService.php
+++ b/modules/datastore/src/Service/ImportService.php
@@ -4,6 +4,7 @@ namespace Drupal\datastore\Service;
 
 use CsvParser\Parser\Csv;
 use Drupal\common\DataResource;
+use \Drupal\common\Events\Event;
 use Drupal\datastore\Events\DatastoreImportedEvent;
 use Drupal\datastore\Plugin\QueueWorker\ImportJob;
 use Drupal\datastore\Storage\DatabaseTable;
@@ -214,6 +215,8 @@ class ImportService {
    *
    * @param string $delimiter
    *   Delimiter character.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *   Event dispatcher.
    *
    * @return \CsvParser\Parser\Csv
    *   A parser which does not keep track of every execution steps.

--- a/modules/datastore/src/Service/ImportService.php
+++ b/modules/datastore/src/Service/ImportService.php
@@ -4,7 +4,6 @@ namespace Drupal\datastore\Service;
 
 use CsvParser\Parser\Csv;
 use Drupal\common\DataResource;
-use Drupal\common\EventDispatcherTrait;
 use Drupal\datastore\Events\DatastoreImportedEvent;
 use Drupal\datastore\Plugin\QueueWorker\ImportJob;
 use Drupal\datastore\Storage\DatabaseTable;
@@ -24,8 +23,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * @see \Drupal\datastore\Service\Factory\ImportServiceFactory::getInstance
  */
 class ImportService {
-
-  use EventDispatcherTrait;
 
   /**
    * Event name used when configuring the parser during import.
@@ -229,7 +226,9 @@ class ImportService {
       'record_end' => ["\n", "\r"],
     ];
 
-    $parserConfiguration = $this->dispatchEvent(self::EVENT_CONFIGURE_PARSER, $parserConfiguration);
+    $event = new Event($parserConfiguration);
+    $this->eventDispatcher->dispatch($event, self::EVENT_CONFIGURE_PARSER);
+    $parserConfiguration = $event->getData();
 
     $parser = Csv::getParser($parserConfiguration['delimiter'], $parserConfiguration['quote'], $parserConfiguration['escape'], $parserConfiguration['record_end']);
     $parser->machine->stopRecording();

--- a/modules/datastore/src/Service/ResourceLocalizer.php
+++ b/modules/datastore/src/Service/ResourceLocalizer.php
@@ -4,7 +4,7 @@ namespace Drupal\datastore\Service;
 
 use Contracts\FactoryInterface;
 use Drupal\common\DataResource;
-use Drupal\common\EventDispatcherTrait;
+use Drupal\common\Events\Event;
 use Drupal\common\UrlHostTokenResolver;
 use Drupal\common\Util\DrupalFiles;
 use Drupal\Core\File\FileSystemInterface;
@@ -14,6 +14,7 @@ use Drupal\metastore\Exception\AlreadyRegistered;
 use Drupal\metastore\ResourceMapper;
 use FileFetcher\FileFetcher;
 use Procrastinator\Result;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Resource localizer.
@@ -71,6 +72,11 @@ class ResourceLocalizer {
   private QueueFactory $queueFactory;
 
   /**
+   * Event dispatcher service.
+   */
+  private EventDispatcherInterface $eventDispatcher;
+
+  /**
    * Constructor.
    */
   public function __construct(
@@ -79,12 +85,14 @@ class ResourceLocalizer {
     DrupalFiles $drupalFiles,
     FileFetcherJobStoreFactory $fileFetcherJobStoreFactory,
     QueueFactory $queueFactory,
+    EventDispatcherInterface $eventDispatcher
   ) {
     $this->resourceMapper = $fileMapper;
     $this->fileFetcherFactory = $fileFetcherFactory;
     $this->drupalFiles = $drupalFiles;
     $this->fileFetcherJobStoreFactory = $fileFetcherJobStoreFactory;
     $this->queueFactory = $queueFactory;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
@@ -102,10 +110,11 @@ class ResourceLocalizer {
         // Localization is done. Register the perspectives.
         $this->registerNewPerspectives($resource, $ff->getStateProperty('destination'));
         // Send the event.
-        $this->dispatchEvent(static::EVENT_RESOURCE_LOCALIZED, [
+        $event = new Event([
           'identifier' => $resource->getIdentifier(),
           'version' => $resource->getVersion(),
         ]);
+        $this->eventDispatcher->dispatch($event, static::EVENT_RESOURCE_LOCALIZED);
       }
       return $result;
     }

--- a/modules/datastore/src/Service/ResourceLocalizer.php
+++ b/modules/datastore/src/Service/ResourceLocalizer.php
@@ -21,8 +21,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class ResourceLocalizer {
 
-  use EventDispatcherTrait;
-
   /**
    * Event sent when a resource is successfully localized.
    *

--- a/modules/datastore/src/SqlEndpoint/WebServiceApi.php
+++ b/modules/datastore/src/SqlEndpoint/WebServiceApi.php
@@ -52,7 +52,6 @@ class WebServiceApi implements ContainerInjectionInterface {
    */
   private $eventDispatcher;
 
-
   /**
    * {@inheritdoc}
    */

--- a/modules/datastore/src/SqlEndpoint/WebServiceApi.php
+++ b/modules/datastore/src/SqlEndpoint/WebServiceApi.php
@@ -2,20 +2,20 @@
 
 namespace Drupal\datastore\SqlEndpoint;
 
-use Drupal\common\EventDispatcherTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\common\Events\Event;
 use Drupal\common\JsonResponseTrait;
 use Drupal\metastore\MetastoreApiResponse;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Api class.
  */
 class WebServiceApi implements ContainerInjectionInterface {
   use JsonResponseTrait;
-  use EventDispatcherTrait;
 
   const EVENT_RUN_QUERY = 'dkan_datastore_sql_run_query';
 
@@ -46,6 +46,14 @@ class WebServiceApi implements ContainerInjectionInterface {
   private MetastoreApiResponse $metastoreApiResponse;
 
   /**
+   * Event dispatcher service.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  private $eventDispatcher;
+
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
@@ -53,7 +61,8 @@ class WebServiceApi implements ContainerInjectionInterface {
       $container->get('dkan.datastore.sql_endpoint.service'),
       $container->get('database'),
       $container->get('request_stack'),
-      $container->get('dkan.metastore.api_response')
+      $container->get('dkan.metastore.api_response'),
+      $container->get('event_dispatcher')
     );
   }
 
@@ -64,12 +73,14 @@ class WebServiceApi implements ContainerInjectionInterface {
     DatastoreSqlEndpointService $service,
     Connection $database,
     RequestStack $requestStack,
-    MetastoreApiResponse $metastoreApiResponse
+    MetastoreApiResponse $metastoreApiResponse,
+    EventDispatcherInterface $eventDispatcher
   ) {
     $this->service = $service;
     $this->database = $database;
     $this->requestStack = $requestStack;
     $this->metastoreApiResponse = $metastoreApiResponse;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
@@ -129,7 +140,8 @@ class WebServiceApi implements ContainerInjectionInterface {
     try {
       $uuid = $this->service->getResourceUuid($query);
 
-      $this->dispatchEvent(self::EVENT_RUN_QUERY, $uuid);
+      $event = new Event($uuid);
+      $this->eventDispatcher->dispatch($event, self::EVENT_RUN_QUERY);
 
       $result = $this->service->runQuery($query, $showDbColumns);
     }

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -6,7 +6,6 @@ use Drupal\Core\Database\Connection;
 use Drupal\common\DataResource;
 use Drupal\common\Storage\AbstractDatabaseTable;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Database storage object.
@@ -45,14 +44,12 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     Connection $connection,
     DataResource $resource,
     LoggerInterface $loggerChannel,
-    EventDispatcherInterface $eventDispatcher
   ) {
     // Set resource before calling the parent constructor. The parent calls
     // getTableName which we implement and needs the resource to operate.
     $this->resource = $resource;
     $this->connection = $connection;
     $this->logger = $loggerChannel;
-    parent::__construct($eventDispatcher);
 
     if ($this->tableExist($this->getTableName())) {
       $this->setSchemaFromTable();

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -41,7 +41,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    * @param \Psr\Log\LoggerInterface $loggerChannel
    *   DKAN logger channel service.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
-   *    The event dispatcher service.
+   *   The event dispatcher service.
    */
   public function __construct(
     Connection $connection,

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -6,6 +6,7 @@ use Drupal\Core\Database\Connection;
 use Drupal\common\DataResource;
 use Drupal\common\Storage\AbstractDatabaseTable;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Database storage object.
@@ -44,12 +45,14 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     Connection $connection,
     DataResource $resource,
     LoggerInterface $loggerChannel,
+    EventDispatcherInterface $eventDispatcher
   ) {
     // Set resource before calling the parent constructor. The parent calls
     // getTableName which we implement and needs the resource to operate.
     $this->resource = $resource;
     $this->connection = $connection;
     $this->logger = $loggerChannel;
+    parent::__construct($eventDispatcher);
 
     if ($this->tableExist($this->getTableName())) {
       $this->setSchemaFromTable();

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -51,9 +51,14 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
   ) {
     // Set resource before calling the parent constructor. The parent calls
     // getTableName which we implement and needs the resource to operate.
+    $this->connection = $connection;
     $this->resource = $resource;
     $this->logger = $loggerChannel;
     parent::__construct($connection, $eventDispatcher);
+
+    if (!$this->schema && $this->tableExist($this->getTableName())) {
+      $this->setSchemaFromTable();
+    }
 
   }
 
@@ -186,6 +191,9 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     $canGetComment = method_exists($this->connection->schema(), 'getComment');
     $schema = ['fields' => []];
     foreach ($fieldsInfo as $info) {
+      if (!isset($info->Field)) {
+        continue;
+      }
       $name = $info->Field;
       $schema['fields'][$name] = $this->translateType($info->Type, ($info->Extra ?? NULL));
       $schema['fields'][$name] += [

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -6,6 +6,7 @@ use Drupal\Core\Database\Connection;
 use Drupal\common\DataResource;
 use Drupal\common\Storage\AbstractDatabaseTable;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Database storage object.
@@ -39,21 +40,21 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    *   A resource.
    * @param \Psr\Log\LoggerInterface $loggerChannel
    *   DKAN logger channel service.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *    The event dispatcher service.
    */
   public function __construct(
     Connection $connection,
     DataResource $resource,
     LoggerInterface $loggerChannel,
+    EventDispatcherInterface $eventDispatcher
   ) {
     // Set resource before calling the parent constructor. The parent calls
     // getTableName which we implement and needs the resource to operate.
     $this->resource = $resource;
-    $this->connection = $connection;
     $this->logger = $loggerChannel;
+    parent::__construct($connection, $eventDispatcher);
 
-    if ($this->tableExist($this->getTableName())) {
-      $this->setSchemaFromTable();
-    }
   }
 
   /**

--- a/modules/datastore/src/Storage/DatabaseTableFactory.php
+++ b/modules/datastore/src/Storage/DatabaseTableFactory.php
@@ -6,6 +6,7 @@ use Contracts\FactoryInterface;
 use Drupal\common\DataResource;
 use Drupal\Core\Database\Connection;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * DatabaseTable data object factory.
@@ -25,14 +26,21 @@ class DatabaseTableFactory implements FactoryInterface {
   protected LoggerInterface $logger;
 
   /**
+   * The event dispatcher.
+   */
+  protected EventDispatcherInterface $eventDispatcher;
+
+  /**
    * Constructor.
    */
   public function __construct(
     Connection $connection,
     LoggerInterface $loggerChannel,
+    EventDispatcherInterface $eventDispatcher
   ) {
     $this->connection = $connection;
     $this->logger = $loggerChannel;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
@@ -66,7 +74,7 @@ class DatabaseTableFactory implements FactoryInterface {
    *   A DatabaseTable object.
    */
   protected function getDatabaseTable(DataResource $resource) {
-    return new DatabaseTable($this->connection, $resource, $this->logger);
+    return new DatabaseTable($this->connection, $resource, $this->logger, $this->eventDispatcher);
   }
 
 }

--- a/modules/datastore/tests/src/Kernel/DatastoreServiceTest.php
+++ b/modules/datastore/tests/src/Kernel/DatastoreServiceTest.php
@@ -45,6 +45,7 @@ class DatastoreServiceTest extends KernelTestBase {
         $this->container->get('dkan.common.drupal_files'),
         $this->container->get('dkan.common.filefetcher_job_store_factory'),
         $this->container->get('queue'),
+        $this->container->get('event_dispatcher')
       ])
       ->onlyMethods(['get'])
       ->getMock();

--- a/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/LocalizeQueueWorkerTest.php
+++ b/modules/datastore/tests/src/Kernel/Plugin/QueueWorker/LocalizeQueueWorkerTest.php
@@ -138,6 +138,7 @@ class LocalizeQueueWorkerTest extends KernelTestBase {
         $this->container->get('dkan.common.drupal_files'),
         $this->container->get('dkan.common.filefetcher_job_store_factory'),
         $this->container->get('queue'),
+        $this->container->get('event_dispatcher')
       ])
       ->onlyMethods(['localizeTask'])
       ->getMock();
@@ -172,6 +173,7 @@ class LocalizeQueueWorkerTest extends KernelTestBase {
         $this->container->get('dkan.common.drupal_files'),
         $this->container->get('dkan.common.filefetcher_job_store_factory'),
         $this->container->get('queue'),
+        $this->container->get('event_dispatcher')
       ])
       ->onlyMethods(['localizeTask'])
       ->getMock();

--- a/modules/datastore/tests/src/Kernel/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Kernel/Storage/DatabaseTableTest.php
@@ -12,6 +12,7 @@ use Drupal\datastore\Storage\DatabaseTableFactory;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\common\Unit\Connection;
 use Procrastinator\Result;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @covers \Drupal\datastore\Storage\DatabaseTable
@@ -97,6 +98,7 @@ class DatabaseTableTest extends KernelTestBase {
         $this->createStub(Connection::class),
         $this->createStub(DataResource::class),
         $logger,
+        $this->createStub(EventDispatcherInterface::class),
         $this->createStub(DatabaseTableFactory::class),
       ])
       ->getMock();

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -24,6 +24,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -539,7 +540,8 @@ class QueryControllerTest extends TestCase {
     $storage = new SqliteDatabaseTable(
       $connection,
       $this->resource,
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
     $storage->setSchema([
       'fields' => [

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -24,6 +24,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -482,11 +483,12 @@ class QueryDownloadControllerTest extends TestCase {
    *   A database table storage class useable for datastore queries.
    */
   public function mockDatastoreTable(DataResource $resource, $fields, $connection) {
-    
+
     $storage = new SqliteDatabaseTable(
       $connection,
       $resource,
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
     $storage->setSchema([
       'fields' => $fields,
@@ -496,7 +498,7 @@ class QueryDownloadControllerTest extends TestCase {
     foreach ($fields as $field) {
       $types[] = $field['type'];
     }
-    
+
     $fp = fopen($resource->getFilePath(), 'rb');
     $sampleData = [];
     while (!feof($fp)) {

--- a/modules/datastore/tests/src/Unit/EventSubscriber/DatastoreSubscriberTest.php
+++ b/modules/datastore/tests/src/Unit/EventSubscriber/DatastoreSubscriberTest.php
@@ -22,6 +22,7 @@ use MockChain\Options;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @coversDefaultClass \Drupal\datastore\EventSubscriber\DatastoreSubscriber
@@ -109,6 +110,7 @@ class DatastoreSubscriberTest extends TestCase {
       ->add('dkan.common.job_store', JobStoreFactory::class)
       ->add('dkan.datastore.import_job_store_factory', ImportJobStoreFactory::class)
       ->add("database", Connection::class)
+      ->add('event_dispatcher', EventDispatcherInterface::class)
       ->index(0);
 
     $chain = (new Chain($this))
@@ -121,7 +123,8 @@ class DatastoreSubscriberTest extends TestCase {
       ->add(ImportJobStoreFactory::class, 'getInstance', JobStore::class)
       ->add(JobStore::class, 'remove')
       ->add(LoggerInterface::class, 'error', NULL, 'errors')
-      ->add(LoggerInterface::class, 'notice', NULL, 'notices');
+      ->add(LoggerInterface::class, 'notice', NULL, 'notices')
+      ->add(EventDispatcherInterface::class, 'dispatch');
 
     $subscriber = DatastoreSubscriber::create($chain->getMock());
     $subscriber->drop($event);
@@ -145,6 +148,7 @@ class DatastoreSubscriberTest extends TestCase {
       ->add('dkan.common.job_store', JobStoreFactory::class)
       ->add('dkan.datastore.import_job_store_factory', ImportJobStoreFactory::class)
       ->add("database", Connection::class)
+      ->add('event_dispatcher', EventDispatcherInterface::class)
       ->index(0);
 
     $chain = (new Chain($this))
@@ -156,7 +160,8 @@ class DatastoreSubscriberTest extends TestCase {
       ->add(ImportJobStoreFactory::class, 'getInstance', JobStore::class)
       ->add(JobStore::class, 'remove')
       ->add(LoggerInterface::class, 'error', NULL, 'errors')
-      ->add(LoggerInterface::class, 'notice', NULL, 'notices');
+      ->add(LoggerInterface::class, 'notice', NULL, 'notices')
+      ->add(EventDispatcherInterface::class, 'dispatch');
 
     $subscriber = DatastoreSubscriber::create($chain->getMock());
     $subscriber->drop($event);
@@ -179,6 +184,7 @@ class DatastoreSubscriberTest extends TestCase {
       ->add('dkan.common.job_store', JobStoreFactory::class)
       ->add('dkan.datastore.import_job_store_factory', ImportJobStoreFactory::class)
       ->add("database", Connection::class)
+      ->add('event_dispatcher', EventDispatcherInterface::class)
       ->index(0);
 
     $chain = (new Chain($this))
@@ -190,7 +196,8 @@ class DatastoreSubscriberTest extends TestCase {
       ->add(ImportJobStoreFactory::class, 'getInstance', JobStore::class)
       ->add(JobStore::class, 'remove', new \Exception('error'))
       ->add(LoggerInterface::class, 'error', NULL, 'errors')
-      ->add(LoggerInterface::class, 'notice', NULL, 'notices');
+      ->add(LoggerInterface::class, 'notice', NULL, 'notices')
+      ->add(EventDispatcherInterface::class, 'dispatch');
 
     $subscriber = DatastoreSubscriber::create($chain->getMock());
     $subscriber->drop($event);
@@ -208,6 +215,7 @@ class DatastoreSubscriberTest extends TestCase {
       ->add('dkan.datastore.service.resource_purger', ResourcePurger::class)
       ->add('dkan.common.job_store', JobStoreFactory::class)
       ->add('dkan.datastore.import_job_store_factory', ImportJobStoreFactory::class)
+      ->add('event_dispatcher', EventDispatcherInterface::class)
       ->index(0);
 
     return (new Chain($this))

--- a/modules/datastore/tests/src/Unit/Service/ResourceLocalizerTest.php
+++ b/modules/datastore/tests/src/Unit/Service/ResourceLocalizerTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\TestCase;
 use Procrastinator\Result;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @group dkan
@@ -65,7 +66,8 @@ class ResourceLocalizerTest extends TestCase {
       $fileFetcher,
       $this->getDrupalFilesChain()->getMock(),
       $this->getJobStoreFactoryChain()->getMock(),
-      $this->createMock(QueueFactory::class)
+      $this->createMock(QueueFactory::class),
+      $this->createMock(EventDispatcherInterface::class)
     );
 
     \Drupal::setContainer($this->getContainer()->getMock());

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableFactoryTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableFactoryTest.php
@@ -9,6 +9,7 @@ use Drupal\sqlite\Driver\Database\sqlite\Connection;
 use MockChain\Chain;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @group dkan
@@ -34,6 +35,7 @@ class DatabaseTableFactoryTest extends TestCase {
     $factory = $builder->setConstructorArgs([
       $connection,
       $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class),
     ])
       ->onlyMethods(["getDatabaseTable"])
       ->getMock();

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -15,6 +15,7 @@ use MockChain\Chain;
 use MockChain\Sequence;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @coversDefaultClass \Drupal\datastore\Storage\DatabaseTable
@@ -33,7 +34,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $this->getConnectionChain()->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
 
     $reflection = new \ReflectionClass($databaseTable);
@@ -127,7 +129,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $this->getConnectionChain()->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
     $this->assertTrue(is_object($databaseTable));
   }
@@ -141,7 +144,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
 
     $schema = $databaseTable->getSchema();
@@ -206,7 +210,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connection,
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
     $this->assertEquals([], $databaseTable->retrieveAll());
   }
@@ -229,7 +234,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
     $this->assertEquals("1", $databaseTable->store('["Gerardo", "Gonzalez"]', "1"));
   }
@@ -252,7 +258,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
     $this->expectExceptionMessageMatches("/The number of fields and data given do not match:/");
     $this->assertEquals("1", $databaseTable->store('["Foobar"]', "1"));
@@ -276,7 +283,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
     $data = [
       '["Gerardo", "Gonzalez"]',
@@ -304,7 +312,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
     $data = [
       '["One"]',
@@ -329,7 +338,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
     $this->assertEquals(1, $databaseTable->count());
   }
@@ -348,7 +358,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
 
     $actual = json_decode(json_encode(
@@ -370,7 +381,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
     $databaseTable->destruct();
     $this->assertTrue(TRUE);
@@ -395,7 +407,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
     $this->expectExceptionMessage('Import for 1 returned an error when preparing table header: {"foo":"bar"}');
     $this->assertEquals("1", $databaseTable->store('{"foo":"bar"}', "1"));
@@ -419,7 +432,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
     $this->expectExceptionMessage("Import for 1 error when decoding foobar");
     $this->assertEquals("1", $databaseTable->store("foobar", "1"));
@@ -441,7 +455,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
 
     $this->assertEquals([], $databaseTable->query($query));
@@ -462,7 +477,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
 
     $this->expectExceptionMessage("Database internal error.");
@@ -484,7 +500,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
 
     $this->expectExceptionMessage("Column not found");
@@ -506,7 +523,8 @@ class DatabaseTableTest extends TestCase {
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
       $this->getResource(),
-      $this->createStub(LoggerInterface::class)
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
     );
 
     $this->expectExceptionMessage("You have attempted a fulltext match against a column that is not indexed for fulltext searching");

--- a/modules/harvest/harvest.services.yml
+++ b/modules/harvest/harvest.services.yml
@@ -28,6 +28,7 @@ services:
     class: Drupal\harvest\Storage\DatabaseTableFactory
     arguments:
       - '@database'
+      - '@event_dispatcher'
   dkan.harvest.storage.hashes_database_table:
     class: Drupal\harvest\Storage\HarvestHashesDatabaseTableFactory
     arguments:
@@ -52,6 +53,7 @@ services:
     class: Drupal\harvest\Storage\DatabaseTableFactory
     arguments:
       - '@database'
+      - '@event_dispatcher'
   harvest.logger_channel:
     parent: logger.channel_base
     arguments: ['harvest']

--- a/modules/harvest/src/Storage/DatabaseTable.php
+++ b/modules/harvest/src/Storage/DatabaseTable.php
@@ -4,6 +4,7 @@ namespace Drupal\harvest\Storage;
 
 use Drupal\Core\Database\Connection;
 use Drupal\common\Storage\AbstractDatabaseTable;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Harvest database table storage.
@@ -30,11 +31,17 @@ class DatabaseTable extends AbstractDatabaseTable {
    *   Drupal's database connection object.
    * @param string $identifier
    *   Each unique identifier represents a table.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *   The event dispatcher service.
    */
-  public function __construct(Connection $connection, string $identifier) {
+  public function __construct(
+    Connection $connection,
+    string $identifier,
+    EventDispatcherInterface $eventDispatcher
+  ) {
     $this->identifier = $identifier;
     $this->setOurSchema();
-    parent::__construct($connection);
+    parent::__construct($connection, $eventDispatcher);
   }
 
   /**

--- a/modules/harvest/src/Storage/DatabaseTable.php
+++ b/modules/harvest/src/Storage/DatabaseTable.php
@@ -4,7 +4,6 @@ namespace Drupal\harvest\Storage;
 
 use Drupal\Core\Database\Connection;
 use Drupal\common\Storage\AbstractDatabaseTable;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Harvest database table storage.
@@ -32,10 +31,10 @@ class DatabaseTable extends AbstractDatabaseTable {
    * @param string $identifier
    *   Each unique identifier represents a table.
    */
-  public function __construct(Connection $connection, EventDispatcherInterface $eventDispatcher, string $identifier) {
+  public function __construct(Connection $connection, string $identifier) {
     $this->identifier = $identifier;
     $this->setOurSchema();
-    parent::__construct($connection, $eventDispatcher);
+    parent::__construct($connection);
   }
 
   /**

--- a/modules/harvest/src/Storage/DatabaseTable.php
+++ b/modules/harvest/src/Storage/DatabaseTable.php
@@ -4,6 +4,7 @@ namespace Drupal\harvest\Storage;
 
 use Drupal\Core\Database\Connection;
 use Drupal\common\Storage\AbstractDatabaseTable;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Harvest database table storage.
@@ -31,10 +32,10 @@ class DatabaseTable extends AbstractDatabaseTable {
    * @param string $identifier
    *   Each unique identifier represents a table.
    */
-  public function __construct(Connection $connection, string $identifier) {
+  public function __construct(Connection $connection, EventDispatcherInterface $eventDispatcher, string $identifier) {
     $this->identifier = $identifier;
     $this->setOurSchema();
-    parent::__construct($connection);
+    parent::__construct($connection, $eventDispatcher);
   }
 
   /**

--- a/modules/harvest/src/Storage/DatabaseTableFactory.php
+++ b/modules/harvest/src/Storage/DatabaseTableFactory.php
@@ -4,6 +4,7 @@ namespace Drupal\harvest\Storage;
 
 use Contracts\FactoryInterface;
 use Drupal\Core\Database\Connection;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Database table factory.
@@ -18,6 +19,13 @@ class DatabaseTableFactory implements FactoryInterface {
   private $connection;
 
   /**
+   * The event dispatcher.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  private $eventDispatcher;
+
+  /**
    * Database table data objects.
    *
    * @var \Drupal\harvest\Storage\DatabaseTable
@@ -27,8 +35,9 @@ class DatabaseTableFactory implements FactoryInterface {
   /**
    * Constructor.
    */
-  public function __construct(Connection $connection) {
+  public function __construct(Connection $connection, EventDispatcherInterface $eventDispatcher) {
     $this->connection = $connection;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
@@ -47,7 +56,7 @@ class DatabaseTableFactory implements FactoryInterface {
    * Protected.
    */
   protected function getDatabaseTable($identifier) {
-    return new DatabaseTable($this->connection, $identifier);
+    return new DatabaseTable($this->connection, $identifier, $this->eventDispatcher);
   }
 
 }

--- a/modules/harvest/tests/src/Unit/Storage/DatabaseTableFactoryTest.php
+++ b/modules/harvest/tests/src/Unit/Storage/DatabaseTableFactoryTest.php
@@ -7,6 +7,7 @@ use Drupal\Core\Database\Schema;
 use Drupal\harvest\Storage\DatabaseTableFactory;
 use PHPUnit\Framework\TestCase;
 use MockChain\Chain;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @group dkan
@@ -19,7 +20,7 @@ class DatabaseTableFactoryTest extends TestCase {
    *
    */
   public function test() {
-    $factory = new DatabaseTableFactory($this->getConnection());
+    $factory = new DatabaseTableFactory($this->getConnection(), $this->getEventDispatcher());
     $this->assertNotNull($factory->getInstance('blah', []));
   }
 
@@ -31,6 +32,13 @@ class DatabaseTableFactoryTest extends TestCase {
       ->add(Connection::class, 'schema', Schema::class)
       ->add(Schema::class, 'tableExists', FALSE)
       ->getMock();
+  }
+
+  /**
+   * Getter for the event dispatcher.
+   */
+  public function getEventDispatcher(): EventDispatcherInterface {
+    return $this->createMock(EventDispatcherInterface::class);
   }
 
 }

--- a/modules/harvest/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/harvest/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -7,6 +7,7 @@ use Drupal\Core\Database\Schema;
 use MockChain\Chain;
 use Drupal\harvest\Storage\DatabaseTable;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @coversDefaultClass \Drupal\harvest\Storage\DatabaseTable
@@ -26,7 +27,9 @@ class DatabaseTableTest extends TestCase {
       ->add(Schema::class, 'tableExists', FALSE)
       ->getMock();
 
-    $databaseTable = new DatabaseTable($connection, "blah");
+    $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+    $databaseTable = new DatabaseTable($connection, "blah", $eventDispatcher);
     $this->assertTrue(is_object($databaseTable));
   }
 

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -18,6 +18,7 @@ services:
       - '@dkan.metastore.storage'
       - '@queue'
       - '@config.factory'
+      - '@event_dispatcher'
   dkan.metastore.schema_retriever:
     class: \Drupal\metastore\SchemaRetriever
     arguments:

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -6,6 +6,7 @@ services:
       - '@dkan.metastore.storage'
       - '@dkan.metastore.valid_metadata'
       - '@dkan.common.logger_channel'
+      - '@event_dispatcher'
 
   dkan.metastore.lifecycle:
     class: \Drupal\metastore\LifeCycle\LifeCycle

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -38,6 +38,7 @@ services:
       - '@entity_type.manager'
       - '@config.factory'
       - '@dkan.common.logger_channel'
+      - '@event_dispatcher'
 
   dkan.metastore.referencer:
     class: \Drupal\metastore\Reference\Referencer
@@ -74,6 +75,7 @@ services:
     arguments:
       - '@database'
       - '@dkan.common.logger_channel'
+      - '@event_dispatcher'
 
   dkan.metastore.event_subscriber:
     class: \Drupal\metastore\EventSubscriber\MetastoreSubscriber

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -20,6 +20,7 @@ services:
       - '@queue'
       - '@config.factory'
       - '@event_dispatcher'
+
   dkan.metastore.schema_retriever:
     class: \Drupal\metastore\SchemaRetriever
     arguments:

--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -66,6 +66,7 @@ services:
     arguments:
       - '@dkan.metastore.resource_mapper_database_table'
       - '@entity_type.manager'
+      - '@event_dispatcher'
 
   dkan.metastore.resource_mapper_database_table:
     class: \Drupal\metastore\Storage\ResourceMapperDatabaseTable

--- a/modules/metastore/modules/metastore_search/metastore_search.services.yml
+++ b/modules/metastore/modules/metastore_search/metastore_search.services.yml
@@ -5,4 +5,5 @@ services:
       - '@dkan.metastore.service'
       - '@entity_type.manager'
       - '@search_api.query_helper'
+      - '@event_dispatcher'
 

--- a/modules/metastore/modules/metastore_search/src/QueryBuilderTrait.php
+++ b/modules/metastore/modules/metastore_search/src/QueryBuilderTrait.php
@@ -17,6 +17,13 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 trait QueryBuilderTrait {
 
   /**
+   * The event dispatcher service.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  protected EventDispatcherInterface $eventDispatcher;
+
+  /**
    * Private.
    *
    * @param array $params
@@ -125,13 +132,12 @@ trait QueryBuilderTrait {
     foreach ($fields as $field) {
       if (isset($params[$field])) {
 
-        $dispatcher = \Drupal::getContainer()->get('event_dispatcher');
         $event = new Event([
           'field' => $field,
           'values' => $this->getValuesFromCommaSeparatedString($params[$field]),
           'conjunction' => 'AND',
         ]);
-        $dispatcher->dispatch($event, Search::EVENT_SEARCH_QUERY_BUILDER_CONDITION);
+        $this->eventDispatcher->dispatch($event, Search::EVENT_SEARCH_QUERY_BUILDER_CONDITION);
         $info = $event->getData();
 
         $conditions = [];

--- a/modules/metastore/modules/metastore_search/src/QueryBuilderTrait.php
+++ b/modules/metastore/modules/metastore_search/src/QueryBuilderTrait.php
@@ -17,13 +17,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 trait QueryBuilderTrait {
 
   /**
-   * The event dispatcher service.
-   *
-   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
-   */
-  protected EventDispatcherInterface $eventDispatcher;
-
-  /**
    * Private.
    *
    * @param array $params

--- a/modules/metastore/modules/metastore_search/src/QueryBuilderTrait.php
+++ b/modules/metastore/modules/metastore_search/src/QueryBuilderTrait.php
@@ -2,11 +2,12 @@
 
 namespace Drupal\metastore_search;
 
-use Drupal\common\EventDispatcherTrait;
+use Drupal\common\Events\Event;
 use Drupal\search_api\IndexInterface;
 use Drupal\search_api\Query\Query;
 use Drupal\search_api\Query\QueryInterface;
 use Drupal\search_api\Utility\QueryHelperInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Search API query builder trait.
@@ -14,7 +15,6 @@ use Drupal\search_api\Utility\QueryHelperInterface;
  * @package Drupal\metastore_search
  */
 trait QueryBuilderTrait {
-  use EventDispatcherTrait;
 
   /**
    * Private.
@@ -125,12 +125,14 @@ trait QueryBuilderTrait {
     foreach ($fields as $field) {
       if (isset($params[$field])) {
 
-        $info = $this->dispatchEvent(Search::EVENT_SEARCH_QUERY_BUILDER_CONDITION,
-          [
-            'field' => $field,
-            'values' => $this->getValuesFromCommaSeparatedString($params[$field]),
-            'conjunction' => 'AND',
-          ]);
+        $dispatcher = \Drupal::getContainer()->get('event_dispatcher');
+        $event = new Event([
+          'field' => $field,
+          'values' => $this->getValuesFromCommaSeparatedString($params[$field]),
+          'conjunction' => 'AND',
+        ]);
+        $dispatcher->dispatch($event, Search::EVENT_SEARCH_QUERY_BUILDER_CONDITION);
+        $info = $event->getData();
 
         $conditions = [];
         $conditions[$info['field']] = $info['values'];

--- a/modules/metastore/modules/metastore_search/src/QueryBuilderTrait.php
+++ b/modules/metastore/modules/metastore_search/src/QueryBuilderTrait.php
@@ -7,7 +7,6 @@ use Drupal\search_api\IndexInterface;
 use Drupal\search_api\Query\Query;
 use Drupal\search_api\Query\QueryInterface;
 use Drupal\search_api\Utility\QueryHelperInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Search API query builder trait.

--- a/modules/metastore/modules/metastore_search/src/Search.php
+++ b/modules/metastore/modules/metastore_search/src/Search.php
@@ -2,12 +2,14 @@
 
 namespace Drupal\metastore_search;
 
+use Drupal\common\Events\Event;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\metastore\MetastoreService;
 use Drupal\search_api\Query\ResultSet;
 use Drupal\search_api\Utility\QueryHelperInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Search.
@@ -57,6 +59,13 @@ class Search implements ContainerInjectionInterface {
   private $queryHelper;
 
   /**
+   * Event dispatcher service.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  private $eventDispatcher;
+
+  /**
    * Constructor.
    *
    * @param \Drupal\metastore\MetastoreService $metastoreService
@@ -65,15 +74,19 @@ class Search implements ContainerInjectionInterface {
    *   Entity type manager.
    * @param \Drupal\search_api\Utility\QueryHelperInterface $queryHelper
    *   Query helper.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *    Event dispatcher.
    */
   public function __construct(
     MetastoreService $metastoreService,
     EntityTypeManagerInterface $entityTypeManager,
-    QueryHelperInterface $queryHelper
+    QueryHelperInterface $queryHelper,
+    EventDispatcherInterface $eventDispatcher
   ) {
     $this->metastoreService = $metastoreService;
     $this->entityTypeManager = $entityTypeManager;
     $this->queryHelper = $queryHelper;
+    $this->eventDispatcher = $eventDispatcher;
 
     $this->setSearchIndex('dkan');
   }
@@ -87,8 +100,26 @@ class Search implements ContainerInjectionInterface {
     return new static(
       $container->get('dkan.metastore.service'),
       $container->get('entity_type.manager'),
-      $container->get('search_api.query_helper')
+      $container->get('search_api.query_helper'),
+      $container->get('event_dispatcher')
     );
+  }
+
+  /**
+   * Dispatcher.
+   *
+   * @param string $eventName
+   *   The event name.
+   * @param mixed $data
+   *   The event data.
+   *
+   * @return mixed
+   *   The event data after being processed by subscribers.
+   */
+  protected function dispatchEvent(string $eventName, $data) {
+    $event = new Event($data);
+    $this->eventDispatcher->dispatch($event, $eventName);
+    return $event->getData();
   }
 
   /**

--- a/modules/metastore/modules/metastore_search/src/Search.php
+++ b/modules/metastore/modules/metastore_search/src/Search.php
@@ -115,7 +115,9 @@ class Search implements ContainerInjectionInterface {
    *   Search parameters.
    */
   public function search(array $params = []) {
-    $params = $this->dispatchEvent(self::EVENT_SEARCH_PARAMS, $params);
+    $event = new Event($params);
+    $this->eventDispatcher->dispatch($event, self::EVENT_SEARCH_PARAMS);
+    $params = $event->getData();
     $query = $this->getQuery($params, $this->index, $this->queryHelper)[0];
     $result = $query->execute();
 

--- a/modules/metastore/modules/metastore_search/src/Search.php
+++ b/modules/metastore/modules/metastore_search/src/Search.php
@@ -75,7 +75,7 @@ class Search implements ContainerInjectionInterface {
    * @param \Drupal\search_api\Utility\QueryHelperInterface $queryHelper
    *   Query helper.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
-   *    Event dispatcher.
+   *   Event dispatcher.
    */
   public function __construct(
     MetastoreService $metastoreService,

--- a/modules/metastore/modules/metastore_search/src/Search.php
+++ b/modules/metastore/modules/metastore_search/src/Search.php
@@ -106,23 +106,6 @@ class Search implements ContainerInjectionInterface {
   }
 
   /**
-   * Dispatcher.
-   *
-   * @param string $eventName
-   *   The event name.
-   * @param mixed $data
-   *   The event data.
-   *
-   * @return mixed
-   *   The event data after being processed by subscribers.
-   */
-  protected function dispatchEvent(string $eventName, $data) {
-    $event = new Event($data);
-    $this->eventDispatcher->dispatch($event, $eventName);
-    return $event->getData();
-  }
-
-  /**
    * Search.
    *
    * Returns an object with 2 properties: total (the total number of records
@@ -139,7 +122,9 @@ class Search implements ContainerInjectionInterface {
     $count = $result->getResultCount();
     $data = $this->getData($result);
 
-    $data = $this->dispatchEvent(self::EVENT_SEARCH, $data);
+    $event = new Event($data);
+    $this->eventDispatcher->dispatch($event, self::EVENT_SEARCH);
+    $data = $event->getData();
 
     return (object) [
       'total' => $count,

--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -2,6 +2,14 @@
 
 namespace Drupal\metastore\LifeCycle;
 
+<<<<<<< HEAD
+=======
+use Drupal\common\EventDispatcherTrait;
+use Drupal\common\DataResource;
+use Drupal\common\Exception\DataNodeLifeCycleEntityValidationException;
+use Drupal\common\Events\Event;
+use Drupal\common\UrlHostTokenResolver;
+>>>>>>> 73cebc052 (updated datastore subscriber, subscriber test, datastore and metastore services)
 use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Config\ConfigFactory;
@@ -189,8 +197,9 @@ class LifeCycle {
    * Purge resources (if unneeded) of any updated dataset.
    */
   protected function datasetUpdate(MetastoreItemInterface $data): void {
-    //$this->dispatchEvent(self::EVENT_DATASET_UPDATE, $data);
-    $this->eventDispatcher->dispatch($data, self::EVENT_DATASET_UPDATE);
+    // $this->dispatchEvent(self::EVENT_DATASET_UPDATE, $data);
+    $event = new Event($data);
+    $this->eventDispatcher->dispatch($event, self::EVENT_DATASET_UPDATE);
   }
 
   /**

--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -32,7 +32,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * storage systems.
  */
 class LifeCycle {
-  use EventDispatcherTrait;
 
   const EVENT_DATASET_UPDATE = 'dkan_metastore_dataset_update';
   const EVENT_PRE_REFERENCE = 'dkan_metastore_metadata_pre_reference';
@@ -186,7 +185,6 @@ class LifeCycle {
    * Purge resources (if unneeded) of any updated dataset.
    */
   protected function datasetUpdate(MetastoreItemInterface $data): void {
-    // $this->dispatchEvent(self::EVENT_DATASET_UPDATE, $data);
     $event = new Event($data);
     $this->eventDispatcher->dispatch($event, self::EVENT_DATASET_UPDATE);
   }

--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -2,14 +2,6 @@
 
 namespace Drupal\metastore\LifeCycle;
 
-<<<<<<< HEAD
-=======
-use Drupal\common\EventDispatcherTrait;
-use Drupal\common\DataResource;
-use Drupal\common\Exception\DataNodeLifeCycleEntityValidationException;
-use Drupal\common\Events\Event;
-use Drupal\common\UrlHostTokenResolver;
->>>>>>> 73cebc052 (updated datastore subscriber, subscriber test, datastore and metastore services)
 use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Config\ConfigFactory;
@@ -17,8 +9,8 @@ use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
 use Drupal\common\DataResource;
-use Drupal\common\EventDispatcherTrait;
 use Drupal\common\Exception\DataNodeLifeCycleEntityValidationException;
+use Drupal\common\Events\Event;
 use Drupal\common\UrlHostTokenResolver;
 use Drupal\metastore\MetastoreItemInterface;
 use Drupal\metastore\Reference\Dereferencer;
@@ -120,10 +112,7 @@ class LifeCycle {
     DataFactory $dataFactory,
     QueueFactory $queueFactory,
     ConfigFactory $configFactory,
-<<<<<<< HEAD
-=======
-    EventDispatcherInterface $event_dispatcher
->>>>>>> efc5963af (updating only MetastoreItemInterface)
+    EventDispatcherInterface $eventDispatcher
   ) {
     $this->referencer = $referencer;
     $this->dereferencer = $dereferencer;
@@ -133,7 +122,7 @@ class LifeCycle {
     $this->dataFactory = $dataFactory;
     $this->queueFactory = $queueFactory;
     $this->configFactory = $configFactory;
-    $this->eventDispatcher = $event_dispatcher;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
@@ -361,9 +350,10 @@ class LifeCycle {
 
     // Trigger datastore import if applicable.
     // Needs to happen before updating references.
-    $this->dispatchEvent(self::EVENT_PRE_REFERENCE, $data, function ($data) {
-      return $data instanceof MetastoreItemInterface;
-    });
+    if ($data instanceof MetastoreItemInterface) {
+      $event = new Event($data);
+      $this->eventDispatcher->dispatch($event, self::EVENT_PRE_REFERENCE);
+    }
 
     // Convert references in metadata to uuids.
     // Create new reference entities if they do not exist.

--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -19,6 +19,7 @@ use Drupal\metastore\Reference\OrphanChecker;
 use Drupal\metastore\Reference\Referencer;
 use Drupal\metastore\ResourceMapper;
 use Drupal\metastore\Storage\DataFactory;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Abstraction of logic used in entity hooks.
@@ -93,6 +94,13 @@ class LifeCycle {
   protected $configFactory;
 
   /**
+   * Event dispatcher service.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  protected $eventDispatcher;
+
+  /**
    * Constructor.
    */
   public function __construct(
@@ -104,6 +112,10 @@ class LifeCycle {
     DataFactory $dataFactory,
     QueueFactory $queueFactory,
     ConfigFactory $configFactory,
+<<<<<<< HEAD
+=======
+    EventDispatcherInterface $event_dispatcher
+>>>>>>> efc5963af (updating only MetastoreItemInterface)
   ) {
     $this->referencer = $referencer;
     $this->dereferencer = $dereferencer;
@@ -113,6 +125,7 @@ class LifeCycle {
     $this->dataFactory = $dataFactory;
     $this->queueFactory = $queueFactory;
     $this->configFactory = $configFactory;
+    $this->eventDispatcher = $event_dispatcher;
   }
 
   /**
@@ -176,7 +189,8 @@ class LifeCycle {
    * Purge resources (if unneeded) of any updated dataset.
    */
   protected function datasetUpdate(MetastoreItemInterface $data): void {
-    $this->dispatchEvent(self::EVENT_DATASET_UPDATE, $data);
+    //$this->dispatchEvent(self::EVENT_DATASET_UPDATE, $data);
+    $this->eventDispatcher->dispatch($data, self::EVENT_DATASET_UPDATE);
   }
 
   /**

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -238,20 +238,20 @@ class MetastoreService implements ContainerInjectionInterface {
   private function jsonStringsArrayToObjects(array $jsonStringsArray, string $schema_id) {
     return array_map(
       function ($jsonString) use ($schema_id) {
-      try {
-        $data = $this->validMetadataFactory->get($jsonString, $schema_id);
-        return $this->dispatchEvent(self::EVENT_DATA_GET, $data, function ($data) {
-          return $data instanceof RootedJsonData;
-        });
-      }
-      catch (\Exception) {
-        $this->logger->error('A JSON string failed validation.', [
+        try {
+          $data = $this->validMetadataFactory->get($jsonString, $schema_id);
+          return $this->dispatchEvent(self::EVENT_DATA_GET, $data, function ($data) {
+            return $data instanceof RootedJsonData;
+          });
+        }
+        catch (\Exception) {
+          $this->logger->error('A JSON string failed validation.', [
           '@schema_id' => $schema_id,
           '@json' => $jsonString,
         ]);
-        return NULL;
-      }
-    }, $jsonStringsArray);
+          return NULL;
+        }
+      }, $jsonStringsArray);
   }
 
   /**

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -270,13 +270,8 @@ class MetastoreService implements ContainerInjectionInterface {
   public function get(string $schema_id, string $identifier, bool $published = TRUE): RootedJsonData {
     $json_string = $this->getStorage($schema_id)->retrieve($identifier, $published);
     $data = $this->validMetadataFactory->get($json_string, $schema_id);
-
-    $event = new Event($data, function ($data) {
-      return $data instanceof RootedJsonData;
-    });
-
+    $event = new Event($data);
     $this->eventDispatcher->dispatch($event, self::EVENT_DATA_GET);
-
     return $event->getData();
   }
 

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -97,7 +97,7 @@ class MetastoreService implements ContainerInjectionInterface {
   /**
    * Dispatch an event and return the (possibly) modified data.
    *
-   * This method simulates the behavior of the deprecated event dispatcher trait.
+   * This method simulates the deprecated event dispatcher trait.
    *
    * @param string $eventName
    *   The event name.
@@ -109,11 +109,11 @@ class MetastoreService implements ContainerInjectionInterface {
    * @return mixed
    *   The (possibly) modified data.
    */
-  private function dispatchEvent(string $eventName, $data, callable $validate = null) {
+  private function dispatchEvent(string $eventName, $data, callable $validate = NULL) {
     $event = new GenericEvent($data);
     $event = $this->eventDispatcher->dispatch($event, $eventName);
 
-    if (method_exists($event, 'getException') && $event->getException() !== null) {
+    if (method_exists($event, 'getException') && $event->getException() !== NULL) {
       $this->logger->error('A JSON string failed validation.');
       return $data;
     }
@@ -122,7 +122,7 @@ class MetastoreService implements ContainerInjectionInterface {
       ? $event->getSubject()
       : (method_exists($event, 'getData') ? $event->getData() : $data);
 
-    return ($validate !== null && !$validate($modifiedData)) ? $data : $modifiedData;
+    return ($validate !== NULL && !$validate($modifiedData)) ? $data : $modifiedData;
   }
 
   /**

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -246,9 +246,9 @@ class MetastoreService implements ContainerInjectionInterface {
         }
         catch (\Exception) {
           $this->logger->error('A JSON string failed validation.', [
-          '@schema_id' => $schema_id,
-          '@json' => $jsonString,
-        ]);
+            '@schema_id' => $schema_id,
+            '@json' => $jsonString,
+          ]);
           return NULL;
         }
       }, $jsonStringsArray);

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -3,6 +3,7 @@
 namespace Drupal\metastore;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\common\Events\Event;
 use Drupal\metastore\Exception\CannotChangeUuidException;
 use Drupal\metastore\Exception\ExistingObjectException;
 use Drupal\metastore\Exception\MissingObjectException;
@@ -14,7 +15,6 @@ use RootedData\RootedJsonData;
 use Rs\Json\Merge\Patch;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * The metastore service.
@@ -92,37 +92,6 @@ class MetastoreService implements ContainerInjectionInterface {
     $this->validMetadataFactory = $validMetadataFactory;
     $this->logger = $loggerChannel;
     $this->eventDispatcher = $eventDispatcher;
-  }
-
-  /**
-   * Dispatch an event and return the (possibly) modified data.
-   *
-   * This method simulates the deprecated event dispatcher trait.
-   *
-   * @param string $eventName
-   *   The event name.
-   * @param mixed $data
-   *   The data to dispatch.
-   * @param callable|null $validate
-   *   Optional validation callback.
-   *
-   * @return mixed
-   *   The (possibly) modified data.
-   */
-  private function dispatchEvent(string $eventName, $data, callable $validate = NULL) {
-    $event = new GenericEvent($data);
-    $event = $this->eventDispatcher->dispatch($event, $eventName);
-
-    if (method_exists($event, 'getException') && $event->getException() !== NULL) {
-      $this->logger->error('A JSON string failed validation.');
-      return $data;
-    }
-
-    $modifiedData = method_exists($event, 'getSubject')
-      ? $event->getSubject()
-      : (method_exists($event, 'getData') ? $event->getData() : $data);
-
-    return ($validate !== NULL && !$validate($modifiedData)) ? $data : $modifiedData;
   }
 
   /**
@@ -217,9 +186,20 @@ class MetastoreService implements ContainerInjectionInterface {
     $jsonStringsArray = $this->getStorage($schema_id)->retrieveAll($start, $length, $unpublished);
     $objects = array_filter($this->jsonStringsArrayToObjects($jsonStringsArray, $schema_id));
 
-    return $this->dispatchEvent(self::EVENT_DATA_GET_ALL, $objects, function ($data) {
-      return !is_array($data) ? FALSE : (count($data) === 0 || reset($data) instanceof RootedJsonData);
-    });
+    $validator = function ($data) {
+      if (!is_array($data)) {
+        return FALSE;
+      }
+      if (count($data) == 0) {
+        return TRUE;
+      }
+      return reset($data) instanceof RootedJsonData;
+    };
+
+    $event = new Event($objects, $validator);
+    $this->eventDispatcher->dispatch($event, self::EVENT_DATA_GET_ALL);
+
+    return $event->getData();
   }
 
   /**
@@ -240,9 +220,14 @@ class MetastoreService implements ContainerInjectionInterface {
       function ($jsonString) use ($schema_id) {
         try {
           $data = $this->validMetadataFactory->get($jsonString, $schema_id);
-          return $this->dispatchEvent(self::EVENT_DATA_GET, $data, function ($data) {
+
+          $event = new Event($data, function ($data) {
             return $data instanceof RootedJsonData;
           });
+
+          $this->eventDispatcher->dispatch($event, self::EVENT_DATA_GET);
+
+          return $event->getData();
         }
         catch (\Exception) {
           $this->logger->error('A JSON string failed validation.', [
@@ -285,7 +270,14 @@ class MetastoreService implements ContainerInjectionInterface {
   public function get(string $schema_id, string $identifier, bool $published = TRUE): RootedJsonData {
     $json_string = $this->getStorage($schema_id)->retrieve($identifier, $published);
     $data = $this->validMetadataFactory->get($json_string, $schema_id);
-    return $this->dispatchEvent(self::EVENT_DATA_GET, $data);
+
+    $event = new Event($data, function ($data) {
+      return $data instanceof RootedJsonData;
+    });
+
+    $this->eventDispatcher->dispatch($event, self::EVENT_DATA_GET);
+
+    return $event->getData();
   }
 
   /**

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -236,7 +236,8 @@ class MetastoreService implements ContainerInjectionInterface {
    * @todo Exception should not be caught; let controller handle it.
    */
   private function jsonStringsArrayToObjects(array $jsonStringsArray, string $schema_id) {
-    return array_map(function ($jsonString) use ($schema_id) {
+    return array_map(
+      function ($jsonString) use ($schema_id) {
       try {
         $data = $this->validMetadataFactory->get($jsonString, $schema_id);
         return $this->dispatchEvent(self::EVENT_DATA_GET, $data, function ($data) {
@@ -407,6 +408,7 @@ class MetastoreService implements ContainerInjectionInterface {
       $this->getStorage($schema_id)->store($data);
       return ['identifier' => $identifier, 'new' => TRUE];
     }
+
   }
 
   /**
@@ -424,6 +426,7 @@ class MetastoreService implements ContainerInjectionInterface {
    */
   public function patch($schema_id, $identifier, mixed $json_data) {
     $storage = $this->getStorage($schema_id);
+
     if ($this->objectExists($schema_id, $identifier)) {
 
       $json_data_original = $storage->retrieve($identifier);
@@ -494,6 +497,7 @@ class MetastoreService implements ContainerInjectionInterface {
         $no_schema_object = $this->swapReference($property, $value, $no_schema_object);
       }
     }
+
     return self::removeReferences($no_schema_object, "%Ref");
   }
 
@@ -560,17 +564,20 @@ class MetastoreService implements ContainerInjectionInterface {
    */
   public static function removeReferences(RootedJsonData $object, $prefix = "%"): RootedJsonData {
     $array = $object->get('$');
+
     foreach ($array as $property => $value) {
       if (substr_count((string) $property, $prefix) > 0) {
         unset($array[$property]);
       }
     }
+
     if (!empty($array['distribution'])) {
       $array['distribution'] = array_map(function ($dist) {
         unset($dist['%Ref:downloadURL']);
         return $dist;
       }, $array['distribution']);
     }
+
     $object->set('$', $array);
     return $object;
   }
@@ -601,6 +608,7 @@ class MetastoreService implements ContainerInjectionInterface {
     else {
       throw new \InvalidArgumentException("Invalid metadata argument.");
     }
+
     return md5((string) $normalizedData);
   }
 

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -193,11 +193,13 @@ class MetastoreService implements ContainerInjectionInterface {
     $processedData = $event->getData();
 
     if (!is_array($processedData)) {
-      return FALSE;
+      return [];
     }
-    if (count($processedData) == 0) {
-      return TRUE;
+
+    if (empty($processedData)) {
+      return [];
     }
+
     return reset($processedData) instanceof RootedJsonData;
 
   }

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -3,7 +3,7 @@
 namespace Drupal\metastore;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\common\EventDispatcherTrait;
+use Drupal\common\Events\Event;
 use Drupal\metastore\Exception\CannotChangeUuidException;
 use Drupal\metastore\Exception\ExistingObjectException;
 use Drupal\metastore\Exception\MissingObjectException;
@@ -14,12 +14,12 @@ use Psr\Log\LoggerInterface;
 use RootedData\RootedJsonData;
 use Rs\Json\Merge\Patch;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * The metastore service.
  */
 class MetastoreService implements ContainerInjectionInterface {
-  use EventDispatcherTrait;
 
   const EVENT_DATA_GET = 'dkan_metastore_data_get';
   const EVENT_DATA_GET_ALL = 'dkan_metastore_data_get_all';
@@ -58,6 +58,13 @@ class MetastoreService implements ContainerInjectionInterface {
   private LoggerInterface $logger;
 
   /**
+   * Event dispatcher service.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  private EventDispatcherInterface $eventDispatcher;
+
+  /**
    * Inherited.
    *
    * {@inheritDoc}
@@ -67,7 +74,8 @@ class MetastoreService implements ContainerInjectionInterface {
       $container->get('dkan.metastore.schema_retriever'),
       $container->get('dkan.metastore.storage'),
       $container->get('dkan.metastore.valid_metadata'),
-      $container->get('dkan.common.logger_channel')
+      $container->get('dkan.common.logger_channel'),
+      $container->get('event_dispatcher')
     );
   }
 
@@ -78,12 +86,14 @@ class MetastoreService implements ContainerInjectionInterface {
     SchemaRetriever $schemaRetriever,
     DataFactory $factory,
     ValidMetadataFactory $validMetadataFactory,
-    LoggerInterface $loggerChannel
+    LoggerInterface $loggerChannel,
+    EventDispatcherInterface $eventDispatcher
   ) {
     $this->schemaRetriever = $schemaRetriever;
     $this->storageFactory = $factory;
     $this->validMetadataFactory = $validMetadataFactory;
     $this->logger = $loggerChannel;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
@@ -178,15 +188,17 @@ class MetastoreService implements ContainerInjectionInterface {
     $jsonStringsArray = $this->getStorage($schema_id)->retrieveAll($start, $length, $unpublished);
     $objects = array_filter($this->jsonStringsArrayToObjects($jsonStringsArray, $schema_id));
 
-    return $this->dispatchEvent(self::EVENT_DATA_GET_ALL, $objects, function ($data) {
-      if (!is_array($data)) {
-        return FALSE;
-      }
-      if (count($data) == 0) {
-        return TRUE;
-      }
-      return reset($data) instanceof RootedJsonData;
-    });
+    $event = new Event($objects);
+    $this->eventDispatcher->dispatch($event, self::EVENT_DATA_GET_ALL);
+    $processedData = $event->getData();
+
+    if (!is_array($processedData)) {
+      return FALSE;
+    }
+    if (count($processedData) == 0) {
+      return TRUE;
+    }
+    return reset($processedData) instanceof RootedJsonData;
 
   }
 
@@ -208,9 +220,11 @@ class MetastoreService implements ContainerInjectionInterface {
       function ($jsonString) use ($schema_id) {
         try {
           $data = $this->validMetadataFactory->get($jsonString, $schema_id);
-          return $this->dispatchEvent(self::EVENT_DATA_GET, $data, function ($data) {
-            return $data instanceof RootedJsonData;
-          });
+          $event = new Event($data);
+          $this->eventDispatcher->dispatch($event, self::EVENT_DATA_GET);
+          $processedData = $event->getData();
+
+          return $processedData instanceof RootedJsonData;
         }
         catch (\Exception) {
           $this->logger->error('A JSON string failed validation.', [
@@ -253,7 +267,9 @@ class MetastoreService implements ContainerInjectionInterface {
   public function get(string $schema_id, string $identifier, bool $published = TRUE): RootedJsonData {
     $json_string = $this->getStorage($schema_id)->retrieve($identifier, $published);
     $data = $this->validMetadataFactory->get($json_string, $schema_id);
-    return $this->dispatchEvent(self::EVENT_DATA_GET, $data);
+    $event = new Event($data);
+    $this->eventDispatcher->dispatch($event, self::EVENT_DATA_GET);
+    return $event->getData();
   }
 
   /**

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -3,7 +3,6 @@
 namespace Drupal\metastore;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\common\Events\Event;
 use Drupal\metastore\Exception\CannotChangeUuidException;
 use Drupal\metastore\Exception\ExistingObjectException;
 use Drupal\metastore\Exception\MissingObjectException;
@@ -15,6 +14,7 @@ use RootedData\RootedJsonData;
 use Rs\Json\Merge\Patch;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * The metastore service.
@@ -58,15 +58,13 @@ class MetastoreService implements ContainerInjectionInterface {
   private LoggerInterface $logger;
 
   /**
-   * Event dispatcher service.
+   * The event dispatcher.
    *
    * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
    */
   private EventDispatcherInterface $eventDispatcher;
 
   /**
-   * Inherited.
-   *
    * {@inheritDoc}
    */
   public static function create(ContainerInterface $container) {
@@ -94,6 +92,37 @@ class MetastoreService implements ContainerInjectionInterface {
     $this->validMetadataFactory = $validMetadataFactory;
     $this->logger = $loggerChannel;
     $this->eventDispatcher = $eventDispatcher;
+  }
+
+  /**
+   * Dispatch an event and return the (possibly) modified data.
+   *
+   * This method simulates the behavior of the deprecated event dispatcher trait.
+   *
+   * @param string $eventName
+   *   The event name.
+   * @param mixed $data
+   *   The data to dispatch.
+   * @param callable|null $validate
+   *   Optional validation callback.
+   *
+   * @return mixed
+   *   The (possibly) modified data.
+   */
+  private function dispatchEvent(string $eventName, $data, callable $validate = null) {
+    $event = new GenericEvent($data);
+    $event = $this->eventDispatcher->dispatch($event, $eventName);
+
+    if (method_exists($event, 'getException') && $event->getException() !== null) {
+      $this->logger->error('A JSON string failed validation.');
+      return $data;
+    }
+
+    $modifiedData = method_exists($event, 'getSubject')
+      ? $event->getSubject()
+      : (method_exists($event, 'getData') ? $event->getData() : $data);
+
+    return ($validate !== null && !$validate($modifiedData)) ? $data : $modifiedData;
   }
 
   /**
@@ -188,20 +217,9 @@ class MetastoreService implements ContainerInjectionInterface {
     $jsonStringsArray = $this->getStorage($schema_id)->retrieveAll($start, $length, $unpublished);
     $objects = array_filter($this->jsonStringsArrayToObjects($jsonStringsArray, $schema_id));
 
-    $event = new Event($objects);
-    $this->eventDispatcher->dispatch($event, self::EVENT_DATA_GET_ALL);
-    $processedData = $event->getData();
-
-    if (!is_array($processedData)) {
-      return [];
-    }
-
-    if (empty($processedData)) {
-      return [];
-    }
-
-    return reset($processedData) instanceof RootedJsonData;
-
+    return $this->dispatchEvent(self::EVENT_DATA_GET_ALL, $objects, function ($data) {
+      return !is_array($data) ? FALSE : (count($data) === 0 || reset($data) instanceof RootedJsonData);
+    });
   }
 
   /**
@@ -218,24 +236,21 @@ class MetastoreService implements ContainerInjectionInterface {
    * @todo Exception should not be caught; let controller handle it.
    */
   private function jsonStringsArrayToObjects(array $jsonStringsArray, string $schema_id) {
-    return array_map(
-      function ($jsonString) use ($schema_id) {
-        try {
-          $data = $this->validMetadataFactory->get($jsonString, $schema_id);
-          $event = new Event($data);
-          $this->eventDispatcher->dispatch($event, self::EVENT_DATA_GET);
-          $processedData = $event->getData();
-
-          return $processedData instanceof RootedJsonData;
-        }
-        catch (\Exception) {
-          $this->logger->error('A JSON string failed validation.', [
-            '@schema_id' => $schema_id,
-            '@json' => $jsonString,
-          ]);
-          return NULL;
-        }
-      }, $jsonStringsArray);
+    return array_map(function ($jsonString) use ($schema_id) {
+      try {
+        $data = $this->validMetadataFactory->get($jsonString, $schema_id);
+        return $this->dispatchEvent(self::EVENT_DATA_GET, $data, function ($data) {
+          return $data instanceof RootedJsonData;
+        });
+      }
+      catch (\Exception) {
+        $this->logger->error('A JSON string failed validation.', [
+          '@schema_id' => $schema_id,
+          '@json' => $jsonString,
+        ]);
+        return NULL;
+      }
+    }, $jsonStringsArray);
   }
 
   /**
@@ -269,9 +284,7 @@ class MetastoreService implements ContainerInjectionInterface {
   public function get(string $schema_id, string $identifier, bool $published = TRUE): RootedJsonData {
     $json_string = $this->getStorage($schema_id)->retrieve($identifier, $published);
     $data = $this->validMetadataFactory->get($json_string, $schema_id);
-    $event = new Event($data);
-    $this->eventDispatcher->dispatch($event, self::EVENT_DATA_GET);
-    return $event->getData();
+    return $this->dispatchEvent(self::EVENT_DATA_GET, $data);
   }
 
   /**
@@ -424,7 +437,6 @@ class MetastoreService implements ContainerInjectionInterface {
         $storage->store($new, "{$identifier}");
         return $identifier;
       }
-
     }
 
     throw new MissingObjectException("No data with the identifier {$identifier} was found.");
@@ -443,9 +455,7 @@ class MetastoreService implements ContainerInjectionInterface {
    */
   public function delete($schema_id, $identifier) {
     $storage = $this->getStorage($schema_id);
-
     $storage->remove($identifier);
-
     return $identifier;
   }
 
@@ -484,7 +494,6 @@ class MetastoreService implements ContainerInjectionInterface {
         $no_schema_object = $this->swapReference($property, $value, $no_schema_object);
       }
     }
-
     return self::removeReferences($no_schema_object, "%Ref");
   }
 
@@ -551,20 +560,17 @@ class MetastoreService implements ContainerInjectionInterface {
    */
   public static function removeReferences(RootedJsonData $object, $prefix = "%"): RootedJsonData {
     $array = $object->get('$');
-
     foreach ($array as $property => $value) {
       if (substr_count((string) $property, $prefix) > 0) {
         unset($array[$property]);
       }
     }
-
     if (!empty($array['distribution'])) {
       $array['distribution'] = array_map(function ($dist) {
         unset($dist['%Ref:downloadURL']);
         return $dist;
       }, $array['distribution']);
     }
-
     $object->set('$', $array);
     return $object;
   }
@@ -595,7 +601,6 @@ class MetastoreService implements ContainerInjectionInterface {
     else {
       throw new \InvalidArgumentException("Invalid metadata argument.");
     }
-
     return md5((string) $normalizedData);
   }
 

--- a/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php
+++ b/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php
@@ -60,7 +60,7 @@ class OrphanReferenceProcessor extends QueueWorkerBase implements ContainerFacto
    * @param \Drupal\metastore\ReferenceLookupInterface $referenceLookup
    *   The referencer lookup service.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
-   *    The event dispatcher.
+   *   The event dispatcher.
    */
   public function __construct(
     array $configuration,

--- a/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php
+++ b/modules/metastore/src/Plugin/QueueWorker/OrphanReferenceProcessor.php
@@ -6,10 +6,11 @@ namespace Drupal\metastore\Plugin\QueueWorker;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
-use Drupal\common\EventDispatcherTrait;
+use Drupal\common\Events\Event;
 use Drupal\metastore\ReferenceLookupInterface;
 use Drupal\node\NodeStorageInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Verifies if a dataset property reference is orphaned, then deletes it.
@@ -23,8 +24,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @codeCoverageIgnore
  */
 class OrphanReferenceProcessor extends QueueWorkerBase implements ContainerFactoryPluginInterface {
-
-  use EventDispatcherTrait;
 
   const EVENT_ORPHANING_DISTRIBUTION = 'metastore_orphaning_distribution';
 
@@ -41,6 +40,13 @@ class OrphanReferenceProcessor extends QueueWorkerBase implements ContainerFacto
   private ReferenceLookupInterface $referenceLookup;
 
   /**
+   * Event dispatcher service.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  protected EventDispatcherInterface $eventDispatcher;
+
+  /**
    * Constructs a new class instance.
    *
    * @param array $configuration
@@ -53,17 +59,21 @@ class OrphanReferenceProcessor extends QueueWorkerBase implements ContainerFacto
    *   Node storage service.
    * @param \Drupal\metastore\ReferenceLookupInterface $referenceLookup
    *   The referencer lookup service.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *    The event dispatcher.
    */
   public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
     NodeStorageInterface $nodeStorage,
-    ReferenceLookupInterface $referenceLookup
+    ReferenceLookupInterface $referenceLookup,
+    EventDispatcherInterface $eventDispatcher
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->referenceLookup = $referenceLookup;
     $this->nodeStorage = $nodeStorage;
+    $this->eventDispatcher = $eventDispatcher;
   }
 
   /**
@@ -77,7 +87,8 @@ class OrphanReferenceProcessor extends QueueWorkerBase implements ContainerFacto
           $plugin_id,
           $plugin_definition,
           $container->get('dkan.common.node_storage'),
-          $container->get('dkan.metastore.reference_lookup')
+          $container->get('dkan.metastore.reference_lookup'),
+          $container->get('event_dispatcher')
       );
   }
 
@@ -118,7 +129,8 @@ class OrphanReferenceProcessor extends QueueWorkerBase implements ContainerFacto
     if (FALSE !== ($reference = reset($references))) {
       // When orphaning distribution nodes, trigger database clean up.
       if ($property_id === 'distribution') {
-        $this->dispatchEvent(self::EVENT_ORPHANING_DISTRIBUTION, $uuid);
+        $event = new Event($uuid);
+        $this->eventDispatcher->dispatch($event, self::EVENT_ORPHANING_DISTRIBUTION);
       }
       $reference->set('moderation_state', 'orphaned');
       $reference->save();

--- a/modules/metastore/src/Storage/ResourceMapperDatabaseTable.php
+++ b/modules/metastore/src/Storage/ResourceMapperDatabaseTable.php
@@ -5,6 +5,7 @@ namespace Drupal\metastore\Storage;
 use Drupal\Core\Database\Connection;
 use Drupal\common\Storage\AbstractDatabaseTable;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Database storage object.
@@ -32,9 +33,10 @@ class ResourceMapperDatabaseTable extends AbstractDatabaseTable {
    */
   public function __construct(
     Connection $connection,
-    LoggerInterface $loggerChannel
+    LoggerInterface $loggerChannel,
+    EventDispatcherInterface $eventDispatcher
   ) {
-    parent::__construct($connection);
+    parent::__construct($connection, $eventDispatcher);
     $this->logger = $loggerChannel;
 
     $schema = [];

--- a/modules/metastore/src/Storage/ResourceMapperDatabaseTable.php
+++ b/modules/metastore/src/Storage/ResourceMapperDatabaseTable.php
@@ -5,7 +5,6 @@ namespace Drupal\metastore\Storage;
 use Drupal\Core\Database\Connection;
 use Drupal\common\Storage\AbstractDatabaseTable;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Database storage object.
@@ -33,10 +32,9 @@ class ResourceMapperDatabaseTable extends AbstractDatabaseTable {
    */
   public function __construct(
     Connection $connection,
-    LoggerInterface $loggerChannel,
-    EventDispatcherInterface $eventDispatcher
+    LoggerInterface $loggerChannel
   ) {
-    parent::__construct($connection, $eventDispatcher);
+    parent::__construct($connection);
     $this->logger = $loggerChannel;
 
     $schema = [];


### PR DESCRIPTION
Fixes #4313

## Describe your changes

- Added a `@deprecated` annotation to `EventDispatcherTrait.php`
- All usages of the trait have been removed, replaced with direct injection of the `event_dispatcher` service.
- All classes now dispatch events through explicitly injected services instead of relying on global or trait-based dispatching.
- Since this is an injected service rather than a trait, many classes and tests needed updated with new arguments, etc. 

## QA Steps

- N/A

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [x] I have updated or added documentation
