### PR TITLE
UploadOrLink submit fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
             if [[ $CIRCLE_NODE_INDEX == 0 ]]; then
               # Get phpunit major version
               PHPUNIT_VERSION=$(ddev composer show phpunit/phpunit | grep versions | awk '{print $4}' | cut -d. -f1)
-              
+
               if [[ $PHPUNIT_VERSION -lt 11 ]]; then
                 # For phpunit < 11, use comma-separated syntax
                 EXCLUDES="--exclude-group "
@@ -289,13 +289,13 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~10.6.0", "~11.2.0"]
+              drupal_core_constraint: ["~10.6.0", "~11.2.0", "11.3.0"]
               php_version: ["8.3"]
               database_version: ["mariadb:10.11"]
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["10.6.0", "~11.2.0"]
+              drupal_core_constraint: ["10.6.0", "~11.2.0", "~11.3.0"]
               php_version: ["8.4"]
               database_version: ["mariadb:10.11"]
       - phpunit:
@@ -304,7 +304,7 @@ workflows:
               drupal_core_constraint: ["~10.5.0"]
               php_version: ["8.1", "8.2", "8.4"]
               database_version: ["mysql:5.7"]
-            
+
 
   upgrade_and_test:
     jobs:

--- a/modules/json_form_widget/json_form_widget.module
+++ b/modules/json_form_widget/json_form_widget.module
@@ -35,7 +35,7 @@ function json_form_widget_form_alter(&$form, FormStateInterface $form_state, $fo
     return;
   }
   if ($form_state->get('has_json_form_widget')) {
-    $form['actions']['submit']['#submit'][] = [UploadOrLink::class, 'submit'];
+    $form['actions']['submit']['#submit'][] = [UploadOrLink::class, 'formSubmit'];
   }
 }
 

--- a/modules/json_form_widget/src/Element/UploadOrLink.php
+++ b/modules/json_form_widget/src/Element/UploadOrLink.php
@@ -339,7 +339,7 @@ class UploadOrLink extends ManagedFile {
    *
    * Sets up file entities created by upload element.
    */
-  public static function submit(array $form, FormStateInterface $form_state): void {
+  public static function formSubmit(array $form, FormStateInterface $form_state): void {
     $parents = $form_state->get('upload_or_link_element');
     if (empty($parents)) {
       return;


### PR DESCRIPTION
Fixes #4637

The remove button in JSON Form Widget's UploadOrLink element broke in Drupal 11.3. It turns out this is because we had an existing submit() method in that class, which now conflicts with the submit() method in the parent ManagedFile widget. Our submit was unrelated, it's a _form_ submit function that is added in a form_alter function in the module file. (Note, this is very inelegant, hopefully we can handle this differently somehow). What we needed was for the Remove button to have two submit handlers - the regular ManagedFile::submit() (previously just `file_managed_file_submit()` and then our `UploadOrLink::removeSubmit()`. We were suddenly hitting `UploadOrLink::submit()` instead of `ManagedFile::submit()`.

Changing the name of `ManagedFile::submit()` fixes the issue.

Note that, as this was the last blocking issue for Drupal 11.3, I have re-added that to the testing matrix.

## QA Steps

1. Build the branch against Drupal 11.3 (`ddev core-version ~11.3.0`).
2. Import sample content (`ddev dkan-sample-content`)
3. Edit a dataset. Remove one of its files and replace it with another file.
4. Save
5. Re-open the dataset. Confirm new file is still there.

Note, there is an issue that if you save the form without replacing the file, the old file is still there. But I believe this is a pre-existing bug.