### PR TITLE
Drupal 10.6, remove EOL versions from testing matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,4 +303,4 @@ workflows:
       - cypress:
           name: upgrade_test_cypress
           upgrade: true
-          drupal_core_constraint: "10.4.x-dev"
+          drupal_core_constraint: "~10.5.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,7 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["10.6.0", "~11.2.0", "~11.3.0"]
+              drupal_core_constraint: ["10.6.0", "~11.2.0"]
               php_version: ["8.4"]
               database_version: ["mariadb:10.11"]
       - phpunit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,12 +134,34 @@ jobs:
           drupal_core_constraint: << parameters.drupal_core_constraint >>
           upgrade: << parameters.upgrade >>
       - run:
-          name: Set up GROUP_ARG variable for paralallel tests
+          name: Set up GROUP_ARG variable for parallel tests
           command: |
-            EXCLUDES=$(seq -s, 1 $(($CIRCLE_NODE_TOTAL-1)) | sed 's/[0-9]\+/functional&/g')
-            [[ $CIRCLE_NODE_INDEX == 0 ]] \
-              && PHPUNIT_GROUP_ARG="exclude-group $EXCLUDES" \
-              || PHPUNIT_GROUP_ARG="group functional$CIRCLE_NODE_INDEX"
+            if [[ $CIRCLE_NODE_INDEX == 0 ]]; then
+              # Get phpunit major version
+              PHPUNIT_VERSION=$(ddev composer show phpunit/phpunit | grep versions | awk '{print $4}' | cut -d. -f1)
+              
+              if [[ $PHPUNIT_VERSION -lt 11 ]]; then
+                # For phpunit < 11, use comma-separated syntax
+                EXCLUDES="--exclude-group "
+                for i in $(seq 1 $(($CIRCLE_NODE_TOTAL-1))); do
+                  if [[ $i -gt 1 ]]; then
+                    EXCLUDES="${EXCLUDES},functional$i"
+                  else
+                    EXCLUDES="${EXCLUDES}functional$i"
+                  fi
+                done
+                PHPUNIT_GROUP_ARG="$EXCLUDES"
+              else
+                # For phpunit >= 11, use multiple --exclude-group flags
+                EXCLUDES=""
+                for i in $(seq 1 $(($CIRCLE_NODE_TOTAL-1))); do
+                  EXCLUDES="$EXCLUDES --exclude-group functional$i"
+                done
+                PHPUNIT_GROUP_ARG="$EXCLUDES"
+              fi
+            else
+              PHPUNIT_GROUP_ARG="--group functional$CIRCLE_NODE_INDEX"
+            fi
             echo "export PHPUNIT_GROUP_ARG=\"$PHPUNIT_GROUP_ARG\"" >> $BASH_ENV
       - when:
           condition: << parameters.report_coverage >>
@@ -154,7 +176,7 @@ jobs:
                   mkdir -p $CIRCLE_WORKING_DIRECTORY/report/php
                   mkdir -p $CIRCLE_WORKING_DIRECTORY/report/clover
                   ddev phpunit \
-                    --$PHPUNIT_GROUP_ARG \
+                    $PHPUNIT_GROUP_ARG \
                     --coverage-clover /var/www/html/report/clover/clover-$CIRCLE_NODE_INDEX.xml \
                     --coverage-php /var/www/html/report/php/coverage-$CIRCLE_NODE_INDEX.cov \
                     --log-junit /var/www/html/report/junit/junit.xml
@@ -187,7 +209,7 @@ jobs:
                 name: Run PHPUnit tests
                 command: |
                   ddev phpunit \
-                    --$PHPUNIT_GROUP_ARG \
+                    $PHPUNIT_GROUP_ARG \
                     --log-junit /var/www/html/report/junit/junit.xml
       - store_test_results:
           path: report/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
         type: string
       drupal_core_constraint:
         description: "Branch of getdkan/recommended-project to use."
-        default: "~10.5"
+        default: "~10.5.0"
         type: string
       upgrade:
         description: "If true, will install the latest stable DKAN version and test upgrade"
@@ -281,26 +281,20 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~11.1.0"]
-              php_version: ["8.4"]
+              drupal_core_constraint: ["~10.6.0", "~11.2.0"]
+              php_version: ["8.3"]
               database_version: ["mariadb:10.11"]
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~11.1.0", "~11.2.0", "~11.3.0"]
-              php_version: ["8.3"]
+              drupal_core_constraint: ["10.6.0", "~11.2.0", "~11.3.0"]
+              php_version: ["8.4"]
               database_version: ["mariadb:10.11"]
       - phpunit:
           matrix:
             parameters:
               drupal_core_constraint: ["~10.5.0"]
               php_version: ["8.1", "8.2", "8.4"]
-              database_version: ["mysql:5.7"]
-      - phpunit:
-          matrix:
-            parameters:
-              drupal_core_constraint: ["~10.4.0"]
-              php_version: ["8.3"]
               database_version: ["mysql:5.7"]
             
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~11.0.0", "~11.1.0", "~11.2.0"]
+              drupal_core_constraint: ["~11.1.0", "~11.2.0", "~11.3.0"]
               php_version: ["8.3"]
               database_version: ["mariadb:10.11"]
       - phpunit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,15 +136,10 @@ jobs:
       - run:
           name: Set up GROUP_ARG variable for paralallel tests
           command: |
-            if [[ $CIRCLE_NODE_INDEX == 0 ]]; then
-              EXCLUDES=""
-              for i in $(seq 1 $(($CIRCLE_NODE_TOTAL-1))); do
-                EXCLUDES="$EXCLUDES --exclude-group functional$i"
-              done
-              PHPUNIT_GROUP_ARG="$EXCLUDES"
-            else
-              PHPUNIT_GROUP_ARG="--group functional$CIRCLE_NODE_INDEX"
-            fi
+            EXCLUDES=$(seq -s, 1 $(($CIRCLE_NODE_TOTAL-1)) | sed 's/[0-9]\+/functional&/g')
+            [[ $CIRCLE_NODE_INDEX == 0 ]] \
+              && PHPUNIT_GROUP_ARG="exclude-group $EXCLUDES" \
+              || PHPUNIT_GROUP_ARG="group functional$CIRCLE_NODE_INDEX"
             echo "export PHPUNIT_GROUP_ARG=\"$PHPUNIT_GROUP_ARG\"" >> $BASH_ENV
       - when:
           condition: << parameters.report_coverage >>
@@ -159,7 +154,7 @@ jobs:
                   mkdir -p $CIRCLE_WORKING_DIRECTORY/report/php
                   mkdir -p $CIRCLE_WORKING_DIRECTORY/report/clover
                   ddev phpunit \
-                    $PHPUNIT_GROUP_ARG \
+                    --$PHPUNIT_GROUP_ARG \
                     --coverage-clover /var/www/html/report/clover/clover-$CIRCLE_NODE_INDEX.xml \
                     --coverage-php /var/www/html/report/php/coverage-$CIRCLE_NODE_INDEX.cov \
                     --log-junit /var/www/html/report/junit/junit.xml
@@ -192,7 +187,7 @@ jobs:
                 name: Run PHPUnit tests
                 command: |
                   ddev phpunit \
-                    $PHPUNIT_GROUP_ARG \
+                    --$PHPUNIT_GROUP_ARG \
                     --log-junit /var/www/html/report/junit/junit.xml
       - store_test_results:
           path: report/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,10 +136,15 @@ jobs:
       - run:
           name: Set up GROUP_ARG variable for paralallel tests
           command: |
-            EXCLUDES=$(seq -s, 1 $(($CIRCLE_NODE_TOTAL-1)) | sed 's/[0-9]\+/functional&/g')
-            [[ $CIRCLE_NODE_INDEX == 0 ]] \
-              && PHPUNIT_GROUP_ARG="exclude-group $EXCLUDES" \
-              || PHPUNIT_GROUP_ARG="group functional$CIRCLE_NODE_INDEX"
+            if [[ $CIRCLE_NODE_INDEX == 0 ]]; then
+              EXCLUDES=""
+              for i in $(seq 1 $(($CIRCLE_NODE_TOTAL-1))); do
+                EXCLUDES="$EXCLUDES --exclude-group functional$i"
+              done
+              PHPUNIT_GROUP_ARG="$EXCLUDES"
+            else
+              PHPUNIT_GROUP_ARG="--group functional$CIRCLE_NODE_INDEX"
+            fi
             echo "export PHPUNIT_GROUP_ARG=\"$PHPUNIT_GROUP_ARG\"" >> $BASH_ENV
       - when:
           condition: << parameters.report_coverage >>
@@ -154,7 +159,7 @@ jobs:
                   mkdir -p $CIRCLE_WORKING_DIRECTORY/report/php
                   mkdir -p $CIRCLE_WORKING_DIRECTORY/report/clover
                   ddev phpunit \
-                    --$PHPUNIT_GROUP_ARG \
+                    $PHPUNIT_GROUP_ARG \
                     --coverage-clover /var/www/html/report/clover/clover-$CIRCLE_NODE_INDEX.xml \
                     --coverage-php /var/www/html/report/php/coverage-$CIRCLE_NODE_INDEX.cov \
                     --log-junit /var/www/html/report/junit/junit.xml
@@ -187,7 +192,7 @@ jobs:
                 name: Run PHPUnit tests
                 command: |
                   ddev phpunit \
-                    --$PHPUNIT_GROUP_ARG \
+                    $PHPUNIT_GROUP_ARG \
                     --log-junit /var/www/html/report/junit/junit.xml
       - store_test_results:
           path: report/junit

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "require-dev": {
         "colinodell/psr-testlogger": "^1.2",
         "drush/drush": "*",
-        "getdkan/mock-chain": "^1.4.0",
+        "getdkan/mock-chain": "dev-phpunit-11",
         "osteel/openapi-httpfoundation-testing": "^0.13",
         "drupal/admin_toolbar": "^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "getdkan/rooted-json-data": "^0.2.2",
         "guzzlehttp/guzzle": "^7.5",
         "ilbee/csv-response": "^1.2.0",
-        "justinrainbow/json-schema": "^5.2",
+        "justinrainbow/json-schema": "^5.2 || ^6.6.1",
         "m1x0n/opis-json-schema-error-presenter": "^0.5.3",
         "ramsey/uuid": "^3.8.0 || ^4",
         "stolt/json-merge-patch": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
     "config": {
         "allow-plugins": {
             "php-http/discovery": true,
-            "tbachert/spi": true
+            "tbachert/spi": true,
+            "drupal/core-composer-scaffold": true
         }        
     },
     "extra": {

--- a/modules/common/tests/src/Kernel/StreamWrapper/DkanStreamWrapperTest.php
+++ b/modules/common/tests/src/Kernel/StreamWrapper/DkanStreamWrapperTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\common\Kernel\StreamWrapper;
 
+use Drupal\Core\StreamWrapper\StreamWrapperInterface;
 use Drupal\KernelTests\KernelTestBase;
 
 /**
@@ -25,10 +26,10 @@ class DkanStreamWrapperTest extends KernelTestBase {
     $manager = $this->container->get('stream_wrapper_manager');
     $scheme = $manager->getScheme($uri);
     $this->assertEquals('dkan', $scheme);
-    $descriptions = $manager->getDescriptions();
-    $this->assertStringContainsString('Simple way to request DKAN', $descriptions[$scheme]);
-    $names = $manager->getNames();
-    $this->assertEquals('DKAN documents', $names[$scheme]);
+
+    $wrapper = $manager->getViaScheme($scheme);
+    $this->assertStringContainsString('Simple way to request DKAN', $wrapper->getDescription());
+    $this->assertEquals('DKAN documents', $wrapper->getName());
 
     $path = $manager->getViaScheme($scheme)->getDirectoryPath();
     $this->assertStringContainsString('/api/1', $path);

--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -339,7 +339,7 @@ class UploadOrLink extends ManagedFile {
    *
    * Sets up file entities created by upload element.
    */
-  public static function submit(array $form, FormStateInterface $form_state) {
+  public static function submit(array $form, FormStateInterface $form_state): void {
     $parents = $form_state->get('upload_or_link_element');
     if (empty($parents)) {
       return;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,31 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" bootstrap="web/core/tests/bootstrap.php" colors="true" cacheDirectory=".phpunit.cache">
-  <testsuites>
-    <testsuite name="default">
-      <directory>.</directory>
-      <exclude>vendor</exclude>
-      <exclude>web</exclude>
-    </testsuite>
-  </testsuites>
-  <source>
-    <include>
-      <directory>src</directory>
-      <directory>modules</directory>
-    </include>
-    <exclude>
-      <directory>modules/common/tests</directory>
-      <directory>modules/datastore/tests</directory>
-      <directory>modules/datastore/modules/datastore_mysql_import/tests</directory>
-      <directory>modules/dkan_js_frontend/tests</directory>
-      <directory>modules/frontend/tests</directory>
-      <directory>modules/harvest/tests</directory>
-      <directory>modules/json_form_widget/tests</directory>
-      <directory>modules/data_dictionary_widget/tests</directory>
-      <directory>modules/metastore/tests</directory>
-      <directory>modules/metastore/modules/metastore_admin/tests</directory>
-      <directory>modules/metastore/modules/metastore_search/tests</directory>
-      <directory>modules/sample_content/tests</directory>
-      <directory suffix="TestBase.php">./</directory>
-    </exclude>
-  </source>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         bootstrap="web/core/tests/bootstrap.php"
+         verbose="true"
+         colors="true">
+    <coverage>
+        <include>
+            <directory>src</directory>
+            <directory>modules</directory>
+        </include>
+        <exclude>
+            <directory>modules/common/tests</directory>
+            <directory>modules/datastore/tests</directory>
+            <directory>modules/datastore/modules/datastore_mysql_import/tests</directory>
+            <directory>modules/dkan_js_frontend/tests</directory>
+            <directory>modules/frontend/tests</directory>
+            <directory>modules/harvest/tests</directory>
+            <directory>modules/json_form_widget/tests</directory>
+            <directory>modules/data_dictionary_widget/tests</directory>
+            <directory>modules/metastore/tests</directory>
+            <directory>modules/metastore/modules/metastore_admin/tests</directory>
+            <directory>modules/metastore/modules/metastore_search/tests</directory>
+            <directory>modules/sample_content/tests</directory>
+            <directory suffix="TestBase.php">./</directory>
+        </exclude>
+    </coverage>
+    <testsuites>
+        <testsuite name="default">
+            <directory>.</directory>
+            <exclude>vendor</exclude>
+            <exclude>web</exclude>
+        </testsuite>
+    </testsuites>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,35 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
-         bootstrap="web/core/tests/bootstrap.php"
-         verbose="true"
-         colors="true">
-    <coverage>
-        <include>
-            <directory>src</directory>
-            <directory>modules</directory>
-        </include>
-        <exclude>
-            <directory>modules/common/tests</directory>
-            <directory>modules/datastore/tests</directory>
-            <directory>modules/datastore/modules/datastore_mysql_import/tests</directory>
-            <directory>modules/dkan_js_frontend/tests</directory>
-            <directory>modules/frontend/tests</directory>
-            <directory>modules/harvest/tests</directory>
-            <directory>modules/json_form_widget/tests</directory>
-            <directory>modules/data_dictionary_widget/tests</directory>
-            <directory>modules/metastore/tests</directory>
-            <directory>modules/metastore/modules/metastore_admin/tests</directory>
-            <directory>modules/metastore/modules/metastore_search/tests</directory>
-            <directory>modules/sample_content/tests</directory>
-            <directory suffix="TestBase.php">./</directory>
-        </exclude>
-    </coverage>
-    <testsuites>
-        <testsuite name="default">
-            <directory>.</directory>
-            <exclude>vendor</exclude>
-            <exclude>web</exclude>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" bootstrap="web/core/tests/bootstrap.php" colors="true" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="default">
+      <directory>.</directory>
+      <exclude>vendor</exclude>
+      <exclude>web</exclude>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory>src</directory>
+      <directory>modules</directory>
+    </include>
+    <exclude>
+      <directory>modules/common/tests</directory>
+      <directory>modules/datastore/tests</directory>
+      <directory>modules/datastore/modules/datastore_mysql_import/tests</directory>
+      <directory>modules/dkan_js_frontend/tests</directory>
+      <directory>modules/frontend/tests</directory>
+      <directory>modules/harvest/tests</directory>
+      <directory>modules/json_form_widget/tests</directory>
+      <directory>modules/data_dictionary_widget/tests</directory>
+      <directory>modules/metastore/tests</directory>
+      <directory>modules/metastore/modules/metastore_admin/tests</directory>
+      <directory>modules/metastore/modules/metastore_search/tests</directory>
+      <directory>modules/sample_content/tests</directory>
+      <directory suffix="TestBase.php">./</directory>
+    </exclude>
+  </source>
 </phpunit>


### PR DESCRIPTION
This started as a PR to add 11.3 support, but is now focused on adding 10.6 testing and removing 10.4, 11.1 and 11.2 due to EOL dates and new build problems. Will restore 11.3 support in another PR.