### PR TITLE
Additional decoupling of DKAN from JSON Form Widget in tests

### DIFF
--- a/modules/json_form_widget/tests/src/Kernel/Element/UploadOrLinkTest.php
+++ b/modules/json_form_widget/tests/src/Kernel/Element/UploadOrLinkTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\json_form_widget\Tests\Kernel\Element;
+namespace Drupal\Tests\json_form_widget\Kernel\Element;
 
 use Drupal\json_form_widget\Element\UploadOrLink;
 use Drupal\KernelTests\KernelTestBase;
@@ -13,8 +13,6 @@ class UploadOrLinkTest extends KernelTestBase {
     'json_form_widget',
     'file',
     'node',
-    'metastore',
-    'common',
     'user',
     'system',
   ];

--- a/modules/json_form_widget/tests/src/Kernel/Plugin/JsonFormOptionSource/TaxonomySourceTest.php
+++ b/modules/json_form_widget/tests/src/Kernel/Plugin/JsonFormOptionSource/TaxonomySourceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\json_form_widget\Tests\Kernel\Plugin\JsonFormOptionSource;
+namespace Drupal\Tests\json_form_widget\Kernel\Plugin\JsonFormOptionSource;
 
 use Drupal\json_form_widget\Plugin\JsonFormOptionSource\TaxonomySource;
 use Drupal\KernelTests\KernelTestBase;

--- a/modules/json_form_widget/tests/src/Unit/ArrayHelperTest.php
+++ b/modules/json_form_widget/tests/src/Unit/ArrayHelperTest.php
@@ -12,7 +12,6 @@ use Drupal\json_form_widget\IntegerHelper;
 use Drupal\json_form_widget\ObjectHelper;
 use Drupal\json_form_widget\SchemaUiHandler;
 use Drupal\json_form_widget\StringHelper;
-use Drupal\metastore\SchemaRetriever;
 use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;
@@ -44,7 +43,6 @@ class ArrayHelperTest extends TestCase {
 
     $array_helper = ArrayHelper::create($chain);
     $options = (new Options())
-      ->add('dkan.metastore.schema_retriever', SchemaRetriever::class)
       ->add('json_form.router', FieldTypeRouter::class)
       ->add('json_form.string_helper', StringHelper::class)
       ->add('json_form.object_helper', ObjectHelper::class)
@@ -58,7 +56,6 @@ class ArrayHelperTest extends TestCase {
     $distribution_schema = $this->getSchema();
     $container_chain = (new Chain($this))
       ->add(Container::class, 'get', $options)
-      ->add(SchemaRetriever::class, 'retrieve', $distribution_schema)
       ->add(SchemaUiHandler::class, 'setSchemaUi')
       ->add(ObjectHelper::class, 'handleObjectElement', $object)
       ->add(ObjectHelper::class, 'setBuilder')

--- a/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
+++ b/modules/json_form_widget/tests/src/Unit/JsonFormBuilderTest.php
@@ -13,7 +13,6 @@ use Drupal\json_form_widget\IntegerHelper;
 use Drupal\json_form_widget\ObjectHelper;
 use Drupal\json_form_widget\SchemaUiHandler;
 use Drupal\json_form_widget\StringHelper;
-use Drupal\metastore\SchemaRetriever;
 use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;
@@ -131,7 +130,6 @@ class JsonFormBuilderTest extends TestCase {
    */
   protected function getDetaultContainerChain(): Chain {
     $options = (new Options())
-      ->add('dkan.metastore.schema_retriever', SchemaRetriever::class)
       ->add('json_form.router', $this->getRouter())
       ->add('json_form.schema_ui_handler', SchemaUiHandler::class)
       ->add('dkan.json_form.logger_channel', LoggerInterface::class)

--- a/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
+++ b/modules/json_form_widget/tests/src/Unit/SchemaUiHandlerTest.php
@@ -11,11 +11,9 @@ use Drupal\Core\Language\LanguageDefault;
 use Drupal\Core\Language\LanguageManager;
 use Drupal\json_form_widget\OptionSource\JsonFormOptionSourcePluginManager;
 use Drupal\json_form_widget\Plugin\JsonFormOptionSource\TaxonomySource;
-use Drupal\Tests\metastore\Unit\MetastoreServiceTest;
 use Drupal\json_form_widget\SchemaUiHandler;
 use Drupal\json_form_widget\StringHelper;
 use Drupal\json_form_widget\WidgetRouter;
-use Drupal\metastore\MetastoreService;
 use Drupal\taxonomy\TermStorageInterface;
 use MockChain\Chain;
 use MockChain\Options;
@@ -30,17 +28,9 @@ use Psr\Log\LoggerInterface;
  * @group unit
  */
 class SchemaUiHandlerTest extends TestCase {
-
-  /**
-   * The ValidMetadataFactory class used for testing.
-   *
-   * @var \Drupal\metastore\ValidMetadataFactory|\PHPUnit\Framework\MockObject\MockObject
-   */
-  protected $validMetadataFactory;
-
+  
   protected function setUp(): void {
     parent::setUp();
-    $this->validMetadataFactory = MetastoreServiceTest::getValidMetadataFactory($this);
 
     // We need a global container with language_manager.
     $language_manager = new LanguageManager(new LanguageDefault(['en']));
@@ -818,7 +808,6 @@ class SchemaUiHandlerTest extends TestCase {
     $options = (new Options())
       ->add('json_form.string_helper', $string_helper)
       ->add('uuid', Php::class)
-      ->add('dkan.metastore.service', MetastoreService::class)
       ->add('plugin.manager.json_form_option_source', JsonFormOptionSourcePluginManager::class)
       ->index(0);
 


### PR DESCRIPTION
Continuing with #4383, there are some remaining calls to DKAN modules in the Unit and Kernel tests. These changes remove them. None of them were needed for the tests to pass anymore; simply overlooked during previous decoupling work.

We still have the functional tests entangled. These should probably just be moved wholesale to metastore, and equivalents made that don't rely on DKAN and its schema retriever in the main module. Not quite at a point where we can do that yet though.

Also fixes some incorrect test namespaces.