### PR TITLE
Test coverage for API delete, and for unauthorized request

### DIFF
--- a/modules/common/tests/src/Functional/Api1TestBase.php
+++ b/modules/common/tests/src/Functional/Api1TestBase.php
@@ -10,6 +10,12 @@ use Opis\JsonSchema\Schema;
 use Opis\JsonSchema\Validator;
 use Osteel\OpenApi\Testing\ValidatorBuilder;
 
+/**
+ * Base class for API v1 tests.
+ *
+ * Provides common functionality for API 1 tests, including HTTP client setup,
+ * OpenAPI spec validation, and user creation.
+ */
 abstract class Api1TestBase extends BrowserTestBase {
   use UserCreationTrait;
 
@@ -18,9 +24,26 @@ abstract class Api1TestBase extends BrowserTestBase {
    */
   protected Client $httpClient;
 
-  protected $spec;
-  protected $auth;
-  protected $endpoint;
+  /**
+   * Decoded OpenAPI spec.
+   */
+  protected object $spec;
+
+  /**
+   * Login credentials for the API, in format ['username', 'password'].
+   */
+  protected array $auth;
+
+  /**
+   * Another set of credentials, for a user without proper perms.
+   */
+  protected array $authNoPerms;
+
+  /**
+   * Base URL for the API.
+   *
+   */
+  protected string $endpoint;
 
   /**
    * OpenApi Validator.
@@ -30,7 +53,6 @@ abstract class Api1TestBase extends BrowserTestBase {
   protected $validator;
 
   protected $defaultTheme = 'stark';
-  protected $strictConfigSchema = FALSE;
 
   protected static $modules = [
     'common',
@@ -46,11 +68,15 @@ abstract class Api1TestBase extends BrowserTestBase {
   public function setUp(): void {
     parent::setUp();
     $user = $this->createUser(['post put delete datasets through the api'], 'testapiuser', FALSE);
+    $user2 = $this->createUser(['access content'], 'testnopermsuser', FALSE);
+
     $this->httpClient = $this->container->get('http_client_factory')
       ->fromOptions([
         'base_uri' => $this->baseUrl,
       ]);
     $this->auth = ['testapiuser', $user->pass_raw];
+    $this->authNoPerms = ['testnopermsuser', $user2->pass_raw];
+
     $this->endpoint = $this->getEndpoint();
 
     // Load the API spec for use by tests.

--- a/modules/metastore/src/Controller/MetastoreController.php
+++ b/modules/metastore/src/Controller/MetastoreController.php
@@ -311,7 +311,10 @@ class MetastoreController implements ContainerInjectionInterface {
   public function delete($schema_id, $identifier) {
     try {
       $this->service->delete($schema_id, $identifier);
-      return $this->apiResponse->cachedJsonResponse((object) ["message" => "Dataset {$identifier} has been deleted."]);
+      return $this->apiResponse->cachedJsonResponse(
+        (object) ["message" => "Dataset {$identifier} has been deleted."],
+        204
+      );
     }
     catch (\Exception $e) {
       return $this->getResponseFromException($e);

--- a/modules/metastore/src/Controller/MetastoreController.php
+++ b/modules/metastore/src/Controller/MetastoreController.php
@@ -313,7 +313,6 @@ class MetastoreController implements ContainerInjectionInterface {
       $this->service->delete($schema_id, $identifier);
       return $this->apiResponse->cachedJsonResponse(
         (object) ["message" => "Dataset {$identifier} has been deleted."],
-        204
       );
     }
     catch (\Exception $e) {

--- a/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
@@ -53,6 +53,14 @@ class DatasetItemTest extends Api1TestBase {
     $response = $this->post($dataset, FALSE);
     $this->assertEquals(409, $response->getStatusCode());
     $this->validator->validate($response, $this->endpoint, 'post');
+
+    // Now an unauthorized user.
+    $response = $this->httpClient->post($this->endpoint, [
+      RequestOptions::JSON => $dataset,
+      RequestOptions::AUTH => $this->authNoPerms,
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(403, $response->getStatusCode());
   }
 
   public function testPatch() {
@@ -86,6 +94,13 @@ class DatasetItemTest extends Api1TestBase {
     $this->assertEquals(412, $response->getStatusCode());
     $this->validator->validate($response, "$this->endpoint/$datasetId", 'patch');
 
+    // Now an unauthorized user.
+    $response = $this->httpClient->patch("{$this->endpoint}/{$datasetId}", [
+      RequestOptions::HTTP_ERRORS => FALSE,
+      RequestOptions::JSON => [],
+      RequestOptions::AUTH => $this->authNoPerms,
+    ]);
+    $this->assertEquals(403, $response->getStatusCode());
   }
 
   public function testPut() {
@@ -113,6 +128,39 @@ class DatasetItemTest extends Api1TestBase {
     ]);
     $this->assertEquals(409, $response->getStatusCode());
     $this->validator->validate($response, "$this->endpoint/$datasetId", 'put');
+
+    // Now an unauthorized user.
+    $response = $this->httpClient->put("{$this->endpoint}/{$datasetId}", [
+      RequestOptions::JSON => $newDataset,
+      RequestOptions::AUTH => $this->authNoPerms,
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(403, $response->getStatusCode());
+
+  }
+
+  public function testDelete() {
+    $dataset = $this->getSampleDataset();
+    $this->post($dataset);
+    $datasetId = $dataset->identifier;
+
+    $response = $this->httpClient->delete("{$this->endpoint}/{$datasetId}", [
+      RequestOptions::AUTH => $this->auth,
+    ]);
+    $this->assertEquals(204, $response->getStatusCode());
+
+    // Now try to get the deleted dataset.
+    $response = $this->httpClient->get("{$this->endpoint}/{$datasetId}", [
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(404, $response->getStatusCode());
+
+    // Now an unauthorized user.
+    $response = $this->httpClient->delete("{$this->endpoint}/{$datasetId}", [
+      RequestOptions::AUTH => $this->authNoPerms,
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(403, $response->getStatusCode());
   }
 
   private function assertDatasetGet($dataset) {

--- a/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\RequestOptions;
 /**
  * Tests the DatasetItem API.
  *
+ * @group metastore
  * @group functional1
  */
 class DatasetItemTest extends Api1TestBase {
@@ -144,6 +145,14 @@ class DatasetItemTest extends Api1TestBase {
     $this->post($dataset);
     $datasetId = $dataset->identifier;
 
+    // Delete as unauthorized user.
+    $response = $this->httpClient->delete("{$this->endpoint}/{$datasetId}", [
+      RequestOptions::AUTH => $this->authNoPerms,
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(403, $response->getStatusCode());
+
+    // Now delete as authorized user.
     $response = $this->httpClient->delete("{$this->endpoint}/{$datasetId}", [
       RequestOptions::AUTH => $this->auth,
     ]);
@@ -155,13 +164,6 @@ class DatasetItemTest extends Api1TestBase {
       RequestOptions::HTTP_ERRORS => FALSE,
     ]);
     $this->assertEquals(404, $response->getStatusCode());
-
-    // Now an unauthorized user.
-    $response = $this->httpClient->delete("{$this->endpoint}/{$datasetId}", [
-      RequestOptions::AUTH => $this->authNoPerms,
-      RequestOptions::HTTP_ERRORS => FALSE,
-    ]);
-    $this->assertEquals(403, $response->getStatusCode());
   }
 
   private function assertDatasetGet($dataset) {

--- a/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
@@ -147,6 +147,7 @@ class DatasetItemTest extends Api1TestBase {
     $response = $this->httpClient->delete("{$this->endpoint}/{$datasetId}", [
       RequestOptions::AUTH => $this->auth,
     ]);
+    // @todo Add delete to the spec so we can validate it.
     $this->assertEquals(204, $response->getStatusCode());
 
     // Now try to get the deleted dataset.

--- a/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
@@ -148,7 +148,7 @@ class DatasetItemTest extends Api1TestBase {
       RequestOptions::AUTH => $this->auth,
     ]);
     // @todo Add delete to the spec so we can validate it.
-    $this->assertEquals(204, $response->getStatusCode());
+    $this->assertEquals(200, $response->getStatusCode());
 
     // Now try to get the deleted dataset.
     $response = $this->httpClient->get("{$this->endpoint}/{$datasetId}", [


### PR DESCRIPTION
Related to #4510

Adds missing coverage in the functional API tests for using the delete method in the API. Also cleans up a bit of code in the API tests, and adds a check for 403 if unauthorized user.

Note: Some additional items needed in the spec so that we can validate DELETE requests.