### PR TITLE
Explain how to avoid losing transitional modules in 3.x in upgrade docs

### DIFF
--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -116,7 +116,8 @@ version control.
     instance, with an Acquia post-deploy cloud hook), you also need to export your
     ``core.extension`` and add it to the commit that upgrades DKAN to 2.23.x. 
     Otherwise, the new DKAN modules that are enabled via the database updates will be
-    disabled again when your old config is imported.
+    disabled again when your old config is imported. If this happens, re-enable them
+    manually on your production server before proceeding to the next step.
 
 Step 2: Export configuration
 ############################

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -111,6 +111,13 @@ version control.
     part of a post-deploy hook or script that runs automatically after any new
     code deployment.
 
+    Ensure that after deployment, the new transitional DKAN modules (for instance,
+    ``dkan_metastore``) are enabled. Note that if you automatically import configuration as part of your deployment (for
+    instance, with an Acquia post-deploy cloud hook), you also need to export your
+    ``core.extension`` and add it to the commit that upgrades DKAN to 2.23.x. 
+    Otherwise, the new DKAN modules that are enabled via the database updates will be
+    disabled again when your old config is imported.
+
 Step 2: Export configuration
 ############################
 
@@ -148,6 +155,11 @@ composer command ensures that this new dependency will also be added.
 
     Do not deploy these code changes to production until you have completed
     steps 4-7 or you may lose functionality on your live site.
+
+    As detailed in the deployment notes for step 1, ensure that the transitional
+    namespaced DKAN modules are enabled before deploying DKAN 3. If they were
+    disabled inadvertently during the upgrade to 2.23.x, reenable them manually or
+    via config before deploying DKAN 3.
 
 Step 4: Refactor custom code
 ############################


### PR DESCRIPTION
Some additional info in the upgrade docs after running into problems upgrading production sites.

Also fixes some incorrect version constraints in CircleCI.

## QA Steps

Read the deployment notes for steps 1 and 3 in the [upgrade doc](https://dkan--4696.org.readthedocs.build/en/4696/upgrade.html).