### PR TITLE
Managed remote files

### DIFF
--- a/modules/json_form_widget/json_form_widget.module
+++ b/modules/json_form_widget/json_form_widget.module
@@ -12,7 +12,7 @@ use Drupal\file\Entity\File;
 use Drupal\file\FileInterface;
 use Drupal\json_form_widget\Plugin\Field\FieldWidget\JsonFormWidget;
 use Drupal\json_form_widget\ArrayHelper;
-
+use Drupal\json_form_widget\Element\UploadOrLink;
 
 /**
  * Submit handler for the "add-one-more" button.
@@ -35,7 +35,7 @@ function json_form_widget_remove_one(array &$form, FormStateInterface $form_stat
 /**
  * Update count property by the given offset.
  *
- * @param FormStateInterface $form_state
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   Form state.
  * @param int $offset
  *   Offset to change count by.
@@ -90,78 +90,8 @@ function json_form_widget_form_alter(&$form, FormStateInterface $form_state, $fo
     return;
   }
   if ($form_state->get('has_json_form_widget')) {
-    $form['actions']['submit']['#submit'][] = 'json_form_widget_file_submit';
+    $form['actions']['submit']['#submit'][] = [UploadOrLink::class, 'submit'];
   }
-}
-
-/**
- * Submit handler for uploaded elements on upload_or_link.
- *
- * Sets up file entities created by upload element.
- */
-function json_form_widget_file_submit(array $form, FormStateInterface $form_state) {
-  $parents = $form_state->get('upload_or_link_element');
-  if (empty($parents)) {
-    return;
-  }
-
-  // Avoid double usage if URL is duplicated in form object.
-  $urls = [];
-  foreach ($parents as $parent) {
-    $urls[] = $form_state->getValue($parent);
-  }
-  $urls = array_unique(array_filter($urls));
-
-  foreach ($urls as $url) {
-    _json_form_widget_update_file($url, $form_state);
-  }
-}
-
-/**
- * Find recently-uploaded file entity, set to permanent and add usage.
- *
- * @param string $url
- *   The URL of the file stored in the form submission.
- * @param \Drupal\Core\Form\FormStateInterface $form_state
- *   The form_state object.
- */
-function _json_form_widget_update_file(string $url, FormStateInterface $form_state) {
-  $fo = $form_state->getFormObject();
-  $storage = \Drupal::entityTypeManager()->getStorage('file');
-  $uri = ['uri' => _json_form_widget_get_file_uri($url)];
-  $props = $storage->loadByProperties($uri);
-  $file = reset($props);
-
-  if ($file instanceof FileInterface) {
-    $file->setPermanent();
-    $file->save();
-  }
-  else {
-    return FALSE;
-  }
-  // If we're working with an entity form, set up usage.
-  if ($fo instanceof EntityFormInterface && $entity = $fo->getEntity()) {
-    $fu = \Drupal::service('file.usage');
-    $fu->add($file, 'json_form_widget', $entity->getEntityTypeId(), $entity->id());
-  }
-}
-
-
-/**
- * Generate a Drupal internal URI from a URL in the widget.
- *
- * @todo The module should be using internal URIs which would make this step
- * unnecessary.
- */
-function _json_form_widget_get_file_uri($url) {
-  $path = urldecode((string) \Drupal::service('file_url_generator')->transformRelative($url));
-  // We're loading scheme from config, but this will probably break if not
-  // "public".
-  $scheme = \Drupal::config('system.file')->get('default_scheme') . "://";
-  $scheme_path = \Drupal::service('file_url_generator')->generateString($scheme);
-  $uri = str_replace($scheme_path, $scheme, $path, $count);
-
-  return $count ? $uri : $path;
 }
 
 /**

--- a/modules/json_form_widget/json_form_widget.module
+++ b/modules/json_form_widget/json_form_widget.module
@@ -5,11 +5,9 @@
  * Defines a multi-field form element based on a JSON Schema.
  */
 
-use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\file\Entity\File;
-use Drupal\file\FileInterface;
 use Drupal\json_form_widget\Plugin\Field\FieldWidget\JsonFormWidget;
 use Drupal\json_form_widget\ArrayHelper;
 use Drupal\json_form_widget\Element\UploadOrLink;
@@ -84,6 +82,9 @@ function json_form_widget_field_widget_complete_form_alter(&$field_widget_comple
  * Implements hook_form_alter().
  *
  * Add custom submit handler to form if it contains an upload_or_link element.
+ *
+ * @todo This seems like it should not be necessary. How else can we get
+ * UploadOrLink::submit to execute on the form submit, or avoid this?
  */
 function json_form_widget_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if (!isset($form['actions']['submit'])) {
@@ -117,5 +118,31 @@ function json_form_widget_entity_delete(EntityInterface $entity) {
   // Remove one usage for each file related to deleted entity.
   foreach ($files as $file) {
     \Drupal::service('file.usage')->delete($file, 'json_form_widget', $type, $id);
+  }
+
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for json_form_widget_file_link.
+ */
+function json_form_widget_preprocess_file_link(array &$variables) {
+  $file = $variables['file'];
+  if (!$file instanceof File) {
+    return;
+  }
+  // Find out if file has json_form_widget usage.
+  $usage = \Drupal::service('file.usage')->listUsage($file);
+  $jfw_usage = FALSE;
+  foreach (array_keys($usage) as $type) {
+    if ($type == 'json_form_widget') {
+      $jfw_usage = TRUE;
+      break;
+    }
+  }
+  // If it does, and the URI does not start with public://, show the full URL as
+  // the link title. Otherwise, show the file name.
+  if ($jfw_usage && (strpos($file->getFileUri(), 'public://') !== 0) && isset($variables['link'])) {
+    unset($variables['file_size']);
+    $variables['link']['#title'] = $file->getFileUri();
   }
 }

--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -4,6 +4,7 @@ namespace Drupal\json_form_widget\Element;
 
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\file\Element\ManagedFile;
 use Drupal\file\Entity\File;
@@ -132,8 +133,8 @@ class UploadOrLink extends ManagedFile {
     return [
       '#type' => 'radios',
       '#options' => [
-        static::TYPE_UPLOAD => t('Upload Data File'),
-        static::TYPE_REMOTE => t('Link to Data File'),
+        static::TYPE_UPLOAD => new TranslatableMarkup('Upload Data File'),
+        static::TYPE_REMOTE => new TranslatableMarkup('Link to Data File'),
       ],
       '#default_value' => $file_url_type,
       '#prefix' => '<div class="container-inline">',
@@ -149,9 +150,9 @@ class UploadOrLink extends ManagedFile {
   private static function getFileUrlRemoteElement($file_url_remote, $access_file_url_elements, $remote_visible) {
     return [
       '#type' => 'url',
-      '#title' => t('Remote URL'),
+      '#title' => new TranslatableMarkup('Remote URL'),
       '#title_display' => 'invisible',
-      '#description' => t('This must be an external URL such as <em>http://example.com</em>.'),
+      '#description' => new TranslatableMarkup('This must be an external URL such as <em>http://example.com</em>.'),
       '#default_value' => $file_url_remote,
       // Only show this field when the 'remote' radio is selected.
       '#states' => ['visible' => $remote_visible],

--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -2,12 +2,16 @@
 
 namespace Drupal\json_form_widget\Element;
 
+use Drupal\Component\Utility\NestedArray;
 use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Entity\EntityFormInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\file\Element\ManagedFile;
 use Drupal\file\Entity\File;
+use Drupal\file\FileInterface;
 use Drupal\json_form_widget\Entity\RemoteFile;
 
 /**
@@ -29,8 +33,6 @@ class UploadOrLink extends ManagedFile {
   const TYPE_REMOTE = 'remote';
 
   /**
-   * Inherited.
-   *
    * {@inheritDoc}
    *
    * @codeCoverageIgnore
@@ -58,6 +60,75 @@ class UploadOrLink extends ManagedFile {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  public static function valueCallback(&$element, $input, FormStateInterface $form_state) {
+    // If the input is empty, return the default value.
+    if ($input === FALSE) {
+      $input = [];
+    }
+
+    $uri = $element['#uri'] ?? NULL;
+    $remove = FALSE;
+    $file_remove = $form_state->get('file_remove') ?? [];
+    $diff = array_diff($file_remove, $element['#array_parents']);
+
+    if (!empty($file_remove) && empty($diff)) {
+      $remove = TRUE;
+    }
+
+    if (empty($input['fids']) && $uri && !$remove) {
+      $uri = static::getFileUri($uri);
+      $file = static::getManagedFile($uri);
+      if ($remove) {
+        $element['#uri'] = '';
+      }
+      else {
+        $input['fids'] = $file->id() ?? NULL;
+      }
+    }
+
+    // If the input is not empty, return the input value.
+    return parent::valueCallback($element, $input, $form_state);
+  }
+
+  public static function getManagedFile(string $uri): ?FileInterface {
+    $file = \Drupal::entityTypeManager()->getStorage('file')->loadByProperties(['uri' => $uri]);
+    $file = !empty($file) ? reset($file) : NULL;
+    if ($file) {
+      return $file;
+    }
+    // If no File entity matches the URI, create one.
+    $file = File::create([
+      'uri' => $uri,
+      'status' => File::STATUS_PERMANENT,
+      'uid' => \Drupal::currentUser()->id(),
+    ]);
+    if ($file) {
+      $file->save();
+      return $file;
+    }
+    return NULL;
+  }
+
+  /**
+   * Generate a Drupal internal URI from an absolute URL in the widget.
+   *
+   * This lets absolute URLs to local files be used correctly. Ideally, the
+   * JSON would simply contain public:// URLs, but this is not always the case.
+   */
+  public static function getFileUri(string $url): string {
+    $path = urldecode((string) \Drupal::service('file_url_generator')->transformRelative($url));
+    // We're loading scheme from config, but this will probably break if not
+    // "public".
+    $scheme = \Drupal::config('system.file')->get('default_scheme') . "://";
+    $scheme_path = \Drupal::service('file_url_generator')->generateString($scheme);
+    $uri = str_replace($scheme_path, $scheme, $path, $count);
+
+    return $count ? $uri : $path;
+  }
+
+  /**
    * Render API callback: Expands the managed_file element type.
    *
    * Expands file_managed type to include option for links to remote files/urls.
@@ -67,7 +138,6 @@ class UploadOrLink extends ManagedFile {
     // Build element.
     $element = parent::processManagedFile($element, $form_state, $complete_form);
     $file_url_type = static::getUrlType($element);
-    $element = static::unsetFilesWhenRemoving($form_state, $element);
 
     $file_url_remote = static::setRemoteFile($element, $form_state);
     $file_url_remote_is_valid = isset($file_url_remote) && UrlHelper::isValid($file_url_remote, TRUE);
@@ -86,6 +156,10 @@ class UploadOrLink extends ManagedFile {
     $element['file_url_remote'] = static::getFileUrlRemoteElement($file_url_remote, $access_file_url_elements, $remote_visible);
     $element = static::overrideUploadSubfield($element, $file_url_type_selector);
 
+    if (!empty($element['remove_button'])) {
+      $element['remove_button']['#submit'][] = [static::class, 'removeSubmit'];
+    }
+
     return $element;
   }
 
@@ -101,29 +175,7 @@ class UploadOrLink extends ManagedFile {
       $file_url_remote = $element['#uri'];
     }
 
-    return static::setPreviousFormFiles($element, $form_state, $file_url_remote);
-  }
-
-  /**
-   * Helper function to previous remote files.
-   */
-  private static function setPreviousFormFiles($element, $form_state, $file_url_remote = NULL) {
-    $previous_files = $form_state->get('previous_files') ?? [];
-    $element_key = $element['#array_parents'][6];
-
-    if ($file_url_remote == NULL && isset($previous_files[$element_key])) {
-      $file_url_remote = $previous_files[$element_key];
-    }
-    elseif ($file_url_remote != NULL && !isset($previous_files[$element_key])) {
-      $previous_files[$element_key] = $file_url_remote;
-    }
-    elseif ($file_url_remote != NULL && isset($previous_files[$element_key]) && $previous_files[$element_key] != $file_url_remote) {
-      unset($previous_files[$element_key]);
-      $previous_files[$element_key] = $file_url_remote;
-    }
-    $form_state->set('previous_files', $previous_files);
-
-    return $file_url_remote != NULL ? $file_url_remote : '';
+    return $file_url_remote;
   }
 
   /**
@@ -159,51 +211,6 @@ class UploadOrLink extends ManagedFile {
       '#access' => $access_file_url_elements,
       '#weight' => 15,
     ];
-  }
-
-  /**
-   * Helper function to return element without files when removing.
-   */
-  private static function unsetFilesWhenRemoving($form_state, $element) {
-    $triggering_element = $form_state->getTriggeringElement();
-    $previous_files = $form_state->get('previous_files') ?? [];
-    $element_key = $element['#array_parents'][6];
-    $button = is_array($triggering_element) ? array_pop($triggering_element['#array_parents']) : '';
-    $count = $form_state->get('json_form_widget_info')['distribution']['count'];
-
-    if ($button == 'remove_button') {
-      unset($element['#files']);
-      unset($previous_files[$element_key]);
-      $element = static::unsetFids($element);
-    }
-
-    if ($button == 'remove' && isset($previous_files[$element_key]) &&  $element_key == $count) {
-      $previous_files = static::unsetPreviousFiles($previous_files, $element_key);
-    }
-
-    $form_state->set('previous_files', $previous_files);
-    return $element;
-  }
-
-  /**
-   * Helper function to unset previous_files.
-   */
-  private static function unsetPreviousFiles($previous_files, $element_key) {
-    if (isset($previous_files[$element_key])) {
-      unset($previous_files[$element_key]);
-    }
-    return $previous_files;
-  }
-
-  /**
-   * Helper function to unsetFids.
-   */
-  private static function unsetFids($element) {
-    foreach ($element['#value']['fids'] as $fid) {
-      unset($element['file_' . $fid]);
-    }
-    $element['#value']['fids'] = [];
-    return $element;
   }
 
   /**
@@ -349,6 +356,74 @@ class UploadOrLink extends ManagedFile {
       $element['remove_button']['#access'] = FALSE;
     }
     return $element;
+  }
+
+  /**
+   * Submit handler for uploaded elements on upload_or_link.
+   *
+   * Sets up file entities created by upload element.
+   */
+  public static function submit(array $form, FormStateInterface $form_state) {
+    $parents = $form_state->get('upload_or_link_element');
+    if (empty($parents)) {
+      return;
+    }
+
+    // Get attached entity if present.
+    $fo = $form_state->getFormObject();
+    $entity = $fo instanceof EntityFormInterface ? $fo->getEntity() : NULL;
+
+    // Avoid double-processing if URL is duplicated in form object.
+    $urls = [];
+    foreach ($parents as $parent) {
+      $urls[] = $form_state->getValue($parent);
+    }
+    $urls = array_unique(array_filter($urls));
+    foreach ($urls as $url) {
+      static::updateFile($url, $entity);
+    }
+  }
+
+  public static function removeSubmit(array $form, FormStateInterface $form_state) {
+    $parents = $form_state->getTriggeringElement()['#array_parents'];
+    $button_key = array_pop($parents);
+    // $element = NestedArray::getValue($form, $parents);
+
+    if (($button_key) == 'remove_button') {
+      $form_state->set('file_remove', $parents);
+    }
+  }
+
+  /**
+   * Find recently-uploaded file entity, set to permanent and add usage.
+   *
+   * @param string $url
+   *   The URL of the file stored in the form submission.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form_state object.
+   */
+  public static function updateFile(string $url, ?EntityInterface $entity): ?int {
+    $uri = static::getFileUri($url);
+    $file = static::getManagedFile($uri);
+
+    if (!$file) {
+      return NULL;
+    }
+
+    $file->setPermanent();
+    $file->save();
+
+    // If we're working with an entity form, set up usage.
+    if ($entity) {
+      $fu = \Drupal::service('file.usage');
+      /** @var Drupal\file\FileUsage\FileUsageInterface $fu */
+      $usage = $fu->listUsage($file);
+      // If the file is already used by this entity, don't add usage again.
+      if (!isset($usage['json_form_widget'][$entity->getEntityTypeId()][$entity->id()])) {
+        $fu->add($file, 'json_form_widget', $entity->getEntityTypeId(), $entity->id());
+      }
+    }
+    return $file->id();
   }
 
 }

--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -2,17 +2,14 @@
 
 namespace Drupal\json_form_widget\Element;
 
-use Drupal\Component\Utility\NestedArray;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\Core\Url;
 use Drupal\file\Element\ManagedFile;
 use Drupal\file\Entity\File;
 use Drupal\file\FileInterface;
-use Drupal\json_form_widget\Entity\RemoteFile;
 
 /**
  * Provides a new Element for uploading or linking to files.
@@ -69,29 +66,45 @@ class UploadOrLink extends ManagedFile {
     }
 
     $uri = $element['#uri'] ?? NULL;
+
+    // Detect whether the remove button was clicked.
     $remove = FALSE;
     $file_remove = $form_state->get('file_remove') ?? [];
     $diff = array_diff($file_remove, $element['#array_parents']);
-
     if (!empty($file_remove) && empty($diff)) {
       $remove = TRUE;
     }
 
-    if (empty($input['fids']) && $uri && !$remove) {
+    if (empty($input['fids']) && $uri) {
       $uri = static::getFileUri($uri);
       $file = static::getManagedFile($uri);
+      // If remove was clicked, we need to unset the uri. If not, we need to add
+      // the fid to the input array.
       if ($remove) {
         $element['#uri'] = '';
       }
       else {
+        // Add filet to input array and update the entity.
+        $fo = $form_state->getFormObject();
+        $entity = $fo instanceof EntityFormInterface ? $fo->getEntity() : NULL;
+        static::updateFile($file, $entity);
         $input['fids'] = $file->id() ?? NULL;
+
       }
     }
 
-    // If the input is not empty, return the input value.
     return parent::valueCallback($element, $input, $form_state);
   }
 
+  /**
+   * Retrieve or create a file entity based on a URI.
+   *
+   * @param string $uri
+   *   The URI of the file.
+   *
+   * @return \Drupal\file\FileInterface|null
+   *   The file entity or NULL if not found or able to create.
+   */
   public static function getManagedFile(string $uri): ?FileInterface {
     $file = \Drupal::entityTypeManager()->getStorage('file')->loadByProperties(['uri' => $uri]);
     $file = !empty($file) ? reset($file) : NULL;
@@ -149,7 +162,7 @@ class UploadOrLink extends ManagedFile {
     $remote_visible = [$file_url_type_selector => ['value' => static::TYPE_REMOTE]];
 
     $element['file_url_type'] = static::getFileUrlTypeElement($file_url_type, $access_file_url_elements);
-    // $element['file_url_remote'] = static::getFileUrlRemoteElement($file_url_remote, $access_file_url_elements, $remote_visible);
+    $element['file_url_remote'] = static::getFileUrlRemoteElement($file_url_remote, $access_file_url_elements, $remote_visible);
     $element = static::overrideUploadSubfield($element, $file_url_type_selector);
 
     if (!empty($element['remove_button'])) {
@@ -358,15 +371,18 @@ class UploadOrLink extends ManagedFile {
     }
     $urls = array_unique(array_filter($urls));
     foreach ($urls as $url) {
-      static::updateFile($url, $entity);
+      $uri = static::getFileUri($url);
+      $file = static::getManagedFile($uri);
+      static::updateFile($file, $entity);
     }
   }
 
+  /**
+   * Submit handler for remove button.
+   */
   public static function removeSubmit(array $form, FormStateInterface $form_state) {
     $parents = $form_state->getTriggeringElement()['#array_parents'];
     $button_key = array_pop($parents);
-    // $element = NestedArray::getValue($form, $parents);
-
     if (($button_key) == 'remove_button') {
       $form_state->set('file_remove', $parents);
     }
@@ -375,15 +391,12 @@ class UploadOrLink extends ManagedFile {
   /**
    * Find recently-uploaded file entity, set to permanent and add usage.
    *
-   * @param string $url
-   *   The URL of the file stored in the form submission.
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   The form_state object.
+   * @param \Drupal\file\FileInterface $file
+   *   The file entity to update.
+   * @param \Drupal\Core\Entity\EntityInterface|null $entity
+   *   The entity to which the file is attached.
    */
-  public static function updateFile(string $url, ?EntityInterface $entity): ?int {
-    $uri = static::getFileUri($url);
-    $file = static::getManagedFile($uri);
-
+  public static function updateFile(FileInterface $file, ?EntityInterface $entity): ?int {
     if (!$file) {
       return NULL;
     }

--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -290,7 +290,7 @@ class UploadOrLink extends ManagedFile {
         return \Drupal::service('file_url_generator')->generateAbsoluteString($uri);
       }
     }
-    return $element['#uri'];
+    return $element['#uri'] ?? NULL;
   }
 
   /**

--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -141,19 +141,15 @@ class UploadOrLink extends ManagedFile {
 
     $file_url_remote = static::setRemoteFile($element, $form_state);
     $file_url_remote_is_valid = isset($file_url_remote) && UrlHelper::isValid($file_url_remote, TRUE);
-    $is_remote = $file_url_remote_is_valid && $file_url_type == static::TYPE_REMOTE;
-    if ($is_remote) {
-      $element = static::loadRemoteFile($element, $file_url_remote);
-    }
 
     $access_file_url_elements = (empty($element['#files']) && !$file_url_remote_is_valid) || !$file_url_type;
-    $element['#uri'] = !isset($element['#uri']) ? $file_url_remote : $element['#uri'];
+    $element['#uri'] = $element['#uri'] ?? $file_url_remote;
 
     $file_url_type_selector = ':input[name="' . $element['#name'] . '[file_url_type]"]';
     $remote_visible = [$file_url_type_selector => ['value' => static::TYPE_REMOTE]];
 
     $element['file_url_type'] = static::getFileUrlTypeElement($file_url_type, $access_file_url_elements);
-    $element['file_url_remote'] = static::getFileUrlRemoteElement($file_url_remote, $access_file_url_elements, $remote_visible);
+    // $element['file_url_remote'] = static::getFileUrlRemoteElement($file_url_remote, $access_file_url_elements, $remote_visible);
     $element = static::overrideUploadSubfield($element, $file_url_type_selector);
 
     if (!empty($element['remove_button'])) {
@@ -211,24 +207,6 @@ class UploadOrLink extends ManagedFile {
       '#access' => $access_file_url_elements,
       '#weight' => 15,
     ];
-  }
-
-  /**
-   * Load remote file into element.
-   */
-  private static function loadRemoteFile($element, $file_url_remote) {
-    $remote_file = RemoteFile::load($file_url_remote);
-    $element['#files'] = [$file_url_remote => $remote_file];
-    $file_link = [
-      '#type' => 'link',
-      '#title' => $remote_file->getFileUri(),
-      '#url' => Url::fromUri($remote_file->getFileUri()),
-    ];
-    $element["file_{$file_url_remote}"]['filename'] = $file_link + ['#weight' => -10];
-    $element['#value']['file_url_type'] = static::TYPE_REMOTE;
-    $element['#value']['file_url_remote'] = $file_url_remote;
-    $element['#value']['upload'] = NULL;
-    return $element;
   }
 
   /**

--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -126,6 +126,9 @@ class UploadOrLink extends ManagedFile {
    */
   public static function getFileUri(string $url): string {
     $path = urldecode((string) \Drupal::service('file_url_generator')->transformRelative($url));
+    if (strpos($path, '/') !== 0) {
+      return $path;
+    }
     // We're loading scheme from config, but this will probably break if not
     // "public".
     $scheme = \Drupal::config('system.file')->get('default_scheme') . "://";

--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -61,11 +61,7 @@ class UploadOrLink extends ManagedFile {
    */
   public static function valueCallback(&$element, $input, FormStateInterface $form_state) {
     // If the input is empty, return the default value.
-    if ($input === FALSE) {
-      $input = [];
-    }
-
-    $uri = $element['#uri'] ?? NULL;
+    $input = $input === FALSE ? [] : $input;
 
     // Detect whether the remove button was clicked.
     $remove = FALSE;
@@ -75,9 +71,8 @@ class UploadOrLink extends ManagedFile {
       $remove = TRUE;
     }
 
-    if (empty($input['fids']) && $uri) {
-      $uri = static::getFileUri($uri);
-      $file = static::getManagedFile($uri);
+    if (empty($input['fids']) && ($element['#uri'] ?? FALSE)) {
+      $file = static::getManagedFile(static::getFileUri($element['#uri']));
       // If remove was clicked, we need to unset the uri. If not, we need to add
       // the fid to the input array.
       if ($remove) {
@@ -87,8 +82,7 @@ class UploadOrLink extends ManagedFile {
         // Add filet to input array and update the entity.
         $fo = $form_state->getFormObject();
         $entity = $fo instanceof EntityFormInterface ? $fo->getEntity() : NULL;
-        static::updateFile($file, $entity);
-        $input['fids'] = $file->id() ?? NULL;
+        $input['fids'] = static::updateFile($file, $entity) ?? NULL;
 
       }
     }
@@ -106,18 +100,18 @@ class UploadOrLink extends ManagedFile {
    *   The file entity or NULL if not found or able to create.
    */
   public static function getManagedFile(string $uri): ?FileInterface {
-    $file = \Drupal::entityTypeManager()->getStorage('file')->loadByProperties(['uri' => $uri]);
-    $file = !empty($file) ? reset($file) : NULL;
-    if ($file) {
-      return $file;
+    $files = \Drupal::entityTypeManager()->getStorage('file')->loadByProperties(['uri' => $uri]);
+    if (!empty($files)) {
+      // If a file entity already exists, return it.
+      return reset($files);
     }
+
     // If no File entity matches the URI, create one.
-    $file = File::create([
+    if ($file = File::create([
       'uri' => $uri,
       'status' => File::STATUS_PERMANENT,
       'uid' => \Drupal::currentUser()->id(),
-    ]);
-    if ($file) {
+    ])) {
       $file->save();
       return $file;
     }
@@ -152,7 +146,7 @@ class UploadOrLink extends ManagedFile {
     $element = parent::processManagedFile($element, $form_state, $complete_form);
     $file_url_type = static::getUrlType($element);
 
-    $file_url_remote = static::setRemoteFile($element, $form_state);
+    $file_url_remote = $element['#value']['file_url_remote'] ?? $element['#uri'];
     $file_url_remote_is_valid = isset($file_url_remote) && UrlHelper::isValid($file_url_remote, TRUE);
 
     $access_file_url_elements = (empty($element['#files']) && !$file_url_remote_is_valid) || !$file_url_type;
@@ -170,21 +164,6 @@ class UploadOrLink extends ManagedFile {
     }
 
     return $element;
-  }
-
-  /**
-   * Helper function to set file_url_remote variable.
-   */
-  private static function setRemoteFile($element, $form_state) {
-    $file_url_remote = '';
-    if (isset($element['#value']['file_url_remote'])) {
-      $file_url_remote = $element['#value']['file_url_remote'];
-    }
-    elseif (isset($element['#uri'])) {
-      $file_url_remote = $element['#uri'];
-    }
-
-    return $file_url_remote;
   }
 
   /**

--- a/modules/json_form_widget/tests/src/Functional/AdminDatasetFileUploadTest.php
+++ b/modules/json_form_widget/tests/src/Functional/AdminDatasetFileUploadTest.php
@@ -217,7 +217,7 @@ class AdminDatasetFileUploadTest extends BrowserTestBase {
 
     // Find the URL.
     $assert->elementContains('css', 'h1', 'Edit Data');
-    $uploaded_file_url = $this->baseUrl . '/' . PublicStream::basePath() . '/uploaded_resources/' . basename($upload_file);
+    $uploaded_file_url = PublicStream::basePath() . '/uploaded_resources/' . basename($upload_file);
     $assert->elementAttributeContains(
       'css',
       '#edit-field-json-metadata-0-value-distribution-distribution-0-distribution-downloadurl a',

--- a/modules/json_form_widget/tests/src/Functional/AdminDatasetFileUploadTest.php
+++ b/modules/json_form_widget/tests/src/Functional/AdminDatasetFileUploadTest.php
@@ -20,18 +20,19 @@ class AdminDatasetFileUploadTest extends BrowserTestBase {
 
   use QueueRunnerTrait;
 
+  /**
+   * {@inheritdoc}
+   */
   protected static $modules = [
     'dkan',
     'json_form_widget',
     'node',
   ];
 
-  protected $defaultTheme = 'stark';
-
   /**
-   * @todo Remove this when we drop support for Drupal 10.0.
+   * {@inheritdoc}
    */
-  protected $strictConfigSchema = FALSE;
+  protected $defaultTheme = 'stark';
 
   /**
    * Test creating datasets.

--- a/modules/json_form_widget/tests/src/Kernel/Element/UploadOrLinkTest.php
+++ b/modules/json_form_widget/tests/src/Kernel/Element/UploadOrLinkTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\json_form_widget\Tests\Kernel\Element;
+
+use Drupal\json_form_widget\Element\UploadOrLink;
+use Drupal\KernelTests\KernelTestBase;
+
+class UploadOrLinkTest extends KernelTestBase {
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'json_form_widget',
+    'file',
+    'node',
+    'metastore',
+    'common',
+    'user',
+    'system',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('node');
+  }
+
+  public function testGetFileUri() {
+    // Host is probably localhost, but let's set it just in case.
+    $host = \Drupal::request()->getHost();
+    $scheme = 'public';
+    $this->config('system.file')
+      ->set('default_scheme', $scheme)
+      ->save();
+
+    // A URL with a different host will be preserved.
+    $url = "http://example.com/sites/default/files/something.txt";
+    $uri = UploadOrLink::getFileUri($url);
+    $this->assertEquals($url, $uri);
+
+    // We need to get the files path dynamically, in a kernel test running in
+    // Docker it is likely something like
+    // "/vfs://root/sites/simpletest/95827600/files/"
+    $scheme_path = \Drupal::service('file_url_generator')->generateString("{$scheme}://");
+    // A URL from the same domain will be converted to a file URI.
+    $url = "http://{$host}{$scheme_path}something.txt";
+    $uri = UploadOrLink::getFileUri($url);
+    $this->assertEquals("public://something.txt", $uri);
+  }
+}

--- a/modules/json_form_widget/tests/src/Unit/Element/UploadOrLinkTest.php
+++ b/modules/json_form_widget/tests/src/Unit/Element/UploadOrLinkTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\Tests\json_form_widget\Unit\Element;
+
+use Drupal\Component\DependencyInjection\Container;
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\File\FileUrlGenerator;
+use Drupal\json_form_widget\Element\UploadOrLink;
+use MockChain\Chain;
+use MockChain\Options;
+use PHPUnit\Framework\TestCase;
+
+class UploadOrLinkTest extends TestCase {
+
+  /**
+   * Test the getFileUri method.
+   *
+   * @covers \Drupal\json_form_widget\Element\UploadOrLink::getFileUri
+   *
+   * @dataProvider getFileUriDataProvider
+   */
+  public function testGetFileUri($url, $relative, $scheme_path, $expected) {
+    $options = (new Options())
+      ->add('file_url_generator', FileUrlGenerator::class)
+      ->add('config.factory', ConfigFactory::class)
+      ->index(0);
+
+    $containerMock = (new Chain($this))
+      ->add(Container::class, 'get', $options)
+      ->add(FileUrlGenerator::class, 'transformRelative', $relative)
+      ->add(FileUrlGenerator::class, 'generateString', $scheme_path)
+      ->add(ConfigFactory::class, 'get', ImmutableConfig::class)
+      ->add(ImmutableConfig::class, 'get', 'public')
+      ->getMock();
+
+    \Drupal::setContainer($containerMock);
+
+    $result = UploadOrLink::getFileUri($url);
+    $this->assertEquals($expected, $result);
+  }
+
+  /**
+   * Data provider for testGetFileUri.
+   *
+   * Based on real-life tests.
+   *
+   * @return array
+   *   An array of test data.
+   */
+  public static function getFileUriDataProvider(): array {
+    return [
+      [
+        'url' => 'https//example.com/test1.csv',
+        'relative' => 'https//example.com/test1.csv',
+        'scheme_path' => '/sites/default/files/',
+        'expected' => 'https//example.com/test1.csv',
+      ],
+      [
+        'url' => 'https//example.com/sites/default/files/test1.csv',
+        'relative' => 'https//example.com/sites/default/files/test1.csv',
+        'scheme_path' => '/sites/default/files/',
+        'expected' => 'https//example.com/sites/default/files/test1.csv',
+      ],
+      [
+        'url' => 'http://localhost/test2.csv',
+        'relative' => '/test2.csv',
+        'scheme_path' => '/sites/default/files/',
+        'expected' => '/test2.csv',
+      ],
+      [
+        'url' => 'http://localhost/sites/default/files/test3.csv',
+        'relative' => '/sites/default/files/test3.csv',
+        'scheme_path' => '/sites/default/files/',
+        'expected' => 'public://test3.csv',
+      ],
+    ];
+ }
+}

--- a/modules/json_form_widget/tests/src/Unit/Element/UploadOrLinkTest.php
+++ b/modules/json_form_widget/tests/src/Unit/Element/UploadOrLinkTest.php
@@ -74,6 +74,12 @@ class UploadOrLinkTest extends TestCase {
         'scheme_path' => '/sites/default/files/',
         'expected' => 'public://test3.csv',
       ],
+      [
+        'url' => "http://localhost/vfs://root/sites/simpletest/10834342/files/test4.csv",
+        'relative' => '/vfs://root/sites/simpletest/10834342/files/test4.csv',
+        'scheme_path' => '/vfs://root/sites/simpletest/10834342/files/',
+        'expected' => 'public://test4.csv',
+      ],
     ];
  }
 }


### PR DESCRIPTION
Fixes #4461 

## Describe your changes

This is a significant rewrite of the UploadOrLink element in the JSON Form Widget. It works more in harmony with the MangedFile widget that it overwrites. Whereas previously we'd been overwriting the widget's behavior in more ways, this new approach creates a managed file for any value - whether an uploaded or remote file - and uses MangagedFile's own display/theming stuff to show the file once created. This hopefully makes the code easier to work with and more importantly will make the values play nice with #4335. 

## Known issues

* The codeclimate error - I don't see a way to make that one method better that's as readable. Open to suggestions. 
* I don't like the additional submit function that's added to the form submit button in the module form alter hook. That feels very hacky and I'm hoping we can find a better way to add that file usage after the form is submitted. That said, the form_alter was there before this PR.
* In the claro theme, you get a "( )" after the filename, as the template expects a filesize variable and doesn't check to see if it exists before adding the parenthesis. Not sure if we should override this in the theming system or make more of an attempt to get the file size from a remote file and save that to the file entity.

## QA Steps

1. Create a new dataset. In the distribution section, upload a file. Save the dataset and edit it again, confirm the file still appears as expected.
2. Add a distribution. Instead of uploading, link to a remote file like [this one](https://download.cms.gov/openpayments/PGYR2023_P01302025_01212025/OP_DTL_GNRL_PGYR2023_P01302025_01212025.csv).
3. Save, re-edit, confirm the file is there correctly
4. Remove the file, save and re-open, confirm correct behavior.
5. Otherwise try to beat up on it/try to break it


## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
