### PR TITLE
Updates to datastore install to create a valid schema for post import…

### DIFF
--- a/modules/datastore/datastore.install
+++ b/modules/datastore/datastore.install
@@ -52,8 +52,20 @@ function datastore_update_9001(&$sandbox) {
         'mysql_type' => 'mediumtext',
         'not null' => FALSE,
       ],
+      'id' => [
+        'type' => 'serial',
+        'length' => 10,
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'timestamp' => [
+        'type' => 'int',
+        'length' => 11,
+        'not null' => TRUE,
+        'default' => 0,
+      ],
     ],
-    'primary key' => ['resource_identifier', 'resource_version'],
+    'primary key' => ['id'],
   ];
 
   $schema = Database::getConnection()->schema();
@@ -96,8 +108,20 @@ function datastore_schema() {
         'mysql_type' => 'mediumtext',
         'not null' => FALSE,
       ],
+      'id' => [
+        'type' => 'serial',
+        'length' => 10,
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'timestamp' => [
+        'type' => 'int',
+        'length' => 11,
+        'not null' => TRUE,
+        'default' => 0,
+      ],
     ],
-    'primary key' => ['resource_identifier', 'resource_version'],
+    'primary key' => ['id'],
   ];
 
   return $schema;
@@ -110,13 +134,19 @@ function datastore_update_9003(&$sandbox) {
   $schema = \Drupal::database()->schema();
   $table_name = 'dkan_post_import_job_status';
 
-  // Drop the current primary keys.
-  $schema->dropPrimaryKey($table_name);
+  if (!$schema->fieldExists($table_name, 'id')) {
+    // Drop the current primary keys.
+    $schema->dropPrimaryKey($table_name);
 
-  $query = "
-      ALTER TABLE {$table_name}
-      ADD COLUMN id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
-      ADD COLUMN timestamp INT NOT NULL DEFAULT 0
-  ";
-  \Drupal::database()->query($query);
+    $query = "
+        ALTER TABLE {$table_name}
+        ADD COLUMN id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        ADD COLUMN timestamp INT NOT NULL DEFAULT 0
+    ";
+    \Drupal::database()->query($query);
+  }
+  else {
+    \Drupal::logger('datstore')->notice("No schema update required for $table_name, skipping update.");
+  }
+
 }

--- a/modules/datastore/datastore.install
+++ b/modules/datastore/datastore.install
@@ -134,6 +134,25 @@ function datastore_update_9003(&$sandbox) {
   $schema = \Drupal::database()->schema();
   $table_name = 'dkan_post_import_job_status';
 
+  // Drop the current primary keys.
+  $schema->dropPrimaryKey($table_name);
+
+  $query = "
+      ALTER TABLE {$table_name}
+      ADD COLUMN id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+      ADD COLUMN timestamp INT NOT NULL DEFAULT 0
+  ";
+  \Drupal::database()->query($query);
+}
+
+/**
+ * Add 'id' and 'timestamp' to the dkan_post_import_job_status table
+ * if it does not exist.
+ */
+function datastore_update_9004(&$sandbox) {
+  $schema = \Drupal::database()->schema();
+  $table_name = 'dkan_post_import_job_status';
+
   if (!$schema->fieldExists($table_name, 'id')) {
     // Drop the current primary keys.
     $schema->dropPrimaryKey($table_name);


### PR DESCRIPTION
… result table

Fixes #4407 

## Describe your changes

### Checkout this branch : `2.x`

- [ ] run `ddev dkan-site-install`
- [ ] run `ddev drush sqlc` then `describe dkan_post_import_job_status;` and confirm id and timestamp fields DO NOT exist.
- [ ] running `ddev drush updatedb` DOES NOT do anything
- [ ] checkout this branch `datastore-install-updates`
- [ ] run `ddev drush updatedb`, confirm that `datastore_update_9004` runs successfully. 
- [ ] run `ddev drush sqlc` then `describe dkan_post_import_job_status;` and confirm id and timestamp fields exist.
- [ ] run through creating datasets and applying data dictionaries.
- [ ] confirm dashboard reflects the correct post import status at `/admin/dkan/datastore/status`

### Checkout this branch: `datastore-install-updates`
- [ ] run `ddev dkan-site-install`
- [ ] run `ddev drush sqlc` then `describe dkan_post_import_job_status;` and confirm id and timestamp fields exist.
- [ ] run through creating datasets and applying data dictionaries.
- [ ] confirm dashboard reflects the correct post import status at `/admin/dkan/datastore/status`

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
