### PR TITLE
Remove dependent permissions from roles before disabling modules

### DIFF
--- a/modules/common/common.install
+++ b/modules/common/common.install
@@ -1,0 +1,25 @@
+<?php
+
+use Drupal\user\Entity\Role;
+
+/**
+ * Implements hook_uninstall().
+ */
+function common_uninstall() {
+  // For each role, remove permissions granted by the common module.
+  $roles = Role::loadMultiple();
+  $permissions_to_remove = [];
+  foreach ($roles as $rid => $role_name) {
+    /** @var \Drupal\user\Entity\Role $role */
+    $role = Role::load($rid);
+    $permissions = $role->getPermissions();
+    $permissions_to_remove = array_filter($permissions, function ($permission) {
+      return strpos($permission, 'common') === 0;
+    });
+    foreach ($permissions_to_remove as $permission) {
+      // Remove dependency on the common module for each permission.
+      $role->revokePermission($permission);
+    }
+    $role->save();
+  }
+}

--- a/modules/datastore/datastore.install
+++ b/modules/datastore/datastore.install
@@ -1,25 +1,51 @@
 <?php
 
 use Drupal\user\Entity\Role;
+use Drush\Drush;
 
 /**
  * Implements hook_uninstall().
  */
 function datastore_uninstall() {
+  $permissions_to_remove = [
+    'datastore_api_import',
+    'datastore_api_drop',
+  ];
+
   // For each role, remove permissions granted by the datastore module.
-  $roles = Role::loadMultiple();
-  $permissions_to_remove = [];
-  foreach ($roles as $rid => $role_name) {
+  $roles = array_keys(Role::loadMultiple());
+
+  foreach ($roles as $rid) {
     /** @var \Drupal\user\Entity\Role $role */
     $role = Role::load($rid);
-    $permissions = $role->getPermissions();
-    $permissions_to_remove = array_filter($permissions, function ($permission) {
-      return strpos($permission, 'datastore') === 0;
-    });
+    $changed = FALSE;
     foreach ($permissions_to_remove as $permission) {
-      // Remove dependency on the datastore module for each permission.
+      if (!$role->hasPermission($permission)) {
+        continue;
+      }
+
+      // Remove datastore-specific permissions for each role.
       $role->revokePermission($permission);
+      $changed = TRUE;
     }
-    $role->save();
+    if ($changed) {
+      $message = sprintf('Revoked datastore permissions from role %s on uninstall.', $role->id());
+      \Drupal::logger('datastore')->notice($message);
+      _datastore_uninstall_drush_log($message);
+      $role->save();
+    }
   }
 }
+
+/**
+ * Log a message to Drush if Drush is available.
+ *
+ * @param string $message
+ *   The message to log.
+ */
+function _datastore_uninstall_drush_log($message) {
+  if (class_exists(Drush::class)) {
+    Drush::logger()->notice($message);
+  }
+}
+

--- a/modules/datastore/datastore.install
+++ b/modules/datastore/datastore.install
@@ -1,12 +1,17 @@
 <?php
 
+/**
+ * @file
+ * Install, update and uninstall functions for the datastore module.
+ */
+
 use Drupal\user\Entity\Role;
-use Drush\Drush;
 
 /**
  * Implements hook_uninstall().
  */
 function datastore_uninstall() {
+  // All permissions provided by the harvest module should be removed.
   $permissions_to_remove = [
     'datastore_api_import',
     'datastore_api_drop',
@@ -31,21 +36,7 @@ function datastore_uninstall() {
     if ($changed) {
       $message = sprintf('Revoked datastore permissions from role %s on uninstall.', $role->id());
       \Drupal::logger('datastore')->notice($message);
-      _datastore_uninstall_drush_log($message);
       $role->save();
     }
   }
 }
-
-/**
- * Log a message to Drush if Drush is available.
- *
- * @param string $message
- *   The message to log.
- */
-function _datastore_uninstall_drush_log($message) {
-  if (class_exists(Drush::class)) {
-    Drush::logger()->notice($message);
-  }
-}
-

--- a/modules/datastore/datastore.install
+++ b/modules/datastore/datastore.install
@@ -5,8 +5,8 @@ use Drupal\user\Entity\Role;
 /**
  * Implements hook_uninstall().
  */
-function common_uninstall() {
-  // For each role, remove permissions granted by the common module.
+function datastore_uninstall() {
+  // For each role, remove permissions granted by the datastore module.
   $roles = Role::loadMultiple();
   $permissions_to_remove = [];
   foreach ($roles as $rid => $role_name) {
@@ -14,10 +14,10 @@ function common_uninstall() {
     $role = Role::load($rid);
     $permissions = $role->getPermissions();
     $permissions_to_remove = array_filter($permissions, function ($permission) {
-      return strpos($permission, 'common') === 0;
+      return strpos($permission, 'datastore') === 0;
     });
     foreach ($permissions_to_remove as $permission) {
-      // Remove dependency on the common module for each permission.
+      // Remove dependency on the datastore module for each permission.
       $role->revokePermission($permission);
     }
     $role->save();

--- a/modules/harvest/harvest.install
+++ b/modules/harvest/harvest.install
@@ -1,0 +1,25 @@
+<?php
+
+use Drupal\user\Entity\Role;
+
+/**
+ * Implements hook_uninstall().
+ */
+function harvest_uninstall() {
+  // For each role, remove permissions granted by the harvest module.
+  $roles = Role::loadMultiple();
+  $permissions_to_remove = [];
+  foreach ($roles as $rid => $role_name) {
+    /** @var \Drupal\user\Entity\Role $role */
+    $role = Role::load($rid);
+    $permissions = $role->getPermissions();
+    $permissions_to_remove = array_filter($permissions, function ($permission) {
+      return strpos($permission, 'harvest') === 0;
+    });
+    foreach ($permissions_to_remove as $permission) {
+      // Remove dependency on the harvest module for each permission.
+      $role->revokePermission($permission);
+    }
+    $role->save();
+  }
+}

--- a/modules/harvest/harvest.install
+++ b/modules/harvest/harvest.install
@@ -1,13 +1,16 @@
 <?php
 
+/**
+ * @file
+ * Install, update and uninstall functions for the harvest module.
+ */
+
 use Drupal\user\Entity\Role;
-use Drush\Drush;
 
 /**
  * Implements hook_uninstall().
  */
 function harvest_uninstall() {
-
   // All permissions provided by the harvest module should be removed.
   $permissions_to_remove = [
     'harvest_api_index',
@@ -43,20 +46,7 @@ function harvest_uninstall() {
     if ($changed) {
       $message = sprintf('Revoked harvest permissions from role %s on uninstall.', $role->id());
       \Drupal::logger('harvest')->notice($message);
-      _harvest_uninstall_drush_log($message);
       $role->save();
     }
-  }
-}
-
-/**
- * Log a message to Drush if Drush is available.
- *
- * @param string $message
- *   The message to log.
- */
-function _harvest_uninstall_drush_log($message) {
-  if (class_exists(Drush::class)) {
-    Drush::logger()->notice($message);
   }
 }

--- a/modules/harvest/harvest.install
+++ b/modules/harvest/harvest.install
@@ -1,25 +1,62 @@
 <?php
 
 use Drupal\user\Entity\Role;
+use Drush\Drush;
 
 /**
  * Implements hook_uninstall().
  */
 function harvest_uninstall() {
+
+  // All permissions provided by the harvest module should be removed.
+  $permissions_to_remove = [
+    'harvest_api_index',
+    'harvest_api_register',
+    'harvest_api_run',
+    'harvest_api_info',
+    'dkan.harvest.dashboard',
+    'administer harvest_plan',
+    'view harvest_plan',
+    'edit harvest_plan',
+    'delete harvest_plan',
+    'create harvest_plan',
+    'administer harvest_run',
+    'view harvest_run',
+    'delete harvest_run',
+  ];
   // For each role, remove permissions granted by the harvest module.
-  $roles = Role::loadMultiple();
-  $permissions_to_remove = [];
-  foreach ($roles as $rid => $role_name) {
+  $roles = array_keys(Role::loadMultiple());
+
+  foreach ($roles as $rid) {
     /** @var \Drupal\user\Entity\Role $role */
     $role = Role::load($rid);
-    $permissions = $role->getPermissions();
-    $permissions_to_remove = array_filter($permissions, function ($permission) {
-      return strpos($permission, 'harvest') === 0;
-    });
+    $changed = FALSE;
     foreach ($permissions_to_remove as $permission) {
-      // Remove dependency on the harvest module for each permission.
+      if (!$role->hasPermission($permission)) {
+        continue;
+      }
+
+      // Remove harvest-specific permissions for each role.
       $role->revokePermission($permission);
+      $changed = TRUE;
     }
-    $role->save();
+    if ($changed) {
+      $message = sprintf('Revoked harvest permissions from role %s on uninstall.', $role->id());
+      \Drupal::logger('harvest')->notice($message);
+      _harvest_uninstall_drush_log($message);
+      $role->save();
+    }
+  }
+}
+
+/**
+ * Log a message to Drush if Drush is available.
+ *
+ * @param string $message
+ *   The message to log.
+ */
+function _harvest_uninstall_drush_log($message) {
+  if (class_exists(Drush::class)) {
+    Drush::logger()->notice($message);
   }
 }

--- a/modules/metastore/metastore.install
+++ b/modules/metastore/metastore.install
@@ -1,25 +1,53 @@
 <?php
 
 use Drupal\user\Entity\Role;
+use Drush\Drush;
 
 /**
  * Implements hook_uninstall().
  */
 function metastore_uninstall() {
+
+  $permissions_to_remove = [
+    'post put delete datasets through the api',
+    'administer data dictionary settings',
+    'administer metastore settings',
+    'administer resource mapping',
+  ];
+
   // For each role, remove permissions granted by the metastore module.
-  $roles = Role::loadMultiple();
-  $permissions_to_remove = [];
-  foreach ($roles as $rid => $role_name) {
+  $roles = array_keys(Role::loadMultiple());
+
+  foreach ($roles as $rid) {
     /** @var \Drupal\user\Entity\Role $role */
     $role = Role::load($rid);
-    $permissions = $role->getPermissions();
-    $permissions_to_remove = array_filter($permissions, function ($permission) {
-      return strpos($permission, 'metastore') === 0;
-    });
+    $changed = FALSE;
     foreach ($permissions_to_remove as $permission) {
-      // Remove dependency on the metastore module for each permission.
+      if (!$role->hasPermission($permission)) {
+        continue;
+      }
+
+      // Remove metastore-specific permissions for each role.
       $role->revokePermission($permission);
+      $changed = TRUE;
     }
-    $role->save();
+    if ($changed) {
+      $message = sprintf('Revoked metastore permissions from role %s on uninstall.', $role->id());
+      \Drupal::logger('metastore')->notice($message);
+      _metastore_uninstall_drush_log($message);
+      $role->save();
+    }
+  }
+}
+
+/**
+ * Log a message to Drush if Drush is available.
+ *
+ * @param string $message
+ *   The message to log.
+ */
+function _metastore_uninstall_drush_log($message) {
+  if (class_exists(Drush::class)) {
+    Drush::logger()->notice($message);
   }
 }

--- a/modules/metastore/metastore.install
+++ b/modules/metastore/metastore.install
@@ -1,7 +1,11 @@
 <?php
 
+/**
+ * @file
+ * Install, update and uninstall functions for the metastore module.
+ */
+
 use Drupal\user\Entity\Role;
-use Drush\Drush;
 
 /**
  * Implements hook_uninstall().
@@ -34,20 +38,7 @@ function metastore_uninstall() {
     if ($changed) {
       $message = sprintf('Revoked metastore permissions from role %s on uninstall.', $role->id());
       \Drupal::logger('metastore')->notice($message);
-      _metastore_uninstall_drush_log($message);
       $role->save();
     }
-  }
-}
-
-/**
- * Log a message to Drush if Drush is available.
- *
- * @param string $message
- *   The message to log.
- */
-function _metastore_uninstall_drush_log($message) {
-  if (class_exists(Drush::class)) {
-    Drush::logger()->notice($message);
   }
 }

--- a/modules/metastore/metastore.install
+++ b/modules/metastore/metastore.install
@@ -1,0 +1,25 @@
+<?php
+
+use Drupal\user\Entity\Role;
+
+/**
+ * Implements hook_uninstall().
+ */
+function metastore_uninstall() {
+  // For each role, remove permissions granted by the metastore module.
+  $roles = Role::loadMultiple();
+  $permissions_to_remove = [];
+  foreach ($roles as $rid => $role_name) {
+    /** @var \Drupal\user\Entity\Role $role */
+    $role = Role::load($rid);
+    $permissions = $role->getPermissions();
+    $permissions_to_remove = array_filter($permissions, function ($permission) {
+      return strpos($permission, 'metastore') === 0;
+    });
+    foreach ($permissions_to_remove as $permission) {
+      // Remove dependency on the metastore module for each permission.
+      $role->revokePermission($permission);
+    }
+    $role->save();
+  }
+}

--- a/tests/src/Functional/Dkan4xTransitionalUpdatePathTest.php
+++ b/tests/src/Functional/Dkan4xTransitionalUpdatePathTest.php
@@ -8,6 +8,7 @@ use Drupal\dkan_harvest\ETL\Extract\DataJson;
 use Drupal\dkan_harvest\Load\Dataset;
 use Drupal\dkan_harvest\Transform\ResourceImporter;
 use Drupal\FunctionalTests\Update\UpdatePathTestBase;
+use Drupal\user\Entity\Role;
 
 /**
  * Tests update functions for the metastore module.
@@ -66,6 +67,10 @@ class Dkan4xTransitionalUpdatePathTest extends UpdatePathTestBase {
 
     $this->fixHarvestPlanJsonEscapes();
 
+    // Assert that api_user role is present.
+    $roles = Role::loadMultiple();
+    $this->assertArrayHasKey('api_user', $roles);
+
     // Run all updates.
     $this->runUpdates();
 
@@ -116,6 +121,12 @@ class Dkan4xTransitionalUpdatePathTest extends UpdatePathTestBase {
     $this->assertEquals("\\" . DataJson::class, $updated_plan->extract->type);
     $this->assertEquals("\\" . ResourceImporter::class, $updated_plan->transforms[0]);
     $this->assertEquals("\\" . Dataset::class, $updated_plan->load->type);
+
+    // Assert that api_user role still present (minimal test of the
+    // hook_uninstall functions in the harvest, datastore, and metastore
+    // modules).
+    $roles = Role::loadMultiple();
+    $this->assertArrayHasKey('api_user', $roles);
   }
 
   /**


### PR DESCRIPTION
This prevents roles from disappearing during upgrades because their permissions have temporarily disappeared. They won't get the equivalent permissions  re-added automatically but a `drush cim` should fix this.

## QA Steps

1. Build a site on latest 2.x. 
2. Create a "Site manager" role, give it all DKAN-specific perms.
3. `ddev drush cex`
4. Switch to this branch
5. `ddev poser`
6. `ddev drush updatedb`
7. `ddev drush cim`

Confirm that the site manager role is still there and has all the same perms.