### PR TITLE
JSON Field Validation Improvements

### DIFF
--- a/modules/json_form_widget/css/style.css
+++ b/modules/json_form_widget/css/style.css
@@ -1,0 +1,10 @@
+/* Target any fieldset with the error class */
+fieldset.error {
+  border-width: var(--input--error-border-size) !important;
+  border-color: var(--input--error-border-color) !important;
+}
+
+/* Target any fieldset legend when it has an error */
+fieldset.error > legend > span.fieldset__label {
+  color: var(--input--error-color) !important;
+}

--- a/modules/json_form_widget/json_form_widget.libraries.yml
+++ b/modules/json_form_widget/json_form_widget.libraries.yml
@@ -1,0 +1,4 @@
+style:
+  css:
+    theme:
+      css/style.css: {}

--- a/modules/json_form_widget/json_form_widget.module
+++ b/modules/json_form_widget/json_form_widget.module
@@ -36,7 +36,17 @@ function json_form_widget_form_alter(&$form, FormStateInterface $form_state, $fo
   }
   if ($form_state->get('has_json_form_widget')) {
     $form['actions']['submit']['#submit'][] = [UploadOrLink::class, 'submit'];
+
+    // Add a validation handler.
+    $form['#validate'][] = '_json_form_widget_post_constraint_validation';
   }
+}
+
+/**
+ * Validation handler.
+ */
+function _json_form_widget_post_constraint_validation(array &$form, FormStateInterface $form_state) {
+  \Drupal::service('json_form.form_post_validate')->onPostConstraintValidate($form, $form_state);
 }
 
 /**

--- a/modules/json_form_widget/json_form_widget.services.yml
+++ b/modules/json_form_widget/json_form_widget.services.yml
@@ -42,3 +42,5 @@ services:
     parent: logger.channel_base
     arguments: 
       - 'json_form_widget'
+  json_form.form_post_validate:
+    class: \Drupal\json_form_widget\FormPostValidate

--- a/modules/json_form_widget/src/FormPostValidate.php
+++ b/modules/json_form_widget/src/FormPostValidate.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\json_form_widget;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Component\Utility\NestedArray;
+
+/**
+ * Post validation.
+ */
+class FormPostValidate {
+
+  /**
+   * Handles the post-constraint validation event.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public function onPostConstraintValidate(array &$form, FormStateInterface $form_state) {
+    if (empty($errors = $form_state->getErrors())) {
+      return;
+    }
+
+    $form_state->clearErrors();
+
+    $form['#attached']['library'][] = 'json_form_widget/style';
+
+    foreach ($errors as $error) {
+      $message = $error->__toString();
+      $field_name_json = $error->getArguments()['json_field_pointer'];
+      $field_name = json_decode($field_name_json, TRUE);
+
+      $full_path = ['field_json_metadata', 'widget', 0, 'value'];
+      $full_path = array_merge($full_path, $field_name);
+
+      $element = &NestedArray::getValue($form, $full_path, $key_exists);
+
+      if ($key_exists && is_array($element)) {
+        $form_state->setError($element, $message);
+      }
+    }
+  }
+
+}

--- a/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidgetBase.php
+++ b/modules/json_form_widget/src/Plugin/Field/FieldWidget/JsonFormWidgetBase.php
@@ -103,9 +103,40 @@ abstract class JsonFormWidgetBase extends WidgetBase implements WidgetInterface 
     // Attempt to build the form.
     $json_form = $this->builder->getJsonForm($default_data, $form_state);
     if ($json_form) {
-      return ['value' => $json_form];
+    // Add entity_builders callback - runs AFTER entity validation
+      //$element['#element_validate'][] = [$this, 'lateValidationHandler'];
+      $element['value'] = $json_form;
+    return $element;
     }
   }
+
+/**
+ * Late validation handler.
+ */
+public static function lateValidationHandler(array &$form, FormStateInterface $form_state) {
+  if ($form_state->hasAnyErrors()) {
+    return;
+  }
+  
+  // Get the entity being validated
+  $form_object = $form_state->getFormObject();
+  if (method_exists($form_object, 'getEntity')) {
+    $entity = $form_object->getEntity();
+    
+    // Manually validate the entity constraints
+    $violations = $entity->validate();
+    
+    // If there are violations, process them with your service
+    if (count($violations) > 0) {
+      $field_name = $form_state->get('json_form_widget_field');
+      $element = $form[$field_name]['widget'][0] ?? null;
+      
+      if ($element) {
+        \Drupal::service('json_form.form_post_validate')->onPostConstraintValidate($element, $form, $form_state);
+      }
+    }
+  }
+}
 
   /**
    * {@inheritdoc}

--- a/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
+++ b/modules/metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
@@ -107,7 +107,7 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
       $this->validMetadataFactory->get($item->value, $schema_id);
     }
     catch (ValidationException $e) {
-      $errors = $this->getValidationErrorsMessages($e->getResult()->getErrors());
+      $errors = $e->getResult()->getErrors();
     }
     catch (InvalidArgumentException $e) {
       $errors[] = $e->getMessage();
@@ -116,31 +116,86 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
   }
 
   /**
-   * Presents errors.
-   *
-   * @param array $errors
-   *   Validation errors array.
-   *
-   * @return array
-   *   Presented errors array.
-   */
-  private function getValidationErrorsMessages(array $errors): array {
-    $presented = $this->presenter->present(...$errors);
-    return array_map(
-      function ($presented_error) {
-        return $presented_error->message();
-      },
-      $presented
-    );
-  }
-
-  /**
-   * Add Violations.
+   * Add Violations with field context.
    */
   private function addViolations($errors) {
     foreach ($errors as $error) {
-      $this->context->addViolation($error);
+      // Extract field information from error pointer
+      $field_name = $this->extractFieldFromPointer($error);
+      $message = is_array($error) ? $error['message'] : $this->presenter->present($error)[0]->message();
+      
+      // Add violation with field context
+      $violation = $this->context->buildViolation($message);
+      
+      // Store field information in the violation for later use
+      if ($field_name) {
+        $violation->setParameter('json_field_pointer', json_encode($field_name));
+      }
+      
+      $violation->addViolation();
     }
+  }
+
+  /**
+   * Extract field name from JSON Schema error pointer.
+   */
+  private function extractFieldFromPointer($error) {
+    if (!is_object($error)) {
+      return null;
+    }
+    
+    // Handle required field errors - field name is in keywordArgs['missing']
+    if (method_exists($error, 'keywordArgs')) {
+      $keywordArgs = $error->keywordArgs();
+      if (isset($keywordArgs['missing'])) {
+        return [$keywordArgs['missing']];
+      }
+    }
+    
+    // Handle other validation errors - field name is in dataPointer
+    if (method_exists($error, 'dataPointer')) {
+      $pointer = $error->dataPointer();
+      if (is_array($pointer) && !empty($pointer)) {
+        // If dataPointer contains just one index, return it as an array
+        if (count($pointer) === 1) {
+          return $pointer;
+        }
+        
+        // For array fields with multiple indices, we need to add the field name both before and after numeric indices
+        $processed_pointer = [];
+        
+        foreach ($pointer as $index => $part) {
+          // If this is the first part and it's a field name, add it twice
+          if ($index === 0 && !is_numeric($part)) {
+            $processed_pointer[] = $part; // First occurrence
+            $processed_pointer[] = $part; // Second occurrence for array structure
+          }
+          // If this is a numeric index, add it and then add the field name after
+          elseif (is_numeric($part)) {
+            $processed_pointer[] = $part;
+            // Find the field name (first non-numeric part)
+            $field_name = null;
+            foreach ($pointer as $p) {
+              if (!is_numeric($p)) {
+                $field_name = $p;
+                break;
+              }
+            }
+            if ($field_name) {
+              $processed_pointer[] = $field_name;
+            }
+          }
+          // For other parts (like 'privateEmail'), just add them
+          else {
+            $processed_pointer[] = $part;
+          }
+        }
+        
+        return $processed_pointer;
+      }
+    }
+    
+    return null;
   }
 
 }

--- a/schema/collections/dataset.json
+++ b/schema/collections/dataset.json
@@ -9,7 +9,8 @@
     "identifier",
     "accessLevel",
     "modified",
-    "keyword"
+    "keyword",
+    "creators"
   ],
   "properties": {
     "@type": {
@@ -22,7 +23,80 @@
       "title": "Title",
       "description": "Human-readable name of the asset. Should be in plain English and include sufficient detail to facilitate search and discovery.",
       "type": "string",
-      "minLength": 1
+      "minLength": 10
+    },
+    "number": {
+      "title": "Number",
+      "description": "Human-readable name of the asset. Should be in plain English and include sufficient detail to facilitate search and discovery.",
+      "type": "integer",
+      "minimum": 10
+    },
+    "creators": {
+      "title": "Author Information",
+      "type": "array",
+      "items": {
+        "title": "Author",
+        "type": "object",
+        "properties": {
+          "givenName": {
+            "title": "First Name",
+            "type": "string"
+          },
+          "middleName": {
+            "title": "Middle Name",
+            "type": "string"
+          },
+          "familyName": {
+            "title": "Last Name",
+            "type": "string"
+          },
+          "privateEmail": {
+            "title": "Email",
+            "format": "email",
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "givenName",
+          "familyName",
+          "privateEmail"
+        ]
+      },
+      "minItems": 2
+    },
+    "creators-not-required": {
+      "title": "Author Information NOT",
+      "type": "array",
+      "items": {
+        "title": "Author",
+        "type": "object",
+        "properties": {
+          "givenName": {
+            "title": "First Name",
+            "type": "string"
+          },
+          "middleName": {
+            "title": "Middle Name",
+            "type": "string"
+          },
+          "familyName": {
+            "title": "Last Name",
+            "type": "string"
+          },
+          "privateEmail": {
+            "title": "Email",
+            "format": "email",
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "givenName",
+          "familyName",
+          "privateEmail"
+        ]
+      }
     },
     "identifier": {
       "title": "Unique Identifier",


### PR DESCRIPTION
Fixes #4530 

## Describe your changes

This PR introduces improvements to JSON Field Validation. 

Our forms contain a single field called **field-json-metadata**, and when an error is caught in the entity-layer in`ProperJsonValidator` the user will see the all the fields turn red. This is not ideal and we need to be able to highlight the field that has the error so the user can quickly identify and resolve the issue. 

It's important to understand the order of validation. First form validation occurs, then entity validation. Because entity validation catches integrity issues on the node, it adds violations into the context and when the form reloads it highlights the entire **field-json-metadata** field. 

We have been relying mostly on schemaValidation in Opis\JsonSchema to validate the json string against the json schema. The errors are caught in ProperJsonValidator where they are added as violations to the context. We also have have element and form validation scattered around in the helper classes in json_form_widget module. What I am proposing is that we rely only on the json schema validation as the sole validator. 

The following is generated by copilot and reviewed by @kaise-lafrai 

**Validation and Error Handling Enhancements:**

* Introduced a new `FormPostValidate` service and handler (`FormPostValidate.php`) to process validation errors after constraint validation, attach the error styling library, and set errors on the correct form elements. [[1]](diffhunk://#diff-64f8cd63211ef841010711b9b36071736a73862e78825fd890d0cacc9b27ddc8R1-R46) [[2]](diffhunk://#diff-6d7c6e5152f4a6aac5d677ade3ddb321e9f761ef89f072eb78d95cc177226b02R39-R49) [[3]](diffhunk://#diff-3d6fd296bab3998e52eabc1ab34febbeec4fe4ac357271a1e0c1f070143d240fR45-R46)
* Improved error reporting in `ProperJsonValidator` by extracting field context from validation errors and attaching it to constraint violations, enabling precise error mapping in the form. [[1]](diffhunk://#diff-e0cf37521dd75d79179afae8117f2f20620f23420d01267258d29a20c8a3de53L110-R110) [[2]](diffhunk://#diff-e0cf37521dd75d79179afae8117f2f20620f23420d01267258d29a20c8a3de53L119-R198). 
* NOTE: The code within the method (`extractFieldFromPointer`) found in the `ProperJsonValidator` is not ideal when it comes to handling dataPointers that are complex like nested arrays. I think this can be improved so were not assuming a structure that can change in the future. For example, the dataPointer to the error is an array with the following index ['creator','0','email'] but we need the full path to the element so were building that to be something like ['creator','creator','0','creator','0','email'] this then gets stored using `setParameter` and later used in the `FormPostValidate` to set get the element and set the error. [1](https://github.com/GetDKAN/dkan/pull/4558/files#diff-e0cf37521dd75d79179afae8117f2f20620f23420d01267258d29a20c8a3de53R142-R196)

**User Interface Improvements:**

* Added a CSS file (`style.css`) and library to visually highlight fieldsets and legends with validation errors, making it easier for users to identify problematic fields. [[1]](diffhunk://#diff-1444a000394f6455667642516c7b96f509927415f0cd2b78e5bc8c49ab7995f1R1-R10) [[2]](diffhunk://#diff-f65db8ae2af1eae36f2cf2749bab7a41f190630fb92cca59a947d34a622b606aR1-R4)

**Schema and Data Structure Updates for TESTING PURPOSES ONLY**

* Extended the dataset JSON schema to require a `creators` array (with at least two authors), each having required fields (`givenName`, `familyName`, `privateEmail`), and added new fields like `number` with validation constraints. [[1]](diffhunk://#diff-2f248e1dfc82d874ea5ea266d383439cf7800e376e65920edd45a9379494b97cL12-R13) [[2]](diffhunk://#diff-2f248e1dfc82d874ea5ea266d383439cf7800e376e65920edd45a9379494b97cR26-R99)

**Form Widget Integration:**

* Updated the JSON form widget to support late validation handling, ensuring entity constraints are validated and errors are passed to the new post-validation handler for accurate feedback. 
* NOTE: It was discussed that maybe this get moved over into the metastore module. 

These changes collectively provide more robust and user-friendly validation for complex JSON forms, especially for forms with nested or array-based fields.

### TO DO

- Confirm this approach works and is a good practice. 
- Confirm that this approach does not affect other custom validation that could occur during validation that is not field related. If it does we may need to adjust or pivot from this approach. 
- Since we are planning to decouple json_form_widget, we should look at this code in that lense and see if we can do anything to help move us in that direction in the future. 
- The error messages provided by the json schema validation are generic and don't provide enough info at times about the specific field that has the error. Look into adjusting the message/parameters that can be used to modify the error message.
- Right now the first error that is caught throws an exception and displays to the user after saving the form, we may want to change that so all the errors that are currently present are displayed to the user when they save the form.
- Need tests.

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
