### PR TITLE
Add option to get resource perspective without creating directory.

### DIFF
--- a/modules/datastore/src/DatastoreService.php
+++ b/modules/datastore/src/DatastoreService.php
@@ -278,7 +278,7 @@ class DatastoreService implements ContainerInjectionInterface {
     if ($storage = $this->getStorage($identifier, $version)) {
       $resource = NULL;
       // Check for the resource before sending the pre-drop event.
-      if ($resource = $this->resourceLocalizer->get($identifier, $version)) {
+      if ($resource = $this->resourceLocalizer->get($identifier, $version, ResourceLocalizer::LOCAL_FILE_PERSPECTIVE, FALSE)) {
         // Dispatch the pre-drop event.
         $this->eventDispatcher->dispatch(
           new DatastorePreDropEvent($resource),

--- a/modules/datastore/src/Form/ResourceSettingsForm.php
+++ b/modules/datastore/src/Form/ResourceSettingsForm.php
@@ -45,9 +45,9 @@ class ResourceSettingsForm extends ConfigFormBase {
     ];
     $form['delete_local_resource'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Delete local resource'),
+      '#title' => $this->t('Delete localized resource'),
       '#config_target' => 'datastore.settings:delete_local_resource',
-      '#description' => $this->t('Delete local copy of remote files after the datastore import is complete'),
+      '#description' => $this->t('Delete localized copy of remote files after the datastore import is complete. If your catalog will rely on the remote source for downloads this can keep your web server file storage lean. <p>Note that when a dataset is deleted, any localized resource for that dataset will also be deleted.</p>'),
     ];
     $form['drop_datastore_on_post_import_error'] = [
       '#type' => 'checkbox',

--- a/modules/datastore/src/Service/ResourceLocalizer.php
+++ b/modules/datastore/src/Service/ResourceLocalizer.php
@@ -157,22 +157,25 @@ class ResourceLocalizer {
   }
 
   /**
-   * Get a perspective, and optionally reate local file and URL perspectives in
-   * the mapper.
+   * Get a perspective, and optionally reate local file and URL perspectives.
    *
-   * @param $identifier
+   * @param string $identifier
    *   The resource id.
-   * @param $version
+   * @param string $version
    *   The resource version.
-   * @param $perspective
+   * @param string $perspective
    *   The resource perspective. Defaults to LOCAL_FILE_PERSPECTIVE
-   * @param $create
+   * @param bool $create
    *   If true, creates directory for local file and adds perspective to mapper.
    *
    * @return \Drupal\common\DataResource|null
    *   Return the perspective, or NULL if the source perspective did not exist.
    */
-  public function get($identifier, $version = NULL, $perspective = self::LOCAL_FILE_PERSPECTIVE, $create = TRUE): ?DataResource {
+  public function get(string $identifier,
+                      ?string $version = NULL,
+                      string $perspective = self::LOCAL_FILE_PERSPECTIVE,
+                      bool $create = TRUE
+  ): ?DataResource {
     $resource = $this->getResourceSource($identifier, $version);
 
     if (!$resource) {

--- a/modules/datastore/src/Service/ResourceLocalizer.php
+++ b/modules/datastore/src/Service/ResourceLocalizer.php
@@ -157,29 +157,39 @@ class ResourceLocalizer {
   }
 
   /**
-   * Create local file and URL perspectives in the mapper, get a perspective.
+   * Get a perspective, and optionally reate local file and URL perspectives in
+   * the mapper.
    *
-   * Requires the localized file to exist so it can be checksummed.
+   * @param $identifier
+   *   The resource id.
+   * @param $version
+   *   The resource version.
+   * @param $perspective
+   *   The resource perspective. Defaults to LOCAL_FILE_PERSPECTIVE
+   * @param $create
+   *   If true, creates directory for local file and adds perspective to mapper.
    *
    * @return \Drupal\common\DataResource|null
    *   Return the perspective, or NULL if the source perspective did not exist.
    */
-  public function get($identifier, $version = NULL, $perpective = self::LOCAL_FILE_PERSPECTIVE): ?DataResource {
+  public function get($identifier, $version = NULL, $perspective = self::LOCAL_FILE_PERSPECTIVE, $create = TRUE): ?DataResource {
     $resource = $this->getResourceSource($identifier, $version);
 
     if (!$resource) {
       return NULL;
     }
 
-    $ff = $this->getFileFetcher($resource);
+    if ($create) {
+      $ff = $this->getFileFetcher($resource);
 
-    if ($ff->getResult()->getStatus() != Result::DONE) {
-      return NULL;
+      if ($ff->getResult()->getStatus() != Result::DONE) {
+        return NULL;
+      }
+
+      $this->registerNewPerspectives($resource, $ff->getStateProperty('destination'));
     }
 
-    $this->registerNewPerspectives($resource, $ff->getStateProperty('destination'));
-
-    return $this->resourceMapper->get($resource->getIdentifier(), $perpective, $resource->getVersion());
+    return $this->resourceMapper->get($resource->getIdentifier(), $perspective, $resource->getVersion());
   }
 
   /**
@@ -215,11 +225,11 @@ class ResourceLocalizer {
    */
   public function remove($identifier, $version = NULL): void {
     // Remove the LOCAL_URL_PERSPECTIVE if it exists.
-    if ($local_url_resource = $this->get($identifier, $version, self::LOCAL_URL_PERSPECTIVE)) {
+    if ($local_url_resource = $this->get($identifier, $version, self::LOCAL_URL_PERSPECTIVE, FALSE)) {
       $this->resourceMapper->remove($local_url_resource);
     }
     // Remove the LOCAL_FILE_PERSPECTIVE if it exists.
-    if ($resource = $this->get($identifier, $version, self::LOCAL_FILE_PERSPECTIVE)) {
+    if ($resource = $this->get($identifier, $version, self::LOCAL_FILE_PERSPECTIVE, FALSE)) {
       // Remove the file.
       if (file_exists($resource->getFilePath())) {
         $this->drupalFiles->getFilesystem()

--- a/modules/datastore/src/Service/ResourceLocalizer.php
+++ b/modules/datastore/src/Service/ResourceLocalizer.php
@@ -164,17 +164,18 @@ class ResourceLocalizer {
    * @param string $version
    *   The resource version.
    * @param string $perspective
-   *   The resource perspective. Defaults to LOCAL_FILE_PERSPECTIVE
+   *   The resource perspective. Defaults to LOCAL_FILE_PERSPECTIVE.
    * @param bool $create
    *   If true, creates directory for local file and adds perspective to mapper.
    *
    * @return \Drupal\common\DataResource|null
    *   Return the perspective, or NULL if the source perspective did not exist.
    */
-  public function get(string $identifier,
-                      ?string $version = NULL,
-                      string $perspective = self::LOCAL_FILE_PERSPECTIVE,
-                      bool $create = TRUE
+  public function get(
+    string $identifier,
+    ?string $version = NULL,
+    string $perspective = self::LOCAL_FILE_PERSPECTIVE,
+    bool $create = TRUE,
   ): ?DataResource {
     $resource = $this->getResourceSource($identifier, $version);
 


### PR DESCRIPTION
Fixes [issue#]
27408

When the DKAN Resource setting, "Delete local resource", is enabled, the local resouce directories are deleted after a harvest run, but are recreated after harvest revert. This leaves unused and useless directories in the filesystem.

## Describe your changes
Added an optional parameter to ResourceLocalizer::get(), so that calling functions can skip the code that recreates the directory

## QA Steps
- [ ] View resources directory (` ls -l web/sites/default/files/resources`)  and note the total number of items. 
- [ ] Go to /admin/dkan/resources, check  "Delete local resource", and save.
- [ ] Run harvest (e.g.  `ddev drush dkan:harvest:run sample_content`, then run cron a couple of times
- [ ] Run ` ls -l web/sites/default/files/resources` and confirm the total hasn't changed
- [ ] Revert harvest (e.g. `ddev drush dkan:harvest:revert sample_content`, the nrun cron
- [ ] Run ` ls -l web/sites/default/files/resources` and confirm the total still hasn't changed


## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_
Bug fix
- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
