### PR TITLE
Plugins for JSON Form option sources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ commands:
                 command: |
                   ddev composer config repositories.dkan path dkan
                   # To avoid dependency issues when installing on PHP 8.1 we need to re-require openapi-httpfoundation-testing.
+                  rm composer.lock
                   ddev composer require --dev osteel/openapi-httpfoundation-testing -W
                   ddev composer require getdkan/dkan:@dev --no-install -W
                   ddev composer update getdkan/dkan -W

--- a/modules/json_form_widget/json_form_widget.services.yml
+++ b/modules/json_form_widget/json_form_widget.services.yml
@@ -32,7 +32,7 @@ services:
     arguments:
       - '@uuid'
       - '@json_form.string_helper'
-      - '@dkan.metastore.service'
+      - '@plugin.manager.json_form_option_source'
   json_form.schema_ui_handler:
     class: \Drupal\json_form_widget\SchemaUiHandler
     arguments:
@@ -43,5 +43,5 @@ services:
     arguments: 
       - 'json_form_widget'
   plugin.manager.json_form_option_source:
-    class: Drupal\json_form_widget\JsonFormOptionSourcePluginManager
+    class: Drupal\json_form_widget\OptionSource\JsonFormOptionSourcePluginManager
     parent: default_plugin_manager

--- a/modules/json_form_widget/json_form_widget.services.yml
+++ b/modules/json_form_widget/json_form_widget.services.yml
@@ -42,3 +42,6 @@ services:
     parent: logger.channel_base
     arguments: 
       - 'json_form_widget'
+  plugin.manager.json_form_option_source:
+    class: Drupal\json_form_widget\JsonFormOptionSourcePluginManager
+    parent: default_plugin_manager

--- a/modules/json_form_widget/src/Annotation/JsonFormOptionSource.php
+++ b/modules/json_form_widget/src/Annotation/JsonFormOptionSource.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\json_form_widget\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines json_form_option_source annotation object.
+ *
+ * @Annotation
+ */
+final class JsonFormOptionSource extends Plugin {
+
+  /**
+   * The plugin ID.
+   */
+  public readonly string $id;
+
+  /**
+   * The human-readable name of the plugin.
+   *
+   * @ingroup plugin_translatable
+   */
+  public readonly string $title;
+
+  /**
+   * The description of the plugin.
+   *
+   * @ingroup plugin_translatable
+   */
+  public readonly string $description;
+
+}

--- a/modules/json_form_widget/src/OptionSource/JsonFormOptionSourceInterface.php
+++ b/modules/json_form_widget/src/OptionSource/JsonFormOptionSourceInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\json_form_widget\OptionSource;
+
+/**
+ * Interface for json_form_option_source plugins.
+ */
+interface JsonFormOptionSourceInterface {
+
+  /**
+   * Returns the translated plugin label.
+   */
+  public function label(): string;
+
+  /**
+   * Returns options for a given argument.
+   *
+   * @param object $source
+   *   The source object to get options for.
+   * @param string|null $titleProperty
+   *   (optional) The property to use as the option title, if not the default.
+   *
+   * @return array
+   *   An associative array of options, where the keys are the option values and
+   *   the values are the option titles.
+   */
+  public function getOptions(object $source, ?string $titleProperty): array;
+
+}

--- a/modules/json_form_widget/src/OptionSource/JsonFormOptionSourceInterface.php
+++ b/modules/json_form_widget/src/OptionSource/JsonFormOptionSourceInterface.php
@@ -17,15 +17,25 @@ interface JsonFormOptionSourceInterface {
   /**
    * Returns options for a given argument.
    *
-   * @param object $source
-   *   The source object to get options for.
-   * @param string|null $titleProperty
-   *   (optional) The property to use as the option title, if not the default.
+   * @param array $config
+   *   Arbitrary configuration for the option source.
    *
    * @return array
    *   An associative array of options, where the keys are the option values and
    *   the values are the option titles.
    */
-  public function getOptions(object $source, ?string $titleProperty): array;
+  public function getOptions(array $config): array;
+
+  /**
+   * Validates the configuration for the option source.
+   *
+   * @param array $config
+   *   Arbitrary configuration for the option source.
+   *
+   * @return true
+   *   If the configuration is valid, returns true. Invalid configuration will
+   *   throw an exception.
+   */
+  public function validateConfig(array $config): true;
 
 }

--- a/modules/json_form_widget/src/OptionSource/JsonFormOptionSourceInterface.php
+++ b/modules/json_form_widget/src/OptionSource/JsonFormOptionSourceInterface.php
@@ -46,10 +46,10 @@ interface JsonFormOptionSourceInterface {
    * @param array $config
    *   Arbitrary configuration for the option source.
    *
-   * @return true
+   * @return bool
    *   If the configuration is valid, returns true. Invalid configuration will
-   *   throw an exception.
+   *   throw an exception. Should never return false; bool to support PHP 8.1.
    */
-  public function validateConfig(array $config): true;
+  public function validateConfig(array $config): bool;
 
 }

--- a/modules/json_form_widget/src/OptionSource/JsonFormOptionSourceInterface.php
+++ b/modules/json_form_widget/src/OptionSource/JsonFormOptionSourceInterface.php
@@ -27,8 +27,7 @@ interface JsonFormOptionSourceInterface {
   public function getOptions(array $config): array;
 
   /**
-   * Returns the target entity type for the option source for use by
-   * autocreate features.
+   * Returns the target entity type for the option source for use by autocreate.
    *
    * @param array $config
    *   Arbitrary configuration for the option source.

--- a/modules/json_form_widget/src/OptionSource/JsonFormOptionSourceInterface.php
+++ b/modules/json_form_widget/src/OptionSource/JsonFormOptionSourceInterface.php
@@ -27,7 +27,22 @@ interface JsonFormOptionSourceInterface {
   public function getOptions(array $config): array;
 
   /**
+   * Returns the target entity type for the option source for use by
+   * autocreate features.
+   *
+   * @param array $config
+   *   Arbitrary configuration for the option source.
+   *
+   * @return null|string
+   *   The target type, such as 'node', 'taxonomy_term', etc.
+   */
+  public function getTargetType(array $config): string;
+
+  /**
    * Validates the configuration for the option source.
+   *
+   * @todo This should probably provide a framework for validating with JSON
+   * schema, rather than just arbirary PHP logic.
    *
    * @param array $config
    *   Arbitrary configuration for the option source.

--- a/modules/json_form_widget/src/OptionSource/JsonFormOptionSourcePluginBase.php
+++ b/modules/json_form_widget/src/OptionSource/JsonFormOptionSourcePluginBase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\json_form_widget\OptionSource;
+
+use Drupal\Component\Plugin\PluginBase;
+
+/**
+ * Base class for json_form_option_source plugins.
+ */
+abstract class JsonFormOptionSourcePluginBase extends PluginBase implements JsonFormOptionSourceInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function label(): string {
+    // Cast the label to a string since it is a TranslatableMarkup object.
+    return (string) $this->pluginDefinition['label'];
+  }
+
+}

--- a/modules/json_form_widget/src/OptionSource/JsonFormOptionSourcePluginManager.php
+++ b/modules/json_form_widget/src/OptionSource/JsonFormOptionSourcePluginManager.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\json_form_widget\OptionSource;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\json_form_widget\Annotation\JsonFormOptionSource;
+
+/**
+ * JsonFormOptionSource plugin manager.
+ */
+final class JsonFormOptionSourcePluginManager extends DefaultPluginManager {
+
+  /**
+   * Constructs the object.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/JsonFormOptionSource', $namespaces, $module_handler, JsonFormOptionSourceInterface::class, JsonFormOptionSource::class);
+    $this->alterInfo('json_form_option_source_info');
+    $this->setCacheBackend($cache_backend, 'json_form_option_source_plugins');
+  }
+
+}

--- a/modules/json_form_widget/src/OptionSource/JsonFormOptionSourcePluginManager.php
+++ b/modules/json_form_widget/src/OptionSource/JsonFormOptionSourcePluginManager.php
@@ -12,7 +12,7 @@ use Drupal\json_form_widget\Annotation\JsonFormOptionSource;
 /**
  * JsonFormOptionSource plugin manager.
  */
-final class JsonFormOptionSourcePluginManager extends DefaultPluginManager {
+class JsonFormOptionSourcePluginManager extends DefaultPluginManager {
 
   /**
    * Constructs the object.

--- a/modules/json_form_widget/src/Plugin/JsonFormOptionSource/TaxonomySource.php
+++ b/modules/json_form_widget/src/Plugin/JsonFormOptionSource/TaxonomySource.php
@@ -12,6 +12,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Simple source plugin to get taxonomy terms as options.
  *
+ * Use this as an example for building custom plugins to provide options for
+ * list elements.
+ *
  * @JsonFormOptionSource(
  *   id = "taxonomy",
  *   label = @Translation("Foo"),
@@ -68,13 +71,31 @@ class TaxonomySource extends JsonFormOptionSourcePluginBase implements Container
     $this->validateConfig($config);
     $vocabulary = $config['vocabulary'];
     /** @var \Drupal\taxonomy\TermStorageInterface $termStorage */
-    $termStorage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $termStorage = $this->getEntityTypeManager()->getStorage('taxonomy_term');
     $terms = $termStorage->loadTree($vocabulary);
     $options = [];
     foreach ($terms as $term) {
       $options[$term->name] = $term->name;
     }
     return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTargetType(array $config): string {
+    $this->validateConfig($config);
+    return 'taxonomy_term';
+  }
+
+  /**
+   * Returns the entity type manager.
+   *
+   * @return \Drupal\Core\Entity\EntityTypeManager
+   *   The entity type manager.
+   */
+  public function getEntityTypeManager(): EntityTypeManager {
+    return $this->entityTypeManager;
   }
 
   /**

--- a/modules/json_form_widget/src/Plugin/JsonFormOptionSource/TaxonomySource.php
+++ b/modules/json_form_widget/src/Plugin/JsonFormOptionSource/TaxonomySource.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\json_form_widget\Plugin\JsonFormOptionSource;
+
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\json_form_widget\OptionSource\JsonFormOptionSourcePluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Simple source plugin to get taxonomy terms as options.
+ *
+ * @JsonFormOptionSource(
+ *   id = "taxonomy",
+ *   label = @Translation("Foo"),
+ *   description = @Translation("Foo description.")
+ * )
+ */
+class TaxonomySource extends JsonFormOptionSourcePluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The metastore service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new TaxonomySource instance.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   The entity type manager service.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManager $entityTypeManager,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOptions(array $config): array {
+    $this->validateConfig($config);
+    $vocabulary = $config['vocabulary'];
+    /** @var \Drupal\taxonomy\TermStorageInterface $termStorage */
+    $termStorage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $terms = $termStorage->loadTree($vocabulary);
+    $options = [];
+    foreach ($terms as $term) {
+      $options[$term->name] = $term->name;
+    }
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfig(array $config): true {
+    if (empty($config['vocabulary']) || !is_string($config['vocabulary'])) {
+      throw new \InvalidArgumentException('Vocabulary must be specified in the configuration.');
+    }
+    return TRUE;
+  }
+
+}

--- a/modules/json_form_widget/src/Plugin/JsonFormOptionSource/TaxonomySource.php
+++ b/modules/json_form_widget/src/Plugin/JsonFormOptionSource/TaxonomySource.php
@@ -101,7 +101,7 @@ class TaxonomySource extends JsonFormOptionSourcePluginBase implements Container
   /**
    * {@inheritdoc}
    */
-  public function validateConfig(array $config): true {
+  public function validateConfig(array $config): bool {
     if (empty($config['vocabulary']) || !is_string($config['vocabulary'])) {
       throw new \InvalidArgumentException('Vocabulary must be specified in the configuration.');
     }

--- a/modules/json_form_widget/src/Plugin/JsonFormOptionSource/TaxonomySource.php
+++ b/modules/json_form_widget/src/Plugin/JsonFormOptionSource/TaxonomySource.php
@@ -17,8 +17,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @JsonFormOptionSource(
  *   id = "taxonomy",
- *   label = @Translation("Foo"),
- *   description = @Translation("Foo description.")
+ *   label = @Translation("Drupal Taxonomy"),
+ *   description = @Translation("Get JSON options from a Drupal taxonomy.")
  * )
  */
 class TaxonomySource extends JsonFormOptionSourcePluginBase implements ContainerFactoryPluginInterface {

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -227,14 +227,15 @@ class WidgetRouter implements ContainerInjectionInterface {
    *   Array with options for the dropdown.
    */
   public function getDropdownOptions(object $source, string|false $titleProperty = FALSE) {
+    $options = [];
     if (isset($source->enum)) {
-      return $this->stringHelper->getSelectOptions($source);
+      $options = $this->stringHelper->getSelectOptions($source);
     }
-    if (is_string($source->plugin ?? NULL)) {
+    elseif (is_string($source->plugin ?? NULL)) {
       $option_source = $this->pluginManager->createInstance($source->plugin);
-      return $option_source->getOptions((array) $source->config ?? []);
+      $options = $option_source->getOptions((array) $source->config ?? []);
     }
-    return [];
+    return $options;
   }
 
   /**

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -160,14 +160,14 @@ class WidgetRouter implements ContainerInjectionInterface {
       $element = $this->handleSelectOtherDefaultValue($element, $element['#options']);
       $element['#input_type'] = $spec->other_type ?? 'textfield';
     }
-    $element['#other_option'] = isset($element['#other_option']) ?? FALSE;
+    $element['#other_option'] = $element['#other_option'] ?? FALSE;
 
     if ($element['#type'] === 'select2') {
-      $element['#multiple'] = isset($spec->multiple) ? TRUE : FALSE;
-      $element['#autocreate'] = isset($spec->allowCreate) ? TRUE : FALSE;
+      $element['#multiple'] = ($spec->multiple ?? FALSE) ? TRUE : FALSE;
+      $element['#autocreate'] = ($spec->allowCreate ?? FALSE) ? TRUE : FALSE;
     }
     if (isset($element['#autocreate']) && $spec->type !== 'select2') {
-      $element['#target_type'] = 'node';
+      $element['#target_type'] = $this->getTargetType($spec->source);
     }
     return $element;
   }
@@ -235,6 +235,23 @@ class WidgetRouter implements ContainerInjectionInterface {
       return $option_source->getOptions((array) $source->config ?? []);
     }
     return [];
+  }
+
+  /**
+   * Get the target type for the dropdown based on the source.
+   *
+   * @param mixed $source
+   *   The source object from UI options.
+   *
+   * @return string|null
+   *   The target type for the dropdown.
+   */
+  public function getTargetType(mixed $source): ?string {
+    if (is_string($source->plugin ?? NULL)) {
+      $option_source = $this->pluginManager->createInstance($source->plugin);
+      return $option_source->getTargetType((array) $source->config ?? []);
+    }
+    return NULL;
   }
 
   /**

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -121,10 +121,10 @@ class WidgetRouter implements ContainerInjectionInterface {
       $element[$title_property] = $this->getDropdownElement($element[$title_property], $spec, $title_property);
     }
 
-    if (isset($spec->source->returnValue)) {
+    if (isset($spec->source->config->returnValue)) {
       $element = $this->getDropdownElement($element, $spec, $title_property);
     }
-    elseif (!isset($spec->titleProperty)) {
+    elseif (!isset($spec->source->config->titleProperty)) {
       $element = $this->getDropdownElement($element, $spec);
     }
 

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -154,6 +154,7 @@ class WidgetRouter implements ContainerInjectionInterface {
     }
 
     $element['#type'] = $this->getSelectType($spec);
+    $this->fixOptionSource($spec);
     $element['#options'] = $this->getDropdownOptions($spec->source, $titleProperty);
     if ($element['#type'] === 'select_or_other_select') {
       $element = $this->handleSelectOtherDefaultValue($element, $element['#options']);

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -115,7 +115,8 @@ class WidgetRouter implements ContainerInjectionInterface {
    *   The element configured as a list element.
    */
   public function handleListElement(mixed $spec, array $element) {
-    $title_property = ($spec->titleProperty ?? FALSE);
+    $this->fixOptionSource($spec);
+    $title_property = ($spec->source->config->titleProperty ?? FALSE);
 
     if (isset($title_property, $element[$title_property])) {
       $element[$title_property] = $this->getDropdownElement($element[$title_property], $spec, $title_property);
@@ -154,7 +155,6 @@ class WidgetRouter implements ContainerInjectionInterface {
     }
 
     $element['#type'] = $this->getSelectType($spec);
-    $this->fixOptionSource($spec);
     $element['#options'] = $this->getDropdownOptions($spec->source, $titleProperty);
     if ($element['#type'] === 'select_or_other_select') {
       $element = $this->handleSelectOtherDefaultValue($element, $element['#options']);

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\json_form_widget;
 
-use Drupal\Component\Plugin\PluginManagerInterface;
 use Drupal\Component\Uuid\UuidInterface;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\json_form_widget\OptionSource\JsonFormOptionSourcePluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -30,7 +30,7 @@ class WidgetRouter implements ContainerInjectionInterface {
   /**
    * Option source plugin manager.
    */
-  protected PluginManagerInterface $pluginManager;
+  protected JsonFormOptionSourcePluginManager $pluginManager;
 
   /**
    * Constructor.
@@ -39,13 +39,13 @@ class WidgetRouter implements ContainerInjectionInterface {
    *   Uuid service.
    * @param \Drupal\json_form_widget\StringHelper $string_helper
    *   String Helper service.
-   * @param \Drupal\Component\Plugin\PluginManagerInterface $plugin_manager
+   * @param \Drupal\json_form_widget\OptionSource\JsonFormOptionSourcePluginManager $plugin_manager
    *   Option source plugin manager.
    */
   public function __construct(
     UuidInterface $uuid,
     StringHelper $string_helper,
-    PluginManagerInterface $plugin_manager,
+    JsonFormOptionSourcePluginManager $plugin_manager,
   ) {
     $this->uuidService = $uuid;
     $this->stringHelper = $string_helper;
@@ -172,6 +172,30 @@ class WidgetRouter implements ContainerInjectionInterface {
   }
 
   /**
+   * Fix legacy "metastoreSchema" source property, move titleProperty to config.
+   *
+   * @param object $spec
+   *   The spec object to fix.
+   *
+   * @return object
+   *   The fixed spec object.
+   */
+  protected function fixOptionSource(object $spec): object {
+    if (is_object($spec->source ?? NULL) && is_string($spec->source->metastoreSchema ?? NULL)) {
+      $spec->source = (object) [
+        'plugin' => 'metastoreSchema',
+        'config' => (object) array_filter([
+          'schema' => $spec->source->metastoreSchema,
+          'titleProperty' => $spec->titleProperty ?? NULL,
+          'returnValue' => $spec->source->returnValue ?? NULL,
+        ]),
+      ];
+      unset($spec->titleProperty, $spec->source->metastoreSchema, $spec->source->returnValue);
+    }
+    return $spec;
+  }
+
+  /**
    * Helper function to get type of pick list.
    *
    * @param mixed $spec
@@ -202,22 +226,14 @@ class WidgetRouter implements ContainerInjectionInterface {
    *   Array with options for the dropdown.
    */
   public function getDropdownOptions(object $source, string|false $titleProperty = FALSE) {
-    $source_properties = get_object_vars($source);
-    if (count($source_properties) > 1) {
-      // If the source object has more than one property, reject it.
-      return [];
-    }
     if (isset($source->enum)) {
       return $this->stringHelper->getSelectOptions($source);
     }
-
-    // If not enum, the property name is a plugin, and the value an argument.
-    $plugin = key($source_properties);
-    $arg = $source->$plugin;
-    $plugin_manager = \Drupal::service('plugin.manager.json_form_option_source');
-    /** @var \Drupal\json_form_widget\JsonFormOptionSourceInterface $option_source */
-    $option_source = $plugin_manager->createInstance($plugin);
-    return $option_source->getOptions($arg, $titleProperty);
+    if (is_string($source->plugin ?? NULL)) {
+      $option_source = $this->pluginManager->createInstance($source->plugin);
+      return $option_source->getOptions((array) $source->config ?? []);
+    }
+    return [];
   }
 
   /**

--- a/modules/json_form_widget/src/WidgetRouter.php
+++ b/modules/json_form_widget/src/WidgetRouter.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\json_form_widget;
 
+use Drupal\Component\Plugin\PluginManagerInterface;
 use Drupal\Component\Uuid\UuidInterface;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\metastore\MetastoreService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -28,24 +28,9 @@ class WidgetRouter implements ContainerInjectionInterface {
   protected $stringHelper;
 
   /**
-   * Metastore Service.
-   *
-   * @var \Drupal\metastore\MetastoreService
+   * Option source plugin manager.
    */
-  protected $metastore;
-
-  /**
-   * Inherited.
-   *
-   * @{inheritdocs}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('uuid'),
-      $container->get('json_form.string_helper'),
-      $container->get('dkan.metastore.service')
-    );
-  }
+  protected PluginManagerInterface $pluginManager;
 
   /**
    * Constructor.
@@ -54,13 +39,28 @@ class WidgetRouter implements ContainerInjectionInterface {
    *   Uuid service.
    * @param \Drupal\json_form_widget\StringHelper $string_helper
    *   String Helper service.
-   * @param \Drupal\metastore\MetastoreService $metastore
-   *   Metastore service.
+   * @param \Drupal\Component\Plugin\PluginManagerInterface $plugin_manager
+   *   Option source plugin manager.
    */
-  public function __construct(UuidInterface $uuid, StringHelper $string_helper, MetastoreService $metastore) {
+  public function __construct(
+    UuidInterface $uuid,
+    StringHelper $string_helper,
+    PluginManagerInterface $plugin_manager,
+  ) {
     $this->uuidService = $uuid;
     $this->stringHelper = $string_helper;
-    $this->metastore = $metastore;
+    $this->pluginManager = $plugin_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('uuid'),
+      $container->get('json_form.string_helper'),
+      $container->get('plugin.manager.json_form_option_source')
+    );
   }
 
   /**
@@ -193,87 +193,31 @@ class WidgetRouter implements ContainerInjectionInterface {
   /**
    * Helper function to get options for dropdowns.
    *
-   * @param mixed $source
+   * @param object $source
    *   Source object from UI options.
-   * @param mixed $titleProperty
+   * @param string|false $titleProperty
    *   The title property name in which the dropdown should be added (or FALSE).
    *
    * @return array
    *   Array with options for the dropdown.
    */
-  public function getDropdownOptions(mixed $source, mixed $titleProperty = FALSE) {
-    $options = [];
+  public function getDropdownOptions(object $source, string|false $titleProperty = FALSE) {
+    $source_properties = get_object_vars($source);
+    if (count($source_properties) > 1) {
+      // If the source object has more than one property, reject it.
+      return [];
+    }
     if (isset($source->enum)) {
-      $options = $this->stringHelper->getSelectOptions($source);
+      return $this->stringHelper->getSelectOptions($source);
     }
-    if (isset($source->metastoreSchema)) {
-      $options = $this->getOptionsFromMetastore($source, $titleProperty);
-    }
-    return $options;
-  }
 
-  /**
-   * Helper function to get options from metastore.
-   *
-   * @param mixed $source
-   *   Source object from UI options.
-   * @param mixed $titleProperty
-   *   The title property name in which the dropdown should be added (or FALSE).
-   *
-   * @return array
-   *   Array with options from metastore for the dropdown.
-   */
-  public function getOptionsFromMetastore(mixed $source, mixed $titleProperty = FALSE) {
-    $options = [];
-    $metastore_items = $this->metastore->getAll($source->metastoreSchema);
-    foreach ($metastore_items as $item) {
-      $item = json_decode((string) $item);
-      $title = $this->metastoreOptionTitle($item, $titleProperty);
-      $value = $this->metastoreOptionValue($item, $source, $titleProperty);
-      $options[$value] = $title;
-    }
-    return $options;
-  }
-
-  /**
-   * Determine the title for the select option.
-   *
-   * @param object|string $item
-   *   Single item from Metastore::getAll()
-   * @param string|false $titleProperty
-   *   Title property defined in UI schema.
-   *
-   * @return string
-   *   String to be used in title.
-   */
-  protected function metastoreOptionTitle($item, $titleProperty): string {
-    if ($titleProperty) {
-      return is_object($item) ? $item->data->$titleProperty : $item;
-    }
-    return $item->data;
-  }
-
-  /**
-   * Determine the value for the select option.
-   *
-   * @param object|string $item
-   *   Single item from Metastore::getAll()
-   * @param object $source
-   *   Source defintion from UI schema.
-   * @param string|false $titleProperty
-   *   Title property defined in UI schema.
-   *
-   * @return string
-   *   String to be used as option value.
-   */
-  protected function metastoreOptionValue($item, object $source, $titleProperty): string {
-    if (($source->returnValue ?? NULL) == 'url') {
-      return 'dkan://metastore/schemas/' . $source->metastoreSchema . '/items/' . $item->identifier;
-    }
-    if ($titleProperty) {
-      return is_object($item) ? $item->data->$titleProperty : $item;
-    }
-    return $item->data;
+    // If not enum, the property name is a plugin, and the value an argument.
+    $plugin = key($source_properties);
+    $arg = $source->$plugin;
+    $plugin_manager = \Drupal::service('plugin.manager.json_form_option_source');
+    /** @var \Drupal\json_form_widget\JsonFormOptionSourceInterface $option_source */
+    $option_source = $plugin_manager->createInstance($plugin);
+    return $option_source->getOptions($arg, $titleProperty);
   }
 
   /**

--- a/modules/json_form_widget/tests/src/Kernel/Plugin/JsonFormOptionSource/TaxonomySourceTest.php
+++ b/modules/json_form_widget/tests/src/Kernel/Plugin/JsonFormOptionSource/TaxonomySourceTest.php
@@ -76,4 +76,22 @@ class TaxonomySourceTest extends KernelTestBase {
     ];
     $this->assertEquals($expected_options, $options);
   }
+
+  /**
+   * Tests the validateConfig method.
+   *
+   * @todo This could be a unit test.
+   */
+  public function testValidateConfig() {
+    $plugin_manager = \Drupal::service('plugin.manager.json_form_option_source');
+    $plugin = $plugin_manager->createInstance('taxonomy', ['vocabulary' => 'test']);
+
+    // Valid config should pass without exception.
+    $this->assertTrue($plugin->validateConfig(['vocabulary' => 'test']));
+
+    // Missing vocabulary should throw exception.
+    $this->expectException(\InvalidArgumentException::class);
+    $plugin->validateConfig([]);
+  }
+
 }

--- a/modules/json_form_widget/tests/src/Kernel/Plugin/JsonFormOptionSource/TaxonomySourceTest.php
+++ b/modules/json_form_widget/tests/src/Kernel/Plugin/JsonFormOptionSource/TaxonomySourceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\json_form_widget\Tests\Kernel\Plugin\JsonFormOptionSource;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
+
+/**
+ * Tests the TaxonomySource plugin.
+ *
+ * @group json_form_widget
+ * @coversDefaultClass \Drupal\json_form_widget\Plugin\JsonFormOptionSource\TaxonomySource
+ */
+class TaxonomySourceTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'json_form_widget',
+    'taxonomy',
+    'user',
+    'system',
+    'field',
+    'text',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('taxonomy_vocabulary');
+    $this->installEntitySchema('user');
+    $this->installConfig(['taxonomy', 'json_form_widget']);
+
+    // Create a vocabulary for testing.
+    $vocabulary = Vocabulary::create([
+      'vid' => 'test',
+      'description' => 'Test vocabulary',
+      'name' => 'Test',
+    ]);
+    $vocabulary->save();
+    // Add some terms to the vocabulary.
+    $terms = ['Term 1', 'Term 2', 'Term 3'];
+    foreach ($terms as $term_name) {
+      $term = Term::create([
+        'name' => $term_name,
+        'vid' => 'test',
+      ]);
+      $term->save();
+    }
+  }
+
+  public function testGetOptions() {
+    $plugin_manager = \Drupal::service('plugin.manager.json_form_option_source');
+    $plugin = $plugin_manager->createInstance('taxonomy', ['vocabulary' => 'test']);
+    $options = $plugin->getOptions(['vocabulary' => 'test']);
+
+    // Verify that the options match the terms we created.
+    $expected_options = [
+      'Term 1' => 'Term 1',
+      'Term 2' => 'Term 2',
+      'Term 3' => 'Term 3',
+    ];
+    $this->assertEquals($expected_options, $options);
+  }
+}

--- a/modules/json_form_widget/tests/src/Kernel/Plugin/JsonFormOptionSource/TaxonomySourceTest.php
+++ b/modules/json_form_widget/tests/src/Kernel/Plugin/JsonFormOptionSource/TaxonomySourceTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\json_form_widget\Tests\Kernel\Plugin\JsonFormOptionSource;
 
+use Drupal\json_form_widget\Plugin\JsonFormOptionSource\TaxonomySource;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\Entity\Vocabulary;
@@ -54,9 +55,17 @@ class TaxonomySourceTest extends KernelTestBase {
     }
   }
 
-  public function testGetOptions() {
+  /**
+   * Tests various methods of the TaxonomySource plugin.
+   */
+  public function testPlugin() {
+    $config = ['vocabulary' => 'test'];
     $plugin_manager = \Drupal::service('plugin.manager.json_form_option_source');
-    $plugin = $plugin_manager->createInstance('taxonomy', ['vocabulary' => 'test']);
+    $plugin = $plugin_manager->createInstance('taxonomy', $config);
+    $this->assertInstanceOf(TaxonomySource::class, $plugin);
+    $this->assertEquals('taxonomy_term', $plugin->getTargetType($config));
+    $this->assertEquals('Drupal Taxonomy', $plugin->label());
+
     $options = $plugin->getOptions(['vocabulary' => 'test']);
 
     // Verify that the options match the terms we created.

--- a/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
+++ b/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\json_form_widget\Unit;
 
 use Drupal\Component\DependencyInjection\Container;
 use Drupal\Component\Uuid\Php;
+use Drupal\json_form_widget\OptionSource\JsonFormOptionSourcePluginManager;
 use Drupal\json_form_widget\StringHelper;
 use PHPUnit\Framework\TestCase;
 use Drupal\json_form_widget\WidgetRouter;
@@ -13,6 +14,9 @@ use MockChain\Options;
 
 /**
  * Test class for ValueHandlerTest.
+ *
+ * @group json_form_widget
+ * @coversDefaultClass \Drupal\json_form_widget\WidgetRouter
  */
 class WidgetRouterTest extends TestCase {
 
@@ -32,6 +36,7 @@ class WidgetRouterTest extends TestCase {
       ->add('uuid', Php::class)
       ->add('json_form.string_helper', StringHelper::class)
       ->add('dkan.metastore.service', MetastoreService::class)
+      ->add('plugin.manager.json_form_option_source', JsonFormOptionSourcePluginManager::class)
       ->index(0);
 
     $metastoreGetAllOptions = (new Options())
@@ -297,5 +302,114 @@ class WidgetRouterTest extends TestCase {
     ];
   }
 
+  /**
+   * Test the getDropdownOptions method.
+   *
+   * @dataProvider fixOptionSourceDataProvider
+   * @covers ::fixOptionSource
+   */
+  public function testFixOptionSource($spec, $expected) {
+    $router = WidgetRouter::create($this->getContainerChain()->getMock());
+
+    // Use reflection to access the protected method.
+    $reflection = new \ReflectionClass($router);
+    $method = $reflection->getMethod('fixOptionSource');
+    $method->setAccessible(TRUE);
+
+    $fixed = $method->invokeArgs($router, [$spec]);
+    $this->assertEquals($expected, $fixed);
+  }
+
+  /**
+   * Data provider for testFixOptionSource.
+   *
+   * @return array
+   *   Array of test data with spec and expected values.
+   */
+  public static function fixOptionSourceDataProvider(): array {
+    return [
+      'metastoreSchema and titleProperty' => [
+        (object) [
+          'titleProperty' => 'name',
+          'source' => (object) [
+            'metastoreSchema' => 'publisher',
+          ],
+        ],
+        (object) [
+          'source' => (object) [
+            'plugin' => 'metastoreSchema',
+            'config' => (object) [
+              'titleProperty' => 'name',
+              'schema' => 'publisher',
+            ],
+          ],
+        ],
+      ],
+      'no titleProperty' => [
+        (object) [
+          'source' => (object) [
+            'metastoreSchema' => 'publisher',
+          ],
+        ],
+        (object) [
+          'source' => (object) [
+            'plugin' => 'metastoreSchema',
+            'config' => (object) [
+              'schema' => 'publisher',
+            ],
+          ],
+        ],
+      ],
+      'has returnValue' => [
+        (object) [
+          'source' => (object) [
+            'returnValue' => 'url',
+            'metastoreSchema' => 'data-dictionary',
+          ],
+        ],
+        (object) [
+          'source' => (object) [
+            'plugin' => 'metastoreSchema',
+            'config' => (object) [
+              'schema' => 'data-dictionary',
+              'returnValue' => 'url',
+            ],
+          ],
+        ],
+      ],
+      'already correct' => [
+        (object) [
+          'source' => (object) [
+            'plugin' => 'metastoreSchema',
+            'config' => (object) [
+              'titleProperty' => 'name',
+              'schema' => 'publisher',
+            ],
+          ],
+        ],
+        (object) [
+          'source' => (object) [
+            'plugin' => 'metastoreSchema',
+            'config' => (object) [
+              'titleProperty' => 'name',
+              'schema' => 'publisher',
+            ],
+          ],
+        ],
+      ],
+      'just enum' => [
+        (object) [
+          'source' => (object) [
+            'enum' => ['option1', 'option2'],
+          ],
+        ],
+        (object) [
+          'source' => (object) [
+            'enum' => ['option1', 'option2'],
+          ],
+        ],
+      ],
+    ];
+  }
 
 }

--- a/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
+++ b/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
@@ -8,7 +8,6 @@ use Drupal\json_form_widget\OptionSource\JsonFormOptionSourcePluginManager;
 use Drupal\json_form_widget\StringHelper;
 use PHPUnit\Framework\TestCase;
 use Drupal\json_form_widget\WidgetRouter;
-use Drupal\metastore\MetastoreService;
 use MockChain\Chain;
 use MockChain\Options;
 
@@ -35,19 +34,11 @@ class WidgetRouterTest extends TestCase {
     $containerGetOptions = (new Options())
       ->add('uuid', Php::class)
       ->add('json_form.string_helper', StringHelper::class)
-      ->add('dkan.metastore.service', MetastoreService::class)
       ->add('plugin.manager.json_form_option_source', JsonFormOptionSourcePluginManager::class)
       ->index(0);
 
-    $metastoreGetAllOptions = (new Options())
-      ->add('publisher', self::publishers())
-      ->add('data-dictionary', self::dataDictionaries())
-      ->add('theme', self::themes())
-      ->index(0);
-
     return (new Chain($this))
-      ->add(Container::class, 'get', $containerGetOptions)
-      ->add(MetastoreService::class, 'getAll', $metastoreGetAllOptions);
+      ->add(Container::class, 'get', $containerGetOptions);
   }
 
   /**
@@ -108,33 +99,6 @@ class WidgetRouterTest extends TestCase {
           '#allowed_formats' => ['html'],
         ],
       ],
-      'tagField' => [
-        (object) [
-          'widget' => 'list',
-          'type' => 'autocomplete',
-          'allowComplete' => TRUE,
-          'multiple' => TRUE,
-          'source' => (object) [
-            'metastoreSchema' => 'theme',
-          ],
-        ],
-        [
-          '#type' => 'textfield',
-          '#title' => 'tags',
-        ],
-        [
-          '#type' => 'select2',
-          '#title' => 'tags',
-          '#options' => [
-            'Theme 1' => 'Theme 1',
-            'Theme 2' => 'Theme 2',
-          ],
-          '#other_option' => FALSE,
-          '#multiple' => TRUE,
-          '#autocreate' => FALSE,
-          '#target_type' => 'node',
-        ],
-      ],
       // Number field includes constraints and a "step" for up/down controlls.
       'numberField' => [
         (object) [
@@ -182,72 +146,6 @@ class WidgetRouterTest extends TestCase {
           ],
           '#other_option' => FALSE,
           '#input_type' => 'textfield',
-        ],
-      ],
-      // Publisher popualtes from metastore but returns whole object,
-      // is wrapped in a details element.
-      'publisherField' => [
-        (object) [
-          "widget" => "list",
-          "type" => "autocomplete",
-          "allowCreate" => TRUE,
-          "titleProperty" => "name",
-          "source" => (object) [
-            "metastoreSchema" => "publisher",
-          ],
-        ],
-        [
-          '#type' => 'details',
-          '#title' => 'Organization',
-          'name' => [
-            '#type' => 'textfield',
-            '#title' => "Publisher Name",
-            "#default_value" => NULL,
-            "#required" => TRUE,
-          ],
-        ],
-        [
-          '#type' => 'details',
-          '#title' => 'Organization',
-          'name' => [
-            '#type' => 'select2',
-            '#title' => 'Publisher Name',
-            '#default_value' => NULL,
-            '#required' => TRUE,
-            '#options' => [
-              'Publisher 1' => 'Publisher 1',
-              'Publisher 2' => 'Publisher 2',
-            ],
-            '#other_option' => FALSE,
-            '#multiple' => FALSE,
-            '#autocreate' => TRUE,
-            '#target_type' => 'node',
-          ],
-        ],
-      ],
-      // Data dict field draws from metastore but just shows URLs.
-      'dataDict' => [
-        (object) [
-          "widget" => "list",
-          "type" => "select",
-          "titleProperty" => "title",
-          "source" => (object) [
-            "metastoreSchema" => "data-dictionary",
-            "returnValue" => "url",
-          ],
-        ],
-        [
-          '#type' => 'url',
-          '#title' => 'Data Dictionary',
-        ],
-        [
-          '#type' => 'select',
-          '#title' => 'Data Dictionary',
-          '#options' => [
-            'dkan://metastore/schemas/data-dictionary/items/111' => 'Data dictionary 1',
-            'dkan://metastore/schemas/data-dictionary/items/222' => 'Data dictionary 2',
-          ],
-          '#other_option' => FALSE,
         ],
       ],
     ];

--- a/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
+++ b/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
@@ -2,12 +2,17 @@
 
 namespace Drupal\Tests\json_form_widget\Unit;
 
+use Dom\Entity;
 use Drupal\Component\DependencyInjection\Container;
 use Drupal\Component\Uuid\Php;
+use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\json_form_widget\OptionSource\JsonFormOptionSourcePluginManager;
+use Drupal\json_form_widget\Plugin\JsonFormOptionSource\TaxonomySource;
 use Drupal\json_form_widget\StringHelper;
 use PHPUnit\Framework\TestCase;
 use Drupal\json_form_widget\WidgetRouter;
+use Drupal\taxonomy\TermStorage;
+use Drupal\taxonomy\TermStorageInterface;
 use MockChain\Chain;
 use MockChain\Options;
 
@@ -38,7 +43,13 @@ class WidgetRouterTest extends TestCase {
       ->index(0);
 
     return (new Chain($this))
-      ->add(Container::class, 'get', $containerGetOptions);
+      ->add(Container::class, 'get', $containerGetOptions)
+      ->add(JsonFormOptionSourcePluginManager::class, 'createInstance', TaxonomySource::class)
+      ->add(TaxonomySource::class, 'getEntityTypeManager', EntityTypeManager::class)
+      ->add(EntityTypeManager::class, 'getStorage', (new Options())
+        ->add('taxonomy_term', TermStorageInterface::class)
+        ->index(0))
+      ->add(TermStorageInterface::class, 'loadTree', static::terms());
   }
 
   /**
@@ -148,55 +159,56 @@ class WidgetRouterTest extends TestCase {
           '#input_type' => 'textfield',
         ],
       ],
+      'taxonomyOptionsField' => [
+        (object) [
+          "widget" => "list",
+          "type" => "autocomplete",
+          "allowCreate" => FALSE,
+          "source" => (object) [
+            "plugin" => "taxonomy",
+            "config" => (object) [
+              "vocabulary" => "test_vocabulary",
+            ],
+          ],
+        ],
+        [
+          '#type' => 'textfield',
+          '#title' => 'Taxonomy Options',
+        ],
+        [
+          '#type' => 'select2',
+          '#title' => 'Taxonomy Options',
+          '#options' => [
+            'Term 1' => 'Term 1',
+            'Term 2' => 'Term 2',
+            'Term 3' => 'Term 3',
+          ],
+          '#other_option' => FALSE,
+          '#multiple' => FALSE,
+          '#autocreate' => FALSE,
+          '#target_type' => 'taxonomy_term',
+        ],
+      ],
     ];
   }
 
-  public static function themes() {
+  public static function terms(): array {
     return [
-      json_encode((object) [
-        'identifier' => '111',
-        'data' => 'Theme 1',
-      ]),
-      json_encode((object) [
-        'identifier' => '222',
-        'data' => 'Theme 2',
-      ]),
-    ];
-  }
-
-  public static function publishers() {
-    return [
-      json_encode((object) [
-        'identifier' => '111',
-        'data' => (object) [
-          '@type' => 'org:Organization',
-          'name' => 'Publisher 1',
-        ],
-      ]),
-      json_encode((object) [
-        'identifier' => '222',
-        'data' => (object) [
-          '@type' => 'org:Organization',
-          'name' => 'Publisher 2',
-        ],
-      ]),
-    ];
-  }
-
-  public static function dataDictionaries() {
-    return [
-      json_encode((object) [
-        'identifier' => '111',
-        'data' => (object) [
-          'title' => 'Data dictionary 1',
-        ],
-      ]),
-      json_encode((object) [
-        'identifier' => '222',
-        'data' => (object) [
-          'title' => 'Data dictionary 2',
-        ],
-      ]),
+      (object) [
+        'tid' => 1,
+        'name' => 'Term 1',
+        'vid' => 'test_vocabulary',
+      ],
+      (object) [
+        'tid' => 2,
+        'name' => 'Term 2',
+        'vid' => 'test_vocabulary',
+      ],
+      (object) [
+        'tid' => 3,
+        'name' => 'Term 3',
+        'vid' => 'test_vocabulary',
+      ],
     ];
   }
 

--- a/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
+++ b/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\json_form_widget\Unit;
 
-use Dom\Entity;
 use Drupal\Component\DependencyInjection\Container;
 use Drupal\Component\Uuid\Php;
 use Drupal\Core\Entity\EntityTypeManager;
@@ -11,7 +10,6 @@ use Drupal\json_form_widget\Plugin\JsonFormOptionSource\TaxonomySource;
 use Drupal\json_form_widget\StringHelper;
 use PHPUnit\Framework\TestCase;
 use Drupal\json_form_widget\WidgetRouter;
-use Drupal\taxonomy\TermStorage;
 use Drupal\taxonomy\TermStorageInterface;
 use MockChain\Chain;
 use MockChain\Options;

--- a/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
+++ b/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
@@ -187,6 +187,26 @@ class WidgetRouterTest extends TestCase {
           '#target_type' => 'taxonomy_term',
         ],
       ],
+      'listWithNoOptions' => [
+        (object) [
+          'widget' => 'list',
+          'type' => 'autocomplete',
+          'source' => (object) [],
+        ],
+        [
+          '#type' => 'textfield',
+          '#title' => 'List With No Options',
+        ],
+        [
+          '#type' => 'select2',
+          '#title' => 'List With No Options',
+          '#options' => [],
+          '#multiple' => FALSE,
+          '#autocreate' => FALSE,
+          '#target_type' => NULL,
+          '#other_option' => FALSE,
+        ],
+      ],
     ];
   }
 

--- a/modules/metastore/src/Plugin/JsonFormOptionSource/MetastoreSchema.php
+++ b/modules/metastore/src/Plugin/JsonFormOptionSource/MetastoreSchema.php
@@ -49,7 +49,10 @@ class MetastoreSchema extends JsonFormOptionSourcePluginBase implements Containe
     $this->metastore = $metastore;
   }
   
-  public function getMetastore() {
+  /**
+   * Return the metastore service.
+   */
+  public function getMetastore(): MetastoreService {
     return $this->metastore;
   }
 
@@ -78,6 +81,13 @@ class MetastoreSchema extends JsonFormOptionSourcePluginBase implements Containe
       $options[$value] = $title;
     }
     return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTargetType(array $config): string {
+    return 'node';
   }
 
   /**

--- a/modules/metastore/src/Plugin/JsonFormOptionSource/MetastoreSchema.php
+++ b/modules/metastore/src/Plugin/JsonFormOptionSource/MetastoreSchema.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   description = @Translation("Foo description.")
  * )
  */
-final class MetastoreSchema extends JsonFormOptionSourcePluginBase implements ContainerFactoryPluginInterface {
+class MetastoreSchema extends JsonFormOptionSourcePluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * The metastore service.
@@ -48,6 +48,10 @@ final class MetastoreSchema extends JsonFormOptionSourcePluginBase implements Co
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->metastore = $metastore;
   }
+  
+  public function getMetastore() {
+    return $this->metastore;
+  }
 
   /**
    * {@inheritdoc}
@@ -66,10 +70,10 @@ final class MetastoreSchema extends JsonFormOptionSourcePluginBase implements Co
    */
   public function getOptions(array $config): array {
     $options = [];
-    $metastore_items = $this->metastore->getAll($config['schema']);
+    $metastore_items = $this->getMetastore()->getAll($config['schema']);
     foreach ($metastore_items as $item) {
       $item = json_decode((string) $item);
-      $title = $this->metastoreOptionTitle($item, $config['titleProperty']);
+      $title = $this->metastoreOptionTitle($item, $config['titleProperty'] ?? NULL);
       $value = $this->metastoreOptionValue($item, $config);
       $options[$value] = $title;
     }
@@ -81,7 +85,7 @@ final class MetastoreSchema extends JsonFormOptionSourcePluginBase implements Co
    *
    * @param object|string $item
    *   Single item from Metastore::getAll()
-   * @param string|false $titleProperty
+   * @param string|null $titleProperty
    *   Title property defined in UI schema.
    *
    * @return string
@@ -109,7 +113,7 @@ final class MetastoreSchema extends JsonFormOptionSourcePluginBase implements Co
     if (($config['returnValue'] ?? NULL) == 'url') {
       return 'dkan://metastore/schemas/' . $config['schema'] . '/items/' . $item->identifier;
     }
-    if ($config['titleProperty']) {
+    if ($config['titleProperty'] ?? FALSE) {
       return is_object($item) ? $item->data->{$config['titleProperty']} : $item;
     }
     return $item->data;

--- a/modules/metastore/src/Plugin/JsonFormOptionSource/MetastoreSchema.php
+++ b/modules/metastore/src/Plugin/JsonFormOptionSource/MetastoreSchema.php
@@ -6,6 +6,7 @@ namespace Drupal\metastore\Plugin\JsonFormOptionSource;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\json_form_widget\OptionSource\JsonFormOptionSourcePluginBase;
+use Drupal\metastore\MetastoreService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -38,7 +39,12 @@ final class MetastoreSchema extends JsonFormOptionSourcePluginBase implements Co
    * @param \Drupal\metastore\MetastoreService $metastore
    *   The metastore service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, \Drupal\metastore\MetastoreService $metastore) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    MetastoreService $metastore,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->metastore = $metastore;
   }
@@ -58,13 +64,13 @@ final class MetastoreSchema extends JsonFormOptionSourcePluginBase implements Co
   /**
    * {@inheritdoc}
    */
-  public function getOptions(object $source, ?string $titleProperty): array {
+  public function getOptions(array $config): array {
     $options = [];
-    $metastore_items = $this->metastore->getAll($source->metastoreSchema);
+    $metastore_items = $this->metastore->getAll($config['schema']);
     foreach ($metastore_items as $item) {
       $item = json_decode((string) $item);
-      $title = $this->metastoreOptionTitle($item, $titleProperty);
-      $value = $this->metastoreOptionValue($item, $source, $titleProperty);
+      $title = $this->metastoreOptionTitle($item, $config['titleProperty']);
+      $value = $this->metastoreOptionValue($item, $config);
       $options[$value] = $title;
     }
     return $options;
@@ -93,22 +99,37 @@ final class MetastoreSchema extends JsonFormOptionSourcePluginBase implements Co
    *
    * @param object|string $item
    *   Single item from Metastore::getAll()
-   * @param object $source
-   *   Source defintion from UI schema.
-   * @param string|false $titleProperty
-   *   Title property defined in UI schema.
+   * @param array $config
+   *   Configuration array containing the schema and other options.
    *
    * @return string
    *   String to be used as option value.
    */
-  protected function metastoreOptionValue($item, object $source, $titleProperty): string {
-    if (($source->returnValue ?? NULL) == 'url') {
-      return 'dkan://metastore/schemas/' . $source->metastoreSchema . '/items/' . $item->identifier;
+  protected function metastoreOptionValue($item, $config): string {
+    if (($config['returnValue'] ?? NULL) == 'url') {
+      return 'dkan://metastore/schemas/' . $config['schema'] . '/items/' . $item->identifier;
     }
-    if ($titleProperty) {
-      return is_object($item) ? $item->data->$titleProperty : $item;
+    if ($config['titleProperty']) {
+      return is_object($item) ? $item->data->{$config['titleProperty']} : $item;
     }
     return $item->data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfig(array $config): true {
+    // Must have a schema.
+    if (empty($config['schema'])) {
+      throw new \InvalidArgumentException('The "schema" config property is required.');
+    }
+    // The titleProperty and returnValue, if present, must be strings.
+    foreach (['titleProperty', 'returnValue'] as $property) {
+      if (isset($config[$property]) && !is_string($config[$property])) {
+        throw new \InvalidArgumentException("The \"{$property}\" config property must be a string.");
+      }
+    }
+    return TRUE;
   }
 
 }

--- a/modules/metastore/src/Plugin/JsonFormOptionSource/MetastoreSchema.php
+++ b/modules/metastore/src/Plugin/JsonFormOptionSource/MetastoreSchema.php
@@ -48,7 +48,7 @@ class MetastoreSchema extends JsonFormOptionSourcePluginBase implements Containe
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->metastore = $metastore;
   }
-  
+
   /**
    * Return the metastore service.
    */
@@ -133,16 +133,16 @@ class MetastoreSchema extends JsonFormOptionSourcePluginBase implements Containe
    * {@inheritdoc}
    */
   public function validateConfig(array $config): true {
-    // Must have a schema.
-    if (empty($config['schema'])) {
-      throw new \InvalidArgumentException('The "schema" config property is required.');
-    }
-    // The titleProperty and returnValue, if present, must be strings.
-    foreach (['titleProperty', 'returnValue'] as $property) {
-      if (isset($config[$property]) && !is_string($config[$property])) {
-        throw new \InvalidArgumentException("The \"{$property}\" config property must be a string.");
-      }
-    }
+    // Validate config properties using match expressions.
+    match (TRUE) {
+      empty($config['schema']) =>
+        throw new \InvalidArgumentException('The "schema" config property is required.'),
+      isset($config['titleProperty']) && !is_string($config['titleProperty']) =>
+        throw new \InvalidArgumentException("The \"titleProperty\" config property must be a string."),
+      isset($config['returnValue']) && !is_string($config['returnValue']) =>
+        throw new \InvalidArgumentException("The \"returnValue\" config property must be a string."),
+      default => NULL,
+    };
     return TRUE;
   }
 

--- a/modules/metastore/src/Plugin/JsonFormOptionSource/MetastoreSchema.php
+++ b/modules/metastore/src/Plugin/JsonFormOptionSource/MetastoreSchema.php
@@ -14,8 +14,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @JsonFormOptionSource(
  *   id = "metastoreSchema",
- *   label = @Translation("Foo"),
- *   description = @Translation("Foo description.")
+ *   label = @Translation("DKAN Metastore Option Source"),
+ *   description = @Translation("Provides options to JSON Forms based on a DKAN schema.")
  * )
  */
 class MetastoreSchema extends JsonFormOptionSourcePluginBase implements ContainerFactoryPluginInterface {
@@ -72,6 +72,7 @@ class MetastoreSchema extends JsonFormOptionSourcePluginBase implements Containe
    * {@inheritdoc}
    */
   public function getOptions(array $config): array {
+    $this->validateConfig($config);
     $options = [];
     $metastore_items = $this->getMetastore()->getAll($config['schema']);
     foreach ($metastore_items as $item) {

--- a/modules/metastore/src/Plugin/JsonFormOptionSource/MetastoreSchema.php
+++ b/modules/metastore/src/Plugin/JsonFormOptionSource/MetastoreSchema.php
@@ -132,7 +132,7 @@ class MetastoreSchema extends JsonFormOptionSourcePluginBase implements Containe
   /**
    * {@inheritdoc}
    */
-  public function validateConfig(array $config): true {
+  public function validateConfig(array $config): bool {
     // Validate config properties using match expressions.
     match (TRUE) {
       empty($config['schema']) =>

--- a/modules/metastore/src/Plugin/JsonFormOptionSource/MetastoreSchema.php
+++ b/modules/metastore/src/Plugin/JsonFormOptionSource/MetastoreSchema.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\metastore\Plugin\JsonFormOptionSource;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\json_form_widget\OptionSource\JsonFormOptionSourcePluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the json_form_option_source.
+ *
+ * @JsonFormOptionSource(
+ *   id = "metastoreSchema",
+ *   label = @Translation("Foo"),
+ *   description = @Translation("Foo description.")
+ * )
+ */
+final class MetastoreSchema extends JsonFormOptionSourcePluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The metastore service.
+   *
+   * @var \Drupal\metastore\MetastoreService
+   */
+  protected $metastore;
+
+  /**
+   * Constructs a new MetastoreSchema instance.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\metastore\MetastoreService $metastore
+   *   The metastore service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, \Drupal\metastore\MetastoreService $metastore) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->metastore = $metastore;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('dkan.metastore.service')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOptions(object $source, ?string $titleProperty): array {
+    $options = [];
+    $metastore_items = $this->metastore->getAll($source->metastoreSchema);
+    foreach ($metastore_items as $item) {
+      $item = json_decode((string) $item);
+      $title = $this->metastoreOptionTitle($item, $titleProperty);
+      $value = $this->metastoreOptionValue($item, $source, $titleProperty);
+      $options[$value] = $title;
+    }
+    return $options;
+  }
+
+  /**
+   * Determine the title for the select option.
+   *
+   * @param object|string $item
+   *   Single item from Metastore::getAll()
+   * @param string|false $titleProperty
+   *   Title property defined in UI schema.
+   *
+   * @return string
+   *   String to be used in title.
+   */
+  protected function metastoreOptionTitle($item, $titleProperty): string {
+    if ($titleProperty) {
+      return is_object($item) ? $item->data->$titleProperty : $item;
+    }
+    return $item->data;
+  }
+
+  /**
+   * Determine the value for the select option.
+   *
+   * @param object|string $item
+   *   Single item from Metastore::getAll()
+   * @param object $source
+   *   Source defintion from UI schema.
+   * @param string|false $titleProperty
+   *   Title property defined in UI schema.
+   *
+   * @return string
+   *   String to be used as option value.
+   */
+  protected function metastoreOptionValue($item, object $source, $titleProperty): string {
+    if (($source->returnValue ?? NULL) == 'url') {
+      return 'dkan://metastore/schemas/' . $source->metastoreSchema . '/items/' . $item->identifier;
+    }
+    if ($titleProperty) {
+      return is_object($item) ? $item->data->$titleProperty : $item;
+    }
+    return $item->data;
+  }
+
+}

--- a/modules/metastore/tests/src/Kernel/Plugin/JsonFormOptionSource/MetastoreSchemaTest.php
+++ b/modules/metastore/tests/src/Kernel/Plugin/JsonFormOptionSource/MetastoreSchemaTest.php
@@ -73,12 +73,35 @@ class MetastoreSchemaTest extends KernelTestBase {
       'Theme 2' => 'Theme 2',
     ];
     $this->assertEquals($expected_options, $options);
+
+    // Test with invalid config.
+    $this->expectException(\InvalidArgumentException::class);
+    $plugin->getOptions(['invalid' => 'config']);
+  }
+
+  public static function invalidConfigProvider() {
+    return [
+      'missing schema' => [
+        [],
+        \InvalidArgumentException::class,
+      ],
+      'invalid titleProperty type' => [
+        ['schema' => 'theme', 'titleProperty' => 123],
+        \InvalidArgumentException::class,
+      ],
+      'invalid returnValue type' => [
+        ['schema' => 'theme', 'returnValue' => (object) ['key' => 'value']],
+        \InvalidArgumentException::class,
+      ],
+    ];
   }
 
   /**
    * Test validateConfig method against various configs.
+   *
+   * @dataProvider invalidConfigProvider
    */
-  public function testValidateConfig() {
+  public function testValidateConfig($schema, $expected_exception = NULL) {
     $plugin_manager = \Drupal::service('plugin.manager.json_form_option_source');
     $plugin = $plugin_manager->createInstance('metastoreSchema', ['schema' => 'theme']);
 
@@ -93,16 +116,8 @@ class MetastoreSchemaTest extends KernelTestBase {
     ]));
 
     // Test missing schema.
-    $this->expectException(\InvalidArgumentException::class);
-    $plugin->validateConfig([]);
-
-    // Test invalid titleProperty type.
-    $this->expectException(\InvalidArgumentException::class);
-    $plugin->validateConfig(['schema' => 'theme', 'titleProperty' => 123]);
-
-    // Test invalid returnValue type.
-    $this->expectException(\InvalidArgumentException::class);
-    $plugin->validateConfig(['schema' => 'theme', 'returnValue' => (object) ['key' => 'value']]);
+    $this->expectException($expected_exception);
+    $plugin->validateConfig($schema);
   }
 
   /**

--- a/modules/metastore/tests/src/Kernel/Plugin/JsonFormOptionSource/MetastoreSchemaTest.php
+++ b/modules/metastore/tests/src/Kernel/Plugin/JsonFormOptionSource/MetastoreSchemaTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\metastore\Kernel\Plugin\JsonFormOptionSource;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\metastore\MetastoreService;
+use Drupal\metastore\Plugin\JsonFormOptionSource\MetastoreSchema;
+use MockChain\Chain;
+use MockChain\Options;
+
+/**
+ * Test coverage for MetastoreSchema plugin.
+ *
+ * @group metastore
+ * @coversDefaultClass \Drupal\metastore\Plugin\JsonFormOptionSource\MetastoreSchema
+ */
+class MetastoreSchemaTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'common',
+    'metastore',
+    'workflows',
+    'content_moderation',
+    'json_form_widget',
+    'node',
+    'user',
+    'system',
+    'field',
+    'text',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('node');
+    // $this->installEntitySchema('user');
+    $this->installConfig(['node']);
+    $this->installConfig(['workflows']);
+    $this->installConfig(['metastore']);
+
+    $metastore = (new Chain($this))
+      ->add(MetastoreService::class, 'getAll', (new Options())
+        ->add('theme', static::themes())
+        ->index(0)
+      )
+      ->getMock();
+
+    // Replace dkan.metastore.service in the container with the mock.
+    $this->container->set('dkan.metastore.service', $metastore);
+  }
+
+  /**
+   * Test getOptions method.
+   */
+  public function testGetOptions() {
+    $plugin_manager = \Drupal::service('plugin.manager.json_form_option_source');
+    $plugin = $plugin_manager->createInstance('metastoreSchema', ['schema' => 'theme']);
+    assert($plugin instanceof MetastoreSchema);
+    $options = $plugin->getOptions(['schema' => 'theme']);
+
+    // Verify that the options match the terms we created.
+    $expected_options = [
+      'Theme 1' => 'Theme 1',
+      'Theme 2' => 'Theme 2',
+    ];
+    $this->assertEquals($expected_options, $options);
+  }
+
+  /**
+   * Test getTargetType method returns 'node'.
+   */
+  public function testGetTargetType() {
+    $plugin_manager = \Drupal::service('plugin.manager.json_form_option_source');
+    $plugin = $plugin_manager->createInstance('metastoreSchema', ['schema' => 'theme']);
+    $target_type = $plugin->getTargetType(['schema' => 'theme']);
+
+    // Verify that the target type is as expected.
+    $expected_target_type = 'node';
+    $this->assertEquals($expected_target_type, $target_type);
+  }
+
+  /**
+   * Test validateConfig method against various configs.
+   */
+  public function testValidateConfig() {
+    $plugin_manager = \Drupal::service('plugin.manager.json_form_option_source');
+    $plugin = $plugin_manager->createInstance('metastoreSchema', ['schema' => 'theme']);
+
+    // Test valid config.
+    $this->assertTrue($plugin->validateConfig(['schema' => 'theme']));
+    $this->assertTrue($plugin->validateConfig([
+      'schema' => 'theme',
+      'config' => [
+        'titleProperty' => 'name',
+        'returnValue' => 'id',
+      ],
+    ]));
+
+    // Test missing schema.
+    $this->expectException(\InvalidArgumentException::class);
+    $plugin->validateConfig([]);
+
+    // Test invalid titleProperty type.
+    $this->expectException(\InvalidArgumentException::class);
+    $plugin->validateConfig(['schema' => 'theme', 'titleProperty' => 123]);
+
+    // Test invalid returnValue type.
+    $this->expectException(\InvalidArgumentException::class);
+    $plugin->validateConfig(['schema' => 'theme', 'returnValue' => (object) ['key' => 'value']]);
+  }
+
+  /**
+   * Dummy list of themes to mock metastore service.
+   */
+  public static function themes() {
+    return [
+      json_encode((object) [
+        'identifier' => '111',
+        'data' => 'Theme 1',
+      ]),
+      json_encode((object) [
+        'identifier' => '222',
+        'data' => 'Theme 2',
+      ]),
+    ];
+  }
+
+}

--- a/modules/metastore/tests/src/Kernel/Plugin/JsonFormOptionSource/MetastoreSchemaTest.php
+++ b/modules/metastore/tests/src/Kernel/Plugin/JsonFormOptionSource/MetastoreSchemaTest.php
@@ -57,13 +57,15 @@ class MetastoreSchemaTest extends KernelTestBase {
   }
 
   /**
-   * Test getOptions method.
+   * Test getOptions and other plugin basics.
    */
   public function testGetOptions() {
+    $config = ['schema' => 'theme'];
     $plugin_manager = \Drupal::service('plugin.manager.json_form_option_source');
-    $plugin = $plugin_manager->createInstance('metastoreSchema', ['schema' => 'theme']);
-    assert($plugin instanceof MetastoreSchema);
-    $options = $plugin->getOptions(['schema' => 'theme']);
+    $plugin = $plugin_manager->createInstance('metastoreSchema', $config);
+    $this->assertInstanceOf(MetastoreSchema::class, $plugin);
+    $options = $plugin->getOptions($config);
+    $this->assertEquals('node', $plugin->getTargetType($config));
 
     // Verify that the options match the terms we created.
     $expected_options = [
@@ -71,19 +73,6 @@ class MetastoreSchemaTest extends KernelTestBase {
       'Theme 2' => 'Theme 2',
     ];
     $this->assertEquals($expected_options, $options);
-  }
-
-  /**
-   * Test getTargetType method returns 'node'.
-   */
-  public function testGetTargetType() {
-    $plugin_manager = \Drupal::service('plugin.manager.json_form_option_source');
-    $plugin = $plugin_manager->createInstance('metastoreSchema', ['schema' => 'theme']);
-    $target_type = $plugin->getTargetType(['schema' => 'theme']);
-
-    // Verify that the target type is as expected.
-    $expected_target_type = 'node';
-    $this->assertEquals($expected_target_type, $target_type);
   }
 
   /**

--- a/modules/metastore/tests/src/Unit/Plugin/Field/FieldWidget/DkanJsonFieldWidgetTest.php
+++ b/modules/metastore/tests/src/Unit/Plugin/Field/FieldWidget/DkanJsonFieldWidgetTest.php
@@ -69,7 +69,7 @@ class DkanJsonFieldWidgetTest extends TestCase {
         (object) [
           'widget' => 'list',
           'type' => 'autocomplete',
-          'allowComplete' => TRUE,
+          'allowCreate' => TRUE,
           'multiple' => TRUE,
           'source' => (object) [
             'metastoreSchema' => 'theme',
@@ -88,7 +88,7 @@ class DkanJsonFieldWidgetTest extends TestCase {
           ],
           '#other_option' => FALSE,
           '#multiple' => TRUE,
-          '#autocreate' => FALSE,
+          '#autocreate' => TRUE,
           '#target_type' => 'node',
         ],
       ],

--- a/modules/metastore/tests/src/Unit/Plugin/Field/FieldWidget/DkanJsonFieldWidgetTest.php
+++ b/modules/metastore/tests/src/Unit/Plugin/Field/FieldWidget/DkanJsonFieldWidgetTest.php
@@ -82,7 +82,10 @@ class DkanJsonFieldWidgetTest extends TestCase {
         [
           '#type' => 'select2',
           '#title' => 'tags',
-          '#options' => [],
+          '#options' => [
+            'Theme 1' => 'Theme 1',
+            'Theme 2' => 'Theme 2',
+          ],
           '#other_option' => FALSE,
           '#multiple' => TRUE,
           '#autocreate' => FALSE,
@@ -198,15 +201,11 @@ class DkanJsonFieldWidgetTest extends TestCase {
     return [
       json_encode((object) [
         'identifier' => '111',
-        'data' => (object) [
-          'name' => 'Theme 1',
-        ],
+        'data' => 'Theme 1',
       ]),
       json_encode((object) [
         'identifier' => '222',
-        'data' => (object) [
-          'name' => 'Theme 2',
-        ],
+        'data' => 'Theme 2',
       ]),
     ];
   }

--- a/modules/metastore/tests/src/Unit/Plugin/Field/FieldWidget/DkanJsonFieldWidgetTest.php
+++ b/modules/metastore/tests/src/Unit/Plugin/Field/FieldWidget/DkanJsonFieldWidgetTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\metastore\Unit\Field\FieldWidget;
 use Drupal\Component\DependencyInjection\Container;
 use Drupal\Component\Uuid\Php;
 use Drupal\json_form_widget\OptionSource\JsonFormOptionSourcePluginManager;
+use Drupal\json_form_widget\SchemaUiHandler;
 use Drupal\json_form_widget\StringHelper;
 use PHPUnit\Framework\TestCase;
 use Drupal\json_form_widget\WidgetRouter;
@@ -12,6 +13,7 @@ use Drupal\metastore\MetastoreService;
 use Drupal\metastore\Plugin\JsonFormOptionSource\MetastoreSchema;
 use MockChain\Chain;
 use MockChain\Options;
+use Psr\Log\LoggerInterface;
 
 /**
  * Test class for ValueHandlerTest.
@@ -39,6 +41,7 @@ class DkanJsonFieldWidgetTest extends TestCase {
       ->add('json_form.string_helper', StringHelper::class)
       ->add('dkan.metastore.service', MetastoreService::class)
       ->add('plugin.manager.json_form_option_source', JsonFormOptionSourcePluginManager::class)
+      ->add('dkan.json_form.logger_channel', LoggerInterface::class)
       ->index(0);
 
     $metastoreGetAllOptions = (new Options())
@@ -208,6 +211,83 @@ class DkanJsonFieldWidgetTest extends TestCase {
         'data' => 'Theme 2',
       ]),
     ];
+  }
+
+  /**
+   * Test autocomplete on complex publisher elements.
+   *
+   * Inherited from SchemaUiHandlerTest::testAutocompleteOnComplex
+   * before decoupling.
+   */
+  public function testAutocompleteOnPublisher() {
+    // Test options with autocomplete widget, titleProperty and options from metastore.
+    // $widget_router = $this->getRouter($results);
+    $widget_router = WidgetRouter::create($this->getContainerChain()->getMock());
+    $options = (new Options())
+      ->add('json_form.string_helper', StringHelper::class)
+      ->add('dkan.json_form.logger_channel', LoggerInterface::class)
+      ->add('uuid', Php::class)
+      ->add('json_form.widget_router', $widget_router)
+      ->index(0);
+
+    $container_chain = (new Chain($this))
+      ->add(Container::class, 'get', $options);
+
+    $container = $container_chain->getMock();
+    $ui_handler = SchemaUiHandler::create($container);
+
+    $ui_schema = json_decode('{"publisher": {
+      "ui:options": {
+        "widget": "list",
+        "type": "autocomplete",
+        "titleProperty": "name",
+        "allowCreate": "true",
+        "multiple": "true",
+        "source": {
+          "metastoreSchema": "publisher"
+        }
+      }
+    }}');
+    $ui_handler->setSchemaUi($ui_schema);
+    $form = [
+      'publisher' => [
+        '#type' => 'details',
+        '#open' => TRUE,
+        '#title' => 'Organization',
+        '#description' => 'Some description',
+        'name' => [
+          '#type' => 'string',
+          '#title' => 'Publisher',
+          '#description' => 'Some description',
+          '#required' => FALSE,
+        ],
+      ],
+    ];
+    $expected = [
+      'publisher' => [
+        '#type' => 'details',
+        '#open' => TRUE,
+        '#title' => 'Organization',
+        '#description' => 'Some description',
+        'name' => [
+          '#type' => 'select2',
+          '#title' => 'Publisher',
+          '#description' => 'Some description',
+          '#required' => FALSE,
+          '#options' => [
+            'Publisher 1' => 'Publisher 1',
+            'Publisher 2' => 'Publisher 2',
+          ],
+          '#other_option' => '',
+          '#multiple' => TRUE,
+          '#autocreate' => TRUE,
+          '#target_type' => 'node',
+        ],
+      ],
+    ];
+    $form = $ui_handler->applySchemaUi($form);
+
+    $this->assertEquals($expected, $form);
   }
 
 }

--- a/modules/metastore/tests/src/Unit/Plugin/Field/FieldWidget/DkanJsonFieldWidgetTest.php
+++ b/modules/metastore/tests/src/Unit/Plugin/Field/FieldWidget/DkanJsonFieldWidgetTest.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Drupal\Tests\metastore\Unit\Field\FieldWidget;
+
+use Drupal\Component\DependencyInjection\Container;
+use Drupal\Component\Uuid\Php;
+use Drupal\json_form_widget\OptionSource\JsonFormOptionSourcePluginManager;
+use Drupal\json_form_widget\StringHelper;
+use PHPUnit\Framework\TestCase;
+use Drupal\json_form_widget\WidgetRouter;
+use Drupal\metastore\MetastoreService;
+use Drupal\metastore\Plugin\JsonFormOptionSource\MetastoreSchema;
+use MockChain\Chain;
+use MockChain\Options;
+
+/**
+ * Test class for ValueHandlerTest.
+ *
+ * @group metastore
+ * @coversDefaultClass \Drupal\metastore\WidgetRouter
+ */
+class DkanJsonFieldWidgetTest extends TestCase {
+
+  /**
+   * Some tests we inhereted from the original WidgetRouterTest.
+   * @dataProvider dataProvider
+   */
+  public function testHandleListElement($spec, $element, $handledElement) {
+    $router = WidgetRouter::create($this->getContainerChain()->getMock());
+
+    $new_element = $router->getConfiguredWidget($spec, $element);
+
+    $this->assertEquals($handledElement, $new_element);
+  }
+
+  private function getContainerChain() {
+    $containerGetOptions = (new Options())
+      ->add('uuid', Php::class)
+      ->add('json_form.string_helper', StringHelper::class)
+      ->add('dkan.metastore.service', MetastoreService::class)
+      ->add('plugin.manager.json_form_option_source', JsonFormOptionSourcePluginManager::class)
+      ->index(0);
+
+    $metastoreGetAllOptions = (new Options())
+      ->add('publisher', self::publishers())
+      ->add('data-dictionary', self::dataDictionaries())
+      ->add('theme', self::themes())
+      ->index(0);
+
+    return (new Chain($this))
+      ->add(Container::class, 'get', $containerGetOptions)
+      ->add(MetastoreService::class, 'getAll', $metastoreGetAllOptions)
+      ->add(JsonFormOptionSourcePluginManager::class, 'createInstance', MetastoreSchema::class)
+      ->add(MetastoreSchema::class, 'getMetastore', MetastoreService::class)
+      ->add(MetastoreService::class, 'getAll', $metastoreGetAllOptions);
+  }
+
+  /**
+   * Data provider.
+   *
+   * Each dataset gets is an array with three elements:
+   * 1. The spec object.
+   * 2. The element array.
+   * 3. The expected handled element array.
+   */
+  public static function dataProvider(): array {
+    return [
+      'tagField' => [
+        (object) [
+          'widget' => 'list',
+          'type' => 'autocomplete',
+          'allowComplete' => TRUE,
+          'multiple' => TRUE,
+          'source' => (object) [
+            'metastoreSchema' => 'theme',
+          ],
+        ],
+        [
+          '#type' => 'textfield',
+          '#title' => 'tags',
+        ],
+        [
+          '#type' => 'select2',
+          '#title' => 'tags',
+          '#options' => [],
+          '#other_option' => FALSE,
+          '#multiple' => TRUE,
+          '#autocreate' => FALSE,
+          '#target_type' => 'node',
+        ],
+      ],
+      // Publisher popualtes from metastore but returns whole object,
+      // is wrapped in a details element.
+      'publisherField' => [
+        (object) [
+          "widget" => "list",
+          "type" => "autocomplete",
+          "allowCreate" => TRUE,
+          "titleProperty" => "name",
+          "source" => (object) [
+            "metastoreSchema" => "publisher",
+          ],
+        ],
+        [
+          '#type' => 'details',
+          '#title' => 'Organization',
+          'name' => [
+            '#type' => 'textfield',
+            '#title' => "Publisher Name",
+            "#default_value" => NULL,
+            "#required" => TRUE,
+          ],
+        ],
+        [
+          '#type' => 'details',
+          '#title' => 'Organization',
+          'name' => [
+            '#type' => 'select2',
+            '#title' => 'Publisher Name',
+            '#default_value' => NULL,
+            '#required' => TRUE,
+            '#options' => [
+              'Publisher 1' => 'Publisher 1',
+              'Publisher 2' => 'Publisher 2',
+            ],
+            '#other_option' => FALSE,
+            '#multiple' => FALSE,
+            '#autocreate' => TRUE,
+            '#target_type' => 'node',
+          ],
+        ],
+      ],
+      // Data dict field draws from metastore but just shows URLs.
+      'dataDict' => [
+        (object) [
+          "widget" => "list",
+          "type" => "select",
+          "titleProperty" => "title",
+          "source" => (object) [
+            "metastoreSchema" => "data-dictionary",
+            "returnValue" => "url",
+          ],
+        ],
+        [
+          '#type' => 'url',
+          '#title' => 'Data Dictionary',
+        ],
+        [
+          '#type' => 'select',
+          '#title' => 'Data Dictionary',
+          '#options' => [
+            'dkan://metastore/schemas/data-dictionary/items/111' => 'Data dictionary 1',
+            'dkan://metastore/schemas/data-dictionary/items/222' => 'Data dictionary 2',
+          ],
+          '#other_option' => FALSE,
+        ],
+      ],
+    ];
+  }
+
+  public static function publishers() {
+    return [
+      json_encode((object) [
+        'identifier' => '111',
+        'data' => (object) [
+          '@type' => 'org:Organization',
+          'name' => 'Publisher 1',
+        ],
+      ]),
+      json_encode((object) [
+        'identifier' => '222',
+        'data' => (object) [
+          '@type' => 'org:Organization',
+          'name' => 'Publisher 2',
+        ],
+      ]),
+    ];
+  }
+
+  public static function dataDictionaries() {
+    return [
+      json_encode((object) [
+        'identifier' => '111',
+        'data' => (object) [
+          'title' => 'Data dictionary 1',
+        ],
+      ]),
+      json_encode((object) [
+        'identifier' => '222',
+        'data' => (object) [
+          'title' => 'Data dictionary 2',
+        ],
+      ]),
+    ];
+  }
+
+  public static function themes() {
+    return [
+      json_encode((object) [
+        'identifier' => '111',
+        'data' => (object) [
+          'name' => 'Theme 1',
+        ],
+      ]),
+      json_encode((object) [
+        'identifier' => '222',
+        'data' => (object) [
+          'name' => 'Theme 2',
+        ],
+      ]),
+    ];
+  }
+
+}


### PR DESCRIPTION
Fixes #4538

This PR adds another plugin type for "options sources." These plugins allow us to provide an array of options from any arbitrary source to be used for select fields, autocompletes etc when not supplied directly in the schema. This replaces the old "metastoreSchema" source property in UI schemas so that we can fully decouple JSON Form Widget from DKAN.

Backwards compatibility is provided with the old approach in the UI schema. Tests have been moved around to reflect where the code lives now, but should be equivilant.

A new Taxonomy source plugin is provided in the JSON Form Widget module, mostly as an example for other implementations.

## QA Steps

Functionality should not actually change, this is more about decoupling the code. Confirm the form still works as expected.

## Merge instructions

This should probably be rebased and merged after #4533 is merged. I tested a rebase locally and tests still passed...