### PR TITLE
Remove .gitattributes in ddev-init script

### DIFF
--- a/ddev-init.sh
+++ b/ddev-init.sh
@@ -27,11 +27,16 @@ ddev add-on get ddev/ddev-drupal-contrib
 ddev dotenv set .ddev/.env.web --drupal-core $DRUPAL_VERSION \
   --drupal-root "/var/www/html/web"
 
+  
 # Set up the ddev project. See https://github.com/ddev/ddev-drupal-contrib
 ddev start
 ddev poser
 ddev select2
 ddev symlink-project
+
+# Remove .gitattributes added by ddev-drupal-contrib to avoid conflicts
+rm -f .gitattributes
+
 ddev config --update
 ddev restart
 


### PR DESCRIPTION
After running `ddev poser` which applies some Drupal core repo templates, a .gitattributes file is added. This enforces some Drupal standards in the repo, including removing CLRF line endings anywhere they are found. That sounds great, except we have at least two files in the repo that have the line endings, and once git touches those files they get into a kind of permanent conflict state which is very hard to deal with. If we remove the line endings and commit those changes, it becomes impossible to check out an old branch in some situations, or to switch back to a new branch from an old one.

I'm thinking maybe we deal with this in 4.x when we move to the drupal.org repo.

To reproduce, try opening the file modules/metastore_admin/tests/src/Functional/RedirectToDatasetsTest.php. Save it without making any content changes to the file (for instance, add a space to a random line, delete it, and re-save the file. The file will now show up as modified in git. But if you try to restore the file to an unmodified state (`git restore RedirectToDatasetsTest.php`) you won't be able to. If you add and commit the changes, you'll have problems switching away from and back to the branch where the commit lives.