### PR TITLE
#4655 Add link to node/123 to dataset import status table.

### DIFF
--- a/modules/datastore/datastore.module
+++ b/modules/datastore/datastore.module
@@ -15,7 +15,6 @@ function datastore_theme($existing, $type, $theme, $path) {
         'uuid' => NULL,
         'title' => NULL,
         'url' => NULL,
-        'node_url' => NULL,
         'node_id' => NULL,
       ],
     ],

--- a/modules/datastore/datastore.module
+++ b/modules/datastore/datastore.module
@@ -15,6 +15,8 @@ function datastore_theme($existing, $type, $theme, $path) {
         'uuid' => NULL,
         'title' => NULL,
         'url' => NULL,
+        'node_url' => NULL,
+        'node_id' => NULL,
       ],
     ],
     'datastore_dashboard_revision_cell' => [

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -511,7 +511,6 @@ class DashboardForm extends FormBase {
           '#uuid' => $rev['uuid'],
           '#title' => $rev['title'],
           '#url' => Url::fromUri("internal:/dataset/$rev[uuid]"),
-          '#node_url' => Url::fromRoute('entity.node.canonical', ['node' => $rev['node_id']], ['absolute' => TRUE])->toString(),
           '#node_id' => $rev['node_id'],
         ],
       ],

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -502,6 +502,7 @@ class DashboardForm extends FormBase {
     if ($moderation_class == 'hidden') {
       $moderation_class = 'published-hidden';
     }
+$play = Url::fromRoute('entity.node.canonical', ['node' => $rev['node_id']], ['absolute' => TRUE]);
     return [
       [
         'rowspan' => $resourceCount,
@@ -510,6 +511,8 @@ class DashboardForm extends FormBase {
           '#uuid' => $rev['uuid'],
           '#title' => $rev['title'],
           '#url' => Url::fromUri("internal:/dataset/$rev[uuid]"),
+          '#node_url' => Url::fromRoute('entity.node.canonical', ['node' => $rev['node_id']], ['absolute' => TRUE])->toString(),
+          '#node_id' => $rev['node_id'],
         ],
       ],
       [

--- a/modules/datastore/src/Form/DashboardForm.php
+++ b/modules/datastore/src/Form/DashboardForm.php
@@ -502,7 +502,7 @@ class DashboardForm extends FormBase {
     if ($moderation_class == 'hidden') {
       $moderation_class = 'published-hidden';
     }
-$play = Url::fromRoute('entity.node.canonical', ['node' => $rev['node_id']], ['absolute' => TRUE]);
+
     return [
       [
         'rowspan' => $resourceCount,

--- a/modules/datastore/templates/datastore-dashboard-dataset-cell.html.twig
+++ b/modules/datastore/templates/datastore-dashboard-dataset-cell.html.twig
@@ -1,2 +1,9 @@
 <div class="datastore-status-dataset-uuid">{{ uuid }}</div>
-<div class="datastore-status-dataset-link">{{ link(title, url) }}</div>
+<ul>
+  <li>
+    <div class="datastore-status-dataset-link">{{ link(title, url) }}</div>
+  </li>
+  <li>
+    <div class="datastore-status-dataset-node-link">{{ link("node " ~ node_id, node_url) }}</div>
+  </li>
+</ul>

--- a/modules/datastore/templates/datastore-dashboard-dataset-cell.html.twig
+++ b/modules/datastore/templates/datastore-dashboard-dataset-cell.html.twig
@@ -1,9 +1,8 @@
-<div class="datastore-status-dataset-uuid">{{ uuid }}</div>
-<ul>
-  <li>
-    <div class="datastore-status-dataset-link">{{ link(title, url) }}</div>
-  </li>
-  <li>
-    <div class="datastore-status-dataset-node-link">{{ link("node " ~ node_id, node_url) }}</div>
-  </li>
-</ul>
+  <div class="datastore-status-dataset-link">
+    {{title}} <a href="{{ path('entity.node.canonical', {'node': node_id}) }}" aria-label="{{ 'admin'|t }}: {{title}}">{{ 'admin'|t }}</a>
+    {% if url is not empty %}
+      {% set link_attributes = create_attribute({'aria-label': 'view: @title'|t({'@title': title})}) %}
+        | {{ link('view', url, {'attributes': link_attributes}) }}
+      {% endif %}
+  </div>
+  <div class="datastore-status-dataset-uuid">{{ uuid }}</div>

--- a/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
+++ b/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
@@ -155,6 +155,7 @@ class DashboardFormTest extends TestCase {
     $this->assertEquals('NEW', $form['table']['#rows'][0][2]['data']);
     $this->assertEquals('done', $form['table']['#rows'][0][6]['data']['#status']);
     $this->assertEquals(NULL, $form['table']['#rows'][0][6]['data']['#error']);
+    $this->assertEquals(1, $form['table']['#rows'][0][0]['data']['#node_id']);
   }
 
   /**
@@ -224,6 +225,7 @@ class DashboardFormTest extends TestCase {
     $this->assertEquals('NEW', $form['table']['#rows'][0][2]['data']);
     $this->assertEquals('done', $form['table']['#rows'][0][6]['data']['#status']);
     $this->assertEquals(NULL, $form['table']['#rows'][0][6]['data']['#error']);
+    $this->assertEquals(2, $form['table']['#rows'][0][0]['data']['#node_id']);
   }
 
   /**
@@ -517,6 +519,7 @@ class DashboardFormTest extends TestCase {
     $this->assertEquals('done', $form["table"]["#rows"][1][3]["data"]["#status"]);
     // The second row post import class is correct.
     $this->assertEquals('done', $form["table"]["#rows"][1][3]["class"]);
+    $this->assertEquals(5, $form['table']['#rows'][0][0]['data']['#node_id']);
   }
 
   /**

--- a/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
+++ b/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
@@ -2,36 +2,37 @@
 
 namespace Drupal\Tests\datastore\Unit\Form;
 
+use Drupal\common\DataResource;
+use Drupal\common\DatasetInfo;
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\DependencyInjection\Container;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Form\FormState;
 use Drupal\Core\Pager\Pager;
 use Drupal\Core\Pager\PagerManagerInterface;
 use Drupal\Core\Path\PathValidator;
+use Drupal\Core\Routing\UrlGenerator;
 use Drupal\Core\StreamWrapper\PublicStream;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
 use Drupal\Core\StringTranslation\TranslationManager;
-use Drupal\Tests\metastore\Unit\MetastoreServiceTest;
-use Drupal\common\DatasetInfo;
-use Drupal\Core\Database\Connection;
 use Drupal\datastore\Form\DashboardForm;
+use Drupal\datastore\PostImportResult;
+use Drupal\datastore\PostImportResultFactory;
 use Drupal\datastore\Service\PostImport;
 use Drupal\harvest\Entity\HarvestRunRepository;
 use Drupal\harvest\HarvestService;
 use Drupal\metastore\MetastoreService;
+use Drupal\metastore\ResourceMapper;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\metastore\Unit\MetastoreServiceTest;
 use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Drupal\metastore\ResourceMapper;
-use Drupal\datastore\PostImportResult;
-use Drupal\datastore\PostImportResultFactory;
-use Drupal\common\DataResource;
-use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\Query\QueryInterface;
-use Drupal\node\NodeInterface;
 
 /**
  * @group dkan
@@ -145,6 +146,7 @@ class DashboardFormTest extends TestCase {
       ->add(RequestStack::class, 'getCurrentRequest', new Request(['harvest_id' => 'dataset-1']))
       ->add(DatasetInfo::class, 'gather', ['latest_revision' => $info + ['distributions' => [$distribution]]])
       ->add(PostImportResultFactory::class, 'initializeFromDistribution', $postImportResultMock)
+      ->add(UrlGenerator::class, 'generateFromRoute', 'http://example.com/node/1')
       ->getMock();
     \Drupal::setContainer($container);
     $form = DashboardForm::create($container)->buildForm([], new FormState());

--- a/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
+++ b/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
@@ -110,6 +110,7 @@ class DashboardFormTest extends TestCase {
       'moderation_state' => 'published',
       'modified_date_metadata' => '2020-01-15',
       'modified_date_dkan' => '2021-02-11',
+      'node_id' => 1,
     ];
     $distribution = [
       'distribution_uuid' => 'dist-1',
@@ -167,6 +168,7 @@ class DashboardFormTest extends TestCase {
       'moderation_state' => 'published',
       'modified_date_metadata' => '2020-01-15',
       'modified_date_dkan' => '2021-02-11',
+      'node_id' => 2,
     ];
     $distribution = [
       'distribution_uuid' => 'dist-1',
@@ -235,6 +237,7 @@ class DashboardFormTest extends TestCase {
       'moderation_state' => 'published',
       'modified_date_metadata' => '2020-01-15',
       'modified_date_dkan' => '2021-02-11',
+      'node_id' => 3,
     ];
     $distribution = [
       'distribution_uuid' => 'dist-1',
@@ -295,6 +298,7 @@ class DashboardFormTest extends TestCase {
         'title' => 'Dataset 1',
         'modified_date_metadata' => '2019-08-12',
         'modified_date_dkan' => '2021-07-08',
+        'node_id' => 3,
         'distributions' => [
           [
             'distribution_uuid' => 'dist-1',
@@ -395,6 +399,7 @@ class DashboardFormTest extends TestCase {
         'modified_date_metadata' => '2019-08-12',
         'modified_date_dkan' => '2021-07-08',
         'distributions' => ['Not found'],
+        'node_id' => 1,
       ],
     ];
 
@@ -421,6 +426,7 @@ class DashboardFormTest extends TestCase {
         'title' => 'Dataset 1',
         'modified_date_metadata' => '2019-08-12',
         'modified_date_dkan' => '2021-07-08',
+        'node_id' => 5,
         'distributions' => [
           [
             'distribution_uuid' => 'dist-1',
@@ -524,6 +530,7 @@ class DashboardFormTest extends TestCase {
         'title' => 'Dataset 1',
         'modified_date_metadata' => '2019-08-12',
         'modified_date_dkan' => '2021-07-08',
+        'node_id' => 7,
         'distributions' => [
           [
             'distribution_uuid' => 'dist-1',

--- a/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
+++ b/modules/datastore/tests/src/Unit/Form/DashboardFormTest.php
@@ -2,37 +2,36 @@
 
 namespace Drupal\Tests\datastore\Unit\Form;
 
-use Drupal\common\DataResource;
-use Drupal\common\DatasetInfo;
-use Drupal\Core\Database\Connection;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\DependencyInjection\Container;
-use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Form\FormState;
 use Drupal\Core\Pager\Pager;
 use Drupal\Core\Pager\PagerManagerInterface;
 use Drupal\Core\Path\PathValidator;
-use Drupal\Core\Routing\UrlGenerator;
 use Drupal\Core\StreamWrapper\PublicStream;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
 use Drupal\Core\StringTranslation\TranslationManager;
+use Drupal\Tests\metastore\Unit\MetastoreServiceTest;
+use Drupal\common\DatasetInfo;
+use Drupal\Core\Database\Connection;
 use Drupal\datastore\Form\DashboardForm;
-use Drupal\datastore\PostImportResult;
-use Drupal\datastore\PostImportResultFactory;
 use Drupal\datastore\Service\PostImport;
 use Drupal\harvest\Entity\HarvestRunRepository;
 use Drupal\harvest\HarvestService;
 use Drupal\metastore\MetastoreService;
-use Drupal\metastore\ResourceMapper;
-use Drupal\node\NodeInterface;
-use Drupal\Tests\metastore\Unit\MetastoreServiceTest;
 use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Drupal\metastore\ResourceMapper;
+use Drupal\datastore\PostImportResult;
+use Drupal\datastore\PostImportResultFactory;
+use Drupal\common\DataResource;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * @group dkan
@@ -146,7 +145,6 @@ class DashboardFormTest extends TestCase {
       ->add(RequestStack::class, 'getCurrentRequest', new Request(['harvest_id' => 'dataset-1']))
       ->add(DatasetInfo::class, 'gather', ['latest_revision' => $info + ['distributions' => [$distribution]]])
       ->add(PostImportResultFactory::class, 'initializeFromDistribution', $postImportResultMock)
-      ->add(UrlGenerator::class, 'generateFromRoute', 'http://example.com/node/1')
       ->getMock();
     \Drupal::setContainer($container);
     $form = DashboardForm::create($container)->buildForm([], new FormState());
@@ -326,6 +324,7 @@ class DashboardFormTest extends TestCase {
         'title' => 'Non-Harvest Dataset',
         'modified_date_metadata' => '2019-08-12',
         'modified_date_dkan' => '2021-07-08',
+        'node_id' => 3,
         'distributions' => [
           [
             'distribution_uuid' => 'dist-2',


### PR DESCRIPTION
Fixes #4655 

## Describe your changes

## QA Steps

- [ ] git checkout 4655-add-node-link-to-import-status
- [ ] drush cr to pick up twig changes
- [ ] visit /dashboard/datastore
- [ ] validate that the dataset identifier comes after/below the title
- [ ] validate that the dataset title has no link
- [ ] validate the "view" links to the FE version of the dataset page
- [ ] validate the "admin" links to the node version of the dataset page
- [ ] inspect the source and validate that the "admin" link has an aria-label that reads "admin: <dataset title>"
- [ ] inspect the source and validate that the "view" link has an aria-label that reads "view: <dataset title>"

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
