### PR TITLE
Update Sqlite Connection usage for Drupal 11.3 / PHP 8.4 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,14 +289,8 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~10.6.0", "~11.2.0"]
-              php_version: ["8.3"]
-              database_version: ["mariadb:10.11"]
-      - phpunit:
-          matrix:
-            parameters:
-              drupal_core_constraint: ["10.6.0", "~11.2.0"]
-              php_version: ["8.4"]
+              drupal_core_constraint: ["~10.6.0", "~11.2.0", "11.3.0"]
+              php_version: ["8.3", "8.4"]
               database_version: ["mariadb:10.11"]
       - phpunit:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,8 +289,14 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~10.6.0", "~11.2.0", "11.3.0"]
-              php_version: ["8.3", "8.4"]
+              drupal_core_constraint: ["~10.6.0", "~11.2.0"]
+              php_version: ["8.3"]
+              database_version: ["mariadb:10.11"]
+      - phpunit:
+          matrix:
+            parameters:
+              drupal_core_constraint: ["10.6.0", "~11.2.0"]
+              php_version: ["8.4"]
               database_version: ["mariadb:10.11"]
       - phpunit:
           matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 .swp
 .vscode
+.zed
 composer.lock
 package-lock.json
 tagfile

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -15,7 +15,8 @@ use Drupal\metastore\MetastoreApiResponse;
 use Drupal\metastore\NodeWrapper\Data;
 use Drupal\metastore\NodeWrapper\NodeDataFactory;
 use Drupal\metastore\Storage\DataFactory;
-use Drupal\sqlite\Driver\Database\sqlite\Connection as SqliteConnection;
+use Drupal\sqlite\Driver\Database\sqlite\Connection;
+use Drupal\sqlite\Driver\Database\sqlite\SqliteConnection;
 use Ilbee\CSVResponse\CSVResponse as CsvResponse;
 use MockChain\Chain;
 use MockChain\Options;
@@ -536,8 +537,8 @@ class QueryControllerTest extends TestCase {
    *   A database table storage class useable for datastore queries.
    */
   public function mockDatastoreTable() {
-    $pdo = (class_exists(Sqlite::class)) ? new Sqlite('sqlite::memory:') : new \PDO('sqlite::memory:');
-    $connection = new SqliteConnection($pdo, []);
+    $pdo = (class_exists(SqliteConnection::class)) ? new SqliteConnection('sqlite::memory:') : new \PDO('sqlite::memory:');
+    $connection = new Connection($pdo, []);
     $storage = new SqliteDatabaseTable(
       $connection,
       $this->resource,

--- a/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -537,7 +537,10 @@ class QueryControllerTest extends TestCase {
    *   A database table storage class useable for datastore queries.
    */
   public function mockDatastoreTable() {
-    $pdo = (class_exists(SqliteConnection::class)) ? new SqliteConnection('sqlite::memory:') : new \PDO('sqlite::memory:');
+    $pdo = match(TRUE) {
+      \PHP_VERSION_ID >= 80400 && class_exists(SqliteConnection::class) => new SqliteConnection('sqlite::memory:'),
+      default => new \PDO('sqlite::memory:'),
+    }; 
     $connection = new Connection($pdo, []);
     $storage = new SqliteDatabaseTable(
       $connection,

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -20,7 +20,6 @@ use Drupal\sqlite\Driver\Database\sqlite\Connection;
 use Drupal\sqlite\Driver\Database\sqlite\SqliteConnection;
 use MockChain\Chain;
 use MockChain\Options;
-use Pdo\Sqlite;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Container;
@@ -402,7 +401,10 @@ class QueryDownloadControllerTest extends TestCase {
    *   MockChain mock object.
    */
   private function getQueryContainer(int $rowLimit, ?int $responseStreamMaxAge = NULL) {
-    $pdo = (class_exists(SqliteConnection::class)) ? new SqliteConnection('sqlite::memory:') : new \PDO('sqlite::memory:');
+    $pdo = match(TRUE) {
+      \PHP_VERSION_ID >= 80400 && class_exists(SqliteConnection::class) => new SqliteConnection('sqlite::memory:'),
+      default => new \PDO('sqlite::memory:'),
+    }; 
     $connection = new Connection($pdo, []);
     $options = (new Options())
       ->add("dkan.metastore.storage", DataFactory::class)

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -16,7 +16,8 @@ use Drupal\metastore\MetastoreApiResponse;
 use Drupal\metastore\NodeWrapper\Data;
 use Drupal\metastore\NodeWrapper\NodeDataFactory;
 use Drupal\metastore\Storage\DataFactory;
-use Drupal\sqlite\Driver\Database\sqlite\Connection as SqliteConnection;
+use Drupal\sqlite\Driver\Database\sqlite\Connection;
+use Drupal\sqlite\Driver\Database\sqlite\SqliteConnection;
 use MockChain\Chain;
 use MockChain\Options;
 use Pdo\Sqlite;
@@ -401,8 +402,8 @@ class QueryDownloadControllerTest extends TestCase {
    *   MockChain mock object.
    */
   private function getQueryContainer(int $rowLimit, ?int $responseStreamMaxAge = NULL) {
-    $pdo = (class_exists(Sqlite::class)) ? new Sqlite('sqlite::memory:') : new \PDO('sqlite::memory:');
-    $connection = new SqliteConnection($pdo, []);
+    $pdo = (class_exists(SqliteConnection::class)) ? new SqliteConnection('sqlite::memory:') : new \PDO('sqlite::memory:');
+    $connection = new Connection($pdo, []);
     $options = (new Options())
       ->add("dkan.metastore.storage", DataFactory::class)
       ->add("dkan.datastore.service", DatastoreService::class)


### PR DESCRIPTION
Related to #4637 

Connection class handling has gone through some deprecation. The SQLite connection we use in some tests needs to be refactored to support 11.3. Note we are still not adding 11.3 to the testing matrix because it is blocked by the form issue described in #4637.

For "proof" it works, see the [CircleCI builds for 11.3, before removing it from the matrix again](https://app.circleci.com/pipelines/github/GetDKAN/dkan/7385/workflows/8a3a1d22-361d-43ec-bf41-02bf23b424d3). The only errors are related to the Form API changes, not the SQLite connection. Compare to the initial commit, [where we get SQLite-related errors for PHP 8.4](https://app.circleci.com/pipelines/github/GetDKAN/dkan/7384/workflows/9352f0fa-8719-4c4f-a49e-3f7387ad1110/jobs/54912).