### PR TITLE
Updates to query schema

### DIFF
--- a/modules/datastore/docs/query.json
+++ b/modules/datastore/docs/query.json
@@ -213,7 +213,7 @@
                     "default": "="
                  }
             },
-            "required": [ "property", "value", "operator" ]
+            "required": [ "property", "value" ]
         },
         "expression": {
             "type": "object",

--- a/modules/datastore/docs/query.json
+++ b/modules/datastore/docs/query.json
@@ -165,7 +165,8 @@
                         ]
                     }
                 }
-            }
+            },
+            "required": ["conditions"]
         },
         "condition": {
             "type": "object",
@@ -212,7 +213,7 @@
                     "default": "="
                  }
             },
-            "required": [ "property", "value" ]
+            "required": [ "property", "value", "operator" ]
         },
         "expression": {
             "type": "object",

--- a/modules/datastore/tests/data/query/invalidConditionGroupQuery.json
+++ b/modules/datastore/tests/data/query/invalidConditionGroupQuery.json
@@ -5,12 +5,25 @@
           "alias": "t"
         }
     ],
-    "conditions": [
+  "conditions":[
+    {
+      "operator":"=",
+      "property":"column_a",
+      "value":"value"
+    },
+    {
+      "conditions":[
         {
-          "operator": "=",
-          "property": "filterable",
-          "value": "value"
+          "operator":"=",
+          "property":"column_b",
+          "value":"value"
+        },
+        {
+          "operator":"=",
+          "property":"column_b",
+          "value":"value"
         }
-    ],
-    "invalidGroupOperator":"or"
+      ]
+    }
+  ]
 }

--- a/modules/datastore/tests/data/query/invalidConditionGroupQuery.json
+++ b/modules/datastore/tests/data/query/invalidConditionGroupQuery.json
@@ -1,0 +1,16 @@
+{
+    "resources": [
+        {
+          "id": "asdf",
+          "alias": "t"
+        }
+    ],
+    "conditions": [
+        {
+          "operator": "=",
+          "property": "filterable",
+          "value": "value"
+        }
+    ],
+    "invalidGroupOperator":"or"
+}

--- a/modules/datastore/tests/src/Unit/Service/DatastoreQueryTest.php
+++ b/modules/datastore/tests/src/Unit/Service/DatastoreQueryTest.php
@@ -88,12 +88,21 @@ class DatastoreQueryTest extends TestCase {
     $this->assertIsArray($response->{"$.results[0]"});
   }
 
-  public function testBadCondition() {
-    $this->expectExceptionMessage("Invalid condition");
+  public function testRequiredCondition() {
+    $this->expectExceptionMessage("JSON Schema validation failed.");
     $container = $this->getCommonMockChain();
     \Drupal::setContainer($container->getMock());
     $queryService = new Query(DatastoreService::create($container->getMock()));
     $datastoreQuery = $this->getDatastoreQueryFromJson("badConditionQuery");
+    $queryService->runQuery($datastoreQuery);
+  }
+
+  public function testInvalidConditionGroup() {
+    $this->expectExceptionMessage("Invalid condition");
+    $container = $this->getCommonMockChain();
+    \Drupal::setContainer($container->getMock());
+    $queryService = new Query(DatastoreService::create($container->getMock()));
+    $datastoreQuery = $this->getDatastoreQueryFromJson("invalidConditionGroupQuery");
     $queryService->runQuery($datastoreQuery);
   }
 


### PR DESCRIPTION
Fixes #4527 

## Describe your changes

Query Schema not as strict as we want. Updates made to throw json schema validation errors if any of the conditions are not met. For example: "operator": "='" currently results in a status 500 when it should result is status 400, JSON Schema validation failed. 

## QA Steps

- [ ] Setup a dataset
- [ ] Create a post request to search for a column with a specific value. Request should return a 200 and results should be returned. Example request:
```
POST https://example.site/api/1/datastore/query/{datasetid}/0/ HTTP/1.1a

{
  "conditions":[
    {
      "operator":"=",
      "property":"column_name",
      "value":"any_value"
    }
  ]
}
```

- [ ] Now try to modify the same request and pass a bad operator. For example: change operator to `='`.
- [ ] Result should fail with 400 error with message: JSON Schema validation failed.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
