### PR TITLE
Add getTableName() to DatabaseTableInterface

### DIFF
--- a/modules/common/src/Storage/DatabaseTableInterface.php
+++ b/modules/common/src/Storage/DatabaseTableInterface.php
@@ -53,4 +53,15 @@ interface DatabaseTableInterface extends
    */
   public function getSchema(): array;
 
+
+  /**
+   * Get the full name of datastore db table.
+   *
+   * @todo Add return type.
+   *
+   * @return string
+   *   Table name.
+   */
+  public function getTableName();
+
 }

--- a/modules/common/src/Storage/JobStore.php
+++ b/modules/common/src/Storage/JobStore.php
@@ -60,7 +60,7 @@ class JobStore extends AbstractDatabaseTable {
   /**
    * {@inheritDoc}
    */
-  protected function getTableName() {
+  public function getTableName() {
     return $this->tableName;
   }
 

--- a/modules/datastore/src/Storage/DatabaseTable.php
+++ b/modules/datastore/src/Storage/DatabaseTable.php
@@ -89,10 +89,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
   }
 
   /**
-   * Get the full name of datastore db table.
-   *
-   * @return string
-   *   Table name.
+   * {@inheritdoc}
    */
   public function getTableName() {
     if ($this->resource) {

--- a/modules/datastore/tests/src/Unit/Plugin/QueueWorker/TestMemStorage.php
+++ b/modules/datastore/tests/src/Unit/Plugin/QueueWorker/TestMemStorage.php
@@ -130,4 +130,8 @@ class TestMemStorage implements DatabaseTableInterface, \JsonSerializable
         return substr($md5, 0, 4);
     }
 
+    public function getTableName() {
+        return "test_mem_storage";
+    }
+
   }

--- a/modules/harvest/src/Storage/DatabaseTable.php
+++ b/modules/harvest/src/Storage/DatabaseTable.php
@@ -57,7 +57,7 @@ class DatabaseTable extends AbstractDatabaseTable {
   /**
    * {@inheritdoc}
    */
-  protected function getTableName() {
+  public function getTableName() {
     return "{$this->identifier}";
   }
 

--- a/modules/harvest/src/Storage/HarvestHashesEntityDatabaseTable.php
+++ b/modules/harvest/src/Storage/HarvestHashesEntityDatabaseTable.php
@@ -271,7 +271,7 @@ class HarvestHashesEntityDatabaseTable implements DatabaseTableInterface {
    * {@inheritdoc}
    */
   public function getTableName() {
-    return 'harvest_hashes';
+    throw new \RuntimeException(__METHOD__ . ' not yet implemented.');
   }
 
 }

--- a/modules/harvest/src/Storage/HarvestHashesEntityDatabaseTable.php
+++ b/modules/harvest/src/Storage/HarvestHashesEntityDatabaseTable.php
@@ -267,4 +267,11 @@ class HarvestHashesEntityDatabaseTable implements DatabaseTableInterface {
     return NULL;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getTableName() {
+    return 'harvest_hashes';
+  }
+
 }

--- a/modules/metastore/src/Storage/ResourceMapperDatabaseTable.php
+++ b/modules/metastore/src/Storage/ResourceMapperDatabaseTable.php
@@ -83,12 +83,9 @@ class ResourceMapperDatabaseTable extends AbstractDatabaseTable {
   }
 
   /**
-   * Get the full name of datastore db table.
-   *
-   * @return string
-   *   Table name.
+   * {@inheritdoc}
    */
-  protected function getTableName() {
+  public function getTableName() {
     return "dkan_metastore_resource_mapper";
   }
 


### PR DESCRIPTION
Noticed in IDE that `AbstractDatabaseTable` calls `$this->getTableName()` but that method is not defined either in the abstract class or the interface. Added to the interface, and updated implementations.