### PR TITLE
Make dkan:dataset-info return string rather than print

### DIFF
--- a/modules/common/src/Commands/CommonCommands.php
+++ b/modules/common/src/Commands/CommonCommands.php
@@ -40,7 +40,7 @@ class CommonCommands extends DrushCommands {
    * @command dkan:dataset-info
    */
   public function datasetInfo(string $uuid) {
-    print_r(json_encode($this->datasetInfo->gather($uuid), JSON_PRETTY_PRINT));
+    return json_encode($this->datasetInfo->gather($uuid), JSON_PRETTY_PRINT);
   }
 
 }

--- a/modules/common/tests/src/Unit/Commands/CommonCommandsTest.php
+++ b/modules/common/tests/src/Unit/Commands/CommonCommandsTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\common\Unit\Commands;
 
 use Drupal\common\Commands\CommonCommands;
 use Drupal\common\DatasetInfo;
+use Drush\TestTraits\CliTestTrait;
 use MockChain\Chain;
 use PHPUnit\Framework\TestCase;
 
@@ -12,20 +13,26 @@ use PHPUnit\Framework\TestCase;
  */
 class CommonCommandsTest extends TestCase {
 
+  use CliTestTrait;
+
   /**
    *
    */
   public function testDatasetInfo() {
 
-    $datasetInfo = (new Chain($this))
-      ->add(DatasetInfo::class, 'gather', ['uuid' => 'foo']);
+    $datasetInfo = $this->getMockBuilder(DatasetInfo::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['gather'])
+      ->getMock();
+    $datasetInfo->expects($this->once())
+      ->method('gather')
+      ->willReturn(['uuid' => 'foo']);
 
-    $drush = new CommonCommands($datasetInfo->getMock());
+    $drush = new CommonCommands($datasetInfo);
     $result = $drush->datasetInfo('foo');
+    $expected = "{\n    \"uuid\": \"foo\"\n}";
 
-    $expected = json_encode(['uuid' => 'foo'], JSON_PRETTY_PRINT);
-
-    $this->expectOutputString($expected, $result);
+    $this->assertEquals($expected, $result);
   }
 
 }

--- a/modules/common/tests/src/Unit/Commands/CommonCommandsTest.php
+++ b/modules/common/tests/src/Unit/Commands/CommonCommandsTest.php
@@ -4,19 +4,16 @@ namespace Drupal\Tests\common\Unit\Commands;
 
 use Drupal\common\Commands\CommonCommands;
 use Drupal\common\DatasetInfo;
-use Drush\TestTraits\CliTestTrait;
-use MockChain\Chain;
 use PHPUnit\Framework\TestCase;
 
 /**
- *
+ * @covers \Drupal\common\Commands\CommonCommands
+ * @coversDefaultClass \Drupal\common\Commands\CommonCommands
  */
 class CommonCommandsTest extends TestCase {
 
-  use CliTestTrait;
-
   /**
-   *
+   * @covers ::datasetInfo
    */
   public function testDatasetInfo() {
 


### PR DESCRIPTION
For some reason `drush dkan:dataset-info` uses `print_r()` to output the information to the terminal. The command should be handling output in one of several ways, this isn't one of them. Simplest approach is just to return a string which prints to terminal identically. 

## QA Steps

- [x] Build site from branch
- [x] Load sample content
- [x] Run `drush dkan:dataset-info cedcd327-4e5d-43f9-8eb1-c11850fa7c55`
- [x] Confirm the expected response prints to screen

This also means we can test this a lot more straightforwardly. 

Spark to do this came because this test breaks on PHP 8.4 due to deprecation warnings in output. Skipping the output piece (we don't need to test that drush prints to the terminal!) means we don't have to account for possible deprecation warnings in the terminal output.
