### PR TITLE
WIP: Adds run operation for harvest plan entities

### DIFF
--- a/modules/harvest/harvest.module
+++ b/modules/harvest/harvest.module
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Harvest module file.
+ */
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_entity_operation().
+ */
+function harvest_entity_operation(EntityInterface $entity) {
+  $operations = [];
+  if ($entity->getEntityTypeId() === 'harvest_plan') {
+    $operations['run'] = [
+      'title' => t('Run'),
+      'url' => $entity->toUrl('run-form'),
+      'weight' => 0,
+    ];
+  }
+  return $operations;
+}

--- a/modules/harvest/harvest.permissions.yml
+++ b/modules/harvest/harvest.permissions.yml
@@ -18,13 +18,15 @@ administer harvest_plan:
   title: 'Administer harvest plans'
   restrict access: true
 view harvest_plan:
-  title: 'View harvest plan'
+  title: 'View harvest plans'
 edit harvest_plan:
-  title: 'Edit harvest plan'
+  title: 'Edit harvest plans'
 delete harvest_plan:
-  title: 'Delete harvest plan'
+  title: 'Delete harvest plans'
 create harvest_plan:
-  title: 'Create harvest plan'
+  title: 'Create harvest plans'
+harvest_plan.run:
+  title: "Run harvest plans"
 
 # These permissions refer to harvest_run entities, not the act of running a
 # harvest.

--- a/modules/harvest/src/ContentAccessControlHandler.php
+++ b/modules/harvest/src/ContentAccessControlHandler.php
@@ -11,37 +11,45 @@ use Drupal\Core\Session\AccountInterface;
 
 /**
  * Defines an access control handler for content entities.
+ *
+ * @see \Drupal\harvest\Entity\HarvestPlan
  */
 class ContentAccessControlHandler extends EntityAccessControlHandler {
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    */
-  protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account): AccessResult {
-    return match($operation) {
-      'view' => AccessResult::allowedIfHasPermissions($account, [
-        'view ' . $this->entityTypeId,
-        'administer ' . $this->entityTypeId,
-      ], 'OR'),
-      'update' => AccessResult::allowedIfHasPermissions($account, [
-        'edit ' . $this->entityTypeId,
-        'administer ' . $this->entityTypeId,
-      ], 'OR'),
-      'delete' => AccessResult::allowedIfHasPermissions($account, [
-        'delete ' . $this->entityTypeId,
-        'administer ' . $this->entityTypeId,
-      ], 'OR'),
-      default => AccessResult::neutral(),
-    };
+  protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+    if ($admin_permission = $this->entityType->getAdminPermission()) {
+      return AccessResult::allowedIfHasPermission($account, $admin_permission);
+    }
+    switch ($operation) {
+      case 'delete':
+      case 'view':
+      case 'run':
+        return AccessResult::allowedIfHasPermission(
+          $account,
+          $this->entityTypeId . '.' . $operation
+        );
+
+      case 'update':
+        return AccessResult::allowedIfHasPermission(
+          $account,
+          'edit ' . $this->entityTypeId
+        );
+
+      default:
+        return parent::checkAccess($entity, $operation, $account);
+    }
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    */
   protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL): AccessResult {
     return AccessResult::allowedIfHasPermissions($account, [
       'create ' . $this->entityTypeId,
-      'administer ' . $this->entityTypeId,
+      $this->entityType->getAdminPermission(),
     ], 'OR');
   }
 

--- a/modules/harvest/src/Entity/HarvestPlan.php
+++ b/modules/harvest/src/Entity/HarvestPlan.php
@@ -33,6 +33,9 @@ use Drupal\harvest\HarvestPlanInterface;
  *     "access" = "Drupal\harvest\ContentAccessControlHandler",
  *     "route_provider" = {
  *       "html" = "Drupal\harvest\Routing\HarvestDashboardHtmlRouteProvider",
+ *     },
+ *     "form" = {
+ *       "run" = "Drupal\harvest\Form\HarvestPlanRunForm",
  *     }
  *   },
  *   base_table = "harvest_plans",
@@ -44,6 +47,7 @@ use Drupal\harvest\HarvestPlanInterface;
  *   links = {
  *     "collection" = "/admin/dkan/harvest",
  *     "canonical" = "/harvest-plan/{harvest_plan}",
+ *     "run-form" = "/admin/harvest-plan/{harvest_plan}/run",
  *   },
  *   internal = TRUE,
  * )
@@ -64,6 +68,7 @@ final class HarvestPlan extends HarvestEntityBase implements HarvestPlanInterfac
    * Provides identifier and JSON data base fields.
    */
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+    // Get base fields based on annotated config above.
     $base_fields = parent::baseFieldDefinitions($entity_type);
 
     // The 'id' field is the unique identifier for each harvest plan row.

--- a/modules/harvest/src/Form/HarvestPlanRunForm.php
+++ b/modules/harvest/src/Form/HarvestPlanRunForm.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\harvest\Form;
+
+use Drupal\Core\Entity\ContentEntityConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\harvest\Entity\HarvestRunRepository;
+use Drupal\harvest\HarvestService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Confirmation form for when you want to run a harvest plan.
+ */
+class HarvestPlanRunForm extends ContentEntityConfirmFormBase {
+
+  /**
+   * Harvest service.
+   *
+   * @var \Drupal\harvest\HarvestService
+   */
+  protected HarvestService $harvestService;
+
+  /**
+   * Harvest run entity repository.
+   *
+   * @var \Drupal\harvest\Entity\HarvestRunRepository
+   */
+  protected HarvestRunRepository $harvestRunRepository;
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $form = parent::create($container);
+    $form->harvestService = $container->get('dkan.harvest.service');
+    $form->harvestRunRepository = $container->get('dkan.harvest.storage.harvest_run_repository');
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Are you sure you want to run the harvest plan %name?', ['%name' => $this->entity->label()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return $this->entity->toUrl('collection');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->t('Run');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $plan_id = (string) $this->entity->id();
+
+    // @todo Handle exceptions.
+    $result = $this->harvestService->runHarvest($plan_id);
+
+    $harvest_run = $this->harvestRunRepository->loadEntity($plan_id, $result['identifier']);
+    $form_state->setRedirectUrl($harvest_run->toUrl());
+  }
+
+}

--- a/modules/harvest/src/HarvestPlanListBuilder.php
+++ b/modules/harvest/src/HarvestPlanListBuilder.php
@@ -68,13 +68,12 @@ class HarvestPlanListBuilder extends EntityListBuilder {
    * {@inheritdoc}
    */
   public function buildHeader() {
-    // Don't call parent::buildHeader() because we don't want operations (yet).
     return [
       'harvest_link' => $this->t('Harvest ID'),
       'extract_status' => $this->t('Extract Status'),
       'last_run' => $this->t('Last Run'),
       'dataset_count' => $this->t('# of Datasets'),
-    ];
+    ] + parent::buildHeader();
   }
 
   /**
@@ -82,7 +81,7 @@ class HarvestPlanListBuilder extends EntityListBuilder {
    */
   public function buildRow(EntityInterface $entity) {
     /** @var \Drupal\harvest\HarvestPlanInterface $entity */
-    $harvest_plan_id = $entity->get('id')->getString();
+    $harvest_plan_id = (string) $entity->id();
     $run_entity = NULL;
 
     if ($run_id = $this->harvestRunRepository->getLastHarvestRunId($harvest_plan_id)) {
@@ -112,8 +111,7 @@ class HarvestPlanListBuilder extends EntityListBuilder {
       $row['last_run'] = date('m/d/y H:m:s T', $run_entity->get('timestamp')->value);
       $row['dataset_count'] = $interpreter->countProcessed();
     }
-    // Don't call parent::buildRow() because we don't want operations (yet).
-    return $row;
+    return $row + parent::buildRow($entity);
   }
 
   /**

--- a/modules/harvest/src/Routing/HarvestDashboardHtmlRouteProvider.php
+++ b/modules/harvest/src/Routing/HarvestDashboardHtmlRouteProvider.php
@@ -3,7 +3,8 @@
 namespace Drupal\harvest\Routing;
 
 use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Entity\Routing\AdminHtmlRouteProvider;
+use Drupal\Core\Entity\Routing\DefaultHtmlRouteProvider;
+use Symfony\Component\Routing\Route;
 
 /**
  * Provides HTML routes for entities with administrative pages.
@@ -11,22 +12,50 @@ use Drupal\Core\Entity\Routing\AdminHtmlRouteProvider;
  * We override for harvest-oriented dashboards so that they have consistent
  * permissions handling.
  */
-class HarvestDashboardHtmlRouteProvider extends AdminHtmlRouteProvider {
+class HarvestDashboardHtmlRouteProvider extends DefaultHtmlRouteProvider {
 
   /**
    * {@inheritDoc}
    */
-  protected function getCollectionRoute(EntityTypeInterface $entity_type) {
-    $route = NULL;
-    if ($route = parent::getCollectionRoute($entity_type)) {
-      $required_permissions = ['dkan.harvest.dashboard'];
-      if ($permission = $route->getRequirement('_permission')) {
-        $required_permissions += [$permission];
+  public function getRoutes(EntityTypeInterface $entity_type) {
+    // Get the ones Drupal can do.
+    $collection = parent::getRoutes($entity_type);
+
+    $entity_type_id = $entity_type->id();
+    if ($entity_type_id === 'harvest_plan') {
+      if ($run_route = $this->getOperationFormRoute($entity_type, 'run')) {
+        $collection->add('entity.' . $entity_type_id . '.run_form', $run_route);
       }
-      // Use + to specify OR logic in permissions.
-      $route->setRequirement('_permission', implode('+', $required_permissions));
     }
-    return $route;
+    return $collection;
+  }
+
+  /**
+   * Generalized operation route generator.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type.
+   * @param string $operation
+   *   Operation name.
+   *
+   * @return \Symfony\Component\Routing\Route|null
+   *   The generated route, if available. NULL otherwise.
+   */
+  protected function getOperationFormRoute(EntityTypeInterface $entity_type, string $operation): ?Route {
+    if ($entity_type->hasLinkTemplate($operation . '-form')) {
+      $entity_type_id = $entity_type->id();
+      $route = new Route($entity_type->getLinkTemplate($operation . '-form'));
+      $route
+        ->addDefaults([
+          '_entity_form' => $entity_type_id . '.' . $operation,
+        ])
+        ->setOption('parameters', [
+          $entity_type_id => ['type' => 'entity:' . $entity_type_id],
+        ])
+        ->setRequirement('_entity_access', $entity_type_id . '.' . $operation);
+      return $route;
+    }
+    return NULL;
   }
 
 }


### PR DESCRIPTION
Fixes [issue#]

This is basically a proof-of-concept where I teach myself how to wire up entity operations.

### Todo:

Prettify the harvest_run entity display.
Handle a bunch of error cases.

### Discoveries:

Harvests can be 'reverted', which unpublishes the dataset nodes in various ways. This is different from reverting an entity revision, which is where you go back to old content from a previous edit. Drupal's entity system wants us to use 'revert' to mean the latter rather than the former. I got it working by callling it a rollback instead, but that's probably up for discussion.

Many permissions use an '[operation] [entity]' name, such as 'edit node', but the entity access system wants permissions to have a name like '[entity].[operation]', such as 'harvest_plan.run'. We'll need to rename permissions somewhere.

## Demo:

Make a local.
Enable and create sample content.
```
ddev drush pm-enable sample_content
ddev drush dkan:sample-content:create
ddev drush cron
ddev drush cron
```
Visit the harvest page: https://dkan.ddev.site/admin/dkan/harvest
Click 'Run' on the sample_content harvest.
Confirm that you want to run the harvest.
Be redirected to the very ugly entity page for a harvest run entity.

## Describe your changes

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
