### PR TITLE
API delete and 404 error handling

### DIFF
--- a/cypress/e2e/01_metastore.cy.js
+++ b/cypress/e2e/01_metastore.cy.js
@@ -226,7 +226,7 @@ context('Metastore', () => {
           body: dkan.generateMetastore(schema_id, identifier),
           failOnStatusCode: false
         }).then((response) => {
-          expect(response.status).eql(412)
+          expect(response.status).eql(404)
         })
       })
 

--- a/modules/metastore/docs/openapi_spec.json
+++ b/modules/metastore/docs/openapi_spec.json
@@ -58,14 +58,14 @@
                     }
                 }
             },
-            "412MetadataObjectNotFound": {
+            "404MetadataObjectNotFound": {
                 "description": "Missing object, usually due to incorrect identifier.",
                 "content": {
                     "application/json": {
                         "schema": { "$ref": "#/components/schemas/errorResponse" },
                         "example": {
                             "message": "No data with the identifier 00000000-0000-0000-0000-000000000000 was found.",
-                            "status": 412,
+                            "status": 404,
                             "timestamp": "2021-06-14T13:46:06+00:00"
                         }
                     }

--- a/modules/metastore/src/Controller/MetastoreController.php
+++ b/modules/metastore/src/Controller/MetastoreController.php
@@ -187,7 +187,7 @@ class MetastoreController implements ContainerInjectionInterface {
       return $this->getResponseFromException($e, $e->httpCode());
     }
     catch (\Exception $e) {
-      return $this->getResponseFromException($e, 400);
+      return $this->getResponseFromException($e);
     }
   }
 
@@ -314,6 +314,9 @@ class MetastoreController implements ContainerInjectionInterface {
       return $this->apiResponse->cachedJsonResponse(
         (object) ["message" => "Dataset {$identifier} has been deleted."],
       );
+    }
+    catch (MetastoreException $e) {
+      return $this->getResponseFromException($e, $e->httpCode());
     }
     catch (\Exception $e) {
       return $this->getResponseFromException($e);

--- a/modules/metastore/src/Exception/MissingObjectException.php
+++ b/modules/metastore/src/Exception/MissingObjectException.php
@@ -13,7 +13,7 @@ class MissingObjectException extends MetastoreException {
    * {@inheritdoc}
    */
   public function httpCode(): int {
-    return 412;
+    return 404;
   }
 
 }

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -445,10 +445,8 @@ class MetastoreService implements ContainerInjectionInterface {
    */
   public function delete($schema_id, $identifier) {
     $storage = $this->getStorage($schema_id);
-    $result = $storage->remove($identifier);
-    if (!$result) {
-      throw new MissingObjectException("No data with the identifier {$identifier} was found.", 404);
-    }
+    $storage->remove($identifier);
+    // If remove method did not throw an exception, assume the item was deleted.
     return $identifier;
   }
 

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -445,7 +445,10 @@ class MetastoreService implements ContainerInjectionInterface {
    */
   public function delete($schema_id, $identifier) {
     $storage = $this->getStorage($schema_id);
-    $storage->remove($identifier);
+    $result = $storage->remove($identifier);
+    if (!$result) {
+      throw new MissingObjectException("No data with the identifier {$identifier} was found.", 404);
+    }
     return $identifier;
   }
 

--- a/modules/metastore/src/Plugin/DkanApiDocs/MetastoreApiDocs.php
+++ b/modules/metastore/src/Plugin/DkanApiDocs/MetastoreApiDocs.php
@@ -367,7 +367,7 @@ class MetastoreApiDocs extends DkanApiDocsBase {
         "201" => ['$ref' => '#/components/responses/201MetadataCreated'],
         '400' => ['$ref' => '#/components/responses/400BadJson'],
         '409' => ['$ref' => '#/components/responses/409MetadataAlreadyExists'],
-        "412" => ['$ref' => '#/components/responses/412MetadataObjectNotFound'],
+        "404" => ['$ref' => '#/components/responses/404MetadataObjectNotFound'],
       ],
     ];
   }
@@ -405,7 +405,7 @@ class MetastoreApiDocs extends DkanApiDocsBase {
       "responses" => [
         "200" => ['$ref' => '#/components/responses/200MetadataUpdated'],
         '400' => ['$ref' => '#/components/responses/400BadJson'],
-        "412" => ['$ref' => '#/components/responses/412MetadataObjectNotFound'],
+        "404" => ['$ref' => '#/components/responses/404MetadataObjectNotFound'],
       ],
     ];
   }

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -311,7 +311,10 @@ abstract class Data implements MetastoreEntityStorageInterface {
 
     $entity = $this->getEntityLatestRevision($uuid);
     if ($entity) {
-      return $entity->delete();
+      $entity->delete();
+    }
+    else {
+      throw new MissingObjectException("No data with the identifier {$uuid} was found.", 404);
     }
   }
 

--- a/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
@@ -92,7 +92,7 @@ class DatasetItemTest extends Api1TestBase {
       RequestOptions::AUTH => $this->auth,
     ]);
 
-    $this->assertEquals(412, $response->getStatusCode());
+    $this->assertEquals(404, $response->getStatusCode());
     $this->validator->validate($response, "$this->endpoint/$datasetId", 'patch');
 
     // Now an unauthorized user.

--- a/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
@@ -153,6 +153,7 @@ class DatasetItemTest extends Api1TestBase {
     $this->assertEquals(403, $response->getStatusCode());
 
     // Now delete as authorized user.
+    $this->assertDatasetGet($dataset);
     $response = $this->httpClient->delete("{$this->endpoint}/{$datasetId}", [
       RequestOptions::AUTH => $this->auth,
     ]);
@@ -161,6 +162,14 @@ class DatasetItemTest extends Api1TestBase {
 
     // Now try to get the deleted dataset.
     $response = $this->httpClient->get("{$this->endpoint}/{$datasetId}", [
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(404, $response->getStatusCode());
+
+    // Try to delete a non-existent dataset.
+    $datasetId = 'abc-123';
+    $response = $this->httpClient->delete("{$this->endpoint}/{$datasetId}", [
+      RequestOptions::AUTH => $this->auth,
       RequestOptions::HTTP_ERRORS => FALSE,
     ]);
     $this->assertEquals(404, $response->getStatusCode());


### PR DESCRIPTION
This PR fixes two inconsistencies in the Metastore discovered while working on #4510:

1. MissingObjectException was throwing [HTTP 412](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/412) errors. I'm not sure where this came from but there's really no use-case in DKAN I can think of where this would be an appropriate error. I've changed it to the much-more-standard 404.
2. There was not really correct error handling going on between the Metastore service and storage classes for delete methods. The service expects a result of some kind from the storage, but it doesn't give one, as Entity::delete() is not specified to return anything. This has been changed to assume that deletion was successful if no exceptions were thrown.

Note that this will also change the behavior of the PATCH method for the metastore API, which could also make a 412 response if given an invalid ID. It will also now return a 404 in that case.