### PR TITLE
Use entity access to negotiate API permissions

### DIFF
--- a/modules/common/tests/src/Functional/Api1TestBase.php
+++ b/modules/common/tests/src/Functional/Api1TestBase.php
@@ -67,7 +67,13 @@ abstract class Api1TestBase extends BrowserTestBase {
    */
   public function setUp(): void {
     parent::setUp();
-    $user = $this->createUser(['post put delete datasets through the api'], 'testapiuser', FALSE);
+    $user = $this->createUser([
+      'access content',
+      'create data content',
+      'edit own data content',
+      'delete own data content',
+      'use dkan_publishing transition publish',
+    ], 'testapiuser', FALSE);
     $user2 = $this->createUser(['access content'], 'testnopermsuser', FALSE);
 
     $this->httpClient = $this->container->get('http_client_factory')

--- a/modules/common/tests/src/Functional/Api1TestBase.php
+++ b/modules/common/tests/src/Functional/Api1TestBase.php
@@ -60,6 +60,7 @@ abstract class Api1TestBase extends BrowserTestBase {
     'metastore',
     'node',
     'sample_content',
+    'workflows',
   ];
 
   /**
@@ -73,6 +74,9 @@ abstract class Api1TestBase extends BrowserTestBase {
       'edit own data content',
       'delete own data content',
       'use dkan_publishing transition publish',
+      'use dkan_publishing transition archive',
+      'use dkan_publishing transition hidden',
+      'use dkan_publishing transition restore',
       'view data revisions',
       'view any unpublished content',
     ], 'testapiuser', FALSE);

--- a/modules/common/tests/src/Functional/Api1TestBase.php
+++ b/modules/common/tests/src/Functional/Api1TestBase.php
@@ -73,6 +73,8 @@ abstract class Api1TestBase extends BrowserTestBase {
       'edit own data content',
       'delete own data content',
       'use dkan_publishing transition publish',
+      'view data revisions',
+      'view any unpublished content',
     ], 'testapiuser', FALSE);
     $user2 = $this->createUser(['access content'], 'testnopermsuser', FALSE);
 

--- a/modules/metastore/metastore.permissions.yml
+++ b/modules/metastore/metastore.permissions.yml
@@ -1,6 +1,6 @@
 'post put delete datasets through the api':
   title: 'Metastore: post, put, patch, and delete datasets through the api'
-  description: 'post, put, patch, and delete datasets through the api'
+  description: 'DEPRECATED: Use regular content permissions instead'
 'administer data dictionary settings':
   title: 'Metastore: Administer Data Dictionary Settings'
   description: 'Administer data dictionary settings'

--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -44,7 +44,7 @@ metastore.1.metastore.schemas.id.items.post:
   defaults:
     { _controller: '\Drupal\metastore\Controller\MetastoreController::post'}
   requirements:
-    _permission: 'post put delete datasets through the api'
+    _access: 'TRUE'
   options:
     _auth: ['basic_auth', 'cookie']
 
@@ -74,7 +74,7 @@ metastore.1.metastore.schemas.id.items.id.put:
   defaults:
     { _controller: '\Drupal\metastore\Controller\MetastoreController::put'}
   requirements:
-    _permission: 'post put delete datasets through the api'
+    _access: 'TRUE'
   options:
     _auth: ['basic_auth', 'cookie']
 

--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -44,7 +44,7 @@ metastore.1.metastore.schemas.id.items.post:
   defaults:
     { _controller: '\Drupal\metastore\Controller\MetastoreController::post'}
   requirements:
-    _access: 'TRUE'
+    _custom_access: '\Drupal\metastore\Controller\MetastoreAccessManager::canCreate'
   options:
     _auth: ['basic_auth', 'cookie']
 
@@ -74,7 +74,7 @@ metastore.1.metastore.schemas.id.items.id.put:
   defaults:
     { _controller: '\Drupal\metastore\Controller\MetastoreController::put'}
   requirements:
-    _access: 'TRUE'
+    _custom_access: '\Drupal\metastore\Controller\MetastoreAccessManager::canUpdate'
   options:
     _auth: ['basic_auth', 'cookie']
 
@@ -84,7 +84,7 @@ metastore.1.metastore.schemas.id.items.id.patch:
   defaults:
     { _controller: '\Drupal\metastore\Controller\MetastoreController::patch'}
   requirements:
-    _permission: 'post put delete datasets through the api'
+    _custom_access: '\Drupal\metastore\Controller\MetastoreAccessManager::canUpdate'
   options:
     _auth: ['basic_auth', 'cookie']
 
@@ -94,7 +94,7 @@ metastore.1.metastore.schemas.id.items.id.delete:
   defaults:
     { _controller: '\Drupal\metastore\Controller\MetastoreController::delete'}
   requirements:
-    _permission: 'post put delete datasets through the api'
+    _custom_access: '\Drupal\metastore\Controller\MetastoreAccessManager::canDelete'
   options:
     _auth: ['basic_auth', 'cookie']
 

--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -104,7 +104,7 @@ metastore.1.metastore.schemas.id.items.id.revisions:
   defaults:
     { _controller: '\Drupal\metastore\Controller\MetastoreRevisionController::getAll'}
   requirements:
-    _permission: 'post put delete datasets through the api'
+    _custom_access: '\Drupal\metastore\Controller\MetastoreAccessManager::canViewRevisionList'
   options:
     _auth: ['basic_auth', 'cookie']
 
@@ -114,7 +114,7 @@ metastore.1.metastore.schemas.id.items.id.revisions.id:
   defaults:
     { _controller: '\Drupal\metastore\Controller\MetastoreRevisionController::get'}
   requirements:
-    _permission: 'post put delete datasets through the api'
+    _custom_access: '\Drupal\metastore\Controller\MetastoreAccessManager::canViewRevision'
   options:
     _auth: ['basic_auth', 'cookie']
 
@@ -124,7 +124,7 @@ metastore.1.metastore.schemas.id.items.id.revisions.post:
   defaults:
     { _controller: '\Drupal\metastore\Controller\MetastoreRevisionController::post'}
   requirements:
-    _permission: 'post put delete datasets through the api'
+    _custom_access: '\Drupal\metastore\Controller\MetastoreAccessManager::canPublish'
   options:
     _auth: ['basic_auth', 'cookie']
 

--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -64,7 +64,7 @@ metastore.1.metastore.schemas.id.items.id.publish:
   defaults:
     { _controller: '\Drupal\metastore\Controller\MetastoreController::publish'}
   requirements:
-    _permission: 'post put delete datasets through the api'
+    _custom_access: '\Drupal\metastore\Controller\MetastoreAccessManager::canUpdate'
   options:
     _auth: ['basic_auth', 'cookie']
 
@@ -124,7 +124,7 @@ metastore.1.metastore.schemas.id.items.id.revisions.post:
   defaults:
     { _controller: '\Drupal\metastore\Controller\MetastoreRevisionController::post'}
   requirements:
-    _custom_access: '\Drupal\metastore\Controller\MetastoreAccessManager::canPublish'
+    _custom_access: '\Drupal\metastore\Controller\MetastoreAccessManager::canUpdate'
   options:
     _auth: ['basic_auth', 'cookie']
 

--- a/modules/metastore/src/Controller/MetastoreAccessManager.php
+++ b/modules/metastore/src/Controller/MetastoreAccessManager.php
@@ -2,14 +2,23 @@
 
 namespace Drupal\metastore\Controller;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityAccessControlHandlerInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore\Factory\MetastoreEntityItemFactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
+/**
+ * Manages access control for Metastore items in API endpoints.
+ *
+ * This class provides methods to check if a user can create, update, or delete
+ * items based on their schema ID and item ID.
+ */
 class MetastoreAccessManager implements ContainerInjectionInterface {
 
   /**
@@ -44,8 +53,10 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
     EntityTypeManagerInterface $entityTypeManager,
     MetastoreEntityItemFactoryInterface $itemFactory,
   ) {
+    $this->itemFactory = $itemFactory;
     $this->entityType = $itemFactory->getEntityType();
-    $this->bundle = reset($itemFactory->getBundles());
+    $bundles = $itemFactory->getBundles();
+    $this->bundle = reset($bundles);
     $this->accessControlHandler = $entityTypeManager->getAccessControlHandler($this->entityType);
   }
 
@@ -55,74 +66,103 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('entity_type.manager'),
-      $container->get('metastore.entity_item_factory'),
+      $container->get('dkan.metastore.metastore_item_factory'),
     );
   }
 
   /**
    * Check if user can create an item from a schema.
    *
-   * @param \Drupal\Core\Session\AccountInterface $account
-   *   The user account.
    * @param string $schema_id
    *   The schema ID.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
    *
-   * @return bool
-   *   TRUE if the user can create an item, FALSE otherwise.
+   * @return \Drupal\Core\Access\AccessResult
+   *   An access result object indicating whether the user can create an item.
    */
-  public function canCreate(AccountInterface $account): bool {
-    return $this->accessControlHandler->createAccess($this->bundle, $account);
+  public function canCreate(string $schema_id, AccountInterface $account): AccessResult {
+    if ($this->accessControlHandler->createAccess($this->bundle, $account)) {
+      return AccessResult::allowed();
+    }
+    return AccessResult::forbidden();
   }
 
   /**
    * Check if user can update an item from a schema.
    *
-   * @param \Drupal\Core\Session\AccountInterface $account
-   *   The user account.
    * @param string $schema_id
    *   The schema ID.
-   * @param string $item_id
+   * @param string $identifier
    *   The item ID.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
    *
-   * @return bool
-   *   TRUE if the user can update the item, FALSE otherwise.
+   * @return \Drupal\Core\Access\AccessResult
+   *   An access result object indicating whether the user can update the item.
    */
-  public function canUpdate(AccountInterface $account, string $schema_id, string $item_id): bool {
+  public function canUpdate(string $schema_id, string $identifier, AccountInterface $account): AccessResult {
     // Check if the user has permission to update items of this schema.
-    $entity = $this->getEntity($schema_id, $item_id);
-    return $this->accessControlHandler->access($entity, "update", $account);
+    try {
+      $entity = $this->getEntity($schema_id, $identifier);
+      return $this->accessControlHandler->access($entity, "update", $account, TRUE);
+    }
+    catch (MissingObjectException | \InvalidArgumentException $e) {
+      // If the the item does not exist, assume "allowed" and let the controller
+      // handle the 404 response.
+      return AccessResult::allowed();
+    }
   }
 
   /**
    * Check if user can delete an item from a schema.
    *
-   * @param \Drupal\Core\Session\AccountInterface $account
-   *   The user account.
    * @param string $schema_id
    *   The schema ID.
-   * @param string $item_id
+   * @param string $identifier
    *   The item ID.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
    *
-   * @return bool
-   *   TRUE if the user can delete the item, FALSE otherwise.
+   * @return \Drupal\Core\Access\AccessResult
+   *   An access result object indicating whether the user can delete the item.
    */
-  public function canDelete(AccountInterface $account, string $schema_id, string $item_id): bool {
-    // Check if the user has permission to delete items of this schema.
-    $entity = $this->getEntity($schema_id, $item_id);
-    return $this->accessControlHandler->access($entity, "delete", $account);
+  public function canDelete(string $schema_id, string $identifier, AccountInterface $account): AccessResult {
+    try {
+      $entity = $this->getEntity($schema_id, $identifier);
+      return $this->accessControlHandler->access($entity, "delete", $account, TRUE);
+    }
+    catch (MissingObjectException | \InvalidArgumentException $e) {
+      // If the item does not exist, assume "allowed" and let the controller
+      // handle the 404 response.
+      return AccessResult::allowed();
+    }
   }
 
-  protected function getEntity(string $schema_id, string $item_id): EntityInterface {
+  /**
+   * Get the entity for a given schema ID and item ID.
+   *
+   * @param string $schema_id
+   *   The schema ID.
+   * @param string $identifier
+   *   The item ID.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   The entity corresponding to the schema and item ID.
+   *
+   * @throws \InvalidArgumentException
+   *   If no entity is found for the given schema ID and item ID.
+   */
+  protected function getEntity(string $schema_id, string $identifier): EntityInterface {
     // Load the entity based on schema ID and item ID.
-    $item = $this->itemFactory->getInstance($item_id);
-    if ($item && $item->getSchemaId() === $schema_id) {
-      return $item->getEntity();
+    try {
+      $item = $this->itemFactory->getInstance($identifier, ['schema_id' => $schema_id]);
     }
-    throw new \InvalidArgumentException(sprintf(
-      'No entity found for schema ID %s and item ID %s.',
-      $schema_id,
-      $item_id
-    ));
+    catch (\Throwable $e) {
+      throw new MissingObjectException("No item found for schema ID '$schema_id' and identifier '$identifier'.", 0, $e);
+    }
+    assert($item->getSchemaId() === $schema_id, \InvalidArgumentException::class);
+    return $item->getEntity();
   }
 
 }

--- a/modules/metastore/src/Controller/MetastoreAccessManager.php
+++ b/modules/metastore/src/Controller/MetastoreAccessManager.php
@@ -6,12 +6,10 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityAccessControlHandlerInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore\Factory\MetastoreEntityItemFactoryInterface;
-use Drupal\workflows\WorkflowInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -61,8 +59,8 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
     MetastoreEntityItemFactoryInterface $itemFactory,
   ) {
     $this->itemFactory = $itemFactory;
-    $this->entityType = $itemFactory->getEntityType();
-    $bundles = $itemFactory->getBundles();
+    $this->entityType = $itemFactory::getEntityType();
+    $bundles = $itemFactory::getBundles();
     $this->bundle = reset($bundles);
     $this->entityTypeManager = $entityTypeManager;
     $this->accessControlHandler = $entityTypeManager->getAccessControlHandler($this->entityType);
@@ -90,10 +88,7 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
    *   An access result object indicating whether the user can create an item.
    */
   public function canCreate(string $schema_id, AccountInterface $account): AccessResult {
-    if ($this->accessControlHandler->createAccess($this->bundle, $account)) {
-      return AccessResult::allowed();
-    }
-    return AccessResult::forbidden();
+    return $this->accessControlHandler->createAccess($this->bundle, $account, [], TRUE);
   }
 
   /**
@@ -159,15 +154,19 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
     }
   }
 
-  public function canPublish(
-    string $schema_id,
-    string $identifier,
-    AccountInterface $account,
-  ): AccessResult {
-    $workflow_id = $this->getWorkflowIdForBundle();
-    return AccessResult::allowed();
-  }
-
+  /**
+   * Check if user can view the revision list for an item.
+   *
+   * @param string $schema_id
+   *   The schema ID.
+   * @param string $identifier
+   *   The item ID.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   Access result object.
+   */
   public function canViewRevisionList(
     string $schema_id,
     string $identifier,
@@ -176,7 +175,7 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
     try {
       /** @var \Drupal\Core\Entity\RevisionableStorageInterface $storage */
       $entity = $this->getEntity($schema_id, $identifier);
-      return $this->accessControlHandler->access($entity, "view revisions", $account, TRUE);
+      return $this->accessControlHandler->access($entity, "view all revisions", $account, TRUE);
     }
     catch (MissingObjectException | \InvalidArgumentException $e) {
       // If the item does not exist, assume "allowed" and let the controller
@@ -185,6 +184,21 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
     }
   }
 
+  /**
+   * Check if user can view a specific revision of an item.
+   *
+   * @param string $schema_id
+   *   The schema ID.
+   * @param string $identifier
+   *   The item ID.
+   * @param int $revision_id
+   *   The revision ID.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   Access result object.
+   */
   public function canViewRevision(
     string $schema_id,
     string $identifier,
@@ -195,6 +209,9 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
       /** @var \Drupal\Core\Entity\RevisionableStorageInterface $storage */
       $storage = $this->entityTypeManager->getStorage($this->entityType);
       $revision = $storage->loadRevision($revision_id);
+      if (!$revision || $revision->uuid() !== $identifier) {
+        throw new MissingObjectException();
+      }
       return $this->accessControlHandler->access($revision, "view", $account, TRUE);
     }
     catch (MissingObjectException | \InvalidArgumentException $e) {

--- a/modules/metastore/src/Controller/MetastoreAccessManager.php
+++ b/modules/metastore/src/Controller/MetastoreAccessManager.php
@@ -6,10 +6,12 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityAccessControlHandlerInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore\Factory\MetastoreEntityItemFactoryInterface;
+use Drupal\workflows\WorkflowInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -30,6 +32,11 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
    * Metastore Storage Factory service.
    */
   protected MetastoreEntityItemFactoryInterface $itemFactory;
+
+  /**
+   * Entity type manager.
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
 
   /**
    * Entity type ID for the items managed by this factory.
@@ -57,6 +64,7 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
     $this->entityType = $itemFactory->getEntityType();
     $bundles = $itemFactory->getBundles();
     $this->bundle = reset($bundles);
+    $this->entityTypeManager = $entityTypeManager;
     $this->accessControlHandler = $entityTypeManager->getAccessControlHandler($this->entityType);
   }
 
@@ -151,6 +159,51 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
     }
   }
 
+  public function canPublish(
+    string $schema_id,
+    string $identifier,
+    AccountInterface $account,
+  ): AccessResult {
+    $workflow_id = $this->getWorkflowIdForBundle();
+    return AccessResult::allowed();
+  }
+
+  public function canViewRevisionList(
+    string $schema_id,
+    string $identifier,
+    AccountInterface $account,
+  ): AccessResult {
+    try {
+      /** @var \Drupal\Core\Entity\RevisionableStorageInterface $storage */
+      $entity = $this->getEntity($schema_id, $identifier);
+      return $this->accessControlHandler->access($entity, "view revisions", $account, TRUE);
+    }
+    catch (MissingObjectException | \InvalidArgumentException $e) {
+      // If the item does not exist, assume "allowed" and let the controller
+      // handle the 404 response.
+      return AccessResult::allowed();
+    }
+  }
+
+  public function canViewRevision(
+    string $schema_id,
+    string $identifier,
+    int $revision_id,
+    AccountInterface $account,
+  ): AccessResult {
+    try {
+      /** @var \Drupal\Core\Entity\RevisionableStorageInterface $storage */
+      $storage = $this->entityTypeManager->getStorage($this->entityType);
+      $revision = $storage->loadRevision($revision_id);
+      return $this->accessControlHandler->access($revision, "view", $account, TRUE);
+    }
+    catch (MissingObjectException | \InvalidArgumentException $e) {
+      // If the item does not exist, assume "allowed" and let the controller
+      // handle the 404 response.
+      return AccessResult::allowed();
+    }
+  }
+
   /**
    * Get the entity for a given schema ID and item ID.
    *
@@ -175,6 +228,28 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
     }
     assert($item->getSchemaId() === $schema_id, \InvalidArgumentException::class);
     return $item->getEntity();
+  }
+
+  /**
+   * Get the workflow ID for a given entity type and bundle.
+   *
+   * @return string|null
+   *   The workflow ID, or NULL if none is assigned.
+   */
+  protected function getWorkflowIdForBundle(): ?string {
+    /** @var \Drupal\workflows\WorkflowInterface[] $workflows */
+    $workflows = $this->entityTypeManager->getStorage('workflow')->loadMultiple();
+    foreach ($workflows as $workflow) {
+      /** @var \Drupal\metastore\Controller\ContentModerationInterface $type_plugin */
+      $type_plugin = $workflow->getTypePlugin();
+      $entity_types = $type_plugin->getEntityTypes();
+      $bundles = $type_plugin->getBundlesForEntityType($this->entityType);
+
+      if (in_array($this->entityType, $entity_types) && in_array($this->bundle, $bundles)) {
+        return $workflow->id();
+      }
+    }
+    return NULL;
   }
 
 }

--- a/modules/metastore/src/Controller/MetastoreAccessManager.php
+++ b/modules/metastore/src/Controller/MetastoreAccessManager.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\metastore\Controller;
+
+use Contracts\FactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class MetastoreAccessManager implements ContainerInjectionInterface {
+
+  /**
+   * The entity type manager service.
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * Metastore Storage Factory service.
+   */
+  protected FactoryInterface $storageFactory;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entityTypeManager,
+    FactoryInterface $storageFactory,
+  ) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->storageFactory = $storageFactory;
+
+    
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('metastore.storage')
+    );
+  }
+
+  /**
+   * Check if user can create an item from a schema.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   * @param string $schema_id
+   *   The schema ID.
+   *
+   * @return bool
+   *   TRUE if the user can create an item, FALSE otherwise.
+   */
+  public function canCreate(AccountInterface $account): bool {
+    // Check if the user has permission to create items from the schema.
+    return $this->accessControlHandler->createAccess('data', $account);
+  }
+
+}

--- a/modules/metastore/src/Controller/MetastoreAccessManager.php
+++ b/modules/metastore/src/Controller/MetastoreAccessManager.php
@@ -88,6 +88,12 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
    *   An access result object indicating whether the user can create an item.
    */
   public function canCreate(string $schema_id, AccountInterface $account): AccessResult {
+    // Check legacy API access permission.
+    if ($account->hasPermission('post put delete datasets through the api')) {
+      return AccessResult::allowed();
+    }
+
+    // Check entity-specific create access.
     return $this->accessControlHandler->createAccess($this->bundle, $account, [], TRUE);
   }
 
@@ -112,6 +118,10 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
     AccountInterface $account,
     Request $request,
   ): AccessResult {
+    // Check legacy API access permission.
+    if ($account->hasPermission('post put delete datasets through the api')) {
+      return AccessResult::allowed();
+    }
     $method = $request->getMethod();
     // Check if the user has permission to update items of this schema.
     try {
@@ -143,6 +153,11 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
    *   An access result object indicating whether the user can delete the item.
    */
   public function canDelete(string $schema_id, string $identifier, AccountInterface $account): AccessResult {
+    // Check legacy API access permission.
+    if ($account->hasPermission('post put delete datasets through the api')) {
+      return AccessResult::allowed();
+    }
+
     try {
       $entity = $this->getEntity($schema_id, $identifier);
       return $this->accessControlHandler->access($entity, "delete", $account, TRUE);
@@ -172,6 +187,10 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
     string $identifier,
     AccountInterface $account,
   ): AccessResult {
+    // Check legacy API access permission.
+    if ($account->hasPermission('post put delete datasets through the api')) {
+      return AccessResult::allowed();
+    }
     try {
       /** @var \Drupal\Core\Entity\RevisionableStorageInterface $storage */
       $entity = $this->getEntity($schema_id, $identifier);
@@ -205,6 +224,10 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
     int $revision_id,
     AccountInterface $account,
   ): AccessResult {
+    // Check legacy API access permission.
+    if ($account->hasPermission('post put delete datasets through the api')) {
+      return AccessResult::allowed();
+    }
     try {
       /** @var \Drupal\Core\Entity\RevisionableStorageInterface $storage */
       $storage = $this->entityTypeManager->getStorage($this->entityType);
@@ -214,7 +237,7 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
       }
       return $this->accessControlHandler->access($revision, "view", $account, TRUE);
     }
-    catch (MissingObjectException | \InvalidArgumentException $e) {
+    catch (MissingObjectException $e) {
       // If the item does not exist, assume "allowed" and let the controller
       // handle the 404 response.
       return AccessResult::allowed();
@@ -232,7 +255,7 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
    * @return \Drupal\Core\Entity\EntityInterface
    *   The entity corresponding to the schema and item ID.
    *
-   * @throws \InvalidArgumentException
+   * @throws \Drupal\metastore\Exception\MissingObjectException
    *   If no entity is found for the given schema ID and item ID.
    */
   protected function getEntity(string $schema_id, string $identifier): EntityInterface {
@@ -243,7 +266,7 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
     catch (\Throwable $e) {
       throw new MissingObjectException("No item found for schema ID '$schema_id' and identifier '$identifier'.", 0, $e);
     }
-    assert($item->getSchemaId() === $schema_id, \InvalidArgumentException::class);
+    assert($item->getSchemaId() === $schema_id, MissingObjectException::class);
     return $item->getEntity();
   }
 

--- a/modules/metastore/src/Controller/MetastoreAccessManager.php
+++ b/modules/metastore/src/Controller/MetastoreAccessManager.php
@@ -97,6 +97,8 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
    *   The item ID.
    * @param \Drupal\Core\Session\AccountInterface $account
    *   The user account.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The HTTP request object.
    *
    * @return \Drupal\Core\Access\AccessResult
    *   An access result object indicating whether the user can update the item.

--- a/modules/metastore/src/Controller/MetastoreAccessManager.php
+++ b/modules/metastore/src/Controller/MetastoreAccessManager.php
@@ -247,26 +247,4 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
     return $item->getEntity();
   }
 
-  /**
-   * Get the workflow ID for a given entity type and bundle.
-   *
-   * @return string|null
-   *   The workflow ID, or NULL if none is assigned.
-   */
-  protected function getWorkflowIdForBundle(): ?string {
-    /** @var \Drupal\workflows\WorkflowInterface[] $workflows */
-    $workflows = $this->entityTypeManager->getStorage('workflow')->loadMultiple();
-    foreach ($workflows as $workflow) {
-      /** @var \Drupal\metastore\Controller\ContentModerationInterface $type_plugin */
-      $type_plugin = $workflow->getTypePlugin();
-      $entity_types = $type_plugin->getEntityTypes();
-      $bundles = $type_plugin->getBundlesForEntityType($this->entityType);
-
-      if (in_array($this->entityType, $entity_types) && in_array($this->bundle, $bundles)) {
-        return $workflow->id();
-      }
-    }
-    return NULL;
-  }
-
 }

--- a/modules/metastore/src/Controller/MetastoreAccessManager.php
+++ b/modules/metastore/src/Controller/MetastoreAccessManager.php
@@ -10,8 +10,8 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore\Factory\MetastoreEntityItemFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Manages access control for Metastore items in API endpoints.
@@ -101,13 +101,23 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
    * @return \Drupal\Core\Access\AccessResult
    *   An access result object indicating whether the user can update the item.
    */
-  public function canUpdate(string $schema_id, string $identifier, AccountInterface $account): AccessResult {
+  public function canUpdate(
+    string $schema_id,
+    string $identifier,
+    AccountInterface $account,
+    Request $request,
+  ): AccessResult {
+    $method = $request->getMethod();
     // Check if the user has permission to update items of this schema.
     try {
       $entity = $this->getEntity($schema_id, $identifier);
       return $this->accessControlHandler->access($entity, "update", $account, TRUE);
     }
     catch (MissingObjectException | \InvalidArgumentException $e) {
+      // If this is a PUT, we should check if user has CREATE permission.
+      if ($method === 'PUT' && !$this->canCreate($schema_id, $account)->isAllowed()) {
+        return AccessResult::forbidden();
+      }
       // If the the item does not exist, assume "allowed" and let the controller
       // handle the 404 response.
       return AccessResult::allowed();

--- a/modules/metastore/src/Controller/MetastoreAccessManager.php
+++ b/modules/metastore/src/Controller/MetastoreAccessManager.php
@@ -2,35 +2,51 @@
 
 namespace Drupal\metastore\Controller;
 
-use Contracts\FactoryInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityAccessControlHandlerInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\metastore\Factory\MetastoreEntityItemFactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class MetastoreAccessManager implements ContainerInjectionInterface {
 
   /**
-   * The entity type manager service.
+   * Access control handler for data entities.
    */
-  protected EntityTypeManagerInterface $entityTypeManager;
+  protected EntityAccessControlHandlerInterface $accessControlHandler;
 
   /**
    * Metastore Storage Factory service.
    */
-  protected FactoryInterface $storageFactory;
+  protected MetastoreEntityItemFactoryInterface $itemFactory;
+
+  /**
+   * Entity type ID for the items managed by this factory.
+   */
+  protected string $entityType;
+
+  /**
+   * Bundle ID for the items managed by this factory.
+   *
+   * Right now this class only supports a single bundle per factory,
+   * although in theory the factory supports a mapping of schema IDs
+   * to bundles. In the future, this could be extended to support
+   * multiple bundles if needed.
+   */
+  protected string $bundle;
 
   /**
    * Constructor.
    */
   public function __construct(
     EntityTypeManagerInterface $entityTypeManager,
-    FactoryInterface $storageFactory,
+    MetastoreEntityItemFactoryInterface $itemFactory,
   ) {
-    $this->entityTypeManager = $entityTypeManager;
-    $this->storageFactory = $storageFactory;
-
-    
+    $this->entityType = $itemFactory->getEntityType();
+    $this->bundle = reset($itemFactory->getBundles());
+    $this->accessControlHandler = $entityTypeManager->getAccessControlHandler($this->entityType);
   }
 
   /**
@@ -39,7 +55,7 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('entity_type.manager'),
-      $container->get('metastore.storage')
+      $container->get('metastore.entity_item_factory'),
     );
   }
 
@@ -55,8 +71,58 @@ class MetastoreAccessManager implements ContainerInjectionInterface {
    *   TRUE if the user can create an item, FALSE otherwise.
    */
   public function canCreate(AccountInterface $account): bool {
-    // Check if the user has permission to create items from the schema.
-    return $this->accessControlHandler->createAccess('data', $account);
+    return $this->accessControlHandler->createAccess($this->bundle, $account);
+  }
+
+  /**
+   * Check if user can update an item from a schema.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   * @param string $schema_id
+   *   The schema ID.
+   * @param string $item_id
+   *   The item ID.
+   *
+   * @return bool
+   *   TRUE if the user can update the item, FALSE otherwise.
+   */
+  public function canUpdate(AccountInterface $account, string $schema_id, string $item_id): bool {
+    // Check if the user has permission to update items of this schema.
+    $entity = $this->getEntity($schema_id, $item_id);
+    return $this->accessControlHandler->access($entity, "update", $account);
+  }
+
+  /**
+   * Check if user can delete an item from a schema.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user account.
+   * @param string $schema_id
+   *   The schema ID.
+   * @param string $item_id
+   *   The item ID.
+   *
+   * @return bool
+   *   TRUE if the user can delete the item, FALSE otherwise.
+   */
+  public function canDelete(AccountInterface $account, string $schema_id, string $item_id): bool {
+    // Check if the user has permission to delete items of this schema.
+    $entity = $this->getEntity($schema_id, $item_id);
+    return $this->accessControlHandler->access($entity, "delete", $account);
+  }
+
+  protected function getEntity(string $schema_id, string $item_id): EntityInterface {
+    // Load the entity based on schema ID and item ID.
+    $item = $this->itemFactory->getInstance($item_id);
+    if ($item && $item->getSchemaId() === $schema_id) {
+      return $item->getEntity();
+    }
+    throw new \InvalidArgumentException(sprintf(
+      'No entity found for schema ID %s and item ID %s.',
+      $schema_id,
+      $item_id
+    ));
   }
 
 }

--- a/modules/metastore/src/Controller/MetastoreController.php
+++ b/modules/metastore/src/Controller/MetastoreController.php
@@ -45,8 +45,6 @@ class MetastoreController implements ContainerInjectionInterface {
   private MetastoreApiResponse $apiResponse;
 
   /**
-   * Inherited.
-   *
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {

--- a/modules/metastore/src/Controller/MetastoreRevisionController.php
+++ b/modules/metastore/src/Controller/MetastoreRevisionController.php
@@ -68,7 +68,7 @@ class MetastoreRevisionController implements ContainerInjectionInterface {
    */
   public function __construct(
     MetastoreApiResponse $apiResponse,
-    FactoryInterface $storageFactory
+    FactoryInterface $storageFactory,
   ) {
     $this->apiResponse = $apiResponse;
     $this->storageFactory = $storageFactory;

--- a/modules/metastore/src/Factory/MetastoreEntityItemFactoryInterface.php
+++ b/modules/metastore/src/Factory/MetastoreEntityItemFactoryInterface.php
@@ -22,6 +22,9 @@ interface MetastoreEntityItemFactoryInterface extends MetastoreItemFactoryInterf
   /**
    * Get the bundles, if any, used by this factory for storing item entities.
    *
+   * If multiple bundles are used, they should be returned as a keyed array,
+   * in the format ['schema_id' => 'bundle'].
+   *
    * @return array
    *   Array of bundle IDs.
    */

--- a/modules/metastore/src/Factory/MetastoreItemFactoryInterface.php
+++ b/modules/metastore/src/Factory/MetastoreItemFactoryInterface.php
@@ -13,6 +13,11 @@ use Drupal\metastore\MetastoreItemInterface;
  * Used for service dkan.metastore.metastore_item_factory. Decorate the service
  * to use different logic for producing a MetastoreItemInterface object from
  * just an identifier.
+ *
+ * Note that many DKAN services expect the MetastoreEntityItemFactoryInterface
+ * child interface, which extends this one. As there is not a clear use-case
+ * for non-entity-based metastore items, this interface may be deprecated or
+ * combined with the child interface.
  */
 interface MetastoreItemFactoryInterface extends FactoryInterface {
 

--- a/modules/metastore/src/MetastoreItemInterface.php
+++ b/modules/metastore/src/MetastoreItemInterface.php
@@ -57,4 +57,15 @@ interface MetastoreItemInterface extends CacheableDependencyInterface {
    */
   public function isNew();
 
+  /**
+   * Get the relevant entity.
+   *
+   * If the implementation is an entity itself, this should simply
+   * return $this.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   The wrapped entity.
+   */
+  public function getEntity();
+
 }

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -445,10 +445,8 @@ class MetastoreService implements ContainerInjectionInterface {
    */
   public function delete($schema_id, $identifier) {
     $storage = $this->getStorage($schema_id);
-    $result = $storage->remove($identifier);
-    if (!$result) {
-      throw new MissingObjectException("No data with the identifier {$identifier} was found.", 404);
-    }
+    $storage->remove($identifier);
+    // If remove method did not throw an exception, assume the item was deleted.
     return $identifier;
   }
 

--- a/modules/metastore/src/MetastoreService.php
+++ b/modules/metastore/src/MetastoreService.php
@@ -445,8 +445,10 @@ class MetastoreService implements ContainerInjectionInterface {
    */
   public function delete($schema_id, $identifier) {
     $storage = $this->getStorage($schema_id);
-    $storage->remove($identifier);
-    // If remove method did not throw an exception, assume the item was deleted.
+    $result = $storage->remove($identifier);
+    if (!$result) {
+      throw new MissingObjectException("No data with the identifier {$identifier} was found.", 404);
+    }
     return $identifier;
   }
 

--- a/modules/metastore/src/NodeWrapper/Data.php
+++ b/modules/metastore/src/NodeWrapper/Data.php
@@ -86,7 +86,7 @@ class Data implements MetastoreItemInterface {
    *
    * @todo Needing to call fix() on every method seems like a code smell.
    */
-  private function fix() {
+  protected function fix() {
     $this->fixDataType();
     $this->saveRawMetadata();
   }
@@ -196,7 +196,7 @@ class Data implements MetastoreItemInterface {
    */
   public function getSchemaId() {
     $this->fix();
-    return $this->node->get('field_data_type')->getString();
+    return $this->getEntity()->get('field_data_type')->getString();
   }
 
   /**

--- a/modules/metastore/src/NodeWrapper/Data.php
+++ b/modules/metastore/src/NodeWrapper/Data.php
@@ -305,4 +305,14 @@ class Data implements MetastoreItemInterface {
     $this->node->save();
   }
 
+  /**
+   * Get the node entity.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   The wrapped node entity.
+   */
+  public function getEntity() {
+    return $this->node;
+  }
+
 }

--- a/modules/metastore/src/Storage/NodeData.php
+++ b/modules/metastore/src/Storage/NodeData.php
@@ -18,7 +18,7 @@ class NodeData extends Data {
     string $schemaId,
     EntityTypeManagerInterface $entityTypeManager,
     ConfigFactoryInterface $config_factory,
-    LoggerInterface $loggerChannel
+    LoggerInterface $loggerChannel,
   ) {
     $this->entityType = 'node';
     $this->bundle = 'data';

--- a/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\metastore\Functional\Api1;
 
-use Composer\DependencyResolver\Request;
 use Drupal\Tests\common\Functional\Api1TestBase;
 use GuzzleHttp\RequestOptions;
 

--- a/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\metastore\Functional\Api1;
 
+use Composer\DependencyResolver\Request;
 use Drupal\Tests\common\Functional\Api1TestBase;
 use GuzzleHttp\RequestOptions;
 
@@ -73,6 +74,7 @@ class DatasetItemTest extends Api1TestBase {
     $response = $this->httpClient->patch("$this->endpoint/$datasetId", [
       RequestOptions::JSON => $newTitle,
       RequestOptions::AUTH => $this->auth,
+      RequestOptions::HTTP_ERRORS => FALSE,
     ]);
 
     $this->assertEquals(200, $response->getStatusCode());
@@ -81,6 +83,14 @@ class DatasetItemTest extends Api1TestBase {
 
     $dataset->title = $newTitle->title;
     $this->assertDatasetGet($dataset);
+
+    // Now an unauthorized user.
+    $response = $this->httpClient->patch("{$this->endpoint}/{$datasetId}", [
+      RequestOptions::HTTP_ERRORS => FALSE,
+      RequestOptions::JSON => [],
+      RequestOptions::AUTH => $this->authNoPerms,
+    ]);
+    $this->assertEquals(403, $response->getStatusCode());
 
     // Now, try with a non-existent identifier.
     $datasetId = "abc-123";
@@ -94,14 +104,6 @@ class DatasetItemTest extends Api1TestBase {
 
     $this->assertEquals(404, $response->getStatusCode());
     $this->validator->validate($response, "$this->endpoint/$datasetId", 'patch');
-
-    // Now an unauthorized user.
-    $response = $this->httpClient->patch("{$this->endpoint}/{$datasetId}", [
-      RequestOptions::HTTP_ERRORS => FALSE,
-      RequestOptions::JSON => [],
-      RequestOptions::AUTH => $this->authNoPerms,
-    ]);
-    $this->assertEquals(403, $response->getStatusCode());
   }
 
   public function testPut() {
@@ -120,6 +122,14 @@ class DatasetItemTest extends Api1TestBase {
     $this->validator->validate($response, "$this->endpoint/$datasetId", 'put');
     $this->assertDatasetGet($newDataset);
 
+    // Now an unauthorized user.
+    $response = $this->httpClient->put("{$this->endpoint}/{$datasetId}", [
+      RequestOptions::JSON => $newDataset,
+      RequestOptions::AUTH => $this->authNoPerms,
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(403, $response->getStatusCode());
+
     // Now try with mismatched identifiers.
     $datasetId = 'abc-123';
     $response = $this->httpClient->put("$this->endpoint/$datasetId", [
@@ -129,15 +139,6 @@ class DatasetItemTest extends Api1TestBase {
     ]);
     $this->assertEquals(409, $response->getStatusCode());
     $this->validator->validate($response, "$this->endpoint/$datasetId", 'put');
-
-    // Now an unauthorized user.
-    $response = $this->httpClient->put("{$this->endpoint}/{$datasetId}", [
-      RequestOptions::JSON => $newDataset,
-      RequestOptions::AUTH => $this->authNoPerms,
-      RequestOptions::HTTP_ERRORS => FALSE,
-    ]);
-    $this->assertEquals(403, $response->getStatusCode());
-
   }
 
   public function testDelete() {
@@ -155,7 +156,9 @@ class DatasetItemTest extends Api1TestBase {
     // Now delete as authorized user.
     $this->assertDatasetGet($dataset);
     $response = $this->httpClient->delete("{$this->endpoint}/{$datasetId}", [
+      RequestOptions::HTTP_ERRORS => FALSE,
       RequestOptions::AUTH => $this->auth,
+      RequestOptions::TIMEOUT => 100,
     ]);
     // @todo Add delete to the spec so we can validate it.
     $this->assertEquals(200, $response->getStatusCode());

--- a/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetItemTest.php
@@ -92,7 +92,8 @@ class DatasetItemTest extends Api1TestBase {
     ]);
     $this->assertEquals(403, $response->getStatusCode());
 
-    // Now, try with a non-existent identifier.
+    // Now, try with a non-existent identifier. Should be 404 with or without
+    // permissions.
     $datasetId = "abc-123";
     $newTitle = (object) ['title' => 'Modified Title'];
 
@@ -101,9 +102,15 @@ class DatasetItemTest extends Api1TestBase {
       RequestOptions::JSON => $newTitle,
       RequestOptions::AUTH => $this->auth,
     ]);
-
     $this->assertEquals(404, $response->getStatusCode());
     $this->validator->validate($response, "$this->endpoint/$datasetId", 'patch');
+
+    $response = $this->httpClient->patch("$this->endpoint/$datasetId", [
+      RequestOptions::HTTP_ERRORS => FALSE,
+      RequestOptions::JSON => $newTitle,
+      RequestOptions::AUTH => $this->authNoPerms,
+    ]);
+    $this->assertEquals(404, $response->getStatusCode());
   }
 
   public function testPut() {
@@ -114,6 +121,7 @@ class DatasetItemTest extends Api1TestBase {
     $newDataset = $this->getSampleDataset(1);
     $newDataset->identifier = $datasetId;
 
+    // Update the dataset with a PUT request and valid perms.
     $response = $this->httpClient->put("$this->endpoint/$datasetId", [
       RequestOptions::JSON => $newDataset,
       RequestOptions::AUTH => $this->auth,
@@ -122,7 +130,7 @@ class DatasetItemTest extends Api1TestBase {
     $this->validator->validate($response, "$this->endpoint/$datasetId", 'put');
     $this->assertDatasetGet($newDataset);
 
-    // Now an unauthorized user.
+    // Now try as an unauthorized user.
     $response = $this->httpClient->put("{$this->endpoint}/{$datasetId}", [
       RequestOptions::JSON => $newDataset,
       RequestOptions::AUTH => $this->authNoPerms,
@@ -139,6 +147,27 @@ class DatasetItemTest extends Api1TestBase {
     ]);
     $this->assertEquals(409, $response->getStatusCode());
     $this->validator->validate($response, "$this->endpoint/$datasetId", 'put');
+
+    // Now try with a non-existent identifier, without perms.
+    $datasetId = 'non-existent-123';
+    $newDataset->identifier = $datasetId;
+    $response = $this->httpClient->put("$this->endpoint/$datasetId", [
+      RequestOptions::JSON => $newDataset,
+      RequestOptions::AUTH => $this->authNoPerms,
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    // Should get a 403, as this is essentially a create we aren't allowed.
+    $this->assertEquals(403, $response->getStatusCode());
+
+    // Try again with a valid user.
+    $response = $this->httpClient->put("$this->endpoint/$datasetId", [
+      RequestOptions::JSON => $newDataset,
+      RequestOptions::AUTH => $this->auth,
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    // Should get a 201, created.
+    $this->validator->validate($response, "$this->endpoint/$datasetId", 'put');
+    $this->assertEquals(201, $response->getStatusCode());
   }
 
   public function testDelete() {
@@ -169,10 +198,16 @@ class DatasetItemTest extends Api1TestBase {
     ]);
     $this->assertEquals(404, $response->getStatusCode());
 
-    // Try to delete a non-existent dataset.
+    // Try to delete a non-existent dataset. This should return 404 even if the
+    // user does not have delete permissions.
     $datasetId = 'abc-123';
     $response = $this->httpClient->delete("{$this->endpoint}/{$datasetId}", [
       RequestOptions::AUTH => $this->auth,
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(404, $response->getStatusCode());
+    $response = $this->httpClient->delete("{$this->endpoint}/{$datasetId}", [
+      RequestOptions::AUTH => $this->authNoPerms,
       RequestOptions::HTTP_ERRORS => FALSE,
     ]);
     $this->assertEquals(404, $response->getStatusCode());

--- a/modules/metastore/tests/src/Functional/Api1/DatasetRevisionTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetRevisionTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\metastore\Functional\Api1;
 
+use Composer\DependencyResolver\Request;
 use Drupal\Tests\common\Functional\Api1TestBase;
 use GuzzleHttp\RequestOptions;
 
@@ -134,6 +135,7 @@ class DatasetRevisionTest extends Api1TestBase {
       // Validate URL and contents of response object.
       $response = $this->httpClient->get($responseBody->endpoint, [
         RequestOptions::AUTH => $this->auth,
+        RequestOptions::CONNECT_TIMEOUT => 1000,
       ]);
       $responseBody = json_decode($response->getBody());
       // Message and state match the values submitted.
@@ -196,7 +198,7 @@ class DatasetRevisionTest extends Api1TestBase {
     return $this->httpClient->post($this->endpoint, [
       RequestOptions::JSON => $newRevision,
       RequestOptions::AUTH => $this->auth,
-      RequestOptions::HTTP_ERRORS => FALSE,
+      // RequestOptions::HTTP_ERRORS => FALSE,
     ]);
   }
 

--- a/modules/metastore/tests/src/Functional/Api1/DatasetRevisionTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetRevisionTest.php
@@ -10,8 +10,9 @@ use GuzzleHttp\RequestOptions;
  * Tests the revision API.
  *
  * @group functional2
+ * @group metastore
  *
- * @coversDefaultClass \Drupal\metastore\Plugin\rest\resource\DatasetItemResource
+ * @coversDefaultClass \Drupal\metastore\Controller\MetastoreRevisionController
  */
 class DatasetRevisionTest extends Api1TestBase {
 
@@ -116,9 +117,8 @@ class DatasetRevisionTest extends Api1TestBase {
     $states = [
       'draft' => FALSE,
       'published' => TRUE,
-      'orphaned' => FALSE,
-      'archived' => FALSE,
       'hidden' => TRUE,
+      'archived' => FALSE,
     ];
 
     $count = 1;
@@ -135,8 +135,9 @@ class DatasetRevisionTest extends Api1TestBase {
       // Validate URL and contents of response object.
       $response = $this->httpClient->get($responseBody->endpoint, [
         RequestOptions::AUTH => $this->auth,
-        RequestOptions::CONNECT_TIMEOUT => 1000,
+        RequestOptions::HTTP_ERRORS => FALSE,
       ]);
+      $this->assertEquals(200, $response->getStatusCode());
       $responseBody = json_decode($response->getBody());
       // Message and state match the values submitted.
       $this->assertStringContainsString($state, $responseBody->message);
@@ -145,7 +146,9 @@ class DatasetRevisionTest extends Api1TestBase {
       // Confirm revisions list has increased by one item.
       $response = $this->httpClient->get($this->endpoint, [
         RequestOptions::AUTH => $this->auth,
+        RequestOptions::HTTP_ERRORS => FALSE,
       ]);
+      $this->assertEquals(200, $response->getStatusCode());
       $responseBody = json_decode($response->getBody());
       $this->assertEquals($count, count($responseBody));
 
@@ -158,6 +161,9 @@ class DatasetRevisionTest extends Api1TestBase {
       $this->assertEquals($expectedCode, $response->getStatusCode());
     }
 
+    // Reset state.
+    $response = $this->newRevision('published');
+    $count++;
     // Test a bad workflow state.
     $response = $this->newRevision('foo');
     $this->assertEquals(400, $response->getStatusCode());
@@ -198,7 +204,8 @@ class DatasetRevisionTest extends Api1TestBase {
     return $this->httpClient->post($this->endpoint, [
       RequestOptions::JSON => $newRevision,
       RequestOptions::AUTH => $this->auth,
-      // RequestOptions::HTTP_ERRORS => FALSE,
+      RequestOptions::HTTP_ERRORS => FALSE,
+      RequestOptions::TIMEOUT => 1000,
     ]);
   }
 

--- a/modules/metastore/tests/src/Functional/Api1/DatasetRevisionTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetRevisionTest.php
@@ -45,6 +45,13 @@ class DatasetRevisionTest extends Api1TestBase {
     $responseBody = json_decode($response->getBody());
     $this->assertEquals($listRevision, $responseBody);
 
+    // Try to get the list without permissions
+    $response = $this->httpClient->get($this->endpoint . "/$listRevision->identifier", [
+      RequestOptions::AUTH => $this->authNoPerms,
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(403, $response->getStatusCode());
+
     // Confirm error if we have a non-existant dataset ID.
     $badDatasetUrl = "/api/1/metastore/schemas/dataset/items/abc-123/revisions/$listRevision->identifier";
     $response = $this->httpClient->get($badDatasetUrl, [
@@ -112,6 +119,17 @@ class DatasetRevisionTest extends Api1TestBase {
       RequestOptions::JSON => $data,
       RequestOptions::AUTH => $this->auth,
     ]);
+
+    // Try to create a new revision without permissions.
+    $result = $this->httpClient->post($this->endpoint, [
+      RequestOptions::JSON => (object) [
+        'message' => "Unauthorized revision.",
+        'state' => 'published',
+      ],
+      RequestOptions::AUTH => $this->authNoPerms,
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(403, $result->getStatusCode());
 
     // Array with states as keys and whether publicly visible as values.
     $states = [
@@ -205,7 +223,6 @@ class DatasetRevisionTest extends Api1TestBase {
       RequestOptions::JSON => $newRevision,
       RequestOptions::AUTH => $this->auth,
       RequestOptions::HTTP_ERRORS => FALSE,
-      RequestOptions::TIMEOUT => 1000,
     ]);
   }
 

--- a/modules/metastore/tests/src/Functional/Api1/DatasetRevisionTest.php
+++ b/modules/metastore/tests/src/Functional/Api1/DatasetRevisionTest.php
@@ -37,6 +37,13 @@ class DatasetRevisionTest extends Api1TestBase {
     $responseBody = json_decode($response->getBody());
     $listRevision = $responseBody[0];
 
+    // Try to get the list without permissions.
+    $response = $this->httpClient->get($this->endpoint, [
+      RequestOptions::AUTH => $this->authNoPerms,
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(403, $response->getStatusCode());
+
     // Confirm we get the same object from the item get as the list.
     $response = $this->httpClient->get($this->endpoint . "/$listRevision->identifier", [
       RequestOptions::AUTH => $this->auth,
@@ -45,12 +52,11 @@ class DatasetRevisionTest extends Api1TestBase {
     $responseBody = json_decode($response->getBody());
     $this->assertEquals($listRevision, $responseBody);
 
-    // Try to get the list without permissions
+    // This revision is public, so should not need perms to see it.
     $response = $this->httpClient->get($this->endpoint . "/$listRevision->identifier", [
       RequestOptions::AUTH => $this->authNoPerms,
-      RequestOptions::HTTP_ERRORS => FALSE,
     ]);
-    $this->assertEquals(403, $response->getStatusCode());
+    $this->assertEquals(200, $response->getStatusCode());
 
     // Confirm error if we have a non-existant dataset ID.
     $badDatasetUrl = "/api/1/metastore/schemas/dataset/items/abc-123/revisions/$listRevision->identifier";

--- a/modules/metastore/tests/src/Kernel/Controller/MetastoreAccessManagerTest.php
+++ b/modules/metastore/tests/src/Kernel/Controller/MetastoreAccessManagerTest.php
@@ -90,10 +90,7 @@ class MetastoreAccessManagerTest extends KernelTestBase {
       ->add(FieldItemListInterface::class, 'getString', 'dataset')
       ->getMock();
 
-    $this->accessManager = new MetastoreAccessManager(
-      $this->container->get('entity_type.manager'),
-      $itemFactory
-    );
+    $this->container->set('dkan.metastore.metastore_item_factory', $itemFactory);
 
     $this->priviledgedUser = $this->createUser([
       'access content',
@@ -112,13 +109,17 @@ class MetastoreAccessManagerTest extends KernelTestBase {
    * Tests the canCreate() method.
    *
    * @covers ::canCreate
+   * @covers ::create
+   * @covers ::__construct
    */
   public function testCanCreate(): void {
     $schema_id = 'example_schema';
-    $can_create = $this->accessManager->canCreate($schema_id, $this->priviledgedUser);
+    $accessManager = MetastoreAccessManager::create($this->container);
+
+    $can_create = $accessManager->canCreate($schema_id, $this->priviledgedUser);
     $this->assertTrue($can_create->isAllowed());
 
-    $can_create = $this->accessManager->canCreate($schema_id, $this->unpriviledgedUser);
+    $can_create = $accessManager->canCreate($schema_id, $this->unpriviledgedUser);
     $this->assertFalse($can_create->isAllowed());
   }
 
@@ -126,85 +127,95 @@ class MetastoreAccessManagerTest extends KernelTestBase {
    * Tests the canUpdate method.
    *
    * @covers ::canUpdate
+   * @covers ::getEntity
    */
   public function testCanUpdate(): void {
+    $accessManager = MetastoreAccessManager::create($this->container);
     $schema_id = 'dataset';
     $item_id = '123';
     // Create a dummy post request
     $request = new Request([], [], [], [], [], ['REQUEST_METHOD' => 'POST']);
 
-    $can_update = $this->accessManager->canUpdate($schema_id, $item_id, $this->priviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, $item_id, $this->priviledgedUser, $request);
     $this->assertTrue($can_update->isAllowed());
-    $can_update = $this->accessManager->canUpdate($schema_id, $item_id, $this->unpriviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, $item_id, $this->unpriviledgedUser, $request);
     $this->assertFalse($can_update->isAllowed());
 
     // We should be "allowed" to update a non-existant item, the controller will
     // handle the 404 response.
-    $can_update = $this->accessManager->canUpdate($schema_id, '345', $this->priviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, '345', $this->priviledgedUser, $request);
     $this->assertTrue($can_update->isAllowed());
-    $can_update = $this->accessManager->canUpdate($schema_id, '345', $this->unpriviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, '345', $this->unpriviledgedUser, $request);
     $this->assertTrue($can_update->isAllowed());
 
     // Now try with a PUT request, which should check for create permissions if 
     // non-existant node.
     $request->setMethod('PUT');
-    $can_update = $this->accessManager->canUpdate($schema_id, '123', $this->priviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, '123', $this->priviledgedUser, $request);
     $this->assertTrue($can_update->isAllowed());
-    $can_update = $this->accessManager->canUpdate($schema_id, '123', $this->unpriviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, '123', $this->unpriviledgedUser, $request);
     $this->assertFalse($can_update->isAllowed());
 
     $request->setMethod('PUT');
-    $can_update = $this->accessManager->canUpdate($schema_id, '345', $this->priviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, '345', $this->priviledgedUser, $request);
     $this->assertTrue($can_update->isAllowed());
-    $can_update = $this->accessManager->canUpdate($schema_id, '345', $this->unpriviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, '345', $this->unpriviledgedUser, $request);
     $this->assertFalse($can_update->isAllowed());
 
     // Now try with a PATCH request
     $request->setMethod('PATCH');
-    $can_update = $this->accessManager->canUpdate($schema_id, '123', $this->priviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, '123', $this->priviledgedUser, $request);
     $this->assertTrue($can_update->isAllowed());
-    $can_update = $this->accessManager->canUpdate($schema_id, '123', $this->unpriviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, '123', $this->unpriviledgedUser, $request);
     $this->assertFalse($can_update->isAllowed());
   }
 
   /**
    * Tests the canDelete method.
    *
+   * @covers ::create
+   * @covers ::__construct
    * @covers ::canDelete
+   * @covers ::getEntity
    */
   public function testCanDelete(): void {
     $schema_id = 'dataset';
     $item_id = '123';
+    $accessManager = MetastoreAccessManager::create($this->container);
 
-    $can_delete = $this->accessManager->canDelete($schema_id, $item_id, $this->priviledgedUser);
+    $can_delete = $accessManager->canDelete($schema_id, $item_id, $this->priviledgedUser);
     $this->assertTrue($can_delete->isAllowed());
-    $can_delete = $this->accessManager->canDelete($schema_id, $item_id, $this->unpriviledgedUser);
+    $can_delete = $accessManager->canDelete($schema_id, $item_id, $this->unpriviledgedUser);
     $this->assertFalse($can_delete->isAllowed());
 
     // Test with a non-existant item. Should always be allowed, controller handles.
-    $can_delete = $this->accessManager->canDelete($schema_id, '345', $this->priviledgedUser);
+    $can_delete = $accessManager->canDelete($schema_id, '345', $this->priviledgedUser);
     $this->assertTrue($can_delete->isAllowed());
-    $can_delete = $this->accessManager->canDelete($schema_id, '345', $this->unpriviledgedUser);
+    $can_delete = $accessManager->canDelete($schema_id, '345', $this->unpriviledgedUser);
     $this->assertTrue($can_delete->isAllowed());
   }
 
   /**
    * Tests if a user can view the revision list of a dataset.
    *
+   * @covers ::create
+   * @covers ::__construct
+   * @covers ::getEntity
    * @covers ::canViewRevisionList
    */
   public function testCanViewRevisionList(): void {
+    $accessManager = MetastoreAccessManager::create($this->container);
     $schema_id = 'dataset';
     $item_id = '123';
 
-    $can_view = $this->accessManager->canViewRevisionList($schema_id, $item_id, $this->priviledgedUser);
+    $can_view = $accessManager->canViewRevisionList($schema_id, $item_id, $this->priviledgedUser);
     $this->assertTrue($can_view->isAllowed());
 
-    $can_view = $this->accessManager->canViewRevisionList($schema_id, $item_id, $this->unpriviledgedUser);
+    $can_view = $accessManager->canViewRevisionList($schema_id, $item_id, $this->unpriviledgedUser);
     $this->assertFalse($can_view->isAllowed());
 
     // Non-existant item should be allowed, controller handles.
-    $can_view = $this->accessManager->canViewRevisionList($schema_id, '345', $this->unpriviledgedUser);
+    $can_view = $accessManager->canViewRevisionList($schema_id, '345', $this->unpriviledgedUser);
     $this->assertTrue($can_view->isAllowed());
   }
 

--- a/modules/metastore/tests/src/Kernel/Controller/MetastoreAccessManagerTest.php
+++ b/modules/metastore/tests/src/Kernel/Controller/MetastoreAccessManagerTest.php
@@ -37,14 +37,9 @@ class MetastoreAccessManagerTest extends KernelTestBase {
   protected MetastoreAccessManager $accessManager;
 
   /**
-   * A user with permissions to work with the metastore.
-   */
-  protected AccountInterface $priviledgedUser;
-
-  /**
    * A user without permissions to work with the metastore.
    */
-  protected AccountInterface $unpriviledgedUser;
+  protected AccountInterface $unprivilegedUser;
 
   /**
    * A user with the legacy perm 'post put delete datasets through the api'.
@@ -90,6 +85,8 @@ class MetastoreAccessManagerTest extends KernelTestBase {
       ->add(NodeInterface::class, 'get', FieldItemListInterface::class)
       ->add(NodeInterface::class, 'language', LanguageInterface::class)
       ->add(NodeInterface::class, 'getEntityType', EntityTypeInterface::class)
+      ->add(NodeInterface::class, 'getEntityTypeId', 'node')
+      ->add(NodeInterface::class, 'id', '123')
       ->add(EntityTypeInterface::class, 'id', 'node')
       ->add(LanguageInterface::class, 'getId', 'en')
       ->add(FieldItemListInterface::class, 'getString', 'dataset')
@@ -97,15 +94,9 @@ class MetastoreAccessManagerTest extends KernelTestBase {
 
     $this->container->set('dkan.metastore.metastore_item_factory', $itemFactory);
 
-    $this->priviledgedUser = $this->createUser([
-      'access content',
-      'create data content',
-      'edit own data content',
-      'delete own data content',
-      'use dkan_publishing transition publish',
-      'use dkan_publishing transition archive',
-    ], 'privileged_user');
-    $this->unpriviledgedUser = $this->createUser([
+    $this->createUser([], 'superuser', TRUE);
+
+    $this->unprivilegedUser = $this->createUser([
       'access content',
     ], 'unprivileged_user');
     $this->legacyPermUser = $this->createUser([
@@ -124,10 +115,15 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     $schema_id = 'example_schema';
     $accessManager = MetastoreAccessManager::create($this->container);
 
-    $can_create = $accessManager->canCreate($schema_id, $this->priviledgedUser);
+    $privilegedUser = $this->createUser([
+      'access content',
+      'create data content',
+    ], 'privileged_user', FALSE);
+
+    $can_create = $accessManager->canCreate($schema_id, $privilegedUser);
     $this->assertTrue($can_create->isAllowed());
 
-    $can_create = $accessManager->canCreate($schema_id, $this->unpriviledgedUser);
+    $can_create = $accessManager->canCreate($schema_id, $this->unprivilegedUser);
     $this->assertFalse($can_create->isAllowed());
 
     $can_create = $accessManager->canCreate($schema_id, $this->legacyPermUser);
@@ -147,43 +143,59 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     // Create a dummy post request
     $request = new Request([], [], [], [], [], ['REQUEST_METHOD' => 'POST']);
 
-    $can_update = $accessManager->canUpdate($schema_id, $item_id, $this->priviledgedUser, $request);
+    $privilegedUser = $this->createUser([
+      'access content',
+      'edit any data content',
+    ], 'privileged_user', FALSE);
+
+    $can_update = $accessManager->canUpdate($schema_id, $item_id, $privilegedUser, $request);
     $this->assertTrue($can_update->isAllowed());
-    $can_update = $accessManager->canUpdate($schema_id, $item_id, $this->unpriviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, $item_id, $this->unprivilegedUser, $request);
     $this->assertFalse($can_update->isAllowed());
     $can_update = $accessManager->canUpdate($schema_id, $item_id, $this->legacyPermUser, $request);
     $this->assertTrue($can_update->isAllowed());
 
     // We should be "allowed" to update a non-existant item, the controller will
     // handle the 404 response.
-    $can_update = $accessManager->canUpdate($schema_id, '345', $this->priviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, '345', $privilegedUser, $request);
     $this->assertTrue($can_update->isAllowed());
-    $can_update = $accessManager->canUpdate($schema_id, '345', $this->unpriviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, '345', $this->unprivilegedUser, $request);
     $this->assertTrue($can_update->isAllowed());
 
     // Now try with a PUT request, which should check for create permissions if 
     // non-existant node.
     $request->setMethod('PUT');
-    $can_update = $accessManager->canUpdate($schema_id, '123', $this->priviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, '123', $privilegedUser, $request);
     $this->assertTrue($can_update->isAllowed());
-    $can_update = $accessManager->canUpdate($schema_id, '123', $this->unpriviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, '123', $this->unprivilegedUser, $request);
     $this->assertFalse($can_update->isAllowed());
     $can_update = $accessManager->canUpdate($schema_id, '123', $this->legacyPermUser, $request);
     $this->assertTrue($can_update->isAllowed());
 
-    $request->setMethod('PUT');
-    $can_update = $accessManager->canUpdate($schema_id, '345', $this->priviledgedUser, $request);
+    // Putting again; we don't have create permission! This should return
+    // forbidden.
+    $can_update = $accessManager->canUpdate($schema_id, '345', $privilegedUser, $request);
+    $this->assertFalse($can_update->isAllowed());
+    // Change privileged user permissions
+    unset($privilegedUser);
+    $privilegedUser = $this->createUser([
+      'access content',
+      'edit any data content',
+      'create data content',
+    ], 'privileged_user2', FALSE);
+    $can_update = $accessManager->canUpdate($schema_id, '345', $privilegedUser, $request);
     $this->assertTrue($can_update->isAllowed());
-    $can_update = $accessManager->canUpdate($schema_id, '345', $this->unpriviledgedUser, $request);
+
+    $can_update = $accessManager->canUpdate($schema_id, '345', $this->unprivilegedUser, $request);
     $this->assertFalse($can_update->isAllowed());
     $can_update = $accessManager->canUpdate($schema_id, '345', $this->legacyPermUser, $request);
     $this->assertTrue($can_update->isAllowed());
 
     // Now try with a PATCH request
     $request->setMethod('PATCH');
-    $can_update = $accessManager->canUpdate($schema_id, '123', $this->priviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, '123', $privilegedUser, $request);
     $this->assertTrue($can_update->isAllowed());
-    $can_update = $accessManager->canUpdate($schema_id, '123', $this->unpriviledgedUser, $request);
+    $can_update = $accessManager->canUpdate($schema_id, '123', $this->unprivilegedUser, $request);
     $this->assertFalse($can_update->isAllowed());
     $can_update = $accessManager->canUpdate($schema_id, '123', $this->legacyPermUser, $request);
     $this->assertTrue($can_update->isAllowed());
@@ -202,17 +214,22 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     $item_id = '123';
     $accessManager = MetastoreAccessManager::create($this->container);
 
-    $can_delete = $accessManager->canDelete($schema_id, $item_id, $this->priviledgedUser);
+    $privilegedUser = $this->createUser([
+      'access content',
+      'delete any data content',
+    ], 'privileged_user', FALSE);
+
+    $can_delete = $accessManager->canDelete($schema_id, $item_id, $privilegedUser);
     $this->assertTrue($can_delete->isAllowed());
-    $can_delete = $accessManager->canDelete($schema_id, $item_id, $this->unpriviledgedUser);
+    $can_delete = $accessManager->canDelete($schema_id, $item_id, $this->unprivilegedUser);
     $this->assertFalse($can_delete->isAllowed());
     $can_delete = $accessManager->canDelete($schema_id, $item_id, $this->legacyPermUser);
     $this->assertTrue($can_delete->isAllowed());
 
     // Test with a non-existant item. Should always be allowed, controller handles.
-    $can_delete = $accessManager->canDelete($schema_id, '345', $this->priviledgedUser);
+    $can_delete = $accessManager->canDelete($schema_id, '345', $privilegedUser);
     $this->assertTrue($can_delete->isAllowed());
-    $can_delete = $accessManager->canDelete($schema_id, '345', $this->unpriviledgedUser);
+    $can_delete = $accessManager->canDelete($schema_id, '345', $this->unprivilegedUser);
     $this->assertTrue($can_delete->isAllowed());
   }
 
@@ -229,17 +246,22 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     $schema_id = 'dataset';
     $item_id = '123';
 
-    $can_view = $accessManager->canViewRevisionList($schema_id, $item_id, $this->priviledgedUser);
+    $privilegedUser = $this->createUser([
+      'access content',
+      'view data revisions',
+    ], 'privileged_user', FALSE);
+
+    $can_view = $accessManager->canViewRevisionList($schema_id, $item_id, $privilegedUser);
     $this->assertTrue($can_view->isAllowed());
 
-    $can_view = $accessManager->canViewRevisionList($schema_id, $item_id, $this->unpriviledgedUser);
+    $can_view = $accessManager->canViewRevisionList($schema_id, $item_id, $this->unprivilegedUser);
     $this->assertFalse($can_view->isAllowed());
 
     $can_view = $accessManager->canViewRevisionList($schema_id, $item_id, $this->legacyPermUser);
     $this->assertTrue($can_view->isAllowed());
 
     // Non-existant item should be allowed, controller handles.
-    $can_view = $accessManager->canViewRevisionList($schema_id, '345', $this->unpriviledgedUser);
+    $can_view = $accessManager->canViewRevisionList($schema_id, '345', $this->unprivilegedUser);
     $this->assertTrue($can_view->isAllowed());
   }
 

--- a/modules/metastore/tests/src/Kernel/Controller/MetastoreAccessManagerTest.php
+++ b/modules/metastore/tests/src/Kernel/Controller/MetastoreAccessManagerTest.php
@@ -19,8 +19,11 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Tests the MetastoreAccessManager.
  *
+ * Note, no current test for the canViewRevision() method, because it relies
+ * on static methods from the Data wrapper, which can't be mocked.
+ *
  * @coversDefaultClass \Drupal\metastore\Controller\MetastoreAccessManager
- * 
+ *
  * @group dkan
  * @group metastore
  */
@@ -59,6 +62,9 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     'text',
   ];
 
+  /**
+   * {@inheritdoc}
+   */
   public function setUp(): void {
     parent::setUp();
     // Set up the necessary services and configurations for the test.
@@ -103,7 +109,9 @@ class MetastoreAccessManagerTest extends KernelTestBase {
   }
 
   /**
-   * Tests the MetastoreAccessManager.
+   * Tests the canCreate() method.
+   *
+   * @covers ::canCreate
    */
   public function testCanCreate(): void {
     $schema_id = 'example_schema';
@@ -114,6 +122,11 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     $this->assertFalse($can_create->isAllowed());
   }
 
+  /**
+   * Tests the canUpdate method.
+   *
+   * @covers ::canUpdate
+   */
   public function testCanUpdate(): void {
     $schema_id = 'dataset';
     $item_id = '123';
@@ -154,6 +167,11 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     $this->assertFalse($can_update->isAllowed());
   }
 
+  /**
+   * Tests the canDelete method.
+   *
+   * @covers ::canDelete
+   */
   public function testCanDelete(): void {
     $schema_id = 'dataset';
     $item_id = '123';
@@ -170,6 +188,11 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     $this->assertTrue($can_delete->isAllowed());
   }
 
+  /**
+   * Tests if a user can view the revision list of a dataset.
+   *
+   * @covers ::canViewRevisionList
+   */
   public function testCanViewRevisionList(): void {
     $schema_id = 'dataset';
     $item_id = '123';
@@ -185,7 +208,4 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     $this->assertTrue($can_view->isAllowed());
   }
 
-
-
 }
-

--- a/modules/metastore/tests/src/Kernel/Controller/MetastoreAccessManagerTest.php
+++ b/modules/metastore/tests/src/Kernel/Controller/MetastoreAccessManagerTest.php
@@ -2,15 +2,14 @@
 
 namespace Drupal\Tests\metastore\Controller\Kernel;
 
-use Drupal\Core\Entity\EntityRepository;
-use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\metastore\Controller\MetastoreAccessManager;
+use Drupal\metastore\NodeWrapper\Data;
 use Drupal\metastore\NodeWrapper\NodeDataFactory;
-use Drupal\metastore\Storage\NodeData;
-use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use MockChain\Chain;
@@ -67,25 +66,27 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');
 
-
-    $repositoryOptions = (new Options)
-      ->add('123', NodeInterface::class)
-      ->index(0);
-    $entityRepository = (new Chain($this))
-      ->add(EntityRepository::class, 'loadEntityByUuid', NodeInterface::class)
+    // Mock the NodeDataFactory to return a Data wrapper with a data node mock.
+    $itemFactory = (new Chain($this))
+      ->add(NodeDataFactory::class, 'getInstance', (new Options)
+        ->add('123', Data::class)
+        ->add('345', NULL)
+        ->index(0)
+      )
+      ->add(Data::class, 'fix', NULL)
+      ->add(Data::class, 'getEntity', NodeInterface::class)
       ->add(NodeInterface::class, 'bundle', 'data')
       ->add(NodeInterface::class, 'get', FieldItemListInterface::class)
+      ->add(NodeInterface::class, 'language', LanguageInterface::class)
+      ->add(NodeInterface::class, 'getEntityType', EntityTypeInterface::class)
+      ->add(EntityTypeInterface::class, 'id', 'node')
+      ->add(LanguageInterface::class, 'getId', 'en')
       ->add(FieldItemListInterface::class, 'getString', 'dataset')
       ->getMock();
 
-    $metastoreItemFactory = new NodeDataFactory(
-      $entityRepository,
-      $this->container->get('entity_type.manager')
-    );
-
     $this->accessManager = new MetastoreAccessManager(
       $this->container->get('entity_type.manager'),
-      $metastoreItemFactory
+      $itemFactory
     );
 
     $this->priviledgedUser = $this->createUser([
@@ -121,10 +122,70 @@ class MetastoreAccessManagerTest extends KernelTestBase {
 
     $can_update = $this->accessManager->canUpdate($schema_id, $item_id, $this->priviledgedUser, $request);
     $this->assertTrue($can_update->isAllowed());
-
     $can_update = $this->accessManager->canUpdate($schema_id, $item_id, $this->unpriviledgedUser, $request);
     $this->assertFalse($can_update->isAllowed());
+
+    // We should be "allowed" to update a non-existant item, the controller will
+    // handle the 404 response.
+    $can_update = $this->accessManager->canUpdate($schema_id, '345', $this->priviledgedUser, $request);
+    $this->assertTrue($can_update->isAllowed());
+    $can_update = $this->accessManager->canUpdate($schema_id, '345', $this->unpriviledgedUser, $request);
+    $this->assertTrue($can_update->isAllowed());
+
+    // Now try with a PUT request, which should check for create permissions if 
+    // non-existant node.
+    $request->setMethod('PUT');
+    $can_update = $this->accessManager->canUpdate($schema_id, '123', $this->priviledgedUser, $request);
+    $this->assertTrue($can_update->isAllowed());
+    $can_update = $this->accessManager->canUpdate($schema_id, '123', $this->unpriviledgedUser, $request);
+    $this->assertFalse($can_update->isAllowed());
+
+    $request->setMethod('PUT');
+    $can_update = $this->accessManager->canUpdate($schema_id, '345', $this->priviledgedUser, $request);
+    $this->assertTrue($can_update->isAllowed());
+    $can_update = $this->accessManager->canUpdate($schema_id, '345', $this->unpriviledgedUser, $request);
+    $this->assertFalse($can_update->isAllowed());
+
+    // Now try with a PATCH request
+    $request->setMethod('PATCH');
+    $can_update = $this->accessManager->canUpdate($schema_id, '123', $this->priviledgedUser, $request);
+    $this->assertTrue($can_update->isAllowed());
+    $can_update = $this->accessManager->canUpdate($schema_id, '123', $this->unpriviledgedUser, $request);
+    $this->assertFalse($can_update->isAllowed());
   }
+
+  public function testCanDelete(): void {
+    $schema_id = 'dataset';
+    $item_id = '123';
+
+    $can_delete = $this->accessManager->canDelete($schema_id, $item_id, $this->priviledgedUser);
+    $this->assertTrue($can_delete->isAllowed());
+    $can_delete = $this->accessManager->canDelete($schema_id, $item_id, $this->unpriviledgedUser);
+    $this->assertFalse($can_delete->isAllowed());
+
+    // Test with a non-existant item. Should always be allowed, controller handles.
+    $can_delete = $this->accessManager->canDelete($schema_id, '345', $this->priviledgedUser);
+    $this->assertTrue($can_delete->isAllowed());
+    $can_delete = $this->accessManager->canDelete($schema_id, '345', $this->unpriviledgedUser);
+    $this->assertTrue($can_delete->isAllowed());
+  }
+
+  public function testCanViewRevisionList(): void {
+    $schema_id = 'dataset';
+    $item_id = '123';
+
+    $can_view = $this->accessManager->canViewRevisionList($schema_id, $item_id, $this->priviledgedUser);
+    $this->assertTrue($can_view->isAllowed());
+
+    $can_view = $this->accessManager->canViewRevisionList($schema_id, $item_id, $this->unpriviledgedUser);
+    $this->assertFalse($can_view->isAllowed());
+
+    // Non-existant item should be allowed, controller handles.
+    $can_view = $this->accessManager->canViewRevisionList($schema_id, '345', $this->unpriviledgedUser);
+    $this->assertTrue($can_view->isAllowed());
+  }
+
+
 
 }
 

--- a/modules/metastore/tests/src/Kernel/Controller/MetastoreAccessManagerTest.php
+++ b/modules/metastore/tests/src/Kernel/Controller/MetastoreAccessManagerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Drupal\Tests\metastore\Controller\Kernel;
+
+use Drupal\Core\Entity\EntityRepository;
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\metastore\Controller\MetastoreAccessManager;
+use Drupal\metastore\NodeWrapper\NodeDataFactory;
+use Drupal\metastore\Storage\NodeData;
+use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use MockChain\Chain;
+use MockChain\Options;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Tests the MetastoreAccessManager.
+ *
+ * @coversDefaultClass \Drupal\metastore\Controller\MetastoreAccessManager
+ * 
+ * @group dkan
+ * @group metastore
+ */
+class MetastoreAccessManagerTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * The MetastoreAccessManager service.
+   */
+  protected MetastoreAccessManager $accessManager;
+
+  /**
+   * A user with permissions to work with the metastore.
+   */
+  protected AccountInterface $priviledgedUser;
+
+  /**
+   * A user without permissions to work with the metastore.
+   */
+  protected AccountInterface $unpriviledgedUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'metastore',
+    'common',
+    'dkan',
+    'field',
+    'node',
+    'user',
+    'workflows',
+    'content_moderation',
+    'system',
+    'text',
+  ];
+
+  public function setUp(): void {
+    parent::setUp();
+    // Set up the necessary services and configurations for the test.
+    $this->installConfig(['node', 'metastore']);
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+
+
+    $repositoryOptions = (new Options)
+      ->add('123', NodeInterface::class)
+      ->index(0);
+    $entityRepository = (new Chain($this))
+      ->add(EntityRepository::class, 'loadEntityByUuid', NodeInterface::class)
+      ->add(NodeInterface::class, 'bundle', 'data')
+      ->add(NodeInterface::class, 'get', FieldItemListInterface::class)
+      ->add(FieldItemListInterface::class, 'getString', 'dataset')
+      ->getMock();
+
+    $metastoreItemFactory = new NodeDataFactory(
+      $entityRepository,
+      $this->container->get('entity_type.manager')
+    );
+
+    $this->accessManager = new MetastoreAccessManager(
+      $this->container->get('entity_type.manager'),
+      $metastoreItemFactory
+    );
+
+    $this->priviledgedUser = $this->createUser([
+      'access content',
+      'create data content',
+      'edit own data content',
+      'delete own data content',
+      'use dkan_publishing transition publish',
+      'use dkan_publishing transition archive',
+    ], 'privileged_user');
+    $this->unpriviledgedUser = $this->createUser([
+      'access content',
+    ], 'unprivileged_user');
+  }
+
+  /**
+   * Tests the MetastoreAccessManager.
+   */
+  public function testCanCreate(): void {
+    $schema_id = 'example_schema';
+    $can_create = $this->accessManager->canCreate($schema_id, $this->priviledgedUser);
+    $this->assertTrue($can_create->isAllowed());
+
+    $can_create = $this->accessManager->canCreate($schema_id, $this->unpriviledgedUser);
+    $this->assertFalse($can_create->isAllowed());
+  }
+
+  public function testCanUpdate(): void {
+    $schema_id = 'dataset';
+    $item_id = '123';
+    // Create a dummy post request
+    $request = new Request([], [], [], [], [], ['REQUEST_METHOD' => 'POST']);
+
+    $can_update = $this->accessManager->canUpdate($schema_id, $item_id, $this->priviledgedUser, $request);
+    $this->assertTrue($can_update->isAllowed());
+
+    $can_update = $this->accessManager->canUpdate($schema_id, $item_id, $this->unpriviledgedUser, $request);
+    $this->assertFalse($can_update->isAllowed());
+  }
+
+}
+

--- a/modules/metastore/tests/src/Kernel/Controller/MetastoreAccessManagerTest.php
+++ b/modules/metastore/tests/src/Kernel/Controller/MetastoreAccessManagerTest.php
@@ -47,6 +47,11 @@ class MetastoreAccessManagerTest extends KernelTestBase {
   protected AccountInterface $unpriviledgedUser;
 
   /**
+   * A user with the legacy perm 'post put delete datasets through the api'.
+   */
+  protected AccountInterface $legacyPermUser;
+
+  /**
    * {@inheritdoc}
    */
   protected static $modules = [
@@ -103,6 +108,9 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     $this->unpriviledgedUser = $this->createUser([
       'access content',
     ], 'unprivileged_user');
+    $this->legacyPermUser = $this->createUser([
+      'post put delete datasets through the api',
+    ], 'legacy_perm_user');
   }
 
   /**
@@ -121,6 +129,9 @@ class MetastoreAccessManagerTest extends KernelTestBase {
 
     $can_create = $accessManager->canCreate($schema_id, $this->unpriviledgedUser);
     $this->assertFalse($can_create->isAllowed());
+
+    $can_create = $accessManager->canCreate($schema_id, $this->legacyPermUser);
+    $this->assertTrue($can_create->isAllowed());
   }
 
   /**
@@ -140,6 +151,8 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     $this->assertTrue($can_update->isAllowed());
     $can_update = $accessManager->canUpdate($schema_id, $item_id, $this->unpriviledgedUser, $request);
     $this->assertFalse($can_update->isAllowed());
+    $can_update = $accessManager->canUpdate($schema_id, $item_id, $this->legacyPermUser, $request);
+    $this->assertTrue($can_update->isAllowed());
 
     // We should be "allowed" to update a non-existant item, the controller will
     // handle the 404 response.
@@ -155,12 +168,16 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     $this->assertTrue($can_update->isAllowed());
     $can_update = $accessManager->canUpdate($schema_id, '123', $this->unpriviledgedUser, $request);
     $this->assertFalse($can_update->isAllowed());
+    $can_update = $accessManager->canUpdate($schema_id, '123', $this->legacyPermUser, $request);
+    $this->assertTrue($can_update->isAllowed());
 
     $request->setMethod('PUT');
     $can_update = $accessManager->canUpdate($schema_id, '345', $this->priviledgedUser, $request);
     $this->assertTrue($can_update->isAllowed());
     $can_update = $accessManager->canUpdate($schema_id, '345', $this->unpriviledgedUser, $request);
     $this->assertFalse($can_update->isAllowed());
+    $can_update = $accessManager->canUpdate($schema_id, '345', $this->legacyPermUser, $request);
+    $this->assertTrue($can_update->isAllowed());
 
     // Now try with a PATCH request
     $request->setMethod('PATCH');
@@ -168,6 +185,8 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     $this->assertTrue($can_update->isAllowed());
     $can_update = $accessManager->canUpdate($schema_id, '123', $this->unpriviledgedUser, $request);
     $this->assertFalse($can_update->isAllowed());
+    $can_update = $accessManager->canUpdate($schema_id, '123', $this->legacyPermUser, $request);
+    $this->assertTrue($can_update->isAllowed());
   }
 
   /**
@@ -187,6 +206,8 @@ class MetastoreAccessManagerTest extends KernelTestBase {
     $this->assertTrue($can_delete->isAllowed());
     $can_delete = $accessManager->canDelete($schema_id, $item_id, $this->unpriviledgedUser);
     $this->assertFalse($can_delete->isAllowed());
+    $can_delete = $accessManager->canDelete($schema_id, $item_id, $this->legacyPermUser);
+    $this->assertTrue($can_delete->isAllowed());
 
     // Test with a non-existant item. Should always be allowed, controller handles.
     $can_delete = $accessManager->canDelete($schema_id, '345', $this->priviledgedUser);
@@ -213,6 +234,9 @@ class MetastoreAccessManagerTest extends KernelTestBase {
 
     $can_view = $accessManager->canViewRevisionList($schema_id, $item_id, $this->unpriviledgedUser);
     $this->assertFalse($can_view->isAllowed());
+
+    $can_view = $accessManager->canViewRevisionList($schema_id, $item_id, $this->legacyPermUser);
+    $this->assertTrue($can_view->isAllowed());
 
     // Non-existant item should be allowed, controller handles.
     $can_view = $accessManager->canViewRevisionList($schema_id, '345', $this->unpriviledgedUser);

--- a/modules/metastore/tests/src/Unit/Controller/MetastoreControllerTest.php
+++ b/modules/metastore/tests/src/Unit/Controller/MetastoreControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\metastore\Unit;
+namespace Drupal\Tests\metastore\Unit\Controller;
 
 use Drupal\Core\Cache\Context\CacheContextsManager;
 use Drupal\Core\Config\ConfigFactoryInterface;

--- a/modules/metastore/tests/src/Unit/Controller/MetastoreControllerTest.php
+++ b/modules/metastore/tests/src/Unit/Controller/MetastoreControllerTest.php
@@ -21,6 +21,7 @@ use Drupal\metastore\SchemaRetriever;
 use Drupal\metastore\Storage\Data;
 use Drupal\metastore\Storage\NodeData;
 use Drupal\metastore\ValidMetadataFactory;
+use Drupal\Tests\metastore\Unit\MetastoreServiceTest;
 use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;

--- a/modules/metastore/tests/src/Unit/NodeWrapper/DataTest.php
+++ b/modules/metastore/tests/src/Unit/NodeWrapper/DataTest.php
@@ -57,6 +57,9 @@ class DataTest extends TestCase {
     $this->assertTrue(
       $wrapper->getLatestRevision() instanceof Data
     );
+
+    // Test the getEntity method.
+    $this->assertTrue($wrapper->getEntity() instanceof Node);
   }
 
   public function testGetLatestRevisionGiveUsNull() {
@@ -81,6 +84,9 @@ class DataTest extends TestCase {
     $this->assertNull(
       $wrapper->getLatestRevision()
     );
+
+    // Test the getEntity method.
+    $this->assertTrue($wrapper->getEntity() instanceof Node);
   }
 
   public function testGetPublishedRevisionGetUsAWrapper() {
@@ -205,6 +211,9 @@ class DataTest extends TestCase {
     $factory = new NodeDataFactory($entityRepository, $entityTypeManager);
     $data = $factory->wrap($entity);
     $this->assertEquals('123', $data->getIdentifier());
+
+    // Test the getEntity method.
+    $this->assertTrue($data->getEntity() instanceof Node);
   }
 
   public function testDataNodeAdditionalMethods() {


### PR DESCRIPTION
Fixes #4510 

Adds custom access check for Metastore routes.

The permission `post put delete datasets through the api` is deprecated. All API actions now require the same permissions needed to accomplish equivalent things in the Drupal UI. They will, for now, also respect the old "post put..." permission for backward compatibility, but we will remove this in a later release. Release notes should advise people to update their roles. 

The "API User" role has been updated to simply include the appropriate content access permissions. This role should probably be removed/replaced eventually as default install config.

## QA Steps

1. Create a one user with the following permissions:

* `access content`
* `create data content`
* `edit own data content`
* `delete own data content`
* `use dkan_publishing transition publish`
* `use dkan_publishing transition archive`
* `use dkan_publishing transition hidden`
* `use dkan_publishing transition restore`
* `view data revisions`
* `view any unpublished content`

2. Now create another user with just the `access content` permission
3. Try posting a new dataset as the unprivileged user. Confirm 403 response
4. Try posting a new dataset as the priviledged user. Confirm success
5. Try to PATCH and PUT against the new dataset as as the unprivileged user. Confirm 403 response
6. Try to PATCH and PUT against the new dataset as as the privileged user. Confirm success.
7. Try to DELETE the new dataset as the unprivileged user. Confirm 403 response.
8. Optional - temporarily remove the "delete own data content" permission from the privileged user, and confirm you can not DELETE. Restore the permission.
9. Try to DELETE the new dataset as the privileged user. Confirm success.
10. Try the same set of tests for changing publication status via the revisions endpoint.