### PR TITLE
Remove other unneeded properties from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "ilbee/csv-response": "^1.2.0",
         "justinrainbow/json-schema": "^5.2",
         "m1x0n/opis-json-schema-error-presenter": "^0.5.3",
-        "oomphinc/composer-installers-extender": "^2.0",
         "ramsey/uuid": "^3.8.0 || ^4",
         "stolt/json-merge-patch": "^2.0",
         "symfony/polyfill-php80": "^1.27"
@@ -46,18 +45,11 @@
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
-        },
-        "asset": {
-            "type": "composer",
-            "url": "https://asset-packagist.org"
         }
     },
-    "minimum-stability": "dev",
     "config": {
         "allow-plugins": {
-            "composer/installers": true,
             "cweagans/composer-patches": true,
-            "oomphinc/composer-installers-extender": true
         }
     },
     "extra": {
@@ -65,10 +57,6 @@
             "ref": "1.3.0",
             "type": "vcs",
             "url": "https://github.com/GetDKAN/data-catalog-app"
-        },
-        "installer-types": [
-            "bower-asset"
-        ]
-    },
-    "discard-changes": true
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -47,11 +47,6 @@
             "url": "https://packages.drupal.org/8"
         }
     },
-    "config": {
-        "allow-plugins": {
-            "cweagans/composer-patches": true,
-        }
-    },
     "extra": {
         "dkan-frontend": {
             "ref": "1.3.0",


### PR DESCRIPTION
As noted by @stefan-korn in #4545 discussion, there is a lot in DKAN's composer.json that doesn't make sense there; these are properties that belong in a _project root_ composer.json and DKAN as a module will always be a dependency of another Drupal project.

Existing projects will need to ensure that they have `oomphinc/composer-installers-extender` added to their composer.json file. See https://github.com/GetDKAN/recommended-project/commit/547d534365cda9f89d62a38722542b7160042aae.

Make sure to include these instructions in release notes!

## QA Steps

* Start a new project or delete your vendor, composer.lock and docroot/libraries/select2 files/folders
* Check out this branch of DKAN
* Make sure oomphinc/composer-installers-extender (as well as select2) are in your root composer.json file.
* Run composer install
* Confirm that build completes and docroot/libraries/select2 exists