### PR TITLE
Fix tagfield test

### DIFF
--- a/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
+++ b/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
@@ -37,6 +37,7 @@ class WidgetRouterTest extends TestCase {
     $metastoreGetAllOptions = (new Options())
       ->add('publisher', self::publishers())
       ->add('data-dictionary', self::dataDictionaries())
+      ->add('theme', self::themes())
       ->index(0);
 
     return (new Chain($this))
@@ -119,7 +120,10 @@ class WidgetRouterTest extends TestCase {
         [
           '#type' => 'select2',
           '#title' => 'tags',
-          '#options' => [],
+          '#options' => [
+            'Theme 1' => 'Theme 1',
+            'Theme 2' => 'Theme 2',
+          ],
           '#other_option' => FALSE,
           '#multiple' => TRUE,
           '#autocreate' => FALSE,
@@ -241,6 +245,19 @@ class WidgetRouterTest extends TestCase {
           '#other_option' => FALSE,
         ],
       ],
+    ];
+  }
+
+  public static function themes() {
+    return [
+      json_encode((object) [
+        'identifier' => '111',
+        'data' => 'Theme 1',
+      ]),
+      json_encode((object) [
+        'identifier' => '222',
+        'data' => 'Theme 2',
+      ]),
     ];
   }
 

--- a/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
+++ b/modules/json_form_widget/tests/src/Unit/WidgetRouterTest.php
@@ -108,7 +108,7 @@ class WidgetRouterTest extends TestCase {
           'type' => 'autocomplete',
           'allowComplete' => TRUE,
           'multiple' => TRUE,
-          'source' => [
+          'source' => (object) [
             'metastoreSchema' => 'theme',
           ],
         ],


### PR DESCRIPTION
Minor update to JSON Form Widget test to correct a place where we were getting a false positive. 

Because the source in the dataprovider was not being cast to object, it was just being ignored. 