### PR TITLE
Safer caching approach

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,8 +61,7 @@ commands:
 
       - restore_cache:
           keys:
-            - select2-v1-{{ checksum ".ddev/commands/web/select2" }}
-            - select2-v1-
+            - select2-{{ checksum ".ddev/commands/web/select2" }}
       - run:
           name: Build site codebase
           command: |
@@ -89,7 +88,7 @@ commands:
             ddev restart
             ddev status
       - save_cache:
-          key: select2-v1-{{ checksum ".ddev/commands/web/select2" }}
+          key: select2-{{ checksum ".ddev/commands/web/select2" }}
           paths:
             - web/libraries/select2
       - run:


### PR DESCRIPTION
Following some documentation I had originally added a fallback for the select2 cache but I think that was incorrect. We should not use the cache if it doesn't exist for our specific commit.