### PR TITLE
Less complex AbstractDatabaseTable::setTable()

### DIFF
--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -269,19 +269,19 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    *   Throws an exception if the schema was not already set.
    */
   public function setTable() {
-    if (!$this->tableExist($table_name = $this->getTableName())) {
-      if ($schema = $this->schema) {
-        try {
-          $this->tableCreate($table_name, $schema);
-        }
-        catch (SchemaObjectExistsException) {
-          // Table already exists, which is totally OK. Other throwables find
-          // their way out to the caller.
-        }
-      }
-      else {
-        throw new \Exception('Could not instantiate the table due to a lack of schema.');
-      }
+    if ($this->tableExist($table_name = $this->getTableName())) {
+      return;
+    }
+    $schema = $this->schema;
+    if (!$schema) {
+      throw new \Exception('Could not instantiate the table due to a lack of schema.');
+    }
+    try {
+      $this->tableCreate($table_name, $schema);
+    }
+    catch (SchemaObjectExistsException) {
+      // Table already exists, which is totally OK. Other throwables find
+      // their way out to the caller.
     }
   }
 

--- a/modules/common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/common/src/Storage/AbstractDatabaseTable.php
@@ -272,12 +272,11 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
     if ($this->tableExist($table_name = $this->getTableName())) {
       return;
     }
-    $schema = $this->schema;
-    if (!$schema) {
+    if (!$this->schema) {
       throw new \Exception('Could not instantiate the table due to a lack of schema.');
     }
     try {
-      $this->tableCreate($table_name, $schema);
+      $this->tableCreate($table_name, $this->schema);
     }
     catch (SchemaObjectExistsException) {
       // Table already exists, which is totally OK. Other throwables find


### PR DESCRIPTION
In another PR, AbstractDatabaseTable::setTable() was flagged by qlty.sh as too complex. Cherry-picking into its own branch/PR.