### PR TITLE
Restrict view perms, remove routing perms

### DIFF
--- a/modules/metastore/metastore.routing.yml
+++ b/modules/metastore/metastore.routing.yml
@@ -179,5 +179,4 @@ metastore.datasets:
   defaults:
     _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
     _title: 'Datasets'
-  requirements:
-    _permission: 'create data content'
+

--- a/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
+++ b/modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
@@ -1,3 +1,4 @@
+uuid: 46a91364-3cbb-4ebd-a24c-264a2a2f4b58
 langcode: en
 status: true
 dependencies:
@@ -8,6 +9,8 @@ dependencies:
     - content_moderation
     - node
     - user
+_core:
+  default_config_hash: o0UfNa65CPMhdBKibp7p9bkwwQxjlfa-7_DFEN6FDcM
 id: dkan_dataset_content
 label: 'DKAN Datasets'
 module: node
@@ -594,7 +597,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'create data content'
+          perm: 'edit any data content'
       cache:
         type: tag
       empty:

--- a/modules/metastore/modules/metastore_admin/metastore_admin.install
+++ b/modules/metastore/modules/metastore_admin/metastore_admin.install
@@ -132,3 +132,13 @@ function metastore_admin_update_10001() {
   If you have not made customizations to the existing view, pull in the latest updates with
   drush cim --partial --source=modules/contrib/dkan/modules/metastore/modules/metastore_admin/config/install -y');
 }
+
+/**
+ * Notification DKAN admin view permissions change (info only).
+ */
+function metastore_admin_update_10002() {
+  return t('~~~~~ IMPORTANT ~~~~~ There are permission changes to the DKAN admin
+  view; re-import the default configuration if you have not customized the view.
+  
+  See https://github.com/GetDKAN/dkan/releases/tag/2.21.2 for more information.');
+}


### PR DESCRIPTION
Fixes #4531

## Describe your changes

Switches to "edit any data content" as perm in the view config, removes perm requirement from routing.

## Include in release notes

> [!NOTE] 
> This release fixes a problem reported in #4531; that the permissions to access the datasets admin page were too permissive. The change will not be automatically applied; see the section below "View Update Instructions" for how to import the new config.

### View update instructions

The changes to the datasets admin view are not automatically applied, to avoid blowing away any customizations. If you are comfortable replacing the default datasets admin view at admin/dkan/datasets, use either one of the following methods:

* Run the drush command `drush cim --partial --source=modules/contrib/dkan/modules/metastore/modules/metastore_admin/config/install -y`
* Use the configuration sync UI:
  1. Open the file modules/metastore/modules/metastore_admin/config/install/views.view.dkan_dataset_content.yml
  2. Copy the full contents
  3. Navigate to admin/config/development/configuration/single/import
  4. Set "Configuration type" to "View"
  5. Paste the contents of the yml file
  6. Click "Import"

## QA Steps

- [ ] Check out 2.x branch
- [ ] Log in as user 1 (`drush uli`)
- [ ] Create a new role, "depositor"
- [ ] Go to permissions and give depositor permission to create data content
- [ ] Create a user and give it the depositor role
- [ ] In another browser, log in as depositor user and confirm you can see /admin/dkan/datasets
- [ ] Check out branch `datasets-view-auth`
- [ ] Run `drush updatedb`, confirm update hook message makes sense
- [ ] Run `drush cim --partial --source=modules/contrib/dkan/modules/metastore/modules/metastore_admin/config/install -y`
- [ ] Confirm that the depositor can no longer access the dataset list
- [ ] Confirm that User 1 can access it, and all menu behavior is the same

