### PR TITLE
Fix mysql importer empty row skipper.

### DIFF
--- a/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/datastore/modules/datastore_mysql_import/src/Service/MysqlImport.php
@@ -294,9 +294,10 @@ class MysqlImport extends ImportJob {
   protected function removeEmptyRows(string $table_name, array $fields): void {
     $connection = \Drupal::database();
     $query = $connection->delete($table_name);
-    foreach ($fields as $field) {
+    $field_names = array_keys($fields);
+    foreach ($field_names as $field_name) {
       // Build query to look for records with all empty values for all fields.
-      $query->condition($field['description'], '', '=');
+      $query->condition($field_name, '', '=');
     }
     $num_deleted = $query->execute();
     if ($num_deleted > 0) {


### PR DESCRIPTION
Fixes #4539

## Describe your changes

## QA Steps

Unfortunately this needs the full import
- [ ] ddev dkan-site-install
- [ ] ddev drush en datastore_mysql_import -y
- [ ] ddev drush en sample_content -y
- [ ] ddev drush config:set datastore_mysql_import.settings remove_empty_rows 1
- [ ] ddev drush dkan:sample-content:create
- [ ] ddev drush queue:run localize_import
- [ ] ddev drush queue:run datastore_import
- [ ] Validate no errors on import.
- [ ] Validate phpunit testMysqlImporterWithRemoveMultipleEmptyRows passes
- [ ] Validate phpunit testMysqlImporterWithoutRemoveMultipleEmptyRows passes

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
