### PR TITLE
Fix rerun behavior in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,7 @@ jobs:
           name: Run Cypress tests
           max_auto_reruns: 3
           command: |
+            rm -rf cypress/tmp
             mkdir cypress/tmp
             mkdir cypress/results
             mv $(circleci tests glob cypress/e2e/*.cy.js | circleci tests split --split-by=timings) cypress/tmp || true


### PR DESCRIPTION
CircleCI now automatically re-tries the flaky cypress tests up to three times if they fail, but the second and third always fail because there's already data in the cypress/tmp dir. This deletes it before running the job.

Hopefully we can get a failing build on this PR to demonstrate.