### PR TITLE
Minimal cleanup of dkan_js_frontend

### DIFF
--- a/modules/dkan_js_frontend/README.md
+++ b/modules/dkan_js_frontend/README.md
@@ -9,9 +9,9 @@ The paths used are defined by the `dkan_js_frontend.config` yml. In the routes a
 If the Drupal [Simple XML sitemap module](https://www.drupal.org/project/simple_sitemap) is installed, the DKAN JS Frontend module will automatically add static routes and dataset routes listed in the `dkan_js_frontend.config` yml to the default sitemap.
 
 ## JS/CSS
-The module assumes Create React App (CRA) has been loaded into the `/src/frontend` folder of the site. This can be changed by updating the `dkan_js_frontend.config` keys of `css_folder` and `js_folder` with the new directory path.
+The module assumes a JavaScript app has been loaded into the `/src/frontend` folder of the site. This can be changed by updating the `dkan_js_frontend.config` keys of `css_folder` and `js_folder` with the new directory path.
 
-The code will glob all files in the folders specified and attach them to any route/path that has been defined. The glob functionality should allow you to get around issues like CRA's hash in file names. The JS/CSS is directly attached to the page template provided, so the generated `index.html` file from CRA will not be used so all header updates will need to be made in Drupal and not the public files provided by the JS framework.
+The code will glob all files in the folders specified and attach them to any route/path that has been defined. The glob functionality should allow you to get around issues like Create React App (CRA)'s hash in file names. The JS/CSS is directly attached to the page template provided, so the generated `index.html` file from CRA will not be used so all header updates will need to be made in Drupal and not the public files provided by the JS framework.
 
 ## [Data Catalog App](https://github.com/GetDKAN/data-catalog-app#readme)
 

--- a/modules/dkan_js_frontend/dkan_js_frontend.info.yml
+++ b/modules/dkan_js_frontend/dkan_js_frontend.info.yml
@@ -4,4 +4,5 @@ type: module
 core_version_requirement: ^10.2 || ^11
 dependencies:
   - drupal:field
+  - getdkan:metastore
 package: DKAN

--- a/modules/dkan_js_frontend/dkan_js_frontend.info.yml
+++ b/modules/dkan_js_frontend/dkan_js_frontend.info.yml
@@ -4,5 +4,5 @@ type: module
 core_version_requirement: ^10.2 || ^11
 dependencies:
   - drupal:field
-  - getdkan:metastore
+  - dkan:metastore
 package: DKAN

--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -31,7 +31,7 @@ const DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK = [
 function dkan_js_frontend_library_info_build() {
   $libraries = [];
 
-  $config = \Drupal::config('dkan_js_frontend');
+  $config = \Drupal::config('dkan_js_frontend.config');
   $minified = $config->get('minified') ?? FALSE;
   $preprocess = $config->get('preprocess') ?? TRUE;
   $js_path = $config->get('js_folder');

--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -19,19 +19,22 @@ const DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK = [
 
 /**
  * Implements hook_library_info_build().
- * Collects all CSS/JS files in the paths set in config 
- * and adds them the dkan_js_frontend.
+ *
+ * Collects all CSS/JS files in the paths set in config and adds them to
+ * dkan_js_frontend.
  *
  * @return array
  */
 function dkan_js_frontend_library_info_build() {
   $libraries = [];
-  $minified = \Drupal::config('dkan_js_frontend.config')->get('minified');
-  $preprocess = \Drupal::config('dkan_js_frontend.config')->get('preprocess');
-  $js_path = \Drupal::config('dkan_js_frontend.config')->get('js_folder');
-  $css_path = \Drupal::config('dkan_js_frontend.config')->get('css_folder');
-  $js = \Drupal::config('dkan_js_frontend.config')->get('js');
-  $css = \Drupal::config('dkan_js_frontend.config')->get('js');
+
+  $config = \Drupal::config('dkan_js_frontend');
+  $minified = $config->get('minified') ?? FALSE;
+  $preprocess = $config->get('preprocess') ?? TRUE;
+  $js_path = $config->get('js_folder');
+  $css_path = $config->get('css_folder');
+  $js = $config->get('js');
+  $css = $config->get('css');
 
   foreach(glob(\Drupal::root() . $js_path . '*.js') as $full_path) {
     $basename = basename($full_path);
@@ -73,7 +76,7 @@ function dkan_js_frontend_library_info_build() {
       }
       // Set the weight if available.
       if(isset($css['weight'])) {
-        $libraries['dkan_js_frontend']['css']['theme'][$js_pcss_pathath . $basename]['weight'] = $css['weight'];
+        $libraries['dkan_js_frontend']['css']['theme'][$css_path . $basename]['weight'] = $css['weight'];
       }
     }
     $libraries['dkan_js_frontend']['css']['theme'][$css_path . $basename]['minified'] = $minified ?? false;
@@ -88,6 +91,8 @@ function dkan_js_frontend_library_info_build() {
 /**
  * Implements hook_page_attachments().
  *
+ * Any route with a 'name' default with a value of dkan_js_frontend gets the
+ * library attached.
  */
 function dkan_js_frontend_page_attachments(array &$page) {
   $request = \Drupal::routeMatch()->getRouteObject()->getDefault('name');
@@ -108,12 +113,12 @@ function dkan_js_frontend_theme_suggestions_page_alter(array &$suggestions, arra
 
 /**
  * Implements hook_theme().
- * 
+ *
  * Register a module or theme's theme implementations.
  * The implementations declared by this hook specify how a particular render array is to be rendered as HTML.
- * 
+ *
  * See: https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Render%21theme.api.php/function/hook_theme/8.2.x
- * 
+ *
  * If you change this method, clear theme registry and routing table 'drush cc theme-registry' and 'drush cc router'.
  */
 function dkan_js_frontend_theme($existing, $type, $theme, $path) {

--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * This is the DKAN JS Frontend module for using a decoupled frontend w/ DKAN.
+ */
+
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -22,8 +27,6 @@ const DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK = [
  *
  * Collects all CSS/JS files in the paths set in config and adds them to
  * dkan_js_frontend.
- *
- * @return array
  */
 function dkan_js_frontend_library_info_build() {
   $libraries = [];
@@ -36,51 +39,52 @@ function dkan_js_frontend_library_info_build() {
   $js = $config->get('js');
   $css = $config->get('css');
 
-  foreach(glob(\Drupal::root() . $js_path . '*.js') as $full_path) {
+  foreach (glob(\Drupal::root() . $js_path . '*.js') as $full_path) {
     $basename = basename($full_path);
-    if(isset($js)) {
+    if (isset($js)) {
       // Overwrite global minified with JS specific.
-      if(isset($js['minified'])) {
+      if (isset($js['minified'])) {
         $minified = $js['minified'];
       }
       // Overwrite global preprocess with JS specific.
-      if(isset($js['preprocess'])) {
+      if (isset($js['preprocess'])) {
         $preprocess = $js['preprocess'];
       }
       // Set the weight if available.
-      if(isset($js['weight'])) {
+      if (isset($js['weight'])) {
         $libraries['dkan_js_frontend']['js'][$js_path . $basename]['weight'] = $js['weight'];
       }
       // Loop through JS attributes and add to library.
-      if(isset($js['attributes'])) {
-        foreach($js['attributes'] as $attr) {
+      if (isset($js['attributes'])) {
+        $js_attributes = [];
+        foreach ($js['attributes'] as $attr) {
           $exploded_attr = explode(',', (string) $attr);
           $js_attributes[$exploded_attr[0]] = $exploded_attr[1];
         }
         $libraries['dkan_js_frontend']['js'][$js_path . $basename]['attributes'] = $js_attributes;
       }
     }
-    $libraries['dkan_js_frontend']['js'][$js_path . $basename]['minified'] = $minified ?? false;
-    $libraries['dkan_js_frontend']['js'][$js_path . $basename]['preprocess'] = $preprocess ?? true;
+    $libraries['dkan_js_frontend']['js'][$js_path . $basename]['minified'] = $minified ?? FALSE;
+    $libraries['dkan_js_frontend']['js'][$js_path . $basename]['preprocess'] = $preprocess ?? TRUE;
   }
-  foreach(glob(\Drupal::root() . $css_path . '*.css') as $full_path) {
+  foreach (glob(\Drupal::root() . $css_path . '*.css') as $full_path) {
     $basename = basename($full_path);
-    if(isset($css)) {
+    if (isset($css)) {
       // Overwrite global minified with CSS specific.
-      if(isset($css['minified'])) {
+      if (isset($css['minified'])) {
         $minified = $css['minified'];
       }
       // Overwrite global preprocess with CSS specific.
-      if(isset($css['preprocess'])) {
+      if (isset($css['preprocess'])) {
         $preprocess = $css['preprocess'];
       }
       // Set the weight if available.
-      if(isset($css['weight'])) {
+      if (isset($css['weight'])) {
         $libraries['dkan_js_frontend']['css']['theme'][$css_path . $basename]['weight'] = $css['weight'];
       }
     }
-    $libraries['dkan_js_frontend']['css']['theme'][$css_path . $basename]['minified'] = $minified ?? false;
-    $libraries['dkan_js_frontend']['css']['theme'][$css_path . $basename]['preprocess'] = $preprocess ?? true;
+    $libraries['dkan_js_frontend']['css']['theme'][$css_path . $basename]['minified'] = $minified ?? FALSE;
+    $libraries['dkan_js_frontend']['css']['theme'][$css_path . $basename]['preprocess'] = $preprocess ?? TRUE;
   }
   $libraries['dkan_js_frontend']['dependencies'] = [
     'core/drupal',
@@ -96,7 +100,7 @@ function dkan_js_frontend_library_info_build() {
  */
 function dkan_js_frontend_page_attachments(array &$page) {
   $request = \Drupal::routeMatch()->getRouteObject()->getDefault('name');
-  if($request == 'dkan_js_frontend') {
+  if ($request == 'dkan_js_frontend') {
     $page['#attached']['library'][] = 'dkan_js_frontend/dkan_js_frontend';
   }
 }
@@ -106,7 +110,7 @@ function dkan_js_frontend_page_attachments(array &$page) {
  */
 function dkan_js_frontend_theme_suggestions_page_alter(array &$suggestions, array $variables) {
   $request = \Drupal::routeMatch()->getRouteObject()->getDefault('name');
-  if($request == 'dkan_js_frontend') {
+  if ($request == 'dkan_js_frontend') {
     $suggestions[] = 'page__dkan_js_frontend';
   }
 }
@@ -177,7 +181,7 @@ function _dkan_js_frontend_build_request_context(): RequestContext {
  *   Multi-dimensional array for storing arbitrary site links.
  * @param \Symfony\Component\Routing\RouteCollection $routes
  *   Collection of DKAN routes.
- * @param \Drupal\Core\Routing\RequestContext
+ * @param \Drupal\Core\Routing\RequestContext $request_context
  *   Request context containing base URL for sitemap URL generation.
  */
 function _dkan_js_frontend_add_static_links(array &$arbitrary_links, RouteCollection $routes, RequestContext $request_context): void {
@@ -199,9 +203,9 @@ function _dkan_js_frontend_add_static_links(array &$arbitrary_links, RouteCollec
  *
  * @param array $arbitrary_links
  *   Multi-dimensional array for storing arbitrary site links.
- * @param \Symfony\Component\Routing\Route $routes
+ * @param \Symfony\Component\Routing\Route $dataset_route
  *   Collection of DKAN routes.
- * @param \Drupal\Core\Routing\RequestContext
+ * @param \Drupal\Core\Routing\RequestContext $request_context
  *   Request context containing base URL for sitemap URL generation.
  */
 function _dkan_js_frontend_add_dataset_links(array &$arbitrary_links, Route $dataset_route, RequestContext $request_context): void {


### PR DESCRIPTION
## Describe your changes

- Fixes erroneous variable name `$js_pcss_pathath`
- Folds `RouteProvider::routeHelper()` into `addIndexPage()` which is renamed to `addRoutesFromConfig()` which is more descriptive.
- Modifies README to be less about Create React App.
- Declares dependency on metastore module.
- Some code optimization.
- CS.
