### PR TITLE
Remove configure link for dkan_datastore_msql_import

### DIFF
--- a/modules/dkan_datastore/modules/dkan_datastore_mysql_import/dkan_datastore_mysql_import.info.yml
+++ b/modules/dkan_datastore/modules/dkan_datastore_mysql_import/dkan_datastore_mysql_import.info.yml
@@ -3,4 +3,3 @@ description: Provides a MySQL Importer class.
 type: module
 core_version_requirement: ^10.4 || ^11
 package: DKAN 4.x Transition
-configure: datastore.mysql_import.settings


### PR DESCRIPTION
This shouldn't be introduced until 3.x