### PR TITLE
Add some older PHP versions w/10.5 to the matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,8 +265,8 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~10.4", "~10.5"]
-              php_version: ["8.3"]
+              drupal_core_constraint: ["~10.5"]
+              php_version: ["8.1", "8.2", "8.3", "8.4"]
               database_version: ["mysql:5.7"]
             exclude:
               - php_version: "8.3"


### PR DESCRIPTION
We should still be testing PHP 8.1 and 8.2, as they're still supported by Drupal 10.4 and 10.5.