### PR TITLE
Cache the select2 library in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,10 @@ commands:
                   # The following should be removed once the 2.x branch has the ddev add-on config.
                   git checkout $CIRCLE_BRANCH -- .ddev composer.json
 
+      - restore_cache:
+          keys:
+            - select2-v1-{{ checksum ".ddev/commands/web/select2" }}
+            - select2-v1-
       - run:
           name: Build site codebase
           command: |
@@ -84,6 +88,10 @@ commands:
             ddev config --update
             ddev restart
             ddev status
+      - save_cache:
+          key: select2-v1-{{ checksum ".ddev/commands/web/select2" }}
+          paths:
+            - web/libraries/select2
       - run:
           name: Install site
           command: |

--- a/.ddev/commands/web/select2
+++ b/.ddev/commands/web/select2
@@ -6,6 +6,12 @@
 
 set -eu -o pipefail
 
+# Skip download if select2 library already exists
+if [ -d "$DOCROOT/libraries/select2" ]; then
+  echo "No action taken; select2 library already exists."
+  exit 0
+fi
+
 curl -L https://github.com/select2/select2/archive/595494a.tar.gz -o select2.tar.gz
 mkdir -p $DOCROOT/libraries
 tar xzf select2.tar.gz

--- a/.ddev/commands/web/select2
+++ b/.ddev/commands/web/select2
@@ -12,6 +12,8 @@ if [ -d "$DOCROOT/libraries/select2" ]; then
   exit 0
 fi
 
+# TODO Update this when there's a formal release that supports jQuery 4.x.
+# Remember CircleCI cache key is based on checksum of this file.
 curl -L https://github.com/select2/select2/archive/595494a.tar.gz -o select2.tar.gz
 mkdir -p $DOCROOT/libraries
 tar xzf select2.tar.gz


### PR DESCRIPTION
We get failures sometimes when we run the `ddev select2` command in CI. I'm actually not sure why but could be a rate limit from github or something. CircleCI can cache dependencies based on a key, so we can take advantage of that. 

This also modifies the select2 ddev command to exit if the library is already there.

The cache key in circleCI is a hash of the command itself, since the command targets a specific commit, if we ever update that commit ID or anything else about the logic in the script it will invalidate the cache.