### PR TITLE
Restrict openapi testing library to < 0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "colinodell/psr-testlogger": "^1.2",
         "drush/drush": "*",
         "getdkan/mock-chain": "^1.4.0",
-        "osteel/openapi-httpfoundation-testing": "<1.0",
+        "osteel/openapi-httpfoundation-testing": "<0.12",
         "drupal/admin_toolbar": "^3.0"
     },
     "repositories": {


### PR DESCRIPTION
Something about [this change](https://github.com/osteel/openapi-httpfoundation-testing/pull/52) in the latest release of osteel/openapi-httpfoundation-testing breaks the validation function when a request's schema is a reference in the spec. Filing an issue in that library, but need to hold this at 0.11 for now.