### PR TITLE
Move metastore hook_update to hook_deploy

### DIFF
--- a/modules/metastore/metastore.deploy.php
+++ b/modules/metastore/metastore.deploy.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * Deploy hooks for the metastore module.
+ */
+
+/**
+ * Update the dkan_json_form_widget field widget settings.
+ */
+function metastore_deploy_1001(&$sandbox) {
+  // Retrieve the entity form display settings for the 'data' content type.
+  $entity_form_display = \Drupal::service('config.factory')
+    ->getEditable('core.entity_form_display.node.data.default');
+  // Update the 'dkan_json_form_widget' field widget settings.
+  $settings = $entity_form_display->get('content.field_json_metadata');
+  if (empty($settings)) {
+    return "No settings found for 'field_json_metadata'.";
+  }
+  if ($settings['type'] == 'json_form_widget') {
+    $settings['type'] = 'dkan_json_form_widget';
+    $entity_form_display->set('content.field_json_metadata', $settings)->save(TRUE);
+    return "Updated 'field_json_metadata' to use 'dkan_json_form_widget'.";
+  }
+  return "No changes were necessary. Nothing was updated.";
+}

--- a/modules/metastore/metastore.install
+++ b/modules/metastore/metastore.install
@@ -168,16 +168,7 @@ function metastore_update_8010() {
  * Update the dkan_json_form_widget field widget settings.
  */
 function metastore_update_8011() {
-  // Retrieve the entity form display settings for the 'data' content type.
-  $entity_form_display = \Drupal::service('config.factory')
-    ->getEditable('core.entity_form_display.node.data.default');
-  // Update the 'dkan_json_form_widget' field widget settings.
-  $settings = $entity_form_display->get('content.field_json_metadata');
-  if (empty($settings)) {
-    return "No settings found for 'field_json_metadata'.";
-  }
-  if ($settings['type'] == 'json_form_widget') {
-    $settings['type'] = 'dkan_json_form_widget';
-    $entity_form_display->set('content.field_json_metadata', $settings)->save(TRUE);
-  }
+  // All code moved to metastore_deploy_switch_to_dkan_json_form_widget
+  // This is only here to ensure the update number is preserved.
+  return 'Made no changes, they are deferred to happen in a deploy hook.';
 }


### PR DESCRIPTION
Fixes #4554

## Describe your changes
Moves the metastore_update_8011 to a deploy hook so that config changes do not get overwritten during drush deploy.
## QA Steps

- [ ] git checkout 4544-move-hook-update-to-deploy
- [ ] ddev composer install
- [ ] ddev drush deploy
- [ ] validate in the output that the deploy hook ran.
- [ ] ddev drush cex
- [ ] validate that you see new settings for the dkan_json_form_widget

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
