### PR TITLE
Harvest update

### DIFF
--- a/modules/harvest/harvest.install
+++ b/modules/harvest/harvest.install
@@ -214,6 +214,11 @@ function harvest_update_8011(&$sandbox) {
 }
 
 /**
+ * Superceded by harvest_update_10002.
+ */
+function harvest_update_10001() {}
+
+/**
  * Updates namespace for harvest type.
  */
 function harvest_update_10002()

--- a/modules/harvest/harvest.install
+++ b/modules/harvest/harvest.install
@@ -216,7 +216,7 @@ function harvest_update_8011(&$sandbox) {
 /**
  * Updates namespace for harvest type.
  */
-function harvest_update_10001()
+function harvest_update_10002()
 {
   /** @var \Drupal\harvest\HarvestUtility $harvest_utility */
   $harvest_utility = \Drupal::service('dkan.harvest.utility');

--- a/modules/harvest/src/HarvestUtility.php
+++ b/modules/harvest/src/HarvestUtility.php
@@ -271,7 +271,7 @@ class HarvestUtility {
       $this->logger->notice(json_encode($plan));
 
       if (isset($plan->extract->type)) {
-        $plan->extract->type = preg_replace('/^\\\\{0,1}harvest\\\\ETL/i', '\\Drupal\\harvest\\ETL', $plan->extract->type);
+        $plan->extract->type = preg_replace('/^\\\\{0,1}Harvest\\\\ETL/i', '\\Drupal\\harvest\\ETL', $plan->extract->type);
         $this->logger->notice($plan->extract->type);
         $this->harvestService->registerHarvest($plan);
       }

--- a/modules/harvest/src/HarvestUtility.php
+++ b/modules/harvest/src/HarvestUtility.php
@@ -271,7 +271,7 @@ class HarvestUtility {
       $this->logger->notice(json_encode($plan));
 
       if (isset($plan->extract->type)) {
-        $plan->extract->type = str_replace('\\Harvest\\ETL', '\\Drupal\\harvest\\ETL', $plan->extract->type);
+        $plan->extract->type = preg_replace('/^\\\\{0,1}harvest\\\\ETL/i', '\\Drupal\\harvest\\ETL', $plan->extract->type);
         $this->logger->notice($plan->extract->type);
         $this->harvestService->registerHarvest($plan);
       }


### PR DESCRIPTION
Fixes #4508 

(26374)

## Describe your changes
Changed code that updates outdated harvest namespace, to make leading slash optional.

## QA Steps
Use the domain of your local dkan build in step 4

 - [ ] Checkout and build the 2.x branch.
 - [ ] Enable and run the Sample Content module: `ddev drush en sample_content -y; ddev drush dkan:sample_content:create`
 - [ ] Run `ddev drush dkan:harvest:register '{"identifier":"test","extract":{"type":"harvest\\ETL\\Extract\\DataJson","uri":"https://dkan.ddev.site/modules/custom/dkan_core/modules/sample_content/sample_content.json"},"transforms":[],"load":{"type":"\\Drupal\\harvest\\Load\\Dataset"}}'`
- [ ] Run `ddev drush dkan:harvest:run test`. Confirm that the run fails with "No items found to extract, review your harvest plan."
- [ ] Checkout the `harvest_update` branch
- [ ] Run `ddev drush updb`. Confirm that there are no errors.
- [ ] Run `ddev drush  dkan:harvest:run test`. Confirm that the run suceeds.
