### PR TITLE
Change package name from getdkan/dkan to drupal/dkan

### DIFF
--- a/.github/workflows/gitlabintegrations.yml
+++ b/.github/workflows/gitlabintegrations.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 4.x
+    tags:
+      - '4.*'
 
 jobs:
   to_drupalcode:

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "getdkan/dkan",
+    "name": "drupal/dkan",
     "description": "DKAN Open Data Catalog",
     "license": "GPL-2.0-or-later",
     "type": "drupal-module",


### PR DESCRIPTION
Also starts pushing 4.* tags to drupal.org.