### PR TITLE
Allow null on addDistributionInfo in DatastoreInfo

### DIFF
--- a/modules/datastore/src/Plugin/DatasetInfo/DatastoreInfo.php
+++ b/modules/datastore/src/Plugin/DatasetInfo/DatastoreInfo.php
@@ -123,8 +123,8 @@ class DatastoreInfo extends DatasetInfoPluginBase {
    *   The distribution info from a dataset info array.
    */
   protected function addDistributionInfo(array &$distribution): void {
-    $identifier = $distribution['resource_id'];
-    $version = $distribution['resource_version'];
+    $identifier = $distribution['resource_id'] ?? '';
+    $version = $distribution['resource_version'] ?? '';
     $import_info = $this->importInfo->getItem($identifier, $version);
     $fileMapper = $this->resourceMapper->get($identifier, ResourceLocalizer::LOCAL_FILE_PERSPECTIVE, $version);
 


### PR DESCRIPTION
Fixes
```
TypeError: Drupal\datastore\Service\Info\ImportInfo::getItem(): Argument #1 ($identifier) must be of type string, null given, called in /var/www/html/docroot/modules/contrib/dkan/modules/datastore/src/Plugin/DatasetInfo/DatastoreInfo.php on line 128 in Drupal\datastore\Service\Info\ImportInfo->getItem() (line 86 of modules/contrib/dkan/modules/datastore/src/Service/Info/ImportInfo.php). 
```

## Describe your changes
Allow the import dashboard to load even if datasets have no distributions.

## QA Steps

- [ ] Create a dataset without a distribution.
- [ ] Visit /admin/dkan/datastore/status
- [ ] Confirm the page loads and you do not see the error above

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
