### PR TITLE
Make download endpoint respect keys, count and schema params

### DIFF
--- a/modules/datastore/src/Controller/QueryDownloadController.php
+++ b/modules/datastore/src/Controller/QueryDownloadController.php
@@ -150,6 +150,7 @@ class QueryDownloadController extends AbstractQueryController {
     foreach ($metadata_names as $metadata_name) {
       $data[$metadata_name] = $result->get('$.' . $metadata_name);
     }
+    $data = array_filter($data);
 
     $response = new StreamedJsonResponse($data);
     $response->headers->set('Content-Type', 'application/json');
@@ -172,6 +173,9 @@ class QueryDownloadController extends AbstractQueryController {
       // Get the result pointer and send each row to the stream one by one.
       $result = $this->queryService->runResultsQuery($datastoreQuery, FALSE, TRUE);
       while ($row = $result->fetchAssoc()) {
+        if ($datastoreQuery->{"$.keys"} === FALSE) {
+          $row = $this->queryService->stripRowKeys($row);
+        }
         yield $row;
 
         if (0 === ++$count % 100) {

--- a/modules/datastore/src/Service/Query.php
+++ b/modules/datastore/src/Service/Query.php
@@ -182,14 +182,15 @@ class Query implements ContainerInjectionInterface {
   /**
    * Strip keys from results row, convert to array.
    *
-   * @param object $row
+   * @param object|array $row
    *   Query result row.
    *
    * @return array
    *   Values only array.
    */
-  private function stripRowKeys($row) {
+  public function stripRowKeys($row): array {
     $arrayRow = (array) $row;
+    // @todo Shouldn't this just be array_values($arrayRow)?
     $newRow = [];
     foreach ($arrayRow as $value) {
       $newRow[] = $value;

--- a/modules/datastore/tests/src/Functional/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Functional/Controller/QueryDownloadControllerTest.php
@@ -91,9 +91,9 @@ class QueryDownloadControllerTest extends BrowserTestBase {
     $this->config('metastore.settings')
       ->set('csv_headers_mode', 'resource_headers')
       ->save();
+    $client = $this->getHttpClient();
 
     // Query for the dataset, as a streaming CSV.
-    $client = $this->getHttpClient();
     $response = $client->request(
       'GET',
       $this->baseUrl . '/api/1/datastore/query/' . $dataset_id . '/0/download',
@@ -111,7 +111,6 @@ class QueryDownloadControllerTest extends BrowserTestBase {
       ->set('csv_headers_mode', 'machine_names')
       ->save();
 
-    $client = $this->getHttpClient();
     $response = $client->request(
       'GET',
       $this->baseUrl . '/api/1/datastore/query/' . $dataset_id . '/0/download',
@@ -127,17 +126,43 @@ class QueryDownloadControllerTest extends BrowserTestBase {
 
     // Test for valid field names in json output
     // Query for the dataset, as a streaming JSON.
-    $client = $this->getHttpClient();
     $response = $client->request(
       'GET',
       $this->baseUrl . '/api/1/datastore/query/' . $dataset_id . '/0/download',
       ['query' => ['format' => 'json']]
     );
 
-    $json_content = json_decode($response->getBody()->getContents())->results[0];
-    $titles = array_keys(get_object_vars($json_content));
-    $this->assertEquals('id,name,extra_long_column_name_with_tons_of_characters_that_will_ne_e872,extra_long_column_name_with_tons_of_characters_that_will_ne_5127',
-      implode(',',$titles));
+    $json_content = json_decode($response->getBody()->getContents());
+    $titles = array_keys(get_object_vars($json_content->results[0]));
+    $this->assertEquals([
+      'id',
+      'name',
+      'extra_long_column_name_with_tons_of_characters_that_will_ne_e872',
+      'extra_long_column_name_with_tons_of_characters_that_will_ne_5127',
+    ], $titles);
+    // Confirm schema, query and count are present.
+    $this->assertEquals(2, $json_content->count);
+    $this->assertEquals('json', $json_content->query->format);
+    $this->assertIsObject($json_content->schema);
+
+    // Test that we can get just values by setting keys to false, and can
+    // exclude the schema or the count..
+    $response = $client->request(
+      'GET',
+      $this->baseUrl . '/api/1/datastore/query/' . $dataset_id . '/0/download', [
+        'query' => [
+          'format' => 'json',
+          'keys' => 'false',
+          'schema' => 'false',
+          'count' => 'false',
+        ],
+      ]
+    );
+    $json_content = json_decode($response->getBody()->getContents());
+    $this->assertIsArray($json_content->results[0]);
+    $this->assertEquals(['1', 'Greg', '45.6', '4'], $json_content->results[0]);
+    $this->assertFalse(isset($json_content->schema));
+    $this->assertFalse(isset($json_content->count));
   }
 
   /**

--- a/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -133,7 +133,7 @@ class QueryDownloadControllerTest extends TestCase {
   }
 
   /**
-   * Test json stream (without specifying csv format; shouldn't work).
+   * Test json stream.
    */
   public function testStreamedQueryJson() {
     $data = [
@@ -144,6 +144,24 @@ class QueryDownloadControllerTest extends TestCase {
         ],
       ],
       "format" => "json",
+    ];
+    // Need 2 json responses which get combined on output.
+    $this->queryResultCompareJson($data);
+  }
+
+  /**
+   * Test json stream w/o keys.
+   */
+  public function testStreamedQueryJsonNoKeys() {
+    $data = [
+      "resources" => [
+        [
+          "id" => $this->resources[2]->getIdentifier(),
+          "alias" => "t",
+        ],
+      ],
+      "format" => "json",
+      "keys" => "false",
     ];
     // Need 2 json responses which get combined on output.
     $this->queryResultCompareJson($data);
@@ -404,7 +422,7 @@ class QueryDownloadControllerTest extends TestCase {
     $pdo = match(TRUE) {
       \PHP_VERSION_ID >= 80400 && class_exists(SqliteConnection::class) => new SqliteConnection('sqlite::memory:'),
       default => new \PDO('sqlite::memory:'),
-    }; 
+    };
     $connection = new Connection($pdo, []);
     $options = (new Options())
       ->add("dkan.metastore.storage", DataFactory::class)

--- a/modules/datastore/tests/src/Unit/Service/DatastoreQueryTest.php
+++ b/modules/datastore/tests/src/Unit/Service/DatastoreQueryTest.php
@@ -146,6 +146,23 @@ class DatastoreQueryTest extends TestCase {
   }
 
   /**
+   * Simple test for the stripRowKeys() method, now that it's public.
+   */
+  public function testStripRowKeys() {
+    $container = $this->getCommonMockChain();
+    \Drupal::setContainer($container->getMock());
+    $queryService = new Query(DatastoreService::create($container->getMock()));
+
+    $testRow = (object) [
+      'field1' => 'foo',
+      'field2' => 'bar',
+    ];
+
+    $result = $queryService->stripRowKeys($testRow);
+    $this->assertEquals(['foo', 'bar'], $result);
+  }
+
+  /**
    * Ensure if an invalid limit is specified, the query fails.
    */
   public function testInvalidLimitQuery() {
@@ -249,7 +266,6 @@ class DatastoreQueryTest extends TestCase {
       ->add(DatabaseTable::class, "primaryKey", "record_number")
       ->add(ReferenceLookup::class, 'getReferencers', [$resource->getIdentifier()])
       ->add(ReferenceLookup::class, 'invalidateReferencerCacheTags');
-
   }
 
 }


### PR DESCRIPTION
Currently, passing `?keys=false` to the JSON download endpoint has no effect. Neither does setting count or schema to false. This corrects that.

## QA steps

1. Build and load sample content.
2. http://dkan.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0/download?keys=false&schema=false&count=false
3. Confirm that
- Results are arrays, not keyed objects
- Count is not included
- Schema is not included

Compare to http://dkan.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0?keys=false&schema=false&count=false, ensure they are the same.