### PR TITLE
Update README to fix local sandbox ddev link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 [![DPG Badge](https://img.shields.io/badge/Verified-DPG-3333AB?logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzEiIGhlaWdodD0iMzMiIHZpZXdCb3g9IjAgMCAzMSAzMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0LjIwMDggMjEuMzY3OEwxMC4xNzM2IDE4LjAxMjRMMTEuNTIxOSAxNi40MDAzTDEzLjk5MjggMTguNDU5TDE5LjYyNjkgMTIuMjExMUwyMS4xOTA5IDEzLjYxNkwxNC4yMDA4IDIxLjM2NzhaTTI0LjYyNDEgOS4zNTEyN0wyNC44MDcxIDMuMDcyOTdMMTguODgxIDUuMTg2NjJMMTUuMzMxNCAtMi4zMzA4MmUtMDVMMTEuNzgyMSA1LjE4NjYyTDUuODU2MDEgMy4wNzI5N0w2LjAzOTA2IDkuMzUxMjdMMCAxMS4xMTc3TDMuODQ1MjEgMTYuMDg5NUwwIDIxLjA2MTJMNi4wMzkwNiAyMi44Mjc3TDUuODU2MDEgMjkuMTA2TDExLjc4MjEgMjYuOTkyM0wxNS4zMzE0IDMyLjE3OUwxOC44ODEgMjYuOTkyM0wyNC44MDcxIDI5LjEwNkwyNC42MjQxIDIyLjgyNzdMMzAuNjYzMSAyMS4wNjEyTDI2LjgxNzYgMTYuMDg5NUwzMC42NjMxIDExLjExNzdMMjQuNjI0MSA5LjM1MTI3WiIgZmlsbD0id2hpdGUiLz4KPC9zdmc+Cg==)](https://www.digitalpublicgoods.net/r/dkan)
 ---
 
-[![Getting Started with DKAN](https://img.youtube.com/vi/SnA22Lb6r_M/0.jpg)](https://youtu.be/SnA22Lb6r_M?si=WqU-FKGb1iGhc5Vz)
-
 ## Documentation
 DKAN's documentation can be found at https://dkan.readthedocs.io/en/latest
 
@@ -32,8 +30,7 @@ Requirements: https://dkan.readthedocs.io/en/latest/installation/index.html#requ
 - [Code of conduct](https://dkan.readthedocs.io/en/latest/contributing/code_of_conduct.html)
 - [Submission guidelines](https://dkan.readthedocs.io/en/latest/contributing/submission_guidelines.html)
 - [Create an issue](https://github.com/GetDKAN/dkan/issues/new/choose)
-- [Set up local sandbox with DDEV](https://getdkan.github.io/ddev-dkan/getting-started.html)
-
+- [Set up local sandbox with DDEV](https://dkan.readthedocs.io/en/latest/developer-guide/dev_local_setup.html)
 ---
 
 ## License


### PR DESCRIPTION

## Describe your changes

As of DKAN 2.22, we no longer recommend using the ddev-dkan addon. For local development we are now using the [DDEV Drupal Contrib add-on](https://github.com/ddev/ddev-drupal-contrib) and the README should reflect that.

The quick setup video is now out-dated so removing the link to the youtube video.

## QA Steps

- [ ] Review the module README and confirm updates are accurate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
