### PR TITLE
Defensive coding on Query::getQueryStorageMap()

### DIFF
--- a/modules/dkan_datastore/src/Service/Query.php
+++ b/modules/dkan_datastore/src/Service/Query.php
@@ -106,7 +106,7 @@ class Query implements ContainerInjectionInterface {
    */
   public function getQueryStorageMap(DatastoreQuery $datastoreQuery): array {
     $storageMap = [];
-    foreach ($datastoreQuery->{"$.resources"} as $resource) {
+    foreach ($datastoreQuery->{"$.resources"} ?? [] as $resource) {
       [$identifier, $version] = DataResource::getIdentifierAndVersion($resource["id"]);
       $storage = $this->datastore->getStorage($identifier, $version);
       $storageMap[$resource["alias"]] = $storage;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,8 +25,9 @@
     </coverage>
     <testsuites>
         <testsuite name="default">
-            <directory>tests</directory>
-            <directory>modules</directory>
+            <directory>.</directory>
+            <exclude>vendor</exclude>
+            <exclude>web</exclude>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,9 +25,8 @@
     </coverage>
     <testsuites>
         <testsuite name="default">
-            <directory>.</directory>
-            <exclude>vendor</exclude>
-            <exclude>web</exclude>
+            <directory>tests</directory>
+            <directory>modules</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
Fixes [issue#]

## Describe your changes

`getQueryStorageMap()` looks like this:
```
  public function getQueryStorageMap(DatastoreQuery $datastoreQuery) {
    $storageMap = [];
    foreach ($datastoreQuery->{"$.resources"} as $resource) {
      [$identifier, $version] = DataResource::getIdentifierAndVersion($resource["id"]);
      $storage = $this->datastore->getStorage($identifier, $version);
      $storageMap[$resource["alias"]] = $storage;
    }
    return $storageMap;
  }
```

Since the evalution of `$datastoreQuery->{"$.resources"}` can return NULL if metastore nodes are present but datastore tables are not, as when a developer grabs a database from production, this results in a TypeError rather than returning an empty storage map.

We fix this with a NULL-coalesce to allow the `foreach()` to process an empty array instead of erroring out on NULL.

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
