### PR TITLE
Fix closure syntax in Data Dictionary form callback

### DIFF
--- a/modules/data_dictionary_widget/src/Plugin/Field/FieldWidget/DataDictionaryWidget.php
+++ b/modules/data_dictionary_widget/src/Plugin/Field/FieldWidget/DataDictionaryWidget.php
@@ -42,7 +42,7 @@ class DataDictionaryWidget extends WidgetBase implements TrustedCallbackInterfac
     $element = FieldCreation::createGeneralFields($element, $field_json_metadata, $current_fields, $form_state);
 
     $element['dictionary_fields']['#pre_render'] = [
-      $this->preRenderForm(...),
+      [$this, 'preRenderForm'],
     ];
 
     $element['dictionary_fields']['data'] = FieldCreation::createDictionaryDataRows($current_fields, $data_results, $form_state);

--- a/modules/data_dictionary_widget/tests/src/Functional/DataDictionaryWidgetTest.php
+++ b/modules/data_dictionary_widget/tests/src/Functional/DataDictionaryWidgetTest.php
@@ -39,19 +39,39 @@ class DataDictionaryWidgetTest extends BrowserTestBase {
    * Test the behavior of the Data-Dictionary-Widget.
    */
   public function testDataDictionaryWidgetBehavior() {
-    $permissions = ['administer data dictionary settings', 'create data content', 'administer site configuration', 'administer content types', 'bypass node access'];
-    $this->drupalLogin($this->drupalCreateUser($permissions));
+    $this->drupalLogin(
+        $this->drupalCreateUser([], NULL, TRUE)
+      );
+
     $session = $this->assertSession();
-
     $this->drupalGet('node/add/data', ['query' => ['schema' => 'data-dictionary']]);
-    $this->assertSession()->statusCodeEquals(200);
     $session->addressEquals('node/add/data?schema=data-dictionary');
-    $session->elementTextContains('css', '.page-title', 'Create Data');
-    $session->elementExists('css', '.field--widget-data-dictionary-widget');
-    $session->elementExists('css', '#edit-field-json-metadata-0-identifier');
-    $session->elementExists('css', '#edit-field-json-metadata-0-title');
-    $session->elementExists('css', '#edit-field-json-metadata-0-dictionary-fields-add-row-button');
+    $this->assertSession()->statusCodeEquals(200);
 
+    $page = $this->getSession()->getPage();
+    $page->find('css', '[id^="edit-title-0-value"]')->setValue('Test Dictionary');
+    $page->find('css', '[id^="edit-field-json-metadata-0-title"]')->setValue('Test Dictionary');
+
+    // Add a new field to the dictionary.
+    $page->find('css', '[id^="edit-field-json-metadata-0-dictionary-fields-add-row-button"]')->click();
+    $page->find('css', '[id^="edit-field-json-metadata-0-dictionary-fields-field-collection-group-name"]')->setValue('Test Name');
+    $page->find('css', '[id^="edit-field-json-metadata-0-dictionary-fields-field-collection-group-title"]')->setValue('Test Title');
+    $page->find('css', '[id^="edit-field-json-metadata-0-dictionary-fields-field-collection-group-description"]')->setValue('Test Desc');
+    $page->find('css', '[id^="edit-field-json-metadata-0-dictionary-fields-field-collection-group-actions-save-settings"]')->click();
+
+    // Edit the description field and confirm it has updated.
+    $page->find('css', '[id^="edit_0"]')->press();
+    $page->find('css', '[id^="edit-field-json-metadata-0-dictionary-fields-edit-fields-0-update-field-actions-save-update"]');
+    $page->find('css', '[id^="edit-field-json-metadata-0-dictionary-fields-edit-fields-0-update-field-actions-cancel-updates"]');
+    $page->find('css', '[id^="edit-field-json-metadata-0-dictionary-fields-edit-fields-0-update-field-actions-delete-field"]');
+    $page->find('css', '[id^="edit-field-json-metadata-0-dictionary-fields-edit-fields-0-description"]')->setValue('Test Desc Update');
+    $page->find('css', '[id^="edit-field-json-metadata-0-dictionary-fields-edit-fields-0-update-field-actions-save-update"]')->press();
+    $tableValue = $page->find('css', '[id^="field-json-metadata-dictionary-edit-field"]')->getText();
+    $this->assertSame('Test Name Test Title Data Type: string Format: default Description: Test Desc Update', $tableValue, "Expected text not found in tbody.");
+
+    // Confirm successful save.
+    $page->find('css', '[id^="edit-submit"]')->click();
+    $this->assertSession()->pageTextContains('Data Test Dictionary has been created');
   }
 
 }


### PR DESCRIPTION
Fixes #4458 

## Describe your changes

## QA Steps

- [ ] Navigate to the data dictionary form /node/add/data?schema=data-dictionary
- [ ] Confirm you can add fields, edit them, remove them etc..
- [ ] Confirm you can save.
- [ ] Confirm the following test passes: `ddev dkan-phpunit --filter DataDictionaryWidgetTest`

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
