### PR TITLE
Fix @covers annotation

### DIFF
--- a/modules/datastore/tests/src/Unit/Service/PostImportResultTest.php
+++ b/modules/datastore/tests/src/Unit/Service/PostImportResultTest.php
@@ -10,7 +10,8 @@ use Drupal\common\DataResource;
 use Drupal\datastore\PostImportResultFactory;
 
 /**
- * Tests the PostImportResult class.
+ * @covers \Drupal\datastore\PostImportResult
+ * @coversDefaultClass \Drupal\datastore\PostImportResult
  *
  * @group dkan
  * @group datastore


### PR DESCRIPTION
Fixes [issue#]

## Describe your changes

This cleans up our CI workflow, where we have seen difficulty with the 'uploading test results' phase.

<img width="1161" alt="Screenshot 2025-01-22 at 12 45 44 PM" src="https://github.com/user-attachments/assets/8c1f122c-5670-4fb3-b59a-c4695d067ee5" />

This was because we had some code coverage annotation in need of fixing, which was adding 'warning' elements to the PHPUnit JUnit report, which in turn caused CircleCI to behave strangely.

TODO: Figure out why CircleCI can't process warning results.

## QA Steps

- [x] Visit CircleCI from the CI run here and verify that it does not exhibit errors.
