### PR TITLE
Add test for add and remove buttons, remove closures

### DIFF
--- a/modules/json_form_widget/src/ArrayHelper.php
+++ b/modules/json_form_widget/src/ArrayHelper.php
@@ -233,7 +233,7 @@ class ArrayHelper implements ContainerInjectionInterface {
       '#value'  => $title,
       '#submit' => [$function],
       '#ajax'   => [
-        'callback' => $this->addOrRemoveButtonCallback(...),
+        'callback' => [$this, 'addOrRemoveButtonCallback'],
         'wrapper'  => self::buildWrapperIdentifier($context_name),
       ],
       '#attributes' => [

--- a/modules/json_form_widget/src/StringHelper.php
+++ b/modules/json_form_widget/src/StringHelper.php
@@ -6,7 +6,7 @@ use Drupal\Component\Utility\EmailValidator;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Render\Element\FormElement;
+use Drupal\Core\Render\Element\FormElementBase;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -91,7 +91,7 @@ class StringHelper implements ContainerInjectionInterface {
 
     // Add extra validate if element type is email.
     if ($element['#type'] === 'email') {
-      $element['#element_validate'][] = $this->validateEmail(...);
+      $element['#element_validate'][] = [$this, 'validateEmail'];
       $element['#default_value'] = str_replace('mailto:', '', $element['#default_value'] ?? '');
     }
 
@@ -170,7 +170,7 @@ class StringHelper implements ContainerInjectionInterface {
    * Validate string pattern.
    */
   public function validatePattern(&$element, FormStateInterface $form_state, &$complete_form) {
-    FormElement::validatePattern($element, $form_state, $complete_form);
+    FormElementBase::validatePattern($element, $form_state, $complete_form);
   }
 
   /**
@@ -180,7 +180,7 @@ class StringHelper implements ContainerInjectionInterface {
     $element['#maxlength'] = $property->maxLength ?? self::TEXTFIELD_MAXLENGTH;
     if (!empty($property->pattern)) {
       $element['#pattern'] = $property->pattern;
-      $element['#element_validate'][] = $this->validatePattern(...);
+      $element['#element_validate'][] = [$this, 'validatePattern'];
     }
   }
 

--- a/modules/json_form_widget/tests/src/Functional/AdminDatasetJsonFormTest.php
+++ b/modules/json_form_widget/tests/src/Functional/AdminDatasetJsonFormTest.php
@@ -122,6 +122,18 @@ class AdminDatasetJsonFormTest extends BrowserTestBase {
     $this->drupalGet('node/add/data');
     $assert->statusCodeEquals(200);
     $dataset_title = 'DKANTEST dataset title';
+
+    // Quickly test adding and removing a distribution.
+    $page->find('css', '[id^="edit-field-json-metadata-0-value-distribution-actions-actions-add"]')->click();
+    $assert->statusCodeEquals(200);
+    // Now we have two distributions.
+    $this->assertNotNull($page->find('css', '[data-drupal-selector="edit-field-json-metadata-0-value-distribution-distribution-0-distribution"]'));
+    $this->assertNotNull($page->find('css', '[data-drupal-selector="edit-field-json-metadata-0-value-distribution-distribution-1-distribution"]'));
+    $page->find('css', '[id^="edit-field-json-metadata-0-value-distribution-actions-actions-remove"]')->click();
+    // Now we have one again.
+    $this->assertNotNull($page->find('css', '[data-drupal-selector="edit-field-json-metadata-0-value-distribution-distribution-0-distribution"]'));
+    $this->assertNull($page->find('css', '[data-drupal-selector="edit-field-json-metadata-0-value-distribution-distribution-1-distribution"]'));
+
     $this->submitForm([
       'edit-field-json-metadata-0-value-title' => $dataset_title,
       'edit-field-json-metadata-0-value-description' => 'DKANTEST dataset description.',


### PR DESCRIPTION
Fixes #4449

## Describe your changes

Adds a test for the add one and remove one buttons.

Reverts to array syntax for callbacks in json_form_widget.

## QA

* Observe that the first commit, which adds the test, fails.
* The second commit, which reverts to array syntax, and does not modify the test, passes.


