### PR TITLE
Minimum of 1 for the "Limit" property in the datastore query schema

### DIFF
--- a/modules/datastore/docs/query.json
+++ b/modules/datastore/docs/query.json
@@ -84,7 +84,7 @@
         },
         "limit": {
             "type": "integer",
-            "description": "Limit for maximum number of records returned. Pass zero for no limit (may be restricted by user permissions).",
+            "description": "Limit for maximum number of records returned. Must be a minumum of 1.",
             "minimum": 1
         },
         "offset": {

--- a/modules/datastore/docs/query.json
+++ b/modules/datastore/docs/query.json
@@ -84,7 +84,8 @@
         },
         "limit": {
             "type": "integer",
-            "description": "Limit for maximum number of records returned. Pass zero for no limit (may be restricted by user permissions)."
+            "description": "Limit for maximum number of records returned. Pass zero for no limit (may be restricted by user permissions).",
+            "minimum": 1
         },
         "offset": {
             "type": "integer",

--- a/modules/datastore/tests/data/query/invalidLimitQuery.json
+++ b/modules/datastore/tests/data/query/invalidLimitQuery.json
@@ -1,0 +1,9 @@
+{
+    "resources": [
+        {
+            "id": "asdf",
+            "alias": "t"
+        }
+    ],
+    "limit": -1
+}

--- a/modules/datastore/tests/src/Unit/Service/DatastoreQueryTest.php
+++ b/modules/datastore/tests/src/Unit/Service/DatastoreQueryTest.php
@@ -145,6 +145,18 @@ class DatastoreQueryTest extends TestCase {
     $queryService->runQuery($datastoreQuery);
   }
 
+  /**
+   * Ensure if an invalid limit is specified, the query fails.
+   */
+  public function testInvalidLimitQuery() {
+    $this->expectExceptionMessage("JSON Schema validation failed");
+    $container = $this->getCommonMockChain();
+    \Drupal::setContainer($container->getMock());
+    $queryService = new Query(DatastoreService::create($container->getMock()));
+    $datastoreQuery = $this->getDatastoreQueryFromJson("invalidLimitQuery");
+    $queryService->runQuery($datastoreQuery);
+  }
+
   public function testRowIdsQuery() {
     $container = $this->getCommonMockChain()
       ->add(DatabaseTable::class, "getSchema", [


### PR DESCRIPTION
Fixes #4543 

## Describe your changes

Added a minimum attribute set to 1 for the limit property of the query schema. This change will affect both queries and downloads when a limit is present that is not 1 or greater. This change does not affect the existing row limit setting that is found at `/admin/dkan/datastore`. The default row limit is set to 500 and this will continue to work as expected for queries. Downloads are not capped at a specific row limit and will continue to work the same.

## QA Steps

- [ ] Create sample content
- [ ] https://dkan-project.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0/download?&format=csv&limit=0 will throw JSON Schema validation failed.
- [ ] https://dkan-project.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0?limit=0 will throw JSON Schema validation failed.
- [ ] https://dkan-project.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0/download?&format=csv&limit=1 will work
- [ ] https://dkan-project.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0?limit=1 will work

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
