### PR TITLE
Setting sanitizedName to null if array key doesn't exsist

### DIFF
--- a/modules/common/src/Storage/SelectFactory.php
+++ b/modules/common/src/Storage/SelectFactory.php
@@ -105,7 +105,7 @@ class SelectFactory {
     foreach ($meta_data as $definition) {
       // Confirm definition name is in the fields list.
       $name = $this->dbQuery->escapeField($definition['name']);
-      $sanitizedName = $fields[$name]['field'];
+      $sanitizedName = array_key_exists($name, $fields) ? $fields[$name]['field'] : NULL;
       if ($sanitizedName && $definition['type'] == 'date') {
         $db_query->addExpression("DATE_FORMAT(" . $sanitizedName . ", '" . $definition['format'] . "')", $sanitizedName);
       }


### PR DESCRIPTION
Fixes 
Logs are full of these errors:

`Undefined array key ""new_applications_submitted_footnotes"" in Drupal\common\Storage\SelectFactory->addDateExpressions() (line 108 of /mnt/www/html/datamedicaid/docroot/modules/contrib/dkan/modules/common/src/Storage/SelectFactory.php) #0 /mnt/www/html/datamedicaid/docroot/core/includes/bootstrap.inc(166): _drupal_error_handler_real(2, 'Undefined array...', '/mnt/www/html/d...', 108)`

`Trying to access array offset on value of type null in Drupal\common\Storage\SelectFactory->addDateExpressions() (line 108 of /mnt/www/html/datasitename/docroot/modules/contrib/dkan/modules/common/src/Storage/SelectFactory.php) #0 /mnt/www/html/datasitename/docroot/core/includes/bootstrap.inc(166): _drupal_error_handler_real(2, 'Trying to acces...', '/mnt/www/html/d...', 108) 
 
This is the code:

```
private function addDateExpressions($db_query, $fields, $meta_data) {
    foreach ($meta_data as $definition) {
      // Confirm definition name is in the fields list.
      $name = $this->dbQuery->escapeField($definition['name']);
      $sanitizedName = $fields[$name]['field'];
      if ($sanitizedName && $definition['type'] == 'date') {
        $db_query->addExpression("DATE_FORMAT(" . $sanitizedName . ", '" . $definition['format'] . "')", $sanitizedName);
      }
    }
  } 
```
line 108 is 
$sanitizedName = $fields[$name]['field'];

 If the query property does not match any dictionary property then it should move on without error.

## Describe your changes

I updated the sanitizedName variable to null if array key doesn't exsist. 

## QA Steps

- [ ] Enable database logging
- [ ] Create a data dictionary with a field that does exist in your test dataset
- [ ] Assign that dictionary to the dataset.
- [ ] Run cron 3x
- [ ] Check the logs
- [ ] Confirm you do not see the error below instead, you have a message that the property does exist.
Description

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
