### PR TITLE
Use fulltext keys correctly

### DIFF
--- a/modules/dkan_metastore/modules/dkan_metastore_search/src/QueryBuilderTrait.php
+++ b/modules/dkan_metastore/modules/dkan_metastore_search/src/QueryBuilderTrait.php
@@ -58,7 +58,7 @@ trait QueryBuilderTrait {
     if (!isset($params['fulltext']) || empty($params['fulltext']) || empty($index->getFulltextFields())) {
       return [$query, FALSE];
     }
- 
+
     // Use Search API fulltext parsing.
     $query->keys($params['fulltext']);
 

--- a/modules/dkan_metastore/modules/dkan_metastore_search/src/QueryBuilderTrait.php
+++ b/modules/dkan_metastore/modules/dkan_metastore_search/src/QueryBuilderTrait.php
@@ -55,18 +55,12 @@ trait QueryBuilderTrait {
    *   active as the second. Example: [$query, TRUE].
    */
   private function setFullText(QueryInterface $query, array $params, IndexInterface $index): array {
-    if (!isset($params['fulltext']) || empty($params['fulltext'])) {
+    if (!isset($params['fulltext']) || empty($params['fulltext']) || empty($index->getFulltextFields())) {
       return [$query, FALSE];
     }
-
-    $fulltextFields = $index->getFulltextFields();
-
-    if (empty($fulltextFields)) {
-      return [$query, FALSE];
-    }
-
-    // Use Search API fulltext parsing to avoid phrase-only matching.
-    $query->keys($params['fulltext'], $fulltextFields);
+ 
+    // Use Search API fulltext parsing.
+    $query->keys($params['fulltext']);
 
     return [$query, TRUE];
   }

--- a/modules/dkan_metastore/modules/dkan_metastore_search/src/QueryBuilderTrait.php
+++ b/modules/dkan_metastore/modules/dkan_metastore_search/src/QueryBuilderTrait.php
@@ -65,12 +65,8 @@ trait QueryBuilderTrait {
       return [$query, FALSE];
     }
 
-    $conditions = [];
-    foreach ($fulltextFields as $field) {
-      $conditions[$field][] = $params['fulltext'];
-    }
-
-    $query = $this->createConditionGroup($query, $conditions, 'OR');
+    // Use Search API fulltext parsing to avoid phrase-only matching.
+    $query->keys($params['fulltext'], $fulltextFields);
 
     return [$query, TRUE];
   }

--- a/modules/dkan_metastore/modules/dkan_metastore_search/tests/src/Unit/SearchTest.php
+++ b/modules/dkan_metastore/modules/dkan_metastore_search/tests/src/Unit/SearchTest.php
@@ -10,7 +10,10 @@ use Drupal\Tests\dkan_common\Traits\ServiceCheckTrait;
 use Drupal\dkan_metastore\MetastoreService;
 use Drupal\search_api\IndexInterface;
 use Drupal\search_api\Item\Item;
+use Drupal\search_api\ParseMode\ParseModePluginManager;
+use Drupal\search_api\Plugin\search_api\parse_mode\Terms;
 use Drupal\search_api\Query\ConditionGroup;
+use Drupal\search_api\Query\Query;
 use Drupal\search_api\Query\QueryInterface;
 use Drupal\search_api\Query\ResultSet;
 use Drupal\search_api\Utility\QueryHelperInterface;
@@ -70,7 +73,19 @@ class SearchTest extends TestCase {
     ]));
   }
 
-  public function testSearchParameterWithComma() {
+  /**
+   * Test two things.
+   *
+   * 1. That commas in non-fulltext parameters get properly handled and don't
+   *    mess up parsing.
+   * 2. That fulltext parameters get sent to keys()
+   *
+   * Because none of the functions we can test here return the query object, we
+   * can't test that the keys() are being parsed as expected, but we should be
+   * able to trust that if the input is sent to keys(), it will be handled
+   * as expected by Search API.
+   */
+  public function testSearchParameterWithCommaAndFulltext() {
     $options = (new Options())
       ->add('dkan.metastore.service', MetastoreService::class)
       ->add('entity_type.manager', EntityTypeManager::class)
@@ -88,6 +103,7 @@ class SearchTest extends TestCase {
       ->add(QueryHelperInterface::class, 'createQuery', QueryInterface::class)
       ->add(QueryInterface::class, 'execute', ResultSet::class)
       ->add(QueryInterface::class, 'createConditionGroup', ConditionGroup::class)
+      ->add(QueryInterface::class, 'keys', null, 'keys')
       ->add(ConditionGroup::class, 'addCondition', null, 'condition_group');
 
     \Drupal::setContainer($container->getMock());
@@ -101,6 +117,15 @@ class SearchTest extends TestCase {
     $this->assertEquals(
       'Steve, and someone else',
       $container->getStoredInput('condition_group')[1]
+    );
+
+    // Now assert fulltext ends up getting sent to keys()
+    $service->search([
+      'fulltext' => 'Fulltext Param, "Steve, and someone else"',
+    ]);
+    $this->assertEquals(
+      'Fulltext Param, "Steve, and someone else"',
+      $container->getStoredInput('keys')[0]
     );
   }
 


### PR DESCRIPTION
The metastore search uses a strange approach to fulltext searches... it looks at the index, gathers all the fields, and creates an OR group of conditions matching the query text against each one. Changing the code to simply use `keys()` to add fulltext conditions is much more in line with search_api and provides the option of including quoted phrases.

## QA Steps

1. Fresh build
2. `ddev dkan-sample-content`
3. Request https://dkan.ddev.site/api/1/search?fulltext=Election%20Districts%20Afghanistan (title phrase, out of order). You should get one result
4. Compare to a previous version: https://demo.getdkan.org/api/1/search?fulltext=Election%20Districts%20Afghanistan - you should see no results.
5. Now try with quotes - https://dkan.ddev.site/api/1/search?fulltext=%22Election%20Districts%20Afghanistan%22 - you should get no results.
6. With quotes and words in the right order, you should get results: https://demo.getdkan.org/api/1/search?fulltext=%22Afghanistan%20Election%20Districts%22