### PR TITLE
Override file access to allow access to remote files for UploadAndLink.

### DIFF
--- a/modules/json_form_widget/json_form_widget.module
+++ b/modules/json_form_widget/json_form_widget.module
@@ -91,3 +91,12 @@ function json_form_widget_preprocess_file_link(array &$variables) {
     $variables['link']['#title'] = $file->getFileUri();
   }
 }
+
+/**
+ * Gives linked files the same access permissions as uploaded files.
+ */
+function json_form_widget_entity_type_build(array &$entity_types) {
+  if (isset($entity_types['file'])) {
+    $entity_types['file']->setHandlerClass('access', 'Drupal\json_form_widget\UploadOrLinkAccessControlHandler');
+  }
+}

--- a/modules/json_form_widget/src/UploadOrLinkAccessControlHandler.php
+++ b/modules/json_form_widget/src/UploadOrLinkAccessControlHandler.php
@@ -18,11 +18,11 @@ class UploadOrLinkAccessControlHandler extends FileAccessControlHandler {
    * @see: Drupal\file\FileAccessControlHandler
    */
   protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+    $file_scheme = \Drupal::service('stream_wrapper_manager')->getScheme($entity->getFileUri());
     if ($operation == 'download' &&
-        \Drupal::service('stream_wrapper_manager')->getScheme($entity->getFileUri()) === 'https') {
-          return AccessResult::allowed();
-    }
-    else {
+      str_starts_with($file_scheme, 'http')) {
+      return AccessResult::allowed();
+    } else {
       return parent::checkAccess($entity, $operation, $account);
     }
   }

--- a/modules/json_form_widget/src/UploadOrLinkAccessControlHandler.php
+++ b/modules/json_form_widget/src/UploadOrLinkAccessControlHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\json_form_widget;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\file\FileAccessControlHandler;
+
+/**
+ * Override file access to let editors access remote files in UploadOrLink.
+ */
+class UploadOrLinkAccessControlHandler extends FileAccessControlHandler {
+
+  /**
+   * Override file 'download' file access for linked files.
+   *
+   * @see: Drupal\file\FileAccessControlHandler
+   */
+  protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+    if ($operation == 'download' &&
+        \Drupal::service('stream_wrapper_manager')->getScheme($entity->getFileUri()) === 'https') {
+          return AccessResult::allowed();
+    }
+    else {
+      return parent::checkAccess($entity, $operation, $account);
+    }
+  }
+
+}

--- a/modules/json_form_widget/src/UploadOrLinkAccessControlHandler.php
+++ b/modules/json_form_widget/src/UploadOrLinkAccessControlHandler.php
@@ -22,7 +22,8 @@ class UploadOrLinkAccessControlHandler extends FileAccessControlHandler {
     if ($operation == 'download' &&
       str_starts_with($file_scheme, 'http')) {
       return AccessResult::allowed();
-    } else {
+    }
+    else {
       return parent::checkAccess($entity, $operation, $account);
     }
   }

--- a/modules/json_form_widget/tests/src/Kernel/Element/UploadOrLinkTest.php
+++ b/modules/json_form_widget/tests/src/Kernel/Element/UploadOrLinkTest.php
@@ -41,6 +41,10 @@ class UploadOrLinkTest extends KernelTestBase {
     $uri = UploadOrLink::getFileUri($url);
     $this->assertEquals($url, $uri);
 
+    // Files need download access in order for the reference to be accessible.
+    $file = UploadOrLink::getManagedFile($uri);
+    $this->assertEquals($file->access('download'), 'ALLOWED');
+
     // We need to get the files path dynamically, in a kernel test running in
     // Docker it is likely something like
     // "/vfs://root/sites/simpletest/95827600/files/"


### PR DESCRIPTION
Fixes 25771

## Problem:
When using the _Link to Data File_ option in the Download URL field, the field element is hidden for other users on the edit form.

## Details:
In #4463 the UploadOrLink element was refactored to allow remote files to be stored as managed files similar to uploaded files. We have discovered that if an editor other than the original author tries to edit the dataset, the UploadOrLink element will not display due to the _checkAccess_ in the core file **FileAccessControlHandler**. The checkAccess is checking that the scheme is 'public', but for remote files the scheme is 'https', and if you are not the author then access to the field is denied.

## Describe your changes
Added a custom access control handler to allow download access to files using the 'https' scheme.

## QA Steps

- [ ] Create two data publisher accounts, user 1 and user 2
- [ ] Log in as user 1
- [ ] Create a dataset, and use the "Link to Data File" option and enter a remote url to a file.
- [ ] Create a second dataset and use the upload option, upload a local file
- [ ] Confirm the upload option works as expected
- [ ] Log in as user 2.
- [ ] Edit dataset 1 and confirm that the Download URL field displays the link and that you can edit it
- [ ] Edit dataset 2, confirm the file displays in the Download URL field, and that you can edit it

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
