### PR TITLE
Fix the dictionaryEnforcer by passing both the resource ID and version

### DIFF
--- a/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
+++ b/modules/datastore/src/Service/ResourceProcessor/DictionaryEnforcer.php
@@ -155,7 +155,7 @@ class DictionaryEnforcer implements ResourceProcessorInterface {
 
       case "reference":
         $resource = DataResource::getIdentifierAndVersion($identifier);
-        $dictionary_id = $this->dataDictionaryDiscovery->dictionaryIdFromResource($resource[0]);
+        $dictionary_id = $this->dataDictionaryDiscovery->dictionaryIdFromResource($resource[0], $resource[1]);
         break;
 
       default:

--- a/modules/metastore/src/DataDictionary/DataDictionaryDiscovery.php
+++ b/modules/metastore/src/DataDictionary/DataDictionaryDiscovery.php
@@ -56,7 +56,7 @@ class DataDictionaryDiscovery implements DataDictionaryDiscoveryInterface {
   public function dictionaryIdFromResource(string $resourceId, ?int $resourceIdVersion = NULL): ?string {
     $mode = $this->getDataDictionaryMode();
     return match ($mode) {
-      self::MODE_NONE => NULL,
+      self::MODE_NONE => "Disabled",
       self::MODE_SITEWIDE => $this->getSitewideDictionaryId(),
       self::MODE_REFERENCE => $this->getReferenceDictionaryId($resourceId, $resourceIdVersion),
       default => throw new \OutOfRangeException(sprintf('Unsupported data dictionary mode "%s"', $mode)),
@@ -67,10 +67,12 @@ class DataDictionaryDiscovery implements DataDictionaryDiscoveryInterface {
    * {@inheritdoc}
    */
   public function getReferenceDictionaryId(string $resourceId, ?int $resourceIdVersion = NULL): ?string {
-    // Should we log an error when no resource version is given?
-    // This can lead to picking up an orphaned distribution.
-    $partial_resource_id = $resourceId . ($resourceIdVersion ? "__$resourceIdVersion" : '');
-    $referencers = $this->lookup->getReferencers('distribution', $partial_resource_id, 'downloadURL');
+    $resource_id = $resourceId . "__" . $resourceIdVersion;
+    $referencers = $this->lookup->getReferencers('distribution', $resource_id, 'downloadURL');
+    if (empty($referencers)) {
+      throw new \RuntimeException("Distribution lookup: Can not map resource ID {$resource_id}
+      to distribution UUID. Please make sure your resource exists in the database.");
+    }
     $distributionId = $referencers[0] ?? NULL;
     if ($distributionId === NULL) {
       return NULL;

--- a/modules/metastore/src/DataDictionary/DataDictionaryDiscovery.php
+++ b/modules/metastore/src/DataDictionary/DataDictionaryDiscovery.php
@@ -68,27 +68,46 @@ class DataDictionaryDiscovery implements DataDictionaryDiscoveryInterface {
    */
   public function getReferenceDictionaryId(string $resourceId, int $resourceIdVersion): ?string {
     $resource_id = $resourceId . "__" . $resourceIdVersion;
-    $referencers = $this->lookup->getReferencers('distribution', $resource_id, 'downloadURL');
-    if (empty($referencers)) {
-      throw new \RuntimeException("Distribution lookup: Can not map resource ID {$resource_id}
-      to distribution UUID. Please make sure your resource exists in the database.");
-    }
-    $distributionId = $referencers[0] ?? NULL;
+    $distributionId = $this->getDistributionId($resource_id);
     if ($distributionId === NULL) {
       return NULL;
     }
     $distribution = $this->metastore->get('distribution', $distributionId);
-    if (!isset($distribution->{"$.data.describedBy"})) {
+    if (!$this->hasValidDescribedBy($distribution)) {
       return NULL;
     }
-    if (($distribution->{"$.data.describedByType"} ?? NULL) == 'application/vnd.tableschema+json') {
-      try {
-        $uri = $this->urlGenerator->uriFromUrl($distribution->{"$.data.describedBy"});
-        return $this->urlGenerator->extractItemId($uri, "data-dictionary");
-      }
-      catch (\DomainException) {
-        return NULL;
-      }
+    return $this->extractDictionaryId($distribution->{"$.data.describedBy"});
+  }
+
+  /**
+   * Get the distribution ID for a given resource ID.
+   */
+  private function getDistributionId(string $resource_id): ?string {
+    $referencers = $this->lookup->getReferencers('distribution', $resource_id, 'downloadURL');
+    if (empty($referencers)) {
+      throw new \RuntimeException("Distribution lookup: Can not map resource ID {$resource_id} to distribution UUID. Please make sure your resource exists in the database.");
+    }
+    return $referencers[0] ?? NULL;
+  }
+
+  /**
+   * Verify that the distribution has a valid describedBy URL.
+   */
+  private function hasValidDescribedBy($distribution): bool {
+    return isset($distribution->{"$.data.describedBy"})
+      && (($distribution->{"$.data.describedByType"} ?? NULL) === 'application/vnd.tableschema+json');
+  }
+
+  /**
+   * Extract the data dictionary ID from the describedBy URL.
+   */
+  private function extractDictionaryId(string $describedBy): ?string {
+    try {
+      $uri = $this->urlGenerator->uriFromUrl($describedBy);
+      return $this->urlGenerator->extractItemId($uri, "data-dictionary");
+    }
+    catch (\DomainException) {
+      return NULL;
     }
   }
 

--- a/modules/metastore/src/DataDictionary/DataDictionaryDiscovery.php
+++ b/modules/metastore/src/DataDictionary/DataDictionaryDiscovery.php
@@ -67,7 +67,8 @@ class DataDictionaryDiscovery implements DataDictionaryDiscoveryInterface {
    * {@inheritdoc}
    */
   public function getReferenceDictionaryId(string $resourceId, ?int $resourceIdVersion = NULL): ?string {
-    // Should we log an error when no resource version is given? This can lead to picking up an orphaned distribution.
+    // Should we log an error when no resource version is given?
+    // This can lead to picking up an orphaned distribution.
     $partial_resource_id = $resourceId . ($resourceIdVersion ? "__$resourceIdVersion" : '');
     $referencers = $this->lookup->getReferencers('distribution', $partial_resource_id, 'downloadURL');
     $distributionId = $referencers[0] ?? NULL;

--- a/modules/metastore/src/DataDictionary/DataDictionaryDiscovery.php
+++ b/modules/metastore/src/DataDictionary/DataDictionaryDiscovery.php
@@ -53,7 +53,7 @@ class DataDictionaryDiscovery implements DataDictionaryDiscoveryInterface {
   /**
    * {@inheritdoc}
    */
-  public function dictionaryIdFromResource(string $resourceId, ?int $resourceIdVersion = NULL): ?string {
+  public function dictionaryIdFromResource(string $resourceId, int $resourceIdVersion): ?string {
     $mode = $this->getDataDictionaryMode();
     return match ($mode) {
       self::MODE_NONE => "Disabled",
@@ -66,7 +66,7 @@ class DataDictionaryDiscovery implements DataDictionaryDiscoveryInterface {
   /**
    * {@inheritdoc}
    */
-  public function getReferenceDictionaryId(string $resourceId, ?int $resourceIdVersion = NULL): ?string {
+  public function getReferenceDictionaryId(string $resourceId, int $resourceIdVersion): ?string {
     $resource_id = $resourceId . "__" . $resourceIdVersion;
     $referencers = $this->lookup->getReferencers('distribution', $resource_id, 'downloadURL');
     if (empty($referencers)) {

--- a/modules/metastore/src/DataDictionary/DataDictionaryDiscovery.php
+++ b/modules/metastore/src/DataDictionary/DataDictionaryDiscovery.php
@@ -67,6 +67,7 @@ class DataDictionaryDiscovery implements DataDictionaryDiscoveryInterface {
    * {@inheritdoc}
    */
   public function getReferenceDictionaryId(string $resourceId, ?int $resourceIdVersion = NULL): ?string {
+    // Should we log an error when no resource version is given? This can lead to picking up an orphaned distribution.
     $partial_resource_id = $resourceId . ($resourceIdVersion ? "__$resourceIdVersion" : '');
     $referencers = $this->lookup->getReferencers('distribution', $partial_resource_id, 'downloadURL');
     $distributionId = $referencers[0] ?? NULL;

--- a/modules/metastore/src/DataDictionary/DataDictionaryDiscoveryInterface.php
+++ b/modules/metastore/src/DataDictionary/DataDictionaryDiscoveryInterface.php
@@ -31,8 +31,10 @@ interface DataDictionaryDiscoveryInterface {
    *   DKAN datastore resource identifier.
    * @param int $resourceIdVersion
    *   DKAN datastore resource version ID.
+   *
    * @throws \RuntimeException
    *   If no distribution is found.
+   *
    * @return string|null
    *   The data dictionary identifier or NULL if none exists.
    */

--- a/modules/metastore/src/DataDictionary/DataDictionaryDiscoveryInterface.php
+++ b/modules/metastore/src/DataDictionary/DataDictionaryDiscoveryInterface.php
@@ -29,13 +29,14 @@ interface DataDictionaryDiscoveryInterface {
    *
    * @param string $resourceId
    *   DKAN datastore resource identifier.
-   * @param int|null $resourceIdVersion
+   * @param int $resourceIdVersion
    *   DKAN datastore resource version ID.
-   *
+   * @throws \RuntimeException
+   *   If no distribution is found.
    * @return string|null
    *   The data dictionary identifier or NULL if none exists.
    */
-  public function getReferenceDictionaryId(string $resourceId, ?int $resourceIdVersion = NULL): ?string;
+  public function getReferenceDictionaryId(string $resourceId, int $resourceIdVersion): ?string;
 
   /**
    * Get the current data dictionary "mode" from DKAN config.

--- a/modules/metastore/src/DataDictionary/DataDictionaryDiscoveryInterface.php
+++ b/modules/metastore/src/DataDictionary/DataDictionaryDiscoveryInterface.php
@@ -22,7 +22,7 @@ interface DataDictionaryDiscoveryInterface {
    * @return string|null
    *   The data dictionary identifier or NULL if none exists.
    */
-  public function dictionaryIdFromResource(string $resourceId, ?int $resourceIdVersion = NULL): ?string;
+  public function dictionaryIdFromResource(string $resourceId, int $resourceIdVersion): ?string;
 
   /**
    * Look for a data dictionary from a metastore reference.

--- a/modules/metastore/tests/src/Unit/DataDictionary/DataDictionaryDiscoveryTest.php
+++ b/modules/metastore/tests/src/Unit/DataDictionary/DataDictionaryDiscoveryTest.php
@@ -25,8 +25,8 @@ class DataDictionaryDiscoveryTest extends TestCase {
       $this->getLookup(),
       $this->getUrlGenerator()
     );
-    $id = $discovery->dictionaryIdFromResource('resource1');
-    $this->assertNull($id);
+    $id = $discovery->dictionaryIdFromResource('resource1', 1);
+    $this->assertEquals("Disabled", $id);
   }
 
   // If mode is sitewide, and we have a sitewide dictionary ID set, it should be
@@ -38,7 +38,7 @@ class DataDictionaryDiscoveryTest extends TestCase {
       $this->getLookup(),
       $this->getUrlGenerator()
     );
-    $id = $discovery->dictionaryIdFromResource('resource1');
+    $id = $discovery->dictionaryIdFromResource('resource1', 1);
     $this->assertEquals('abc-123', $id);
     $idVersion = $discovery->dictionaryIdFromResource('resource1', '2352643');
     $this->assertEquals('abc-123', $idVersion);
@@ -55,7 +55,7 @@ class DataDictionaryDiscoveryTest extends TestCase {
     );
 
     $this->expectException(\OutOfBoundsException::class);
-    $discovery->dictionaryIdFromResource('resource1');
+    $discovery->dictionaryIdFromResource('resource1', 1);
   }
 
   // Test the reference type, four different flows:
@@ -66,17 +66,17 @@ class DataDictionaryDiscoveryTest extends TestCase {
       $this->getLookup(),
       $this->getUrlGenerator()
     );
-    $id = $discovery->dictionaryIdFromResource('resource1');
+    $id = $discovery->dictionaryIdFromResource('resource1', 1);
     $this->assertEquals('111', $id);
 
-    $id = $discovery->dictionaryIdFromResource('resource2');
+    $id = $discovery->dictionaryIdFromResource('resource3', 3);
     $this->assertNull($id);
 
-    $id = $discovery->dictionaryIdFromResource('resource3');
+    $id = $discovery->dictionaryIdFromResource('resource4', 4);
     $this->assertNull($id);
 
-    $id = $discovery->dictionaryIdFromResource('resource4');
-    $this->assertNull($id);
+    $this->expectExceptionMessage("Distribution lookup: Can not map resource ID");
+    $id = $discovery->dictionaryIdFromResource('resource2', 2);
   }
 
   // Test if bad mode in settings
@@ -89,14 +89,14 @@ class DataDictionaryDiscoveryTest extends TestCase {
     );
 
     $this->expectException(OutOfRangeException::class);
-    $discovery->dictionaryIdFromResource('resource1');
+    $discovery->dictionaryIdFromResource('resource1', 1);
   }
   private function getLookup() {
     $options = (new Options())
-      ->add('resource1', ['111'])
-      ->add('resource2', [])
-      ->add('resource3', ['333'])
-      ->add('resource4', ['444'])
+      ->add('resource1__1', ['111'])
+      ->add('resource3__3', ['333'])
+      ->add('resource4__4', ['444'])
+      ->add('resource2__2', [])
       ->index(1);
     return (new Chain($this))
       ->add(ReferenceLookup::class, 'getReferencers', $options)


### PR DESCRIPTION
Fixes 24997

## The Issue
When in reference mode, the DictionaryEnforcer::returnDataDictionaryFields method is only passing the resource ID without the version, this causes DataDictionaryDiscovery::getReferenceDictionaryId to return the wrong distribution, which can lead to a json schema validation error, which in turn breaks the csv download of filtered datastore results.

## Describe your changes
This change will pass both the resouce ID and the version so that the correct distribution is used when in the data dictionary reference mode. 

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation

## QA steps

1. To test on a down-stream build refer to testing steps in 25439
2. Otherwise
3. Create a dataset with a distribution without a downloadURL
4. Edit the dataset and update the distribution to include a resource file
5. Run cron twice to get a datastore table
6. Visit the csv download url with a query parameter (e.g. https://dkan.ddev.site/api/1/datastore/query/{{datasetUUID}}/0/download?conditions%5B0%5D%5Bproperty%5D=state&conditions%5B0%5D%5Bvalue%5D=wi&conditions%5B0%5D%5Boperator%5D=%3D&format=csv)
7. Confirm you get a csv file with the results you expect and not the "JSON Schema validation failed" error.