### PR TITLE
Remove select2 asset from composer require.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "ilbee/csv-response": "^1.2.0",
         "justinrainbow/json-schema": "^5.2",
         "m1x0n/opis-json-schema-error-presenter": "^0.5.3",
-        "npm-asset/select2": "dev-develop#595494a",
         "oomphinc/composer-installers-extender": "^2.0",
         "ramsey/uuid": "^3.8.0 || ^4",
         "stolt/json-merge-patch": "^2.0",
@@ -68,8 +67,7 @@
             "url": "https://github.com/GetDKAN/data-catalog-app"
         },
         "installer-types": [
-            "bower-asset",
-            "npm-asset"
+            "bower-asset"
         ]
     },
     "discard-changes": true

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -63,7 +63,7 @@ If you already have an existing Drupal site, install DKAN with `composer <https:
    Do note that a bug in Drupal core cron may cause problems with data imports, and applying `this patch <https://www.drupal.org/project/drupal/issues/3274931>`_ is highly recommended. The patch will be applied automatically if you use the `recommended project <https://github.com/GetDKAN/recommended-project>`_.
 
 
-   warning::
+.. warning::
    DKAN requires som additional composer changes due to a dependency on the Select2 library. You should follow the steps in the `Select2 project's Readme <https://git.drupalcode.org/project/select2/-/blob/2.x/README.md?ref_type=heads#installation>`_.
 
 

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -64,7 +64,7 @@ If you already have an existing Drupal site, install DKAN with `composer <https:
 
 
 .. warning::
-   DKAN requires som additional composer changes due to a dependency on the Select2 library. You should follow the steps in the `Select2 project's Readme <https://git.drupalcode.org/project/select2/-/blob/2.x/README.md?ref_type=heads#installation>`_.
+   DKAN requires some additional composer changes due to a dependency on the Select2 library. You should follow the steps in the `Select2 project's Readme <https://git.drupalcode.org/project/select2/-/blob/2.x/README.md?ref_type=heads#installation>`_.
 
 
 Add some example datasets to your site

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -62,6 +62,11 @@ If you already have an existing Drupal site, install DKAN with `composer <https:
 .. warning::
    Do note that a bug in Drupal core cron may cause problems with data imports, and applying `this patch <https://www.drupal.org/project/drupal/issues/3274931>`_ is highly recommended. The patch will be applied automatically if you use the `recommended project <https://github.com/GetDKAN/recommended-project>`_.
 
+
+   warning::
+   DKAN requires som additional composer changes due to a dependency on the Select2 library. You should follow the steps in the `Select2 project's Readme <https://git.drupalcode.org/project/select2/-/blob/2.x/README.md?ref_type=heads#installation>`_.
+
+
 Add some example datasets to your site
 --------------------------------------
 


### PR DESCRIPTION
This should be handled at the project level, following [guidance from the select2 module readme](https://git.drupalcode.org/project/select2#composer-recommended).