### PR TITLE
Use resource id not dist in dashboard

### DIFF
--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -574,7 +574,7 @@ class DashboardForm extends FormBase {
       [
         'data' => [
           '#theme' => 'datastore_dashboard_resource_cell',
-          '#uuid' => $dist['distribution_uuid'],
+          '#uuid' => $dist['resource_id'],
           '#file_name' => basename((string) $dist['source_path']),
           '#file_path' => UrlHostTokenResolver::resolve($dist['source_path']),
         ],

--- a/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
+++ b/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
@@ -424,7 +424,7 @@ class DashboardFormTest extends TestCase {
         'distributions' => [
           [
             'distribution_uuid' => 'dist-1',
-            'resource_id' => '9ad17d45894f823c6a8e4f6d32b9535g',
+            'resource_id' => 'resource-1',
             'resource_version' => '1679508886',
             'fetcher_status' => 'waiting',
             'fetcher_percent_done' => 0,
@@ -436,7 +436,7 @@ class DashboardFormTest extends TestCase {
           ],
           [
             'distribution_uuid' => 'dist-2',
-            'resource_id' => '9ad17d45894f823c6a8e4f6d32b9535g',
+            'resource_id' => 'resource-2',
             'resource_version' => '1679508886',
             'fetcher_status' => 'waiting',
             'fetcher_percent_done' => 0,
@@ -480,7 +480,7 @@ class DashboardFormTest extends TestCase {
     $this->assertEquals(2, count($form['table']['#rows']));
 
     // Table uuid for first row is correct.
-    $this->assertEquals('dist-1', $form['table']['#rows'][0][3]['data']['#uuid']);
+    $this->assertEquals('resource-1', $form['table']['#rows'][0][3]['data']['#uuid']);
     // First row has six columns.
     $this->assertEquals(5, count($form['table']['#rows'][0]));
     // Rowspan on first two columns.
@@ -496,8 +496,8 @@ class DashboardFormTest extends TestCase {
 
     // The second row has only four columns.
     $this->assertEquals(4, count($form['table']['#rows'][1]));
-    // Table uuid for first second row is correct.
-    $this->assertEquals('dist-2', $form['table']['#rows'][1][0]['data']['#uuid']);
+    // Resource ID for first second row is correct.
+    $this->assertEquals('resource-2', $form['table']['#rows'][1][0]['data']['#uuid']);
     // The second row fetch status is correct.
     $this->assertEquals('waiting', $form["table"]["#rows"][1][1]["data"]["#status"]);
     // The second row fetch class is correct.
@@ -527,7 +527,7 @@ class DashboardFormTest extends TestCase {
         'distributions' => [
           [
             'distribution_uuid' => 'dist-1',
-            'resource_id' => '9ad17d45894f823c6a8e4f6d32b9535g',
+            'resource_id' => 'resource-1',
             'resource_version' => '1679508886',
             'fetcher_status' => 'waiting',
             'fetcher_percent_done' => 0,
@@ -539,7 +539,7 @@ class DashboardFormTest extends TestCase {
           ],
           [
             'distribution_uuid' => 'dist-2',
-            'resource_id' => '9ad17d45894f823c6a8e4f6d32b9535g',
+            'resource_id' => 'resource-2',
             'resource_version' => '1679508886',
             'fetcher_status' => 'done',
             'fetcher_percent_done' => 100,
@@ -585,8 +585,8 @@ class DashboardFormTest extends TestCase {
     // The second row has only three columns.
     $this->assertEquals(4, count($form['table']['#rows'][1]));
 
-    $this->assertEquals('dist-1', $form['table']['#rows'][0][3]['data']['#uuid']);
-    $this->assertEquals('dist-2', $form['table']['#rows'][1][0]['data']['#uuid']);
+    $this->assertEquals('resource-1', $form['table']['#rows'][0][3]['data']['#uuid']);
+    $this->assertEquals('resource-2', $form['table']['#rows'][1][0]['data']['#uuid']);
     $this->assertEquals('done', $form['table']['#rows'][0][6]['data']['#status']);
     $this->assertEquals(NULL, $form['table']['#rows'][0][6]['data']['#error']);
   }


### PR DESCRIPTION
Fixes #4561

## QA steps

1. Build from branch
2. Load and import sample content
3. Visit admin/dkan/datastore/status
4. Confirm resource ID for bike lanes dataset is `3a187a87dc6cd47c48b6b4c4785224b7`
5. Run `drush dkan:dataset-info cedcd327-4e5d-43f9-8eb1-c11850fa7c55`
6. Confirm resource ID is correct