### PR TITLE
Plan info in dkan:harvest:info

### DIFF
--- a/modules/harvest/src/Commands/Helper.php
+++ b/modules/harvest/src/Commands/Helper.php
@@ -55,6 +55,24 @@ trait Helper {
   }
 
   /**
+   * Display a JSON harvest plan.
+   *
+   * @param object $plan
+   *   Harvest plan object, as returned from Harvester::getHarvestPlanObject().
+   *
+   * @see Harvester::getHarvestPlanObject()
+   */
+  private function renderHarvestPlan(object $plan) {
+    // Encode the plan as formatted JSON and output it.
+    $consoleOutput = new ConsoleOutput();
+    $consoleOutput->writeln([
+      '<info>Harvest Plan:</info>',
+      json_encode($plan, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+      '',
+    ]);
+  }
+
+  /**
    * Display errors.
    *
    * @param array $errors


### PR DESCRIPTION
There is currently no way to get a harvest plan in Drush without doing a database query. It would seem logical that `drush dkan:harvest:info [plan-id]` would show you _plan_ information, but according to the docs is more for getting _run_ information. While it might make sense to have a separate plan for each, maybe we can just have this command do both for now?

This change simply adds the plan JSON to the top of the command's output. I also changed some docs to use the word "plan" more consistently, rather than the more ambiguous "harvest" (is a "harvest" a _source,_ a _plan_ or a _run_?).

It does not address the fact that the existing functionality of the command - to list all past runs for a plan, or just for a specific run if a second option is passed - is not quite working. 

Also, there were no existing tests for these commands and the command file is excluded from test coverage, so I didn't add any.