### PR TITLE
DB connection factory cleanup

### DIFF
--- a/modules/common/src/Storage/AbstractDatabaseConnectionFactory.php
+++ b/modules/common/src/Storage/AbstractDatabaseConnectionFactory.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\common\Storage;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\Database;
+
+/**
+ * A factory for making database connections with special connection info.
+ *
+ * Subclass this class. Override $this->key and/or $this->target to specify a
+ * new set of connection info.
+ *
+ * It is assumed that the database target we are creating is not already
+ * set up in settings.php, other than default/default.
+ *
+ * We do this mainly so that we can add new session configuration and timeout
+ * values.
+ */
+abstract class AbstractDatabaseConnectionFactory {
+
+  /**
+   * Database connection info key.
+   */
+  protected string $key = 'default';
+
+  /**
+   * Database connection info target.
+   */
+  protected string $target = 'default';
+
+  /**
+   * Build database connection factory.
+   *
+   * Adds connection info for the connection being built.
+   */
+  public function __construct() {
+    $source_key = 'default';
+    $source_target = 'default';
+    // Add a new connection key/target based on default/default if this class
+    // has overridden the key or the target.
+    if ($source_key !== $this->key || $source_target !== $this->target) {
+      Database::addConnectionInfo(
+        $this->key,
+        $this->target,
+        $this->buildConnectionInfo($source_key, $source_target)
+      );
+    }
+  }
+
+  /**
+   * Specify database connection info for our configuration.
+   *
+   * Override this method in your subclass and call the parent method to modify
+   * the connection info.
+   *
+   * @param string $source_key
+   *   Source key to copy.
+   * @param string $source_target
+   *   Source target to copy.
+   *
+   * @return array
+   *   Database connection info array, which will be added at our key/target.
+   */
+  protected function buildConnectionInfo(string $source_key = 'default', string $source_target = 'default'): array {
+    return Database::getConnectionInfo($source_key)[$source_target];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConnection(): Connection {
+    $connection = Database::getConnection($this->target, $this->key);
+    $this->prepareConnection($connection);
+
+    return $connection;
+  }
+
+  /**
+   * Modify the given database connection instance.
+   *
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The connection instance to modify.
+   */
+  abstract protected function prepareConnection(Connection $connection): void;
+
+}

--- a/modules/common/src/Storage/AbstractDatabaseConnectionFactory.php
+++ b/modules/common/src/Storage/AbstractDatabaseConnectionFactory.php
@@ -8,16 +8,22 @@ use Drupal\Core\Database\Database;
 /**
  * A factory for making database connections with special connection info.
  *
- * Subclass this class. Override $this->key and/or $this->target to specify a
- * new set of connection info.
+ * This class is meant to be subclassed, and that the subclass is probably a
+ * factory service for a given module's special connection needs.
+ *
+ * - Override $this->key and/or $this->target to specify a new set of
+ *   connection info.
+ * - Call getConnection() to get a new connection from the key/target
+ *   specified.
+ * - Override buildConnectionInfo() to add special connection info to the new
+ *   target.
+ * - Override prepareConnection() to modify any connection created by the
+ *   factory.
  *
  * It is assumed that the database target we are creating is not already
  * set up in settings.php, other than default/default.
- *
- * We do this mainly so that we can add new session configuration and timeout
- * values.
  */
-abstract class AbstractDatabaseConnectionFactory {
+abstract class AbstractDatabaseConnectionFactory implements DatabaseConnectionFactoryInterface {
 
   /**
    * Database connection info key.
@@ -54,6 +60,8 @@ abstract class AbstractDatabaseConnectionFactory {
    * Override this method in your subclass and call the parent method to modify
    * the connection info.
    *
+   * This method is called once when the service is initialized.
+   *
    * @param string $source_key
    *   Source key to copy.
    * @param string $source_target
@@ -78,6 +86,9 @@ abstract class AbstractDatabaseConnectionFactory {
 
   /**
    * Modify the given database connection instance.
+   *
+   * This method is called when a new connection object is created by the
+   * factory service.
    *
    * @param \Drupal\Core\Database\Connection $connection
    *   The connection instance to modify.

--- a/modules/common/src/Storage/AbstractDatabaseConnectionFactory.php
+++ b/modules/common/src/Storage/AbstractDatabaseConnectionFactory.php
@@ -37,8 +37,8 @@ abstract class AbstractDatabaseConnectionFactory {
   public function __construct() {
     $source_key = 'default';
     $source_target = 'default';
-    // Add a new connection key/target based on default/default if this class
-    // has overridden the key or the target.
+    // Add a new connection key/target based on default/default if the key or
+    // the target have been overridden.
     if ($source_key !== $this->key || $source_target !== $this->target) {
       Database::addConnectionInfo(
         $this->key,

--- a/modules/common/src/Storage/DatabaseConnectionFactory.php
+++ b/modules/common/src/Storage/DatabaseConnectionFactory.php
@@ -6,6 +6,11 @@ use Drupal\Core\Database\Connection;
 
 /**
  * Database connection factory that can set a connection timeout.
+ *
+ * This is the dkan.common.database_connection_factory service.
+ *
+ * @todo Services should not contain state, such as the timeout property here.
+ *   We should have a way to set the timeout as an argument to getConnection().
  */
 class DatabaseConnectionFactory extends AbstractDatabaseConnectionFactory implements DatabaseConnectionFactoryInterface {
 

--- a/modules/common/src/Storage/DatabaseConnectionFactory.php
+++ b/modules/common/src/Storage/DatabaseConnectionFactory.php
@@ -12,7 +12,7 @@ use Drupal\Core\Database\Connection;
  * @todo Services should not contain state, such as the timeout property here.
  *   We should have a way to set the timeout as an argument to getConnection().
  */
-class DatabaseConnectionFactory extends AbstractDatabaseConnectionFactory implements DatabaseConnectionFactoryInterface {
+class DatabaseConnectionFactory extends AbstractDatabaseConnectionFactory {
 
   /**
    * Timeout for database connections in seconds.

--- a/modules/common/src/Storage/DatabaseConnectionFactory.php
+++ b/modules/common/src/Storage/DatabaseConnectionFactory.php
@@ -24,6 +24,7 @@ class DatabaseConnectionFactory extends AbstractDatabaseConnectionFactory implem
    */
   protected function prepareConnection(Connection $connection): void {
     if (isset($this->timeout)) {
+      // @see https://github.com/GetDKAN/dkan/pull/3764
       $connection->query('SET SESSION wait_timeout = ' . $this->timeout);
     }
   }

--- a/modules/common/src/Storage/DatabaseConnectionFactory.php
+++ b/modules/common/src/Storage/DatabaseConnectionFactory.php
@@ -3,65 +3,24 @@
 namespace Drupal\common\Storage;
 
 use Drupal\Core\Database\Connection;
-use Drupal\Core\Database\Database;
 
 /**
- * Create database connection.
- *
- * @return \Drupal\Core\Database\Connection
- *   New connection object.
+ * Database connection factory that can set a connection timeout.
  */
-class DatabaseConnectionFactory implements DatabaseConnectionFactoryInterface {
+class DatabaseConnectionFactory extends AbstractDatabaseConnectionFactory implements DatabaseConnectionFactoryInterface {
 
   /**
-   * Timeout for built database connections in seconds.
+   * Timeout for database connections in seconds.
    */
   protected int $timeout;
 
   /**
-   * Database connection target name.
-   */
-  protected string $target = 'default';
-
-  /**
-   * Database connection key.
-   */
-  protected string $key = 'default';
-
-  /**
-   * Build database connection factory.
-   *
-   * Adds connection info for the connection being built.
-   */
-  public function __construct() {
-    Database::addConnectionInfo($this->key, $this->target, $this->buildConnectionInfo());
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function buildConnectionInfo(): array {
-    return Database::getConnectionInfo()[$this->target];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getConnection(): Connection {
-    $connection = Database::getConnection($this->target, $this->key);
-    $this->prepareConnection($connection);
-
-    return $connection;
-  }
-
-  /**
-   * Prepare database connection.
-   *
-   * @param \Drupal\Core\Database\Connection $connection
-   *   Database connection object.
+   * {@inheritDoc}
    */
   protected function prepareConnection(Connection $connection): void {
-    $this->doSetConnectionTimeout($connection);
+    if (isset($this->timeout)) {
+      $connection->query('SET SESSION wait_timeout = ' . $this->timeout);
+    }
   }
 
   /**
@@ -71,18 +30,6 @@ class DatabaseConnectionFactory implements DatabaseConnectionFactoryInterface {
     $this->timeout = $timeout;
 
     return $this;
-  }
-
-  /**
-   * Set the timeout on the supplied connection object.
-   *
-   * @param \Drupal\Core\Database\Connection $connection
-   *   Database connection object.
-   */
-  protected function doSetConnectionTimeout(Connection $connection): void {
-    if (isset($this->timeout)) {
-      $connection->query('SET SESSION wait_timeout = ' . $this->timeout);
-    }
   }
 
 }

--- a/modules/common/tests/src/Unit/Mocks/DatabaseConnectionFactoryMock.php
+++ b/modules/common/tests/src/Unit/Mocks/DatabaseConnectionFactoryMock.php
@@ -14,7 +14,7 @@ class DatabaseConnectionFactoryMock extends DatabaseConnectionFactory {
   }
 
   public function getConnection(): Connection {
-    $this->doSetConnectionTimeout($this->connection);
+    $this->prepareConnection($this->connection);
 
     return $this->connection;
   }

--- a/modules/common/tests/src/Unit/Storage/DatabaseConnectionFactoryTest.php
+++ b/modules/common/tests/src/Unit/Storage/DatabaseConnectionFactoryTest.php
@@ -9,14 +9,19 @@ use MockChain\Chain;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test DatabaseConnectionFactory class.
+ * @covers \Drupal\common\Storage\DatabaseConnectionFactory
+ * @coversDefaultClass \Drupal\common\Storage\DatabaseConnectionFactory
+ *
+ * @group dkan
+ * @group common
+ * @group unit
  */
 class DatabaseConnectionFactoryTest extends TestCase {
 
   /**
-   * Test ::doSetTimeout method.
+   * @covers ::prepareConnection
    */
-  public function testDoSetConnectionTimeout(): void {
+  public function testConnectionTimeout(): void {
     $connection_chain = (new Chain($this))
       ->add(Connection::class, 'query', StatementInterface::class, 'query');
 

--- a/modules/datastore/src/Storage/DatabaseConnectionFactory.php
+++ b/modules/datastore/src/Storage/DatabaseConnectionFactory.php
@@ -2,13 +2,12 @@
 
 namespace Drupal\datastore\Storage;
 
-use Drupal\common\Storage\DatabaseConnectionFactoryInterface;
 use Drupal\common\Storage\DatabaseConnectionFactory as CommonDatabaseConnectionFactory;
 
 /**
  * Database connection factory for connections with unbuffered queries.
  */
-class DatabaseConnectionFactory extends CommonDatabaseConnectionFactory implements DatabaseConnectionFactoryInterface {
+class DatabaseConnectionFactory extends CommonDatabaseConnectionFactory {
 
   /**
    * {@inheritdoc}

--- a/modules/datastore/src/Storage/DatabaseConnectionFactory.php
+++ b/modules/datastore/src/Storage/DatabaseConnectionFactory.php
@@ -21,6 +21,7 @@ class DatabaseConnectionFactory extends CommonDatabaseConnectionFactory implemen
   protected function buildConnectionInfo(string $source_key = 'default', string $source_target = 'default'): array {
     $connection_info = parent::buildConnectionInfo($source_key, $source_target);
     // All our connections will be unbuffered.
+    // @see https://github.com/GetDKAN/dkan/pull/3810
     $connection_info['pdo'][\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = FALSE;
     return $connection_info;
   }

--- a/modules/datastore/src/Storage/DatabaseConnectionFactory.php
+++ b/modules/datastore/src/Storage/DatabaseConnectionFactory.php
@@ -12,7 +12,7 @@ class DatabaseConnectionFactory extends CommonDatabaseConnectionFactory {
   /**
    * {@inheritdoc}
    */
-  protected string $target = 'datastore';
+  protected string $key = 'datastore';
 
   /**
    * {@inheritdoc}

--- a/modules/datastore/src/Storage/DatabaseConnectionFactory.php
+++ b/modules/datastore/src/Storage/DatabaseConnectionFactory.php
@@ -13,7 +13,7 @@ class DatabaseConnectionFactory extends CommonDatabaseConnectionFactory implemen
   /**
    * {@inheritdoc}
    */
-  protected string $target = 'unbuffered_datastore';
+  protected string $target = 'datastore';
 
   /**
    * {@inheritdoc}

--- a/modules/datastore/src/Storage/DatabaseConnectionFactory.php
+++ b/modules/datastore/src/Storage/DatabaseConnectionFactory.php
@@ -3,31 +3,24 @@
 namespace Drupal\datastore\Storage;
 
 use Drupal\common\Storage\DatabaseConnectionFactoryInterface;
-use Drupal\common\Storage\DatabaseConnectionFactory as DatabaseConnectionFactoryBase;
+use Drupal\common\Storage\DatabaseConnectionFactory as CommonDatabaseConnectionFactory;
 
 /**
- * Create separate datastore connection at runtime with unbuffered queries.
- *
- * @return \Drupal\Core\Database\Connection
- *   New datastore connection object.
+ * Database connection factory for connections with unbuffered queries.
  */
-class DatabaseConnectionFactory extends DatabaseConnectionFactoryBase implements DatabaseConnectionFactoryInterface {
+class DatabaseConnectionFactory extends CommonDatabaseConnectionFactory implements DatabaseConnectionFactoryInterface {
 
   /**
    * {@inheritdoc}
    */
-  protected string $target = 'default';
+  protected string $target = 'unbuffered_datastore';
 
   /**
    * {@inheritdoc}
    */
-  protected string $key = 'datastore';
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function buildConnectionInfo(): array {
-    $connection_info = parent::buildConnectionInfo();
+  protected function buildConnectionInfo(string $source_key = 'default', string $source_target = 'default'): array {
+    $connection_info = parent::buildConnectionInfo($source_key, $source_target);
+    // All our connections will be unbuffered.
     $connection_info['pdo'][\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = FALSE;
     return $connection_info;
   }

--- a/modules/datastore/tests/src/Kernel/Storage/DatabaseConnectionFactoryTest.php
+++ b/modules/datastore/tests/src/Kernel/Storage/DatabaseConnectionFactoryTest.php
@@ -8,8 +8,6 @@ use Drupal\Core\Database\Database;
 use Drupal\KernelTests\KernelTestBase;
 
 /**
- * Find out and document what the limits are for table column names.
- *
  * @covers \Drupal\datastore\Storage\DatabaseConnectionFactory
  * @coversDefaultClass \Drupal\datastore\Storage\DatabaseConnectionFactory
  *
@@ -31,17 +29,26 @@ class DatabaseConnectionFactoryTest extends KernelTestBase {
   public function testConnectionInfo() {
     /** @var \Drupal\datastore\Storage\DatabaseConnectionFactory $factory */
     $factory = $this->container->get('dkan.datastore.database_connection_factory');
-    // Just getting this service should have created a special connection info
-    // target.
+    // Just getting this service should have created the special connection
+    // info target.
     $this->assertNotEmpty(
       $connection_info = Database::getConnectionInfo('default')['unbuffered_datastore'] ?? []
     );
     $this->assertArrayHasKey('pdo', $connection_info);
+    // Should be unbuffered for MySQL.
     $this->assertFalse($connection_info['pdo'][\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] ?? TRUE);
 
+    // Verify that the connection itself is the correct key and target.
     $connection = $factory->getConnection();
     $this->assertEquals('default', $connection->getKey());
     $this->assertEquals('unbuffered_datastore', $connection->getTarget());
+    // Since this is a kernel test, the two targets should have the same test
+    // prefix.
+    $this->assertNotEmpty($connection->getPrefix());
+    $this->assertEquals(
+      Database::getConnection('default', 'default')->getPrefix(),
+      $connection->getPrefix()
+    );
   }
 
 }

--- a/modules/datastore/tests/src/Kernel/Storage/DatabaseConnectionFactoryTest.php
+++ b/modules/datastore/tests/src/Kernel/Storage/DatabaseConnectionFactoryTest.php
@@ -32,7 +32,7 @@ class DatabaseConnectionFactoryTest extends KernelTestBase {
     // Just getting this service should have created the special connection
     // info target.
     $this->assertNotEmpty(
-      $connection_info = Database::getConnectionInfo('default')['unbuffered_datastore'] ?? []
+      $connection_info = Database::getConnectionInfo('default')['datastore'] ?? []
     );
     $this->assertArrayHasKey('pdo', $connection_info);
     // Should be unbuffered for MySQL.
@@ -41,7 +41,7 @@ class DatabaseConnectionFactoryTest extends KernelTestBase {
     // Verify that the connection itself is the correct key and target.
     $connection = $factory->getConnection();
     $this->assertEquals('default', $connection->getKey());
-    $this->assertEquals('unbuffered_datastore', $connection->getTarget());
+    $this->assertEquals('datastore', $connection->getTarget());
     // Since this is a kernel test, the two targets should have the same test
     // prefix.
     $this->assertNotEmpty($connection->getPrefix());

--- a/modules/datastore/tests/src/Kernel/Storage/DatabaseConnectionFactoryTest.php
+++ b/modules/datastore/tests/src/Kernel/Storage/DatabaseConnectionFactoryTest.php
@@ -32,7 +32,7 @@ class DatabaseConnectionFactoryTest extends KernelTestBase {
     // Just getting this service should have created the special connection
     // info target.
     $this->assertNotEmpty(
-      $connection_info = Database::getConnectionInfo('default')['datastore'] ?? []
+      $connection_info = Database::getConnectionInfo('datastore')['default'] ?? []
     );
     $this->assertArrayHasKey('pdo', $connection_info);
     // Should be unbuffered for MySQL.
@@ -40,8 +40,8 @@ class DatabaseConnectionFactoryTest extends KernelTestBase {
 
     // Verify that the connection itself is the correct key and target.
     $connection = $factory->getConnection();
-    $this->assertEquals('default', $connection->getKey());
-    $this->assertEquals('datastore', $connection->getTarget());
+    $this->assertEquals('datastore', $connection->getKey());
+    $this->assertEquals('default', $connection->getTarget());
     // Since this is a kernel test, the two targets should have the same test
     // prefix.
     $this->assertNotEmpty($connection->getPrefix());

--- a/modules/datastore/tests/src/Kernel/Storage/DatabaseConnectionFactoryTest.php
+++ b/modules/datastore/tests/src/Kernel/Storage/DatabaseConnectionFactoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\datastore\Kernel\Storage;
+
+use Drupal\Core\Database\Database;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Find out and document what the limits are for table column names.
+ *
+ * @covers \Drupal\datastore\Storage\DatabaseConnectionFactory
+ * @coversDefaultClass \Drupal\datastore\Storage\DatabaseConnectionFactory
+ *
+ * @group dkan
+ * @group datastore
+ * @group kernel
+ */
+class DatabaseConnectionFactoryTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'common',
+    'datastore',
+    'metastore',
+  ];
+
+  public function testConnectionInfo() {
+    /** @var \Drupal\datastore\Storage\DatabaseConnectionFactory $factory */
+    $factory = $this->container->get('dkan.datastore.database_connection_factory');
+    // Just getting this service should have created a special connection info
+    // target.
+    $this->assertNotEmpty(
+      $connection_info = Database::getConnectionInfo('default')['unbuffered_datastore'] ?? []
+    );
+    $this->assertArrayHasKey('pdo', $connection_info);
+    $this->assertFalse($connection_info['pdo'][\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] ?? TRUE);
+
+    $connection = $factory->getConnection();
+    $this->assertEquals('default', $connection->getKey());
+    $this->assertEquals('unbuffered_datastore', $connection->getTarget());
+  }
+
+}

--- a/modules/datastore/tests/src/Kernel/Storage/DatabaseTableLimitsTest.php
+++ b/modules/datastore/tests/src/Kernel/Storage/DatabaseTableLimitsTest.php
@@ -15,6 +15,7 @@ use Procrastinator\Result;
  * @covers \Drupal\datastore\Storage\DatabaseTable
  * @coversDefaultClass \Drupal\datastore\Storage\DatabaseTable
  *
+ * @group dkan
  * @group datastore
  * @group kernel
  *


### PR DESCRIPTION
Some tech debt before fixing [#2571]

## Describe your changes

- Refactor basic factory behavior into an `AbstractDatabaseConnectionFactory`.
- Common and datastore modules' `DatabaseConnectionFactory` now subclass from this common abstract class and are simplified.
  - This makes their purpose clearer.
- Adds `Drupal\Tests\datastore\Kernel\Storage\DatabaseConnectionFactoryTest`.
- Fixes `Drupal\Tests\common\Unit\Storage\DatabaseConnectionFactoryTest` to work with the refactor.

Needs followup issue related to the TODO in `Drupal\common\Storage\DatabaseConnectionFactory`: This class is a service so it should not hold state, in particular the session timeout.

## QA Steps

- [ ] Create a fresh local ddev DKAN site.
- [ ] Add a database to the ddev environment. Call it `datastore`.
- [ ] Add these lines to `settings.ddev.php`, after the default database config:
```
  $databases['datastore']['default'] = $databases['default']['default'];
  $databases['datastore']['default']['database'] = 'datastore';
```
- [ ] Enable the sample_content module and create the sample content.
- [ ] Run cron a few times to import the data.
- [ ] The datstore data will be imported to the `datastore` database, but this is currently undocumented behavior.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
