### PR TITLE
Allow streamed/download JSON data

### DIFF
--- a/modules/datastore/docs/openapi_spec.json
+++ b/modules/datastore/docs/openapi_spec.json
@@ -18,7 +18,7 @@
                 "schema": {
                     "type": "string"
                 }
-            },         
+            },
             "datastoreDatasetUuid": {
                 "name": "datasetId",
                 "in": "path",
@@ -400,7 +400,7 @@
                             "type": "string"
                         },
                         "example": "csv",
-                        "description": "Response format. Currently, only csv is supported.",
+                        "description": "Response format. Either csv or json.",
                         "style": "deepObject"
                     }
                 ],

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -38,7 +38,7 @@ class QueryDownloadController extends AbstractQueryController {
     DatastoreQuery $datastoreQuery,
     RootedJsonData $result,
     array $dependencies = [],
-    ?ParameterBag $params = NULL
+    ?ParameterBag $params = NULL,
   ) {
     return match ($datastoreQuery->{"$.format"}) {
       'csv' => $this->streamCsvResponse($datastoreQuery, $result),
@@ -138,8 +138,6 @@ class QueryDownloadController extends AbstractQueryController {
    *
    * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
    *   A datastore Query object.
-   * @param \RootedData\RootedJsonData $result
-   *   Query result.
    *
    * @return \Symfony\Component\HttpFoundation\StreamedJsonResponse
    *   Return the StreamedResponse object.
@@ -191,10 +189,10 @@ class QueryDownloadController extends AbstractQueryController {
   /**
    * Stream selected metadata value from json object.
    *
-   * @param RootedJsonData $data
+   * @param \RootedData\RootedJsonData $data
    *   The json object.
    * @param string $metadata_name
-   *   The name of the metadata item to stream
+   *   The name of the metadata item to stream.
    */
   private function getJsonMetadata(RootedJsonData $data, string $metadata_name) {
     yield $data->get('$.' . $metadata_name);

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -148,7 +148,10 @@ class QueryDownloadController extends AbstractQueryController {
     $response = new StreamedJsonResponse(
     // JSON structure with generator which will be streamed as a list.
       [
-        'results' => $this->loadJson($datastoreQuery, $result),
+        'results' => $this->loadJson($datastoreQuery),
+        'count' => $this->getJsonMetadata($result, 'count'),
+        'schema' => $this->getJsonMetadata($result, 'schema'),
+        'query' => $this->getJsonMetadata($result, 'query')
       ],
     );
     $response->headers->set('Content-Type', 'application/json');
@@ -166,7 +169,7 @@ class QueryDownloadController extends AbstractQueryController {
    * @param \RootedData\RootedJsonData $result
    *   Query result.
    */
-  protected function loadJson(DatastoreQuery $datastoreQuery, RootedJsonData $result) {
+  protected function loadJson(DatastoreQuery $datastoreQuery) {
     $count = 0;
 
     try {
@@ -183,6 +186,18 @@ class QueryDownloadController extends AbstractQueryController {
     catch (\Exception $e) {
       yield json_encode(['error' => $e->getMessage()]);
     }
+  }
+
+  /**
+   * Stream selected metadata value from json object.
+   *
+   * @param RootedJsonData $data
+   *   The json object.
+   * @param string $metadata_name
+   *   The name of the metadata item to stream
+   */
+  private function getJsonMetadata(RootedJsonData $data, string $metadata_name) {
+    yield $data->get('$.' . $metadata_name);
   }
 
 }

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -145,15 +145,13 @@ class QueryDownloadController extends AbstractQueryController {
    *   Return the StreamedResponse object.
    */
   protected function streamJsonResponse(DatastoreQuery $datastoreQuery, RootedJsonData $result) {
-    $response = new StreamedJsonResponse(
-    // JSON structure with generator which will be streamed as a list.
-      [
-        'results' => $this->loadJson($datastoreQuery),
-        'count' => $this->getJsonMetadata($result, 'count'),
-        'schema' => $this->getJsonMetadata($result, 'schema'),
-        'query' => $this->getJsonMetadata($result, 'query'),
-      ],
-    );
+    $data = ['results' => $this->loadJson($datastoreQuery)];
+    $metadata_names = ['count', 'schema', 'query'];
+    foreach ($metadata_names as $metadata_name) {
+      $data[$metadata_name] = $result->get('$.' . $metadata_name);
+    }
+
+    $response = new StreamedJsonResponse($data);
     $response->headers->set('Content-Type', 'application/json');
     $response->headers->set('Content-Disposition', "attachment; filename=\"data.json\"");
     $response->headers->set('X-Accel-Buffering', 'no');
@@ -184,18 +182,6 @@ class QueryDownloadController extends AbstractQueryController {
     catch (\Exception $e) {
       yield json_encode(['error' => $e->getMessage()]);
     }
-  }
-
-  /**
-   * Stream selected metadata value from json object.
-   *
-   * @param \RootedData\RootedJsonData $data
-   *   The json object.
-   * @param string $metadata_name
-   *   The name of the metadata item to stream.
-   */
-  private function getJsonMetadata(RootedJsonData $data, string $metadata_name) {
-    yield $data->get('$.' . $metadata_name);
   }
 
 }

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -134,6 +134,31 @@ class QueryDownloadController extends AbstractQueryController {
   }
 
   /**
+   * Set up the Streamed JSON Response.
+   *
+   * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
+   *   A datastore Query object.
+   * @param \RootedData\RootedJsonData $result
+   *   Query result.
+   *
+   * @return \Symfony\Component\HttpFoundation\StreamedJsonResponse
+   *   Return the StreamedResponse object.
+   */
+  protected function streamJsonResponse(DatastoreQuery $datastoreQuery, RootedJsonData $result) {
+    $response = new StreamedJsonResponse(
+    // JSON structure with generator which will be streamed as a list.
+      [
+        'results' => $this->loadJson($datastoreQuery, $result),
+      ],
+    );
+    $response->headers->set('Content-Type', 'application/json');
+    $response->headers->set('Content-Disposition', "attachment; filename=\"data.json\"");
+    $response->headers->set('X-Accel-Buffering', 'no');
+    // Ensure one hour max-age plus public status.
+    return $this->addCacheHeaders($response);
+  }
+
+  /**
    * Set up the Stream query result as json objects.
    *
    * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
@@ -158,31 +183,6 @@ class QueryDownloadController extends AbstractQueryController {
     catch (\Exception $e) {
       yield json_encode(['error' => $e->getMessage()]);
     }
-  }
-
-  /**
-   * Set up the Streamed JSON Response.
-   *
-   * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
-   *   A datastore Query object.
-   * @param \RootedData\RootedJsonData $result
-   *   Query result.
-   *
-   * @return \Symfony\Component\HttpFoundation\StreamedJsonResponse
-   *   Return the StreamedResponse object.
-   */
-  protected function streamJsonResponse(DatastoreQuery $datastoreQuery, RootedJsonData $result) {
-    $response = new StreamedJsonResponse(
-    // JSON structure with generators in which will be streamed as a list.
-      [
-        'results' => $this->loadJson($datastoreQuery, $result),
-      ],
-    );
-    $response->headers->set('Content-Type', 'application.json');
-    $response->headers->set('Content-Disposition', "attachment; filename=\"data.json\"");
-    $response->headers->set('X-Accel-Buffering', 'no');
-    // Ensure one hour max-age plus public status.
-    return $this->addCacheHeaders($response);
   }
 
 }

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -44,7 +44,7 @@ class QueryDownloadController extends AbstractQueryController {
       'csv' => $this->streamCsvResponse($datastoreQuery, $result),
       'json' => $this->streamJsonResponse($datastoreQuery, $result),
       default => $this->getResponseFromException(
-        new \UnexpectedValueException('Streaming not currently available for JSON responses'),
+        new \UnexpectedValueException('Streaming not currently available for ' . $datastoreQuery->{"$.format"} . 'responses'),
         400
       ),
     };

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -139,7 +139,7 @@ class QueryDownloadController extends AbstractQueryController {
    * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
    *   A datastore Query object.
    * @param \RootedData\RootedJsonData $result
-   * *   Query result.
+   *   Query result.
    *
    * @return \Symfony\Component\HttpFoundation\StreamedJsonResponse
    *   Return the StreamedResponse object.

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -138,6 +138,8 @@ class QueryDownloadController extends AbstractQueryController {
    *
    * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
    *   A datastore Query object.
+   * @param \RootedData\RootedJsonData $result
+   * *   Query result.
    *
    * @return \Symfony\Component\HttpFoundation\StreamedJsonResponse
    *   Return the StreamedResponse object.
@@ -149,7 +151,7 @@ class QueryDownloadController extends AbstractQueryController {
         'results' => $this->loadJson($datastoreQuery),
         'count' => $this->getJsonMetadata($result, 'count'),
         'schema' => $this->getJsonMetadata($result, 'schema'),
-        'query' => $this->getJsonMetadata($result, 'query')
+        'query' => $this->getJsonMetadata($result, 'query'),
       ],
     );
     $response->headers->set('Content-Type', 'application/json');
@@ -164,8 +166,6 @@ class QueryDownloadController extends AbstractQueryController {
    *
    * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
    *   A datastore Query object.
-   * @param \RootedData\RootedJsonData $result
-   *   Query result.
    */
   protected function loadJson(DatastoreQuery $datastoreQuery) {
     $count = 0;

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -9,6 +9,7 @@ use Drupal\datastore\Service\Query as QueryService;
 use Drupal\metastore\MetastoreApiResponse;
 use RootedData\RootedJsonData;
 use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -41,6 +42,7 @@ class QueryDownloadController extends AbstractQueryController {
   ) {
     return match ($datastoreQuery->{"$.format"}) {
       'csv' => $this->streamCsvResponse($datastoreQuery, $result),
+      'json' => $this->streamJsonResponse($datastoreQuery, $result),
       default => $this->getResponseFromException(
         new \UnexpectedValueException('Streaming not currently available for JSON responses'),
         400
@@ -129,6 +131,58 @@ class QueryDownloadController extends AbstractQueryController {
     fputcsv($handle, $row, escape: "\\");
     ob_flush();
     flush();
+  }
+
+  /**
+   * Set up the Stream query result as json objects.
+   *
+   * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
+   *   A datastore Query object.
+   * @param \RootedData\RootedJsonData $result
+   *   Query result.
+   */
+  protected function loadJson(DatastoreQuery $datastoreQuery, RootedJsonData $result) {
+    $count = 0;
+
+    try {
+      // Get the result pointer and send each row to the stream one by one.
+      $result = $this->queryService->runResultsQuery($datastoreQuery, FALSE, TRUE);
+      while ($row = $result->fetchAssoc()) {
+        yield $row;
+
+        if (0 === ++$count % 100) {
+          flush();
+        }
+      }
+    }
+    catch (\Exception $e) {
+      yield json_encode(['error' => $e->getMessage()]);
+    }
+  }
+
+  /**
+   * Set up the Streamed JSON Response.
+   *
+   * @param \Drupal\datastore\Service\DatastoreQuery $datastoreQuery
+   *   A datastore Query object.
+   * @param \RootedData\RootedJsonData $result
+   *   Query result.
+   *
+   * @return \Symfony\Component\HttpFoundation\StreamedJsonResponse
+   *   Return the StreamedResponse object.
+   */
+  protected function streamJsonResponse(DatastoreQuery $datastoreQuery, RootedJsonData $result) {
+    $response = new StreamedJsonResponse(
+    // JSON structure with generators in which will be streamed as a list
+      [
+        'results' => $this->loadJson($datastoreQuery, $result),
+      ],
+    );
+    $response->headers->set('Content-Type', 'application.json');
+    $response->headers->set('Content-Disposition', "attachment; filename=\"data.json\"");
+    $response->headers->set('X-Accel-Buffering', 'no');
+    // Ensure one hour max-age plus public status.
+    return $this->addCacheHeaders($response);
   }
 
 }

--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -173,7 +173,7 @@ class QueryDownloadController extends AbstractQueryController {
    */
   protected function streamJsonResponse(DatastoreQuery $datastoreQuery, RootedJsonData $result) {
     $response = new StreamedJsonResponse(
-    // JSON structure with generators in which will be streamed as a list
+    // JSON structure with generators in which will be streamed as a list.
       [
         'results' => $this->loadJson($datastoreQuery, $result),
       ],

--- a/modules/datastore/tests/data/longcolumn.csv
+++ b/modules/datastore/tests/data/longcolumn.csv
@@ -1,3 +1,3 @@
-"id", "name", "extra_long_column_name_with_tons_of_characters_that_will_need_to_be_truncated_in_order_to_work", "extra_long_column_name_with_tons_of_characters_that_will_need_to_be_truncated_in_order_to_work2"
-1, "Greg", 45.6, 4
-2, "Mary", 22.1, 7
+"id","name","extra_long_column_name_with_tons_of_characters_that_will_need_to_be_truncated_in_order_to_work", "extra_long_column_name_with_tons_of_characters_that_will_need_to_be_truncated_in_order_to_work2"
+1,"Greg",45.6,4
+2,"Mary",22.1,7

--- a/modules/datastore/tests/src/Functional/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Functional/Controller/QueryDownloadControllerTest.php
@@ -124,13 +124,30 @@ class QueryDownloadControllerTest extends BrowserTestBase {
       'id,name,extra_long_column_name_with_tons_of_characters_that_will_ne_e872,extra_long_column_name_with_tons_of_characters_that_will_ne_5127',
       $lines[0]
     );
+
+    // Test for valid field names in json output
+    // Query for the dataset, as a streaming JSON.
+    $client = $this->getHttpClient();
+    $response = $client->request(
+      'GET',
+      $this->baseUrl . '/api/1/datastore/query/' . $dataset_id . '/0/download',
+      ['query' => ['format' => 'json']]
+    );
+
+    $json_content = json_decode($response->getBody()->getContents())->results[0];
+    $titles = array_keys(get_object_vars($json_content));
+    $this->assertEquals('id,name,extra_long_column_name_with_tons_of_characters_that_will_ne_e872,extra_long_column_name_with_tons_of_characters_that_will_ne_5127',
+      implode(',',$titles));
+//    $this->assertEquals('1', $json_content->id);
+//    $this->assertEquals('Greg', $json_content->name);
+//    $this->assertEquals('45.6', trim($json_content->extra_long_column_name_with_tons_of_characters_that_will_ne_e872));
   }
 
   /**
    * Test application of data dictionary schema to CSV generated for download.
    */
   public function testDownloadWithDataDictionary() {
-    // Set per-reference data-dictinary in metastore config.
+    // Set per-reference data-dictionary in metastore config.
     $this->config('metastore.settings')
       ->set('data_dictionary_mode', DataDictionaryDiscovery::MODE_REFERENCE)
       ->save();

--- a/modules/datastore/tests/src/Functional/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Functional/Controller/QueryDownloadControllerTest.php
@@ -138,9 +138,6 @@ class QueryDownloadControllerTest extends BrowserTestBase {
     $titles = array_keys(get_object_vars($json_content));
     $this->assertEquals('id,name,extra_long_column_name_with_tons_of_characters_that_will_ne_e872,extra_long_column_name_with_tons_of_characters_that_will_ne_5127',
       implode(',',$titles));
-//    $this->assertEquals('1', $json_content->id);
-//    $this->assertEquals('Greg', $json_content->name);
-//    $this->assertEquals('45.6', trim($json_content->extra_long_column_name_with_tons_of_characters_that_will_ne_e872));
   }
 
   /**

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -78,7 +78,7 @@ class QueryDownloadControllerTest extends TestCase {
   /**
    * Helper function to compare output of streaming vs normal query controller.
    */
-  private function queryResultCompare($data, $resource = NULL) {
+  private function queryResultCompareCsv($data, $resource = NULL) {
     $request = $this->mockRequest($data);
     $qController = QueryController::create($this->getQueryContainer(500));
     $response = $resource ? $qController->queryResource($resource, $request) : $qController->query($request);
@@ -96,6 +96,26 @@ class QueryDownloadControllerTest extends TestCase {
   }
 
   /**
+   * Helper function to compare output of json streaming vs normal query controller.
+   */
+  private function queryResultCompareJson($data, $resource = NULL) {
+    $request = $this->mockRequest($data);
+    $qController = QueryController::create($this->getQueryContainer(500));
+    $response = $resource ? $qController->queryResource($resource, $request) : $qController->query($request);
+    $json = $response->getContent() ?? '';
+
+    $dController = QueryDownloadController::create($this->getQueryContainer(25));
+    ob_start(self::getBuffer(...));
+    $streamResponse = $resource ? $dController->queryResource($resource, $request) : $dController->query($request);
+    $streamResponse->sendContent();
+    ob_get_clean();
+    $streamedJson = $this->buffer ?? '';
+
+    $this->assertEquals(count(json_decode($json)->results), count(json_decode($streamedJson)->results));
+    $this->assertEquals(json_decode($json)->results, json_decode($streamedJson)->results);
+  }
+
+  /**
    * Test streaming of a CSV file from database.
    */
   public function testStreamedQueryCsv() {
@@ -109,7 +129,39 @@ class QueryDownloadControllerTest extends TestCase {
       "format" => "csv",
     ];
     // Need 2 json responses which get combined on output.
-    $this->queryResultCompare($data);
+    $this->queryResultCompareCsv($data);
+  }
+
+  /**
+   * Test json stream (without specifying csv format; shouldn't work).
+   */
+  public function testStreamedQueryJson() {
+    $data = [
+      "resources" => [
+        [
+          "id" => $this->resources[2]->getIdentifier(),
+          "alias" => "t",
+        ],
+      ],
+      "format" => "json",
+    ];
+    // Need 2 json responses which get combined on output.
+    $this->queryResultCompareJson($data);
+
+//    $data = json_encode([
+//      "resources" => [
+//        [
+//          "id" => $this->resources[2]->getIdentifier(),
+//          "alias" => "t",
+//        ],
+//      ],
+//    ]);
+//    // Need 2 json responses which get combined on output.
+//    $container = $this->getQueryContainer(50);
+//    $webServiceApi = QueryDownloadController::create($container);
+//    $request = $this->mockRequest($data);
+//    $result = $webServiceApi->query($request);
+//    $this->assertEquals(400, $result->getStatusCode());
   }
 
   /**
@@ -120,7 +172,7 @@ class QueryDownloadControllerTest extends TestCase {
       "format" => "csv",
     ];
     // Need 2 json responses which get combined on output.
-    $this->queryResultCompare($data, "2");
+    $this->queryResultCompareCsv($data, "2");
   }
 
   /**
@@ -149,7 +201,7 @@ class QueryDownloadControllerTest extends TestCase {
     ];
 
     // Need 2 json responses which get combined on output.
-    $this->queryResultCompare($data);
+    $this->queryResultCompareCsv($data);
   }
 
   /**
@@ -212,27 +264,7 @@ class QueryDownloadControllerTest extends TestCase {
         ],
       ],
     ];
-    $this->queryResultCompare($data);
-  }
-
-  /**
-   * Test json stream (without specifying csv format; shouldn't work).
-   */
-  public function testStreamedQueryJson() {
-    $data = json_encode([
-      "resources" => [
-        [
-          "id" => $this->resources[2]->getIdentifier(),
-          "alias" => "t",
-        ],
-      ],
-    ]);
-    // Need 2 json responses which get combined on output.
-    $container = $this->getQueryContainer(50);
-    $webServiceApi = QueryDownloadController::create($container);
-    $request = $this->mockRequest($data);
-    $result = $webServiceApi->query($request);
-    $this->assertEquals(400, $result->getStatusCode());
+    $this->queryResultCompareCsv($data);
   }
 
   /**
@@ -287,7 +319,7 @@ class QueryDownloadControllerTest extends TestCase {
       "format" => "csv",
       "properties" => ["state", "year"],
     ];
-    $this->queryResultCompare($data);
+    $this->queryResultCompareCsv($data);
   }
 
   /**
@@ -314,7 +346,7 @@ class QueryDownloadControllerTest extends TestCase {
       ],
     ];
 
-    $this->queryResultCompare($data);
+    $this->queryResultCompareCsv($data);
   }
 
 
@@ -333,7 +365,7 @@ class QueryDownloadControllerTest extends TestCase {
       "rowIds" => TRUE,
     ];
 
-    $this->queryResultCompare($data);
+    $this->queryResultCompareCsv($data);
   }
 
   /**

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -147,21 +147,6 @@ class QueryDownloadControllerTest extends TestCase {
     ];
     // Need 2 json responses which get combined on output.
     $this->queryResultCompareJson($data);
-
-//    $data = json_encode([
-//      "resources" => [
-//        [
-//          "id" => $this->resources[2]->getIdentifier(),
-//          "alias" => "t",
-//        ],
-//      ],
-//    ]);
-//    // Need 2 json responses which get combined on output.
-//    $container = $this->getQueryContainer(50);
-//    $webServiceApi = QueryDownloadController::create($container);
-//    $request = $this->mockRequest($data);
-//    $result = $webServiceApi->query($request);
-//    $this->assertEquals(400, $result->getStatusCode());
   }
 
   /**


### PR DESCRIPTION
Fixes #4559 

## Describe your changes
Added option to get download queries in json format.

## QA Steps

- [ ] Get the distribution id of an existing dataset with datastore.
- [ ] In browser url enter `[BASE URL}/api/1/datastore/query/[DATASET ID]/download?format=json` (e.g. 'https://dkan.ddev.site/api/1/datastore/query/0d89f2f7-8472-5121-96af-a43ff7017df1/download?format=json')
- [ ] Confirm that the browser responds by downloading a file named data.json with all of the data in json format.
- [ ] Go to `/api` and scroll down to GET /api/1/datastore/query/{Distribution ID}/download, and expand the section.
- [ ] Click the 'Try it out' button and confirm that the 'format' parameter description is "Response format. Either csv or json." and that both formats work

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [ ] I have updated or added documentation - not necessary
