### PR TITLE
Move JSON form plugin to metastore, de-DKAN-ifying json_form_widget

### DIFF
--- a/modules/json_form_widget/json_form_widget.module
+++ b/modules/json_form_widget/json_form_widget.module
@@ -8,9 +8,8 @@
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\file\Entity\File;
-use Drupal\json_form_widget\Plugin\Field\FieldWidget\JsonFormWidget;
-use Drupal\json_form_widget\ArrayHelper;
 use Drupal\json_form_widget\Element\UploadOrLink;
+use Drupal\metastore\Plugin\Field\FieldWidget\DkanJsonFormWidget;
 
 /**
  * Implements hook_field_widget_complete_form_alter().
@@ -18,7 +17,7 @@ use Drupal\json_form_widget\Element\UploadOrLink;
  * Set json_form_widget flag for later.
  */
 function json_form_widget_field_widget_complete_form_alter(&$field_widget_complete_form, FormStateInterface $form_state, $context) {
-  if ($context['widget'] instanceof JsonFormWidget) {
+  if ($context['widget'] instanceof DkanJsonFormWidget) {
     $form_state->set('has_json_form_widget', TRUE);
   }
 }

--- a/modules/json_form_widget/tests/src/Functional/Plugin/Field/FieldWidget/JsonFormWidgetTest.php
+++ b/modules/json_form_widget/tests/src/Functional/Plugin/Field/FieldWidget/JsonFormWidgetTest.php
@@ -7,7 +7,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemList;
 use Drupal\Core\Form\FormInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\json_form_widget\Plugin\Field\FieldWidget\JsonFormWidget;
+use Drupal\metastore\Plugin\Field\FieldWidget\DkanJsonFormWidget;
 use Drupal\node\Entity\Node;
 use Drupal\Tests\BrowserTestBase;
 use MockChain\Chain;
@@ -112,7 +112,7 @@ class JsonFormWidgetTest extends BrowserTestBase {
 
     // Simulate a new node form, but change the request stack to have query ?schema=distribution
     $this->setSchemaQuery('distribution');
-    $widget = JsonFormWidget::create(
+    $widget = DkanJsonFormWidget::create(
       \Drupal::getContainer(),
       [
         'field_definition' => $this->createMock(FieldDefinitionInterface::class),
@@ -202,7 +202,7 @@ class JsonFormWidgetTest extends BrowserTestBase {
    *   The initialized widget.
    */
   protected function initializeWidget() {
-    return JsonFormWidget::create(
+    return DkanJsonFormWidget::create(
       \Drupal::getContainer(),
       [
         'field_definition' => $this->createMock(FieldDefinitionInterface::class),

--- a/modules/metastore/config/optional/core.entity_form_display.node.data.default.yml
+++ b/modules/metastore/config/optional/core.entity_form_display.node.data.default.yml
@@ -24,7 +24,7 @@ content:
     weight: 6
     settings: {  }
     third_party_settings: {  }
-    type: json_form_widget
+    type: dkan_json_form_widget
     region: content
   path:
     type: path

--- a/modules/metastore/metastore.install
+++ b/modules/metastore/metastore.install
@@ -163,3 +163,21 @@ function metastore_update_8010() {
 
   drupal_flush_all_caches();
 }
+
+/**
+ * Update the dkan_json_form_widget field widget settings.
+ */
+function metastore_update_8011() {
+  // Retrieve the entity form display settings for the 'data' content type.
+  $entity_form_display = \Drupal::service('config.factory')
+    ->getEditable('core.entity_form_display.node.data.default');
+  // Update the 'dkan_json_form_widget' field widget settings.
+  $settings = $entity_form_display->get('content.field_json_metadata');
+  if (empty($settings)) {
+    return "No settings found for 'field_json_metadata'.";
+  }
+  if ($settings['type'] == 'json_form_widget') {
+    $settings['type'] = 'dkan_json_form_widget';
+    $entity_form_display->set('content.field_json_metadata', $settings)->save(TRUE);
+  }
+}

--- a/modules/metastore/src/Plugin/Field/FieldWidget/DkanJsonFormWidget.php
+++ b/modules/metastore/src/Plugin/Field/FieldWidget/DkanJsonFormWidget.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\json_form_widget\Plugin\Field\FieldWidget;
+namespace Drupal\metastore\Plugin\Field\FieldWidget;
 
 use Drupal\Core\Entity\ContentEntityFormInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
@@ -8,6 +8,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\json_form_widget\FormBuilder;
+use Drupal\json_form_widget\Plugin\Field\FieldWidget\JsonFormWidgetBase;
 use Drupal\json_form_widget\ValueHandler;
 use Drupal\metastore\SchemaRetriever;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -18,15 +19,14 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * Plugin implementation of the 'json_form_widget'.
  *
  * @FieldWidget(
- *   id = "json_form_widget",
- *   module = "json_form_widget",
+ *   id = "dkan_json_form_widget",
  *   label = @Translation("DKAN JSON Form"),
  *   field_types = {
  *     "string_long"
  *   }
  * )
  */
-class JsonFormWidget extends JsonFormWidgetBase {
+class DkanJsonFormWidget extends JsonFormWidgetBase {
 
   /**
    * Default DKAN Data Schema.

--- a/modules/metastore/tests/src/Functional/MetastoreUpdatePathTest.php
+++ b/modules/metastore/tests/src/Functional/MetastoreUpdatePathTest.php
@@ -29,14 +29,23 @@ class MetastoreUpdatePathTest extends UpdatePathTestBase {
    */
   public function testUpdates8010on(): void {
     $config = \Drupal::configFactory()->getEditable('metastore.settings');
+    $data_form_config = \Drupal::configFactory()->getEditable('core.entity_form_display.node.data.default');
 
     // Get a baseline for pre-8010.
     $this->assertNull($config->get('redirect_to_datasets'));
+    // Pre-8011
+    $field_settings = $data_form_config->get('content.field_json_metadata');
+    $this->assertEquals('json_form_widget', $field_settings['type']);
 
     $this->runUpdates();
 
     // Confirm results of update 8010.
     $config = \Drupal::configFactory()->getEditable('metastore.settings');
     $this->assertTrue($config->get('redirect_to_datasets'));
+
+    // Confirm results of update 8011.
+    $data_form_config = \Drupal::configFactory()->getEditable('core.entity_form_display.node.data.default');
+    $field_settings = $data_form_config->get('content.field_json_metadata');
+    $this->assertEquals('dkan_json_form_widget', $field_settings['type']);
   }
 }

--- a/modules/metastore/tests/src/Functional/Plugin/Field/FieldWidget/DkanJsonFormWidgetTest.php
+++ b/modules/metastore/tests/src/Functional/Plugin/Field/FieldWidget/DkanJsonFormWidgetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\json_form_widget\Functional\Plugin\Field\FieldWidget;
+namespace Drupal\Tests\metastore\Functional\Plugin\Field\FieldWidget;
 
 use Drupal\Core\Entity\ContentEntityFormInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * @group json_form_widget
  * @group functional
  */
-class JsonFormWidgetTest extends BrowserTestBase {
+class DkanJsonFormWidgetTest extends BrowserTestBase {
 
   protected RequestStack $requestStack;
 


### PR DESCRIPTION
Fixes #4465

Moving the Form widget plugin to metastore, leaving json_form_widget with no DKAN-specific code in src.

Ideally, this PR should also:

* Offer a generic JsonFormWidget plugin that does not rely on DKAN schema retriever
* Refactor the rest of the tests to use this generic widget

## QA Steps

Functionality should not change. Maybe try starting with a 2.x build, either of a client site or with sample content, then switching to this branch, running updatedb and making sure the dataset form still works.