### PR TITLE
Extend HTML filtering to UI and make configurable.

### DIFF
--- a/modules/metastore/metastore.services.yml
+++ b/modules/metastore/metastore.services.yml
@@ -38,6 +38,7 @@ services:
     arguments:
       - '@entity_type.manager'
       - '@config.factory'
+      - '@file_system'
       - '@dkan.common.logger_channel'
       - '@event_dispatcher'
 

--- a/modules/metastore/src/Form/DkanDataSettingsForm.php
+++ b/modules/metastore/src/Form/DkanDataSettingsForm.php
@@ -83,6 +83,7 @@ class DkanDataSettingsForm extends ConfigFormBase {
     $form['description'] = $this->getDescriptionMarkup();
     $form['redirect_to_datasets'] = $this->getRedirectCheckbox($config);
     $form['html_allowed_properties'] = $this->getHtmlAllowedProperties($config);
+    $form['html_allowed_html'] = $this->getHtmlAllowedHtml($config);
     $form['property_list'] = $this->getPropertyList($config);
 
     return parent::buildForm($form, $form_state);
@@ -115,6 +116,26 @@ class DkanDataSettingsForm extends ConfigFormBase {
       '#title' => $this->t('Redirect to datasets view after form submit'),
       '#default_value' => $config->get('redirect_to_datasets'),
       '#description' => $this->t("Disable this option if you want to use Drupal's default or your own custom redirect after submitting a metadata form."),
+    ];
+  }
+
+  /**
+   * Builds the text box for allowed HTML elements.
+   *
+   * @param \Drupal\Core\Config\Config $config
+   *   The metastore settings configuration.
+   *
+   * @return array
+   *   The form element array.
+   */
+  private function getHtmlAllowedHtml(Config $config) {
+    return [
+      '#type' => 'textfield',
+      '#title' => $this->t('Allowed tags and elements for properties that allow HTML'),
+      '#description' => $this->t('Comma-separated lists of allowed tags. Attributes can
+        be allowed on specific tags by appending them in square braces.
+        (Example: "p,br,a[href]")'),
+      '#default_value' => $config->get('html_allowed_html') ?: '',
     ];
   }
 
@@ -174,6 +195,7 @@ class DkanDataSettingsForm extends ConfigFormBase {
       ->set('redirect_to_datasets', $form_state->getValue('redirect_to_datasets'))
       ->set('property_list', $form_state->getValue('property_list'))
       ->set('html_allowed_properties', $form_state->getValue('html_allowed_properties'))
+      ->set('html_allowed_html', $form_state->getValue('html_allowed_html'))
       ->save();
 
     // Rebuild routes, without clearing all caches.

--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -322,6 +322,9 @@ class LifeCycle {
    * @throws \Exception
    */
   protected function datasetPresave(MetastoreItemInterface $data): void {
+    $storage = $this->dataFactory->getInstance('dataset');
+    $metadata = $storage->filterHtml($data->getMetadata());
+    $data->setMetadata($metadata);
     $this->setNodeValuesFromMetadata($data);
     $this->referenceMetadata($data);
 

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -460,6 +460,8 @@ abstract class Data implements MetastoreEntityStorageInterface {
    *   Filtered string.
    */
   private function htmlPurifier(string $input) {
+    $allowed_html = $this->configFactory->get('metastore.settings')->get('html_allowed_html');
+
     // Initialize HTML Purifier cache config settings array.
     $config = [];
 
@@ -475,7 +477,9 @@ abstract class Data implements MetastoreEntityStorageInterface {
     }
     else {
       $config['Cache.SerializerPath'] = $cache_dir;
-      $config['HTML.Allowed'] = 'a[href],em,i,strong,b,br,p,ol,ul,li';
+      if (!empty($allowed_html)) {
+        $config['HTML.Allowed'] = $allowed_html;
+      }
     }
 
     // Create HTML purifier instance using custom cache path.

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -324,8 +324,6 @@ abstract class Data implements MetastoreEntityStorageInterface {
   public function store($data, ?string $uuid = NULL): string {
     $data = json_decode($data);
 
-    $data = $this->filterHtml($data, $this->schemaId);
-
     $uuid = (!$uuid && isset($data->identifier)) ? $data->identifier : $uuid;
 
     if ($uuid) {
@@ -423,7 +421,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
    * @return mixed
    *   Filtered output.
    */
-  private function filterHtml(mixed $input, string $parent = 'dataset') {
+  public function filterHtml(mixed $input, string $parent = 'dataset') {
     $html_allowed = $this->configFactory->get('metastore.settings')->get('html_allowed_properties')
       ?: ['dataset_description', 'distribution_description'];
     switch (gettype($input)) {

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -475,6 +475,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
     }
     else {
       $config['Cache.SerializerPath'] = $cache_dir;
+      $config['HTML.Allowed'] = 'a[href],em,i,strong,b,br,p,ol,ul,li';
     }
 
     // Create HTML purifier instance using custom cache path.

--- a/modules/metastore/src/Storage/Data.php
+++ b/modules/metastore/src/Storage/Data.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Entity\RevisionLogInterface;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\metastore\Exception\MissingObjectException;
 use Drupal\metastore\MetastoreService;
 use Drupal\workflows\WorkflowInterface;
@@ -91,6 +92,13 @@ abstract class Data implements MetastoreEntityStorageInterface {
   protected $configFactory;
 
   /**
+   * The file system.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
    * DKAN logger channel service.
    */
   private LoggerInterface $logger;
@@ -102,12 +110,14 @@ abstract class Data implements MetastoreEntityStorageInterface {
     string $schemaId,
     EntityTypeManagerInterface $entityTypeManager,
     ConfigFactoryInterface $config_factory,
+    FileSystemInterface $file_system,
     LoggerInterface $loggerChannel
   ) {
     $this->entityTypeManager = $entityTypeManager;
     $this->entityStorage = $this->entityTypeManager->getStorage($this->entityType);
     $this->schemaId = $schemaId;
     $this->configFactory = $config_factory;
+    $this->fileSystem = $file_system;
     $this->logger = $loggerChannel;
   }
 
@@ -466,8 +476,7 @@ abstract class Data implements MetastoreEntityStorageInterface {
     $config = [];
 
     // Determine path to tmp directory.
-    // @todo Inject this service.
-    $tmp_path = \Drupal::service('file_system')->getTempDirectory();
+    $tmp_path = $this->fileSystem->getTempDirectory();
     // Specify custom location in tmp directory for storing HTML Purifier cache.
     $cache_dir = rtrim((string) $tmp_path, '/') . '/html_purifier_cache';
 

--- a/modules/metastore/src/Storage/DataFactory.php
+++ b/modules/metastore/src/Storage/DataFactory.php
@@ -5,6 +5,7 @@ namespace Drupal\metastore\Storage;
 use Contracts\FactoryInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -34,6 +35,13 @@ class DataFactory implements FactoryInterface {
   protected $configFactory;
 
   /**
+   * The file system.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
    * DKAN logger channel service.
    */
   private LoggerInterface $logger;
@@ -44,10 +52,12 @@ class DataFactory implements FactoryInterface {
   public function __construct(
     EntityTypeManagerInterface $entityTypeManager,
     ConfigFactoryInterface $config_factory,
+    FileSystemInterface $file_system,
     LoggerInterface $loggerChannel,
   ) {
     $this->entityTypeManager = $entityTypeManager;
     $this->configFactory = $config_factory;
+    $this->fileSystem = $file_system;
     $this->logger = $loggerChannel;
   }
 
@@ -100,6 +110,7 @@ class DataFactory implements FactoryInterface {
       $identifier,
       $this->entityTypeManager,
       $this->configFactory,
+      $this->fileSystem,
       $this->logger
     );
   }

--- a/modules/metastore/src/Storage/NodeData.php
+++ b/modules/metastore/src/Storage/NodeData.php
@@ -4,6 +4,7 @@ namespace Drupal\metastore\Storage;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -18,6 +19,7 @@ class NodeData extends Data {
     string $schemaId,
     EntityTypeManagerInterface $entityTypeManager,
     ConfigFactoryInterface $config_factory,
+    FileSystemInterface $file_system,
     LoggerInterface $loggerChannel,
   ) {
     $this->entityType = 'node';
@@ -26,7 +28,7 @@ class NodeData extends Data {
     $this->labelKey = 'title';
     $this->schemaIdField = 'field_data_type';
     $this->metadataField = 'field_json_metadata';
-    parent::__construct($schemaId, $entityTypeManager, $config_factory, $loggerChannel);
+    parent::__construct($schemaId, $entityTypeManager, $config_factory, $file_system, $loggerChannel);
   }
 
   /**

--- a/modules/metastore/tests/src/Unit/Controller/MetastoreControllerTest.php
+++ b/modules/metastore/tests/src/Unit/Controller/MetastoreControllerTest.php
@@ -8,6 +8,7 @@ use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\metastore\Controller\MetastoreController;
 use Drupal\metastore\DatasetApiDocs;
 use Drupal\metastore\Exception\ExistingObjectException;
@@ -134,7 +135,7 @@ class MetastoreControllerTest extends TestCase {
     $configFactoryMock = (new Chain($this))
       ->add(ConfigFactoryInterface::class, 'get', $immutableConfig)
       ->getMock();
-    $nodeDataMock = new NodeData($schema_id, $entityTypeManagerMock, $configFactoryMock, $this->createStub(LoggerInterface::class));
+    $nodeDataMock = new NodeData($schema_id, $entityTypeManagerMock, $configFactoryMock, $this->createStub(FileSystemInterface::class), $this->createStub(LoggerInterface::class));
     $container = $this->getCommonMockChain()
       ->add(MetastoreService::class, 'getStorage', $nodeDataMock)
       ->getMock();

--- a/modules/metastore/tests/src/Unit/Storage/DataTest.php
+++ b/modules/metastore/tests/src/Unit/Storage/DataTest.php
@@ -5,14 +5,19 @@ namespace Drupal\Tests\metastore\Unit\Storage;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\File\FileSystem;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\metastore\Storage\NodeData;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeStorage;
 use MockChain\Chain;
+use MockChain\Options;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use function PHPUnit\Framework\assertEquals;
 
 /**
  * @coversDefaultClass \Drupal\metastore\Storage\Data
@@ -35,6 +40,8 @@ class DataTest extends TestCase {
     'dataset_identifier' => 0,
   ];
 
+  public const HTML_ALLOWED_HTML = 'a[href],em,i,strong,b,br,p,ol,ul,li';
+
   public function testGetStorageNode() {
     $immutableConfig = (new Chain($this))
       ->add(ImmutableConfig::class, 'get', self::HTML_ALLOWED_PROPERTIES)
@@ -43,7 +50,7 @@ class DataTest extends TestCase {
       ->add(ConfigFactoryInterface::class, 'get', $immutableConfig)
       ->getMock();
 
-    $data = new NodeData('dataset', $this->getEtmChain()->getMock(), $configFactoryMock, $this->createStub(LoggerInterface::class));
+    $data = new NodeData('dataset', $this->getEtmChain()->getMock(), $configFactoryMock, $this->createStub(FileSystemInterface::class), $this->createStub(LoggerInterface::class));
     $this->assertInstanceOf(NodeStorage::class, $data->getEntityStorage());
   }
 
@@ -60,7 +67,7 @@ class DataTest extends TestCase {
       ->getMock();
 
     $this->expectExceptionMessage('Error: 1 not found.');
-    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock, $this->createStub(LoggerInterface::class));
+    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock, $this->createStub(FileSystemInterface::class), $this->createStub(LoggerInterface::class));
     $nodeData->publish('1');
   }
 
@@ -74,14 +81,52 @@ class DataTest extends TestCase {
       ->getMock();
     $immutableConfig = (new Chain($this))
       ->add(ImmutableConfig::class, 'get', self::HTML_ALLOWED_PROPERTIES)
+      ->add(ImmutableConfig::class, 'get', self::HTML_ALLOWED_HTML)
       ->getMock();
     $configFactoryMock = (new Chain($this))
       ->add(ConfigFactoryInterface::class, 'get', $immutableConfig)
       ->getMock();
 
-    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock, $this->createStub(LoggerInterface::class));
+    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock, $this->createStub(FileSystemInterface::class), $this->createStub(LoggerInterface::class));
     $result = $nodeData->publish('1');
     $this->assertEquals(TRUE, $result);
+  }
+
+    public function testFilterHtml() {
+      // Test default behavior.
+      $nodeData = $this->getNodeData([
+        'html_allowed_properties' => self::HTML_ALLOWED_PROPERTIES,
+        'html_allowed_html' => '',
+      ]);
+
+      $uuid = '05aea36e-9e24-452e-9cf9-9727ab90c198';
+      $unsafe_html = '<script src"x">console.log("test")</script><iframe src="https://cms.gov"><video src="https://youtube.com" />';
+      $safe_html = '<table><tr><td>table</td></tr></table>';
+      $restricted_html = '<br /><p>paragraph <em>em</em></p>';
+
+      $filteredHtml = $nodeData->filterHtml((object) [
+        'identifier' => $uuid,
+        'title' => 'title',
+        'data' => (object) [
+          'description' => $unsafe_html . $restricted_html . $safe_html,
+        ],
+      ]);
+      assertEquals($restricted_html . $safe_html, $filteredHtml->data->description);
+
+      // Test with allowed html set in config.
+      $nodeData = $this->getNodeData([
+        'html_allowed_properties' => self::HTML_ALLOWED_PROPERTIES,
+        'html_allowed_html' => self::HTML_ALLOWED_HTML,
+      ]);
+
+      $filteredHtml = $nodeData->filterHtml((object) [
+        'identifier' => $uuid,
+        'title' => 'title',
+        'data' => (object) [
+          'description' => $unsafe_html . $safe_html . $restricted_html,
+        ],
+      ]);
+      assertEquals('table'.$restricted_html, $filteredHtml->data->description);
   }
 
   public function testPublishDatasetAlreadyPublished() {
@@ -97,7 +142,7 @@ class DataTest extends TestCase {
       ->add(ConfigFactoryInterface::class, 'get', $immutableConfig)
       ->getMock();
 
-    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock, $this->createStub(LoggerInterface::class));
+    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock, $this->createStub(FileSystemInterface::class), $this->createStub(LoggerInterface::class));
     $result = $nodeData->publish('1');
     $this->assertEquals(FALSE, $result);
   }
@@ -114,6 +159,31 @@ class DataTest extends TestCase {
       ->add(QueryInterface::class, 'execute', ['1'])
       ->add(NodeStorage::class, 'getLatestRevisionId', '2')
       ->addd('loadRevision', Node::class);
+  }
+
+  public function getNodeData(array $config_options) {
+    $etmMock = $this->getEtmChain()
+      ->add(Node::class, 'get', FieldItemListInterface::class)
+      ->getMock();
+
+    $options = new Options();
+    foreach ($config_options as $input => $return) {
+      $options->add($input, $return);
+    }
+
+    $immutableConfig = (new Chain($this))
+      ->add(ImmutableConfig::class, 'get', $options)
+      ->getMock();
+    $configFactoryMock = (new Chain($this))
+      ->add(ConfigFactoryInterface::class, 'get', $immutableConfig)
+      ->getMock();
+
+    $fileSystemStub = $this->createStub(FileSystemInterface::class);
+    $fileSystemStub->method('getTempDirectory')
+      ->willReturn('/tmp');
+
+    // Create Data object.
+    return new NodeData('dataset', $etmMock, $configFactoryMock, $fileSystemStub, $this->createStub(LoggerInterface::class));
   }
 
   /**
@@ -137,7 +207,7 @@ class DataTest extends TestCase {
       ->getMock();
 
     // Create Data object.
-    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock, $this->createStub(LoggerInterface::class));
+    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock, $this->createStub(FileSystemInterface::class), $this->createStub(LoggerInterface::class));
     // Ensure count matches return value.
     $this->assertEquals($count, $nodeData->count());
   }
@@ -174,7 +244,7 @@ class DataTest extends TestCase {
       ->getMock();
 
     // Create Data object.
-    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock, $this->createStub(LoggerInterface::class));
+    $nodeData = new NodeData('dataset', $etmMock, $configFactoryMock, $this->createStub(FileSystemInterface::class), $this->createStub(LoggerInterface::class));
     // Ensure the returned uuids match those belonging to the generated nodes.
     $this->assertEquals($uuids, $nodeData->retrieveIds(1, 5));
   }

--- a/modules/metastore/tests/src/Unit/Storage/DataTest.php
+++ b/modules/metastore/tests/src/Unit/Storage/DataTest.php
@@ -171,11 +171,9 @@ class DataTest extends TestCase {
       $options->add($input, $return);
     }
 
-    $immutableConfig = (new Chain($this))
-      ->add(ImmutableConfig::class, 'get', $options)
-      ->getMock();
     $configFactoryMock = (new Chain($this))
-      ->add(ConfigFactoryInterface::class, 'get', $immutableConfig)
+      ->add(ConfigFactoryInterface::class, 'get', ImmutableConfig::class)
+      ->add(ImmutableConfig::class, 'get', $options)
       ->getMock();
 
     $fileSystemStub = $this->createStub(FileSystemInterface::class);


### PR DESCRIPTION
Fixes [issue#]

## Describe your changes
- Moved filterHtml() call to datasetPresave so that it's called for both API and UI updates (Requires making filterHtml() public
- Made file_system injected in metastore/storage/Data
- Added test for html filtering.

## QA Steps

- [x] Create or edit a dataset. In the description some 'safe' html, (e.g. `<a href="#">link</a><br /><table><tr><td>cell</td></tr><em>EM</em><b>bold</b>`) and some 'dangerous' html (e.g. `<script src="s"></script><iframe src="https://cms.gov></iframe>`)
- [x] Save and re-edit the dataset. Verify that the safe html is still there, but the dangerous html has been removed.
- [x] Go to /admin/dkan/properties and scroll down to "Allowed tags and elements for properties that allow HTML".
- [x] Enter a subset of the safe tags/elements (e.g. `a[href],em,br`)
- [x] Resave the dataset, then edit it again.
- [x] Verify that any tags not included 'Allowed tags and elements' have been removed from the description.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
