### PR TITLE
Switch to MariaDB for D11 tests to improve speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,10 +58,6 @@ commands:
             # Modify config to use our PHP version and database.
             ddev delete --omit-snapshot --yes
             ddev config --database="<< parameters.database_version >>" --php-version="<< parameters.php_version >>"
-            # With mysql 8, we need to set this permission.
-            # if [ "<< parameters.database_version >>" = "mysql:8.0" ]; then
-            #   yq '.hooks.post-start += [{"exec": "echo '\''GRANT SESSION_VARIABLES_ADMIN on *.* TO db@`%`'\'' | mysql"}]' -i .ddev/config.yaml
-            # fi
             cat .ddev/config.yaml
             ddev restart
             ddev status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
         type: string
       addon_branch:
         description: "Repo branch name for the DKAN DDev add-on you want to test against."
-        default: "mysql-slow"
+        default: "main"
         type: string
       dkan_recommended_branch:
         description: "Branch of getdkan/recommended-project to use."
@@ -59,9 +59,9 @@ commands:
             ddev delete --omit-snapshot --yes
             ddev config --database="<< parameters.database_version >>" --php-version="<< parameters.php_version >>"
             # With mysql 8, we need to set this permission.
-            if [ "<< parameters.database_version >>" = "mysql:8.0" ]; then
-              yq '.hooks.post-start += [{"exec": "echo '\''GRANT SESSION_VARIABLES_ADMIN on *.* TO db@`%`'\'' | mysql"}]' -i .ddev/config.yaml
-            fi
+            # if [ "<< parameters.database_version >>" = "mysql:8.0" ]; then
+            #   yq '.hooks.post-start += [{"exec": "echo '\''GRANT SESSION_VARIABLES_ADMIN on *.* TO db@`%`'\'' | mysql"}]' -i .ddev/config.yaml
+            # fi
             cat .ddev/config.yaml
             ddev restart
             ddev status
@@ -263,11 +263,11 @@ workflows:
             parameters:
               dkan_recommended_branch: ["11.1.x-dev", "11.0.x-dev"]
               php_version: ["8.4", "8.3"]
-              database_version: ["mysql:8.0"]
+              database_version: ["mariadb:10.6"]
             exclude:
               - php_version: "8.4"
                 dkan_recommended_branch: "11.0.x-dev"
-                database_version: "mysql:8.0"
+                database_version: "mariadb:10.6"
       - phpunit:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
         type: string
       addon_branch:
         description: "Repo branch name for the DKAN DDev add-on you want to test against."
-        default: "main"
+        default: "mysql-slow"
         type: string
       dkan_recommended_branch:
         description: "Branch of getdkan/recommended-project to use."


### PR DESCRIPTION
MySQL 8 is, at least without a bunch of tuning, significantly slower than mysql 5.6 OOB. We test with mysql for D10 primarily to more closely mimic the Acquia hosting environment, which is where our flagship DKAN instances are hosted. But none of those are on D11 yet and Acquia doesn't even support MySQL 8. So let's just make our lives easier and switch to mariaDB for D11 tests.

As a bonus, we no longer need to modify the permissions for MySQL 8 in the CI code.

## QA Steps

* Look at the different matrix jobs in CircleCI.
* The D11 builds should average to the same approx. run time as the D10 builds.
* Compare to [a recent 2.x CI run](https://app.circleci.com/pipelines/github/GetDKAN/dkan/6761/workflows/f48b929e-6d03-440c-9755-84f3261fc78a), where the D11 builds are significantly slower.