### PR TITLE
#4621 Add revision time on presave.

### DIFF
--- a/modules/metastore/metastore.module
+++ b/modules/metastore/metastore.module
@@ -5,12 +5,13 @@
  */
 
 use Drupal\Core\Database\Query\AlterableInterface;
-use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\metastore\NodeWrapper\Data;
 use Drupal\metastore\MetastoreService;
+use Drupal\metastore\NodeWrapper\Data;
+use Drupal\metastore\Factory\MetastoreEntityItemFactoryInterface;
 use Drupal\metastore\Service\OrphanNodeProcessor;
 
 /**
@@ -27,6 +28,15 @@ function metastore_entity_load(array $entities) {
  * Implements hook_entity_presave().
  */
 function metastore_entity_presave(EntityInterface $entity) {
+  // Check if the entity is a data entity and a new revision is being created.
+  /** @var MetastoreEntityItemFactoryInterface $storage */
+  $metastore_service = \Drupal::service('dkan.metastore.metastore_item_factory');
+  if ($entity->getEntityTypeId() === $metastore_service::getEntityType() && in_array($entity->bundle(), $metastore_service::getBundles()) && $entity->isNewRevision()) {
+    // Set revision creation time to the current time because programmatically
+    // saved revisions will reuse the previous revision's timestamp if not
+    // explicitly set.
+    $entity->setRevisionCreationTime(\Drupal::time()->getCurrentTime());
+  }
   metastore_data_lifecycle([$entity], "presave");
 }
 


### PR DESCRIPTION
Fixes #4621 

## Describe your changes
This explicitly sets data node revision time so that programatic changes like publish reflect the time of the publish, and don't repeat the time of the draft.
This results in revisions that look like
<img width="782" height="283" alt="different revision dates" src="https://github.com/user-attachments/assets/e830b218-26b9-4b98-b2ae-bc73a613bb44" />

as opposed to the current  situation of 

<img width="865" height="282" alt="confusing same revision dates" src="https://github.com/user-attachments/assets/46e4afe7-52ee-4f88-b4d8-c2075baa9b30" />



## QA Steps

- [ ] Save a a dataset as draft.
- [ ] publish it using either a drush command or a bulk operation in the UI.
- [ ] Visit the revisions tab for the dataset. validate that the first line  for each of the recent revisions has its own date and time. (rather than repeating the time.)
- [ ] validate that the revision message, which also looks like a time stamp did not change should still say something like "Created on <date>" and the date should match the message from the draft revision.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
