### PR TITLE
Require dev version of select2 library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ilbee/csv-response": "^1.2.0",
         "justinrainbow/json-schema": "^5.2",
         "m1x0n/opis-json-schema-error-presenter": "^0.5.3",
-        "npm-asset/select2": "^4.0 || dev-develop",
+        "npm-asset/select2": "dev-develop#595494a",
         "oomphinc/composer-installers-extender": "^2.0",
         "ramsey/uuid": "^3.8.0 || ^4",
         "stolt/json-merge-patch": "^2.0",

--- a/cypress/e2e/08_admin_views.cy.js
+++ b/cypress/e2e/08_admin_views.cy.js
@@ -37,7 +37,7 @@ context('Admin content and dataset views', () => {
         cy.get('#edit-field-json-metadata-0-value-publisher-publisher-name + .select2')
           .find('.select2-selection')
           .click({ force:true })
-        cy.get('input[aria-controls="select2-edit-field-json-metadata-0-value-publisher-publisher-name-results"]').type('DKANTEST Publisher{enter}')
+        cy.get('span[aria-owns="select2-edit-field-json-metadata-0-value-publisher-publisher-name-results"]').type('DKANTEST Publisher{enter}')
         // End filling up publisher.
         cy.get('#edit-field-json-metadata-0-value-contactpoint-contactpoint-fn').type('DKANTEST Contact Name', { force:true } )
         cy.get('#edit-field-json-metadata-0-value-contactpoint-contactpoint-hasemail').type('dkantest@test.com', { force:true } )
@@ -45,7 +45,7 @@ context('Admin content and dataset views', () => {
         cy.get('#edit-field-json-metadata-0-value-keyword-keyword-0 + .select2')
         .find('.select2-selection')
         .click({ force: true })
-        cy.get('input[aria-controls="select2-edit-field-json-metadata-0-value-keyword-keyword-0-results"]').type('open data{enter}')
+        cy.get('span[aria-owns="select2-edit-field-json-metadata-0-value-keyword-keyword-0-results"]').type('open data{enter}')
         // End filling up keyword.
         cy.get('#edit-submit').click({ force:true })
         cy.wait(2000)

--- a/cypress/support/helpers/dkan.js
+++ b/cypress/support/helpers/dkan.js
@@ -219,10 +219,7 @@ export function createDatasetWithModerationState(dataset_title, moderation_state
   cy.get('#edit-field-json-metadata-0-value-modified-date')
     .type('2020-02-02', { force:true } )
   // Fill select2 field for publisher.
-  cy.get('#edit-field-json-metadata-0-value-publisher-publisher-name + .select2')
-    .find('.select2-selection')
-    .click({ force:true })
-  cy.get('input[aria-controls="select2-edit-field-json-metadata-0-value-publisher-publisher-name-results"]')
+  cy.get('#edit-field-json-metadata-0-value-publisher-publisher-name > .fieldset__wrapper > .js-form-item > .select2 > .selection > .select2-selection')
     .type('DKANTEST Publisher{enter}')
   // End filling up publisher.
   cy.get('#edit-field-json-metadata-0-value-contactpoint-contactpoint-fn')
@@ -230,10 +227,7 @@ export function createDatasetWithModerationState(dataset_title, moderation_state
   cy.get('#edit-field-json-metadata-0-value-contactpoint-contactpoint-hasemail')
     .type('dkantest@test.com', { force:true } )
   // Fill select2 field for keyword.
-  cy.get('#edit-field-json-metadata-0-value-keyword-keyword-0 + .select2')
-    .find('.select2-selection')
-    .click({ force: true })
-  cy.get('input[aria-controls="select2-edit-field-json-metadata-0-value-keyword-keyword-0-results"]')
+  cy.get('#edit-field-json-metadata-0-value-keyword-keyword > .fieldset__wrapper > .js-form-item > .select2 > .selection > .select2-selection')
     .type('open data{enter}')
   cy.get('#edit-moderation-state-0-state', {timeout: 2000})
     .select(moderation_state, { force:true } )

--- a/cypress/support/helpers/dkan.js
+++ b/cypress/support/helpers/dkan.js
@@ -219,7 +219,10 @@ export function createDatasetWithModerationState(dataset_title, moderation_state
   cy.get('#edit-field-json-metadata-0-value-modified-date')
     .type('2020-02-02', { force:true } )
   // Fill select2 field for publisher.
-  cy.get('#edit-field-json-metadata-0-value-publisher-publisher-name > .fieldset__wrapper > .js-form-item > .select2 > .selection > .select2-selection')
+  cy.get('#edit-field-json-metadata-0-value-publisher-publisher-name + .select2')
+    .find('.select2-selection')
+    .click({ force:true })
+  cy.get('span[aria-owns="select2-edit-field-json-metadata-0-value-publisher-publisher-name-results"]')
     .type('DKANTEST Publisher{enter}')
   // End filling up publisher.
   cy.get('#edit-field-json-metadata-0-value-contactpoint-contactpoint-fn')
@@ -227,7 +230,10 @@ export function createDatasetWithModerationState(dataset_title, moderation_state
   cy.get('#edit-field-json-metadata-0-value-contactpoint-contactpoint-hasemail')
     .type('dkantest@test.com', { force:true } )
   // Fill select2 field for keyword.
-  cy.get('#edit-field-json-metadata-0-value-keyword-keyword > .fieldset__wrapper > .js-form-item > .select2 > .selection > .select2-selection')
+  cy.get('#edit-field-json-metadata-0-value-keyword-keyword-0 + .select2')
+    .find('.select2-selection')
+    .click({ force: true })
+  cy.get('span[aria-owns="select2-edit-field-json-metadata-0-value-keyword-keyword-0-results"]')
     .type('open data{enter}')
   cy.get('#edit-moderation-state-0-state', {timeout: 2000})
     .select(moderation_state, { force:true } )


### PR DESCRIPTION
Version 2 of the select2 module requires us to use a dev version of the JS library, so that we get jquery 4.

## QA steps

To reproduce the problem, build 2.x and go to /node/add/data. Visit the "tag" field and look at how it looks empty and then with a value:

![image](https://github.com/user-attachments/assets/b2e645d5-d152-4893-8028-774dc68ee3fa)

![image](https://github.com/user-attachments/assets/1be8ebec-1337-4055-b782-0247383cb265)

Pretty bad! Now check out this branch, run `composer update`, run `drush cr` and try again.

You should see:

![image](https://github.com/user-attachments/assets/16ec317e-04e0-430d-85b1-41b8ec2ce5cd)


![image](https://github.com/user-attachments/assets/1e6673ce-a7ea-4a16-808e-0ee7d7121d02)
