### PR TITLE
Fix qlty coverage prefix in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,8 +191,8 @@ jobs:
                   source /home/circleci/.bash_profile
                   cd $CIRCLE_WORKING_DIRECTORY/dkan
                   qlty coverage publish \
+                    --strip-prefix "/var/www/html/dkan" \
                     --total-parts-count $CIRCLE_NODE_TOTAL \
-                    --format clover \
                     $CIRCLE_WORKING_DIRECTORY/report/clover/clover-$CIRCLE_NODE_INDEX.xml
             - persist_to_workspace:
                 root: report


### PR DESCRIPTION
There is an issue with the path handling in qlty coverage reports. See the ["install target" build](https://app.circleci.com/pipelines/github/GetDKAN/dkan/6929/workflows/c7632078-8c2f-4b4e-9369-83efdd077fea/jobs/50167) on the [latest 2.x commit](https://github.com/GetDKAN/dkan/commit/777aebfabb77c4859b8cc971faa7742786e87707).

This should fix them. If the "Upload coverage report to qlty" step passes, that should mean this works. 