### PR TITLE
Make LifeCycle::EVENT_PRE_REFERENCE support metadata alter

### DIFF
--- a/modules/metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/metastore/src/LifeCycle/LifeCycle.php
@@ -347,14 +347,13 @@ class LifeCycle {
    * @throws \Exception
    */
   protected function referenceMetadata(MetastoreItemInterface $data): void {
-    $metadata = $data->getMetadata();
-
     // Trigger datastore import if applicable.
     // Needs to happen before updating references.
     if ($data instanceof MetastoreItemInterface) {
       $event = new Event($data);
       $this->eventDispatcher->dispatch($event, self::EVENT_PRE_REFERENCE);
     }
+    $metadata = $data->getMetadata();
 
     // Convert references in metadata to uuids.
     // Create new reference entities if they do not exist.


### PR DESCRIPTION
Fixes #4627

## Describe your changes
The moves the metadata capture to after the event dispatch, to allow for pulling in changes that might have been made by a subscriber.

## QA Steps

- [ ] There is nothing to QA here as there is only a timing change if someone wants to use this event to alter metadata prior to referencing.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code - No additional tests needed.  Nothing functionally changed for DKAN core, only how custom evensubscribers might interact.
- [ ] I have updated or added documentation - none needed.
