### PR TITLE
Improve type translation for database table

### DIFF
--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -235,7 +235,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    *
    * @see https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Database!database.api.php/group/schemaapi/9.2.x
    */
-  protected function translateType(string $describe_type, $extra = NULL) {
+  protected function translateType(string $describe_type, mixed $extra = NULL) {
     // Clean up things like "int(10) unsigned".
     $db_type = strtok($describe_type, ' ()');
     $driver = $this->connection->driver() ?? 'mysql';

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -223,7 +223,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    *
    * @param string $rawtype
    *   Type returned from the describe query.
-   * @param mixed $extra
+   * @param null|string $extra
    *   Additional information for column.
    *
    * @return array
@@ -231,7 +231,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    *
    * @see https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Database!database.api.php/group/schemaapi/9.2.x
    */
-  public function translateType(string $rawtype, mixed $extra = NULL) {
+  public function translateType(string $rawtype, ?string $extra = NULL) {
     // Clean up things like "int(10) unsigned".
     $db_type = strtok($rawtype, ' ()');
     $driver = $this->connection->driver() ?? 'mysql';
@@ -246,10 +246,9 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     // Ignore size if "normal" or unset.
     $size = (isset($fullType[1]) && $fullType[1] != 'normal') ? $fullType[1] : NULL;
 
-    // We only use length for varchar.
+    // Length is only relevant for varchar types.
     preg_match('#\((.*?)\)#', $rawtype, $match);
-    $length = $match[1] ?? NULL;
-    $length = ($length && $type == 'varchar') ? (int) $length : NULL;
+    $length = ($match[1] ?? NULL) && $type == 'varchar' ? (int) $match[1] : NULL;
 
     // For decimal types, we need to get the precision and scale.
     if ($type == 'numeric') {
@@ -258,7 +257,8 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
       $scale = $match[2] ?? NULL;
     }
 
-    $unsigned = str_contains($rawtype, ' unsigned');
+    // Serial should always be unsigned.
+    $unsigned = (str_contains($rawtype, ' unsigned') || $type == 'serial');
 
     return array_filter([
       'type' => $type,

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -235,7 +235,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    *
    * @see https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Database!database.api.php/group/schemaapi/9.2.x
    */
-  public function translateType(string $describe_type, $extra = NULL) {
+  protected function translateType(string $describe_type, $extra = NULL) {
     // Clean up things like "int(10) unsigned".
     $db_type = strtok($describe_type, ' ()');
     $driver = $this->connection->driver() ?? 'mysql';

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -11,6 +11,10 @@ use Psr\Log\LoggerInterface;
  * Database storage object.
  *
  * @see \Drupal\common\Storage\DatabaseTableInterface
+ *
+ * @todo This class name suggests it is a generic database table but it is
+ * actually MySQL-specific. In the future it should probably be a base class
+ * with a MySQL-specific subclass.
  */
 class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
 
@@ -221,9 +225,9 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
   /**
    * Translate the database type into a table schema type.
    *
-   * @param string $rawtype
+   * @param string $describe_type
    *   Type returned from the describe query.
-   * @param null|string $extra
+   * @param mixed $extra
    *   Additional information for column.
    *
    * @return array
@@ -231,9 +235,9 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    *
    * @see https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Database!database.api.php/group/schemaapi/9.2.x
    */
-  public function translateType(string $rawtype, ?string $extra = NULL) {
+  public function translateType(string $describe_type, $extra = NULL) {
     // Clean up things like "int(10) unsigned".
-    $db_type = strtok($rawtype, ' ()');
+    $db_type = strtok($describe_type, ' ()');
     $driver = $this->connection->driver() ?? 'mysql';
 
     $map = array_flip(array_map('strtolower', $this->connection->schema()->getFieldTypeMap()));
@@ -247,18 +251,18 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     $size = (isset($fullType[1]) && $fullType[1] != 'normal') ? $fullType[1] : NULL;
 
     // Length is only relevant for varchar types.
-    preg_match('#\((.*?)\)#', $rawtype, $match);
+    preg_match('#\((.*?)\)#', $describe_type, $match);
     $length = ($match[1] ?? NULL) && $type == 'varchar' ? (int) $match[1] : NULL;
 
     // For decimal types, we need to get the precision and scale.
     if ($type == 'numeric') {
-      preg_match('#\((\d+),(\d+)\)#', $rawtype, $match);
+      preg_match('#\((\d+),(\d+)\)#', $describe_type, $match);
       $precision = $match[1] ?? NULL;
       $scale = $match[2] ?? NULL;
     }
 
     // Serial should always be unsigned.
-    $unsigned = (str_contains($rawtype, ' unsigned') || $type == 'serial');
+    $unsigned = (str_contains($describe_type, ' unsigned') || $type == 'serial');
 
     return array_filter([
       'type' => $type,

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -221,7 +221,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
   /**
    * Translate the database type into a table schema type.
    *
-   * @param string $type
+   * @param string $rawtype
    *   Type returned from the describe query.
    * @param mixed $extra
    *   Additional information for column.
@@ -231,33 +231,45 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
    *
    * @see https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Database!database.api.php/group/schemaapi/9.2.x
    */
-  protected function translateType(string $type, mixed $extra = NULL) {
+  public function translateType(string $rawtype, mixed $extra = NULL) {
     // Clean up things like "int(10) unsigned".
-    $db_type = strtok($type, '(');
+    $db_type = strtok($rawtype, ' ()');
     $driver = $this->connection->driver() ?? 'mysql';
-
-    preg_match('#\((.*?)\)#', $type, $match);
-    $length = $match[1] ?? NULL;
-    $length = $length ? (int) $length : $length;
 
     $map = array_flip(array_map('strtolower', $this->connection->schema()->getFieldTypeMap()));
 
     $fullType = explode(':', ($map[$db_type] ?? 'varchar'));
     // Set type to serial if auto-increment, else use mapped type.
     $type = ($fullType[0] == 'int' && $extra == 'auto_increment') ? 'serial' : $fullType[0];
-    $unsigned = ($type == 'serial') ? TRUE : NULL;
+    // @todo Add support for NOT NULL for other types.
     $notNull = ($type == 'serial') ? TRUE : NULL;
     // Ignore size if "normal" or unset.
     $size = (isset($fullType[1]) && $fullType[1] != 'normal') ? $fullType[1] : NULL;
 
-    return [
+    // We only use length for varchar.
+    preg_match('#\((.*?)\)#', $rawtype, $match);
+    $length = $match[1] ?? NULL;
+    $length = ($length && $type == 'varchar') ? (int) $length : NULL;
+
+    // For decimal types, we need to get the precision and scale.
+    if ($type == 'numeric') {
+      preg_match('#\((\d+),(\d+)\)#', $rawtype, $match);
+      $precision = $match[1] ?? NULL;
+      $scale = $match[2] ?? NULL;
+    }
+
+    $unsigned = str_contains($rawtype, ' unsigned');
+
+    return array_filter([
       'type' => $type,
       'length' => $length,
       'size' => $size,
       'unsigned' => $unsigned,
       'not null' => $notNull,
+      'precision' => $precision ?? NULL,
+      'scale' => $scale ?? NULL,
       $driver . '_type' => $db_type,
-    ];
+    ]);
   }
 
 }

--- a/modules/datastore/src/Storage/SqliteDatabaseTable.php
+++ b/modules/datastore/src/Storage/SqliteDatabaseTable.php
@@ -37,7 +37,7 @@ class SqliteDatabaseTable extends DatabaseTable {
   /**
    * {@inheritdoc}
    */
-  public function translateType(string $type, ?string $info = NULL) {
+  public function translateType(string $describe_type, $info = NULL) {
     // Clean up things like "int(10) unsigned".
     $driver = $this->connection->driver() ?? 'sqlite';
     $db_type = strtolower($type);
@@ -51,7 +51,7 @@ class SqliteDatabaseTable extends DatabaseTable {
     $size = (isset($fullType[1]) && $fullType[1] != 'normal') ? $fullType[1] : NULL;
 
     return [
-      'type' => $type,
+      'type' => $describe_type,
       'length' => $length,
       'size' => $size,
       'not null' => $notNull,

--- a/modules/datastore/src/Storage/SqliteDatabaseTable.php
+++ b/modules/datastore/src/Storage/SqliteDatabaseTable.php
@@ -37,7 +37,7 @@ class SqliteDatabaseTable extends DatabaseTable {
   /**
    * {@inheritdoc}
    */
-  protected function translateType(string $type, $info = NULL) {
+  public function translateType(string $type, ?string $info = NULL) {
     // Clean up things like "int(10) unsigned".
     $driver = $this->connection->driver() ?? 'sqlite';
     $db_type = strtolower($type);

--- a/modules/datastore/src/Storage/SqliteDatabaseTable.php
+++ b/modules/datastore/src/Storage/SqliteDatabaseTable.php
@@ -37,16 +37,16 @@ class SqliteDatabaseTable extends DatabaseTable {
   /**
    * {@inheritdoc}
    */
-  public function translateType(string $describe_type, $info = NULL) {
+  protected function translateType(string $describe_type, $extra = NULL) {
     // Clean up things like "int(10) unsigned".
     $driver = $this->connection->driver() ?? 'sqlite';
-    $db_type = strtolower($type);
+    $db_type = strtolower($describe_type);
     $map = array_flip(array_map('strtolower', $this->connection->schema()->getFieldTypeMap()));
     $length = NULL;
 
     $fullType = explode(':', ($map[$db_type] ?? 'varchar'));
     // Set type to serial if auto-increment, else use mapped type.
-    $notNull = ($info->notnull == 1) ? TRUE : NULL;
+    $notNull = ($extra->notnull == 1) ? TRUE : NULL;
     // Ignore size if "normal" or unset.
     $size = (isset($fullType[1]) && $fullType[1] != 'normal') ? $fullType[1] : NULL;
 

--- a/modules/datastore/tests/src/Functional/DictionaryEnforcerTest.php
+++ b/modules/datastore/tests/src/Functional/DictionaryEnforcerTest.php
@@ -227,14 +227,12 @@ class DictionaryEnforcerTest extends BrowserTestBase {
       'columns' => [
         'record_number' => [
           'type' => 'serial',
-          'length' => 10,
           'unsigned' => TRUE,
           'not null' => TRUE,
           'mysql_type' => 'int',
         ],
         'a' => [
           'type' => 'int',
-          'length' => 11,
           'mysql_type' => 'int',
         ],
         'b' => [
@@ -244,7 +242,8 @@ class DictionaryEnforcerTest extends BrowserTestBase {
         ],
         'c' => [
           'type' => 'numeric',
-          'length' => 3,
+          'precision' => 3,
+          'scale' => 2,
           'mysql_type' => 'decimal',
           'description' => 'C',
         ],
@@ -257,7 +256,6 @@ class DictionaryEnforcerTest extends BrowserTestBase {
           'type' => 'int',
           'mysql_type' => 'tinyint',
           'description' => 'E',
-          'length' => 1,
           'size' => 'tiny',
         ],
       ],

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -17,11 +17,104 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
+ * @covers \Drupal\datastore\Storage\DatabaseTable
  * @group dkan
  * @group datastore
  * @group unit
  */
 class DatabaseTableTest extends TestCase {
+
+  /**
+   * @covers ::translateType()
+   * @dataProvider translateTypeProvider
+   */
+  public function testTranslateType($type, $extra, $return) {
+    $databaseTable = new DatabaseTable(
+      $this->getConnectionChain()->getMock(),
+      $this->getResource(),
+      $this->createStub(LoggerInterface::class)
+    );
+
+    $this->assertEquals($return, $databaseTable->translateType($type, $extra));
+  }
+
+  public static function translateTypeProvider() {
+    return [
+      [
+        'int unsigned',
+        'auto_increment',
+        [
+          'type' => 'serial',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+          'mysql_type' => 'int',
+        ],
+      ],
+      [
+        'int unsigned',
+        NULL,
+        [
+          'type' => 'int',
+          'unsigned' => TRUE,
+          'mysql_type' => 'int',
+        ],
+      ],
+      [
+        'int(10)',
+        NULL,
+        [
+          'type' => 'int',
+          'mysql_type' => 'int',
+        ],
+      ],
+      [
+        'int (10) unsigned',
+        'auto_increment',
+        [
+          'type' => 'serial',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+          'mysql_type' => 'int',
+        ],
+      ],
+      [
+        'varchar(10)',
+        NULL,
+        [
+          'type' => 'varchar',
+          'length' => 10,
+          'mysql_type' => 'varchar',
+        ],
+      ],
+      [
+        'text',
+        '',
+        [
+          'type' => 'text',
+          'mysql_type' => 'text',
+        ],
+      ],
+      [
+        'tinyint(1)',
+        NULL,
+        [
+          'type' => 'int',
+          'size' => 'tiny',
+          'mysql_type' => 'tinyint',
+        ],
+      ],
+      [
+        'decimal(3,2)',
+        NULL,
+        [
+          'type' => 'numeric',
+          'precision' => 3,
+          'scale' => 2,
+          'mysql_type' => 'decimal',
+        ],
+      ],
+    ];
+  }
 
   /**
    *

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -149,14 +149,13 @@ class DatabaseTableTest extends TestCase {
           "type" => "serial",
           "unsigned" => TRUE,
           "not null" => TRUE,
-          'length' => 10,
           'mysql_type' => 'int',
         ],
         "first_name" => [
           "type" => "varchar",
           "description" => "First Name",
           'length' => 10,
-          'mysql_type' => 'varchar'
+          'mysql_type' => 'varchar',
         ],
         "last_name" => [
           "type" => "text",

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -17,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
- * @covers \Drupal\datastore\Storage\DatabaseTable
+ * @coversDefaultClass \Drupal\datastore\Storage\DatabaseTable
+ *
  * @group dkan
  * @group datastore
  * @group unit

--- a/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -36,7 +36,9 @@ class DatabaseTableTest extends TestCase {
       $this->createStub(LoggerInterface::class)
     );
 
-    $this->assertEquals($return, $databaseTable->translateType($type, $extra));
+    $reflection = new \ReflectionClass($databaseTable);
+    $translateType = $reflection->getMethod('translateType');
+    $this->assertEquals($return, $translateType->invokeArgs($databaseTable, [$type, $extra]));
   }
 
   public static function translateTypeProvider() {


### PR DESCRIPTION
Fixes #4402 

## Describe your changes

Changes the translateType() function to be a little smarter, deal with variations in type strings especially int/auto_increment fields between MySQL versions. Also properly records decimal fields as having precision and scale values rather than length.

## QA Steps

No real human QA necessary. Please review tests to make sure type translations appear accurate and improved. See #4402 for the acceptance criteria.

