### PR TITLE
Update matrix to target 10.5 and build for 11.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
         type: string
       drupal_core_constraint:
         description: "Branch of getdkan/recommended-project to use."
-        default: "~10.4"
+        default: "~10.5"
         type: string
       upgrade:
         description: "If true, will install the latest stable DKAN version and test upgrade"
@@ -247,30 +247,39 @@ workflows:
     jobs:
       - cypress:
           name: install_test_cypress
-          drupal_core_constraint: "10.4.x-dev"
+          drupal_core_constraint: "~10.5"
       - phpunit:
-          name: "Install target (Drupal 10.4, PHP 8.3)"
+          name: "Install target (Drupal 10.5, PHP 8.3)"
           report_coverage: true
           matrix:
             parameters:
-              drupal_core_constraint: ["~10.4"]
+              drupal_core_constraint: ["~10.5"]
               php_version: ["8.3"]
               database_version: ["mysql:5.7"]
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~11.1", "~11.0"]
-              php_version: ["8.4", "8.3"]
+              drupal_core_constraint: ["~11.1"]
+              php_version: ["8.4"]
+              database_version: ["mariadb:10.11"]
+      - phpunit:
+          matrix:
+            parameters:
+              drupal_core_constraint: ["~11.0", "~11.1", "~11.2"]
+              php_version: ["8.3"]
               database_version: ["mariadb:10.11"]
       - phpunit:
           matrix:
             parameters:
               drupal_core_constraint: ["~10.5"]
-              php_version: ["8.1", "8.2", "8.3", "8.4"]
+              php_version: ["8.1", "8.2", "8.4"]
               database_version: ["mysql:5.7"]
-            exclude:
-              - php_version: "8.3"
-                drupal_core_constraint: "~10.4"
+      - phpunit:
+          matrix:
+            parameters:
+              drupal_core_constraint: ["~10.4"]
+              php_version: ["8.3"]
+              database_version: ["mysql:5.7"]
             
 
   upgrade_and_test:


### PR DESCRIPTION
Also cut some combinations that seem redundant. Make 10.5 the "target", start testing against Drupal 11.2, and don't do every possible combination of 11.x and PHP 8.3-8.4. We only really need one PHP 8.4 test per major release for now.