### PR TITLE
3.x config event subscriber

### DIFF
--- a/modules/dkan_common/dkan_common.services.yml
+++ b/modules/dkan_common/dkan_common.services.yml
@@ -45,6 +45,11 @@ services:
     parent: logger.channel_base
     arguments: [ 'dkan' ]
 
+  dkan.common.config_import_rename_dependencies_subscriber:
+    class: Drupal\dkan_common\EventSubscriber\ConfigImportRenameDependenciesSubscriber
+    tags:
+      - { name: event_subscriber }
+
   # @deprecated
   common.docs:
     class: \Drupal\dkan_common\Controller\OpenApiController

--- a/modules/dkan_common/src/EventSubscriber/ConfigImportRenameDependenciesSubscriber.php
+++ b/modules/dkan_common/src/EventSubscriber/ConfigImportRenameDependenciesSubscriber.php
@@ -83,6 +83,18 @@ final class ConfigImportRenameDependenciesSubscriber implements EventSubscriberI
         $changed = $changed || ($before !== $data['dependencies']['module']);
       }
 
+      // Special handling for core.extension: rename module keys.
+      if ($name == 'core.extension' && is_array($data['module'] ?? NULL)) {
+        $before = $data['module'];
+        $updated_modules = [];
+        foreach ($data['module'] as $module_name => $weight) {
+          $new_module_name = self::MAP[$module_name] ?? $module_name;
+          $updated_modules[$new_module_name] = $weight;
+        }
+        $data['module'] = $updated_modules;
+        $changed = $changed || ($before !== $data['module']);
+      }
+
       if ($changed) {
         // Write the modified config back into the import source storage.
         $storage->write($name, $data);

--- a/modules/dkan_common/src/EventSubscriber/ConfigImportRenameDependenciesSubscriber.php
+++ b/modules/dkan_common/src/EventSubscriber/ConfigImportRenameDependenciesSubscriber.php
@@ -21,6 +21,7 @@ final class ConfigImportRenameDependenciesSubscriber implements EventSubscriberI
     'common' => 'dkan_common',
     'datastore' => 'dkan_datastore',
     'datastore_mysql_import' => 'dkan_datastore_mysql_import',
+    'data_dictionary_widget' => 'dkan_data_dictionary_widget',
     'metastore' => 'dkan_metastore',
     'metastore_search' => 'dkan_metastore_search',
     'metastore_facets' => 'dkan_metastore_facets',

--- a/modules/dkan_common/src/EventSubscriber/ConfigImportRenameDependenciesSubscriber.php
+++ b/modules/dkan_common/src/EventSubscriber/ConfigImportRenameDependenciesSubscriber.php
@@ -43,7 +43,28 @@ final class ConfigImportRenameDependenciesSubscriber implements EventSubscriberI
   public function onStorageTransformImport(StorageTransformEvent $event): void {
     $storage = $event->getStorage();
 
-    // Read all config names from the source being imported.
+    // First pass: rename config objects themselves.
+    $renames = [];
+    foreach ($storage->listAll() as $name) {
+      foreach (self::MAP as $old => $new) {
+        if (str_starts_with($name, $old . '.')) {
+          $new_name = $new . substr($name, strlen($old));
+          $renames[$name] = $new_name;
+          break;
+        }
+      }
+    }
+
+    // Execute renames: read from old name, write to new name, delete old.
+    foreach ($renames as $old_name => $new_name) {
+      $data = $storage->read($old_name);
+      if (is_array($data)) {
+        $storage->write($new_name, $data);
+        $storage->delete($old_name);
+      }
+    }
+
+    // Second pass: update dependencies within all config.
     foreach ($storage->listAll() as $name) {
       $data = $storage->read($name);
       if (!is_array($data)) {
@@ -60,18 +81,6 @@ final class ConfigImportRenameDependenciesSubscriber implements EventSubscriberI
           $data['dependencies']['module']
         ));
         $changed = $changed || ($before !== $data['dependencies']['module']);
-      }
-
-      // Update $data['id'] if it matches a renamed module, to prevent import failure due to config name conflicts.
-      if (!empty($data['id']) && is_string($data['id'])) {
-        $before = $data['id'];
-        foreach (self::MAP as $old => $new) {
-          if (str_starts_with($data['id'], $old . '.')) {
-            $data['id'] = $new . substr($data['id'], strlen($old));
-            break;
-          }
-        }
-        $changed = $changed || ($before !== $data['id']);
       }
 
       if ($changed) {

--- a/modules/dkan_common/src/EventSubscriber/ConfigImportRenameDependenciesSubscriber.php
+++ b/modules/dkan_common/src/EventSubscriber/ConfigImportRenameDependenciesSubscriber.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\dkan_common\EventSubscriber;
+
+use Drupal\Core\Config\ConfigEvents;
+use Drupal\Core\Config\StorageTransformEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Rewrites imported config on the fly to account for module renames.
+ *
+ * This runs early in the import pipeline, before dependency validation, so
+ * config that used to depend on "datastore" will instead depend on
+ * "dkan_datastore" during the import.
+ */
+final class ConfigImportRenameDependenciesSubscriber implements EventSubscriberInterface {
+
+  private const MAP = [
+    'common' => 'dkan_common',
+    'datastore' => 'dkan_datastore',
+    'datastore_mysql_import' => 'dkan_datastore_mysql_import',
+    'metastore' => 'dkan_metastore',
+    'metastore_search' => 'dkan_metastore_search',
+    'metastore_facets' => 'dkan_metastore_facets',
+    'metastore_admin' => 'dkan_metastore_admin',
+    'harvest' => 'dkan_harvest',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      ConfigEvents::STORAGE_TRANSFORM_IMPORT => 'onStorageTransformImport',
+    ];
+  }
+
+  /**
+   * Alters the source storage contents that will be imported.
+   */
+  public function onStorageTransformImport(StorageTransformEvent $event): void {
+    $storage = $event->getStorage();
+
+    // Read all config names from the source being imported.
+    foreach ($storage->listAll() as $name) {
+      $data = $storage->read($name);
+      if (!is_array($data)) {
+        continue;
+      }
+
+      $changed = FALSE;
+
+      // Update dependency declaration: dependencies: { module: [...] }.
+      if (!empty($data['dependencies']['module']) && is_array($data['dependencies']['module'])) {
+        $before = $data['dependencies']['module'];
+        $data['dependencies']['module'] = array_values(array_map(
+          static fn(string $m): string => self::MAP[$m] ?? $m,
+          $data['dependencies']['module']
+        ));
+        $changed = $changed || ($before !== $data['dependencies']['module']);
+      }
+
+      // Update $data['id'] if it matches a renamed module, to prevent import failure due to config name conflicts.
+      if (!empty($data['id']) && is_string($data['id'])) {
+        $before = $data['id'];
+        foreach (self::MAP as $old => $new) {
+          if (str_starts_with($data['id'], $old . '.')) {
+            $data['id'] = $new . substr($data['id'], strlen($old));
+            break;
+          }
+        }
+        $changed = $changed || ($before !== $data['id']);
+      }
+
+      if ($changed) {
+        // Write the modified config back into the import source storage.
+        $storage->write($name, $data);
+      }
+    }
+  }
+
+}

--- a/modules/dkan_common/src/EventSubscriber/ConfigImportRenameDependenciesSubscriber.php
+++ b/modules/dkan_common/src/EventSubscriber/ConfigImportRenameDependenciesSubscriber.php
@@ -14,6 +14,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * This runs early in the import pipeline, before dependency validation, so
  * config that used to depend on "datastore" will instead depend on
  * "dkan_datastore" during the import.
+ *
+ * @codeCoverageIgnore
  */
 final class ConfigImportRenameDependenciesSubscriber implements EventSubscriberInterface {
 


### PR DESCRIPTION
Handles issues importing config that was exported before the upgrade to 3.x

## QA Steps

- [ ] Upgrade an existing site to `2.x-transition`
- [ ] Export config
- [ ] Upgrade to `config-event-subscriber`
- [ ] `drush updatedb`
- [ ] Compare staged config with existing config in UI

We expect some discrepancies no matter what but should generally be able to explain the diffs and see incoming config equivalent to what it was pre-upgrade. Any config items that were lost in the update should come back in with updated dependencies.

This is kind of an inherently fuzzy part of the upgrade path, just hoping to get it as good as possible and maybe come back for a second pass after some real world upgrade dry-runs.