### PR TITLE
Split dashboard title search terms into multiple conditions in query to get accurate results

### DIFF
--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -333,9 +333,9 @@ class DashboardForm extends FormBase {
       ->accessCheck(FALSE)
       ->condition('type', 'data')
       ->condition('field_data_type', 'dataset');
-    
+
     $searchTerms = array_filter(explode(' ', trim($filters['dataset_title'])));
-    
+
     if (!empty($searchTerms)) {
       $titleGroup = $query->andConditionGroup();
       foreach ($searchTerms as $term) {
@@ -343,7 +343,7 @@ class DashboardForm extends FormBase {
       }
       $query->condition($titleGroup);
     }
-    
+
     $results = $query->execute();
 
     foreach ($this->nodeStorage->loadMultiple($results) as $node) {

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -345,7 +345,7 @@ class DashboardForm extends FormBase {
     }
     
     $results = $query->execute();
-    
+
     foreach ($this->nodeStorage->loadMultiple($results) as $node) {
       $datasets[] = $node->uuid();
     }

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -323,16 +323,29 @@ class DashboardForm extends FormBase {
    *   Dataset UUIDs .
    */
   protected function getDatasetsByTitle(array $filters): array {
+    $datasets = [];
+
     // Get the ids using an entity query, because our dataset title is in the
     // node title field.
     // @todo Unify different queries against Data nodes using a repository or
     // the NodeData wrapper.
-    $results = $this->nodeStorage->getQuery()
+    $query = $this->nodeStorage->getQuery()
       ->accessCheck(FALSE)
       ->condition('type', 'data')
-      ->condition('field_data_type', 'dataset')
-      ->condition('title', $filters['dataset_title'], 'CONTAINS')
-      ->execute();
+      ->condition('field_data_type', 'dataset');
+    
+    $searchTerms = array_filter(explode(' ', trim($filters['dataset_title'])));
+    
+    if (!empty($searchTerms)) {
+      $titleGroup = $query->andConditionGroup();
+      foreach ($searchTerms as $term) {
+        $titleGroup->condition('title', $term, 'CONTAINS');
+      }
+      $query->condition($titleGroup);
+    }
+    
+    $results = $query->execute();
+    
     foreach ($this->nodeStorage->loadMultiple($results) as $node) {
       $datasets[] = $node->uuid();
     }

--- a/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
+++ b/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
@@ -161,8 +161,8 @@ class DashboardFormTest extends TestCase {
    */
   public function testBuildTableRowsWithDatasetTitleFilter() {
     $info = [
-      'uuid' => 'dataset-1',
-      'title' => 'Dataset 1',
+      'uuid' => 'dataset-1-2',
+      'title' => 'Dataset 1 2',
       'revision_id' => '2',
       'moderation_state' => 'published',
       'modified_date_metadata' => '2020-01-15',
@@ -203,11 +203,12 @@ class DashboardFormTest extends TestCase {
 
     $container = $this->buildContainerChain()
       ->add(EntityTypeManagerInterface::class, 'getStorage', EntityStorageInterface::class)
-      ->add(RequestStack::class, 'getCurrentRequest', new Request(['dataset_title' => 'Dataset 1']))
+      ->add(RequestStack::class, 'getCurrentRequest', new Request(['dataset_title' => 'Dataset 2']))
       ->add(EntityStorageInterface::class, 'getQuery', QueryInterface::class)
       ->add(EntityStorageInterface::class, 'loadMultiple', [$nodeMock])
       ->add(QueryInterface::class, 'accessCheck', QueryInterface::class)
       ->add(QueryInterface::class, 'condition', QueryInterface::class)
+      ->add(QueryInterface::class, 'andConditionGroup', QueryInterface::class)
       ->add(QueryInterface::class, 'execute', [$nodeMock])
       ->add(DatasetInfo::class, 'gather', ['latest_revision' => $info + ['distributions' => [$distribution]]])
       ->add(PostImportResultFactory::class, 'initializeFromDistribution', $postImportResultMock)
@@ -216,8 +217,8 @@ class DashboardFormTest extends TestCase {
     $form = DashboardForm::create($container)->buildForm([], new FormState());
 
     $this->assertEquals(1, count($form['table']['#rows']));
-    $this->assertEquals('dataset-1', $form['table']['#rows'][0][0]['data']['#uuid']);
-    $this->assertEquals('Dataset 1', $form['table']['#rows'][0][0]['data']['#title']);
+    $this->assertEquals('dataset-1-2', $form['table']['#rows'][0][0]['data']['#uuid']);
+    $this->assertEquals('Dataset 1 2', $form['table']['#rows'][0][0]['data']['#title']);
     $this->assertEquals('NEW', $form['table']['#rows'][0][2]['data']);
     $this->assertEquals('done', $form['table']['#rows'][0][6]['data']['#status']);
     $this->assertEquals(NULL, $form['table']['#rows'][0][6]['data']['#error']);


### PR DESCRIPTION
Fixes #4515 

- I set an empty array variable so that we no longer get the 500 error "Return value must be of type array, null returned".
- I refactored the getDatasetsByTitle method to split the search terms and add each word as a separate search condition. This returns accurate results. For example: search term "Florida Bike" returns a dataset, search term "Florida Lanes" does not. With the changes introduces, results for "Florida Lanes" will appear in the dashboard.

## QA Steps

- Run ddev drush en sample_content
- Run ddev drush dkan:sample-content:create
- Run ddev drush cron a couple times
- Visit /admin/dkan/datastore/status
- In the Dataset Title field, type "Florida Lanes" and click filter
- 1 result should appear