### PR TITLE
Make Dataset route and View perms match.

### DIFF
--- a/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
+++ b/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
@@ -591,7 +591,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'access content overview'
+          perm: 'create data content'
       cache:
         type: tag
       empty:


### PR DESCRIPTION
Fixes #4395 

## Describe your changes
Sets the View's access to be the same as the route.

## QA Steps

- [ ] grant a role a perm of `create data content` but NO perm of `access content overview`
- [ ] login as a user with that role
- [ ] validate you can get to `/admin/dkan/datasets`

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
