### PR TITLE
3611 progress indicator with test

### DIFF
--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -303,6 +303,9 @@ class WidgetRouter implements ContainerInjectionInterface {
     if (isset($spec->extensions)) {
       $element['#upload_validators']['FileExtension'] = ['extensions' => $spec->extensions];
     }
+    if (isset($spec->progress_indicator)) {
+      $element['#progress_indicator'] = $spec->progress_indicator;
+    }
     // If a maxlength was set earlier, remove it as it is not allowed here.
     unset($element['#maxlength']);
     return $element;

--- a/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
@@ -500,7 +500,7 @@ class SchemaUiHandlerTest extends TestCase {
     $this->assertEquals($ui_handler->applySchemaUi($form), $expected);
 
     // Test upload_or_link widget.
-    $container_chain->add(SchemaRetriever::class, 'retrieve', '{"downloadURL":{"ui:options":{"widget":"upload_or_link", "extensions": "jpg pdf png csv"}}}');
+    $container_chain->add(SchemaRetriever::class, 'retrieve', '{"downloadURL":{"ui:options":{"widget":"upload_or_link", "extensions": "jpg pdf png csv", "progress_indicator": "bar"}}}');
     $container = $container_chain->getMock();
     \Drupal::setContainer($container);
     $ui_handler = SchemaUiHandler::create($container);
@@ -525,6 +525,7 @@ class SchemaUiHandlerTest extends TestCase {
         '#upload_validators' => [
           'FileExtension' => ['extensions' => 'jpg pdf png csv'],
         ],
+        '#progress_indicator' => 'bar',
       ],
     ];
     $form = $ui_handler->applySchemaUi($form);


### PR DESCRIPTION
Related to #3611 
Adds progress indicator to data upload in json_form_widget. 

(Supersedes https://github.com/GetDKAN/dkan/pull/4410)

## Describe your changes
* Add progress indicator to upload element on dataset form (Credit @stefan-korn )
* Check for existence of progress indicator in SchemaUIHandlerTest

## QA Steps

- [ ] Go to dataset creation form (/node/add/data?schema=dataset)
- [ ] Scroll down to Distribution / Data File / Download URL and select 'Upload Data File'
- [ ] Upload a file
- [ ] Confirm that a progress indicator appears, then disappears.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ /] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
