### PR TITLE
Dashboard updates to display datasets with unsupported mime_types

### DIFF
--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -454,18 +454,12 @@ class DashboardForm extends FormBase {
     // Create a row for each dataset revision (there could be both a published
     // and latest).
     foreach ($datasetInfo as $rev) {
-      // Filter out distributions whose resources are not csv or tsv.
-      $distributions = array_filter($rev['distributions'], function ($v) {
-        return !isset($v['mime_type']) || in_array($v['mime_type'], DataResource::IMPORTABLE_FILE_TYPES);
-      });
-
-      if (!empty($distributions)) {
-        // For first distribution, combine with revision information.
-        $rows[] = array_merge(
-          $this->buildRevisionRow($rev, count($distributions), $harvestStatus),
-          $this->buildResourcesRow(array_shift($distributions))
-        );
-      }
+      $distributions = $rev['distributions'];
+      // For first distribution, combine with revision information.
+      $rows[] = array_merge(
+        $this->buildRevisionRow($rev, count($distributions), $harvestStatus),
+        $this->buildResourcesRow(array_shift($distributions))
+      );
       // If there are more distributions, add additional rows for them.
       while (!empty($distributions)) {
         $rows[] = $this->buildResourcesRow(array_shift($distributions));
@@ -537,24 +531,49 @@ class DashboardForm extends FormBase {
     if (is_array($dist) && isset($dist['distribution_uuid'])) {
       $postImportResult = $this->postImportResultFactory->initializeFromDistribution($dist);
       $postImportInfo = $postImportResult->retrieveJobStatus();
-      $status = $postImportInfo ? $postImportInfo['post_import_status'] : "waiting";
+      $postImportStatus = $postImportInfo ? $postImportInfo['post_import_status'] : "waiting";
       $error = $postImportInfo ? $postImportInfo['post_import_error'] : NULL;
+      $mime_type = in_array($dist['mime_type'], DataResource::IMPORTABLE_FILE_TYPES);
 
-      return [
-        [
-          'data' => [
-            '#theme' => 'datastore_dashboard_resource_cell',
-            '#uuid' => $dist['distribution_uuid'],
-            '#file_name' => basename($dist['source_path']),
-            '#file_path' => UrlHostTokenResolver::resolve($dist['source_path']),
-          ],
-        ],
-        $this->buildStatusCell($dist['fetcher_status']),
-        $this->buildStatusCell($dist['importer_status'], $dist['importer_percent_done'], $this->cleanUpError($dist['importer_error'])),
-        $this->buildPostImportStatusCell($status, $error),
-      ];
+      return $this->buildResourceData($dist, $mime_type, $postImportStatus, $error);
     }
+
     return ['', '', '', ''];
+  }
+
+  /**
+   * Build resource data array.
+   *
+   * @param array $dist
+   *   Distribution details.
+   * @param bool $mime_type
+   *   Whether the mime type is importable.
+   * @param string $postImportStatus
+   *   Post import status.
+   * @param string|null $error
+   *   Error message, if any.
+   *
+   * @return array
+   *   Resource data array.
+   */
+  protected function buildResourceData(array $dist, bool $mime_type, string $postImportStatus, ?string $error): array {
+    $data = [
+      [
+        'data' => [
+          '#theme' => 'datastore_dashboard_resource_cell',
+          '#uuid' => $dist['distribution_uuid'],
+          '#file_name' => basename($dist['source_path']),
+          '#file_path' => UrlHostTokenResolver::resolve($dist['source_path']),
+        ],
+        'class' => $mime_type ? '' : 'unsupported',
+      ],
+      $mime_type ? $this->buildStatusCell($dist['fetcher_status']) : $this->buildStatusCell('unsupported'),
+      $mime_type ? $this->buildStatusCell($dist['importer_status'], $dist['importer_percent_done'], $this->cleanUpError($dist['importer_error'])) : '',
+      $mime_type ? $this->buildPostImportStatusCell($postImportStatus, $error) : '',
+    ];
+
+    // Remove empty cells.
+    return array_filter($data);
   }
 
   /**
@@ -571,15 +590,23 @@ class DashboardForm extends FormBase {
    *   Renderable array.
    */
   protected function buildStatusCell(string $status, ?int $percentDone = NULL, ?string $error = NULL) {
-    return [
+    $statusCell = [
       'data' => [
         '#theme' => 'datastore_dashboard_status_cell',
-        '#status' => $status,
+        '#status' => $status === 'unsupported' ? 'Data import is not supported for this resource type' : $status,
         '#percent' => $percentDone ?? NULL,
         '#error' => $error,
       ],
       'class' => str_replace('_', '-', $status),
     ];
+
+    // If the status is unsupported, we want to span the cell across
+    // all three columns.
+    if ($status === 'unsupported') {
+      $statusCell['colspan'] = 3;
+    }
+
+    return $statusCell;
   }
 
   /**

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -25,6 +25,11 @@ class DashboardForm extends FormBase {
   use StringTranslationTrait;
 
   /**
+   * Resource type unsupported.
+   */
+  const RESOURCE_TYPE_UNSUPPORTED = 'unsupported';
+
+  /**
    * Harvest service.
    *
    * @var \Drupal\harvest\HarvestService
@@ -545,18 +550,19 @@ class DashboardForm extends FormBase {
    * Build resource data array.
    *
    * @param array $dist
-   *   Distribution details.
-   * @param bool $mime_type
+   *   Distribution element from a datastore_info array.
+   * @param bool $importable
    *   Whether the mime type is importable.
-   * @param string $postImportStatus
+   * @param string $post_import_status
    *   Post import status.
    * @param string|null $error
    *   Error message, if any.
    *
    * @return array
-   *   Resource data array.
+   *   Array of render arrays representing the last three
+   *   columns of the dashboard table.
    */
-  protected function buildResourceData(array $dist, bool $mime_type, string $postImportStatus, ?string $error): array {
+  protected function buildResourceData(array $dist, bool $importable, string $post_import_status, ?string $error): array {
     $data = [
       [
         'data' => [
@@ -565,11 +571,12 @@ class DashboardForm extends FormBase {
           '#file_name' => basename($dist['source_path']),
           '#file_path' => UrlHostTokenResolver::resolve($dist['source_path']),
         ],
-        'class' => $mime_type ? '' : 'unsupported',
+        'class' => $importable ? '' : 'unsupported',
       ],
-      $mime_type ? $this->buildStatusCell($dist['fetcher_status']) : $this->buildStatusCell('unsupported'),
-      $mime_type ? $this->buildStatusCell($dist['importer_status'], $dist['importer_percent_done'], $this->cleanUpError($dist['importer_error'])) : '',
-      $mime_type ? $this->buildPostImportStatusCell($postImportStatus, $error) : '',
+
+      $this->buildStatusCell($importable ? $dist['fetcher_status'] : 'unsupported'),
+      $importable ? $this->buildStatusCell($dist['importer_status'], $dist['importer_percent_done'], $this->cleanUpError($dist['importer_error'])) : NULL,
+      $importable ? $this->buildPostImportStatusCell($post_import_status, $error) : NULL,
     ];
 
     // Remove empty cells.
@@ -593,7 +600,7 @@ class DashboardForm extends FormBase {
     $statusCell = [
       'data' => [
         '#theme' => 'datastore_dashboard_status_cell',
-        '#status' => $status === 'unsupported' ? 'Data import is not supported for this resource type' : $status,
+        '#status' => $status === DashboardForm::RESOURCE_TYPE_UNSUPPORTED ? 'Data import is not supported for this resource type' : $status,
         '#percent' => $percentDone ?? NULL,
         '#error' => $error,
       ],
@@ -602,7 +609,7 @@ class DashboardForm extends FormBase {
 
     // If the status is unsupported, we want to span the cell across
     // all three columns.
-    if ($status === 'unsupported') {
+    if ($status === DashboardForm::RESOURCE_TYPE_UNSUPPORTED) {
       $statusCell['colspan'] = 3;
     }
 

--- a/modules/harvest/css/style.css
+++ b/modules/harvest/css/style.css
@@ -49,3 +49,11 @@ table.dashboard-datasets td.error
   color: #a51b00;
   background-color: #fcf4f2;
 }
+
+/**
+ * Unsupported.
+ */
+ table.dashboard-datasets td.unsupported
+ {
+  background-color: var(--color-gray-050);
+ }


### PR DESCRIPTION
Fixes #4332 

Updates made to the dashboard to include datasets with unsupported mime_types but with a new status message 
and styling to distinguish it from other rows and status.

## QA Steps

- [x] Set up vanilla site
- [x] ddev dkan-sample-content
- [x] run cron a few times
- [x] navigate to the dashboard at (/admin/dkan/datastore/status)
- [x] confirm that resources that are not importable (like PDF, DOC, ZIP etc.) appear with a light gray background in the resource column, and a status that spans across fetch/store/post import with the following message: _Data import is not supported for this resource type_
- [x] At this point pagination should not be made available on the page because there is only 10 datasets. 
- [x] Create one more dataset to make it 11 total datasets. Be sure that this dataset has a resource file that is a pdf or zip.
- [x] navigate to the dashboard at (/admin/dkan/datastore/status)
- [x] confirm that you now see the pagination, select next page
- [x] confirm you see a single row and that the resourced, fetch, store, post import all have the light gray background and a status that spans across fetch/store/post import with the following message: _Data import is not supported for this resource type_

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [x] I have updated or added documentation
