### PR TITLE
Frontend module cleanup

### DIFF
--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -98,14 +98,14 @@ function dkan_js_frontend_library_info_build() {
 /**
  * Implements hook_page_attachments().
  *
- * Any route with a 'name' default with a value of dkan_js_frontend gets the
- * library attached.
+ * Any route with a '_is_dkan_js_frontend' default with a value of true gets
+ * the library attached.
  *
  * @see \Drupal\dkan_js_frontend\Routing\RouteProvider::addRoutesFromConfig()
  */
 function dkan_js_frontend_page_attachments(array &$page) {
   if (
-    \Drupal::routeMatch()->getRouteObject()->getDefault('name') === 'dkan_js_frontend'
+    \Drupal::routeMatch()->getRouteObject()->getDefault('_is_dkan_js_frontend') === 'true'
   ) {
     $page['#attached']['library'][] = 'dkan_js_frontend/dkan_js_frontend';
   }
@@ -116,7 +116,7 @@ function dkan_js_frontend_page_attachments(array &$page) {
  */
 function dkan_js_frontend_theme_suggestions_page_alter(array &$suggestions, array $variables) {
   if (
-    \Drupal::routeMatch()->getRouteObject()->getDefault('name') === 'dkan_js_frontend'
+    \Drupal::routeMatch()->getRouteObject()->getDefault('_is_dkan_js_frontend') === 'true'
   ) {
     $suggestions[] = 'page__dkan_js_frontend';
   }

--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -5,6 +5,7 @@
  * This is the DKAN JS Frontend module for using a decoupled frontend w/ DKAN.
  */
 
+use Drupal\dkan_js_frontend\Routing\RouteProvider;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -151,7 +152,7 @@ function dkan_js_frontend_simple_sitemap_arbitrary_links_alter(array &$arbitrary
   $request_context = _dkan_js_frontend_build_request_context();
   _dkan_js_frontend_add_static_links($arbitrary_links, $routes, $request_context);
   // If the 'dataset' route exists, add links for the dataset route.
-  if ($dataset_route = $routes->get('dataset')) {
+  if ($dataset_route = $routes->get(RouteProvider::ROUTE_PREFIX . 'dataset')) {
     _dkan_js_frontend_add_dataset_links($arbitrary_links, $dataset_route, $request_context);
   }
   else {
@@ -209,9 +210,10 @@ function _dkan_js_frontend_add_static_links(array &$arbitrary_links, RouteCollec
  *   Request context containing base URL for sitemap URL generation.
  */
 function _dkan_js_frontend_add_dataset_links(array &$arbitrary_links, Route $dataset_route, RequestContext $request_context): void {
+  $dataset_route_name = RouteProvider::ROUTE_PREFIX . 'dataset';
   // Build route collection.
   $routes = new RouteCollection();
-  $routes->add('dataset', $dataset_route);
+  $routes->add($dataset_route_name, $dataset_route);
   // Build route URL generator.
   $url_generator = new UrlGenerator($routes, $request_context);
 
@@ -220,7 +222,7 @@ function _dkan_js_frontend_add_dataset_links(array &$arbitrary_links, Route $dat
   // Add dataset routes using the fetched UUIDs.
   foreach ($dataset_uuids as $uuid) {
     $arbitrary_links[] = DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK + [
-      'url' => $url_generator->generate('dataset', ['id' => $uuid], UrlGeneratorInterface::ABSOLUTE_URL),
+      'url' => $url_generator->generate($dataset_route_name, ['id' => $uuid], UrlGeneratorInterface::ABSOLUTE_URL),
     ];
   }
 

--- a/modules/dkan_js_frontend/dkan_js_frontend.module
+++ b/modules/dkan_js_frontend/dkan_js_frontend.module
@@ -14,10 +14,12 @@ use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 const DKAN_JS_FRONTEND_MISSING_DATASET_ROUTE_ERROR = 'Missing required DKAN route "dataset"; unable to build sitemap for dataset URLs.';
+
 const DKAN_JS_FRONTEND_DEFAULT_STATIC_LINK = [
   'priority' => '0.7',
   'changefreq' => 'daily',
 ];
+
 const DKAN_JS_FRONTEND_DEFAULT_DATASET_LINK = [
   'priority' => '0.5',
   'changefreq' => 'weekly',
@@ -98,10 +100,13 @@ function dkan_js_frontend_library_info_build() {
  *
  * Any route with a 'name' default with a value of dkan_js_frontend gets the
  * library attached.
+ *
+ * @see \Drupal\dkan_js_frontend\Routing\RouteProvider::addRoutesFromConfig()
  */
 function dkan_js_frontend_page_attachments(array &$page) {
-  $request = \Drupal::routeMatch()->getRouteObject()->getDefault('name');
-  if ($request == 'dkan_js_frontend') {
+  if (
+    \Drupal::routeMatch()->getRouteObject()->getDefault('name') === 'dkan_js_frontend'
+  ) {
     $page['#attached']['library'][] = 'dkan_js_frontend/dkan_js_frontend';
   }
 }
@@ -110,8 +115,9 @@ function dkan_js_frontend_page_attachments(array &$page) {
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function dkan_js_frontend_theme_suggestions_page_alter(array &$suggestions, array $variables) {
-  $request = \Drupal::routeMatch()->getRouteObject()->getDefault('name');
-  if ($request == 'dkan_js_frontend') {
+  if (
+    \Drupal::routeMatch()->getRouteObject()->getDefault('name') === 'dkan_js_frontend'
+  ) {
     $suggestions[] = 'page__dkan_js_frontend';
   }
 }

--- a/modules/dkan_js_frontend/src/Controller/Page.php
+++ b/modules/dkan_js_frontend/src/Controller/Page.php
@@ -2,90 +2,127 @@
 
 namespace Drupal\dkan_js_frontend\Controller;
 
-use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\Core\Path\CurrentPathStack;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\dkan_js_frontend\Routing\RouteProvider;
 use Drupal\dkan_metastore\Exception\MissingObjectException;
-use Drupal\dkan_metastore\MetastoreService;
+use Drupal\dkan_metastore\NodeWrapper\NodeDataFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
- * The Page controller.
+ * Page controller.
+ *
+ * Routes defined in the dkan_js_frontend.config.routes configuration use this
+ * controller.
+ *
+ * For datastore routes, we check if the datastore identifier is valid, and if
+ * not throw an exception signaling a 404 response.
  */
-class Page extends ControllerBase implements ContainerInjectionInterface {
+class Page implements ContainerInjectionInterface {
 
   /**
-   * Metastore service.
-   */
-  private MetastoreService $metastoreService;
-
-  /**
-   * The request stack.
-   */
-  protected RequestStack $requestStack;
-
-  /**
-   * The current path.
-   */
-  protected CurrentPathStack $currentPath;
-
-  /**
-   * Inherited.
+   * Config for dkan_js_frontend.
    *
-   * {@inheritdoc}
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected readonly ImmutableConfig $frontendConfig;
+
+  /**
+   * Renderer service.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected readonly RendererInterface $renderer;
+
+  /**
+   * Node data factory service.
+   *
+   * @var \Drupal\dkan_metastore\NodeWrapper\NodeDataFactory
+   */
+  protected readonly NodeDataFactory $nodeDataFactory;
+
+  /**
+   * {@inheritDoc}
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('dkan.metastore.service'),
-      $container->get('path.current'),
-      $container->get('request_stack'),
+      $container->get('config.factory'),
+      $container->get('renderer'),
+      $container->get('dkan.metastore.metastore_item_factory'),
     );
   }
 
   /**
    * Constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   Config factory service.
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   Renderer service.
+   * @param \Drupal\dkan_metastore\NodeWrapper\NodeDataFactory $nodeDataFactory
+   *   Node data factory service.
    */
-  public function __construct(MetastoreService $service, CurrentPathStack $current_path, RequestStack $request_stack) {
-    $this->metastoreService = $service;
-    $this->currentPath = $current_path;
-    $this->requestStack = $request_stack;
+  public function __construct(
+    ConfigFactoryInterface $configFactory,
+    RendererInterface $renderer,
+    NodeDataFactory $nodeDataFactory,
+  ) {
+    $this->frontendConfig = $configFactory->get('dkan_js_frontend.config');
+    $this->renderer = $renderer;
+    $this->nodeDataFactory = $nodeDataFactory;
   }
 
   /**
-   * Returns a render-able array.
+   * Make a renderable page.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   Route match for this request.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   This request.
+   *
+   * @return array
+   *   Render array.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+   *   Throws a not-found exception for dataset routes which have an invalid
+   *   identifier.
    */
-  public function content() {
-    // Checking for 404 prevents an infinite loop.
-    if ($this->requestStack->getCurrentRequest()->query->get('_exception_statuscode') !== 404) {
-      $this->handleInvalidDatasetId();
-    }
-
-    return [
-      '#theme' => 'page__dkan_js_frontend',
-    ];
-  }
-
-  /**
-   * If a dataset with an invalid ID is being requested, throw a 404 error.
-   */
-  protected function handleInvalidDatasetId() {
-    // Path should always have leading slash.
-    // @see \Symfony\Component\HttpFoundation\Request::getPathInfo()
-    // Match any path that equals or begins with /dataset/[ID].
-    $dataset_path_match = '/^\/dataset\/(?P<id>[^\/]+)/';
-
-    $path = $this->currentPath->getPath();
-
-    if (preg_match($dataset_path_match, $path, $matches)) {
+  public function content(RouteMatchInterface $route_match, Request $request) {
+    $dataset_node = NULL;
+    // Check for valid dataset identifier on the dataset route.
+    // Checking for 404 prevents an infinite loop from the 404 we might cause
+    // later.
+    if (($route_match->getRouteName() === RouteProvider::ROUTE_PREFIX . 'dataset') &&
+      ($request->query->get('_exception_statuscode') !== 404)
+      ) {
       try {
-        $this->metastoreService->get('dataset', $matches['id']);
+        // @todo Figure out a way to find if the identifier exists without
+        //   triggering the lifecycle loading of tertiary nodes, etc.
+        $dataset_node = $this->nodeDataFactory->getInstance(
+          $route_match->getRawParameter('id') ?? ''
+        );
       }
+      // Handle if the dataset does not exist.
       catch (MissingObjectException) {
+        // Throw the exception that tells Drupal send back a 404.
         throw new NotFoundHttpException();
       }
     }
+
+    $build = [
+      '#theme' => 'page__dkan_js_frontend',
+    ];
+    $this->renderer->addCacheableDependency($build, $this->frontendConfig);
+    if ($dataset_node) {
+      $this->renderer->addCacheableDependency($build, $dataset_node);
+    }
+
+    return $build;
   }
 
 }

--- a/modules/dkan_js_frontend/src/Controller/Page.php
+++ b/modules/dkan_js_frontend/src/Controller/Page.php
@@ -15,7 +15,6 @@ use Drupal\dkan_metastore\Exception\MissingObjectException;
 use Drupal\dkan_metastore\NodeWrapper\NodeDataFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Page controller.
@@ -57,8 +56,6 @@ class Page implements ContainerInjectionInterface {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   Config factory service.
-   * @param \Drupal\Core\Render\RendererInterface $renderer
-   *   Renderer service.
    * @param \Drupal\dkan_metastore\NodeWrapper\NodeDataFactory $nodeDataFactory
    *   Node data factory service.
    */
@@ -104,7 +101,7 @@ class Page implements ContainerInjectionInterface {
     if (
       in_array($route_match->getRouteName(), [
         RouteProvider::ROUTE_PREFIX . 'dataset',
-        RouteProvider::ROUTE_PREFIX . 'datasetapi'
+        RouteProvider::ROUTE_PREFIX . 'datasetapi',
       ]) &&
       ($request->query->get('_exception_statuscode') !== 404)
     ) {

--- a/modules/dkan_js_frontend/src/Controller/Page.php
+++ b/modules/dkan_js_frontend/src/Controller/Page.php
@@ -87,16 +87,20 @@ class Page implements ContainerInjectionInterface {
    */
   public function content(RouteMatchInterface $route_match, Request $request) {
     $cacheable_metadata = (new CacheableMetadata())
-      // Keep as long as possible. In practice, this will probably be
-      // overridden by other theming elements during render.
+      // This is the default but let's make it explicit.
       ->setCacheMaxAge(Cache::PERMANENT)
       // Allow cache invalidation if we change config for this module.
-      ->addCacheableDependency($this->frontendConfig);
-    $dataset_node = NULL;
-    // Check for valid dataset identifier on the dataset route.
+      ->addCacheableDependency($this->frontendConfig)
+      // Allow cache invalidation per NodeDataFactory. In practice, this is any
+      // change to any data nodes. This is a wide net to allow for reasonably
+      // easy cache invalidation.
+      ->addCacheTags(NodeDataFactory::getCacheTags());
+
+    // Check for valid dataset identifier on the dataset/api routes.
     // Checking for 404 prevents an infinite loop from the 404 we might cause
     // later.
-    // @todo Make the dataset and dataset API routes a special case.
+    // @todo Make the dataset and dataset API routes their own controller and
+    //   config.
     if (
       in_array($route_match->getRouteName(), [
         RouteProvider::ROUTE_PREFIX . 'dataset',
@@ -105,21 +109,23 @@ class Page implements ContainerInjectionInterface {
       ($request->query->get('_exception_statuscode') !== 404)
     ) {
       try {
-        // Allow cache invalidation if our dataset module changes at all.
-        // @todo Ideally DKAN would give us a way to also get cacheability
-        //   metadata from other related nodes, such as distribution.
-        $cacheable_metadata->addCacheableDependency($dataset_node);
+        // Does this dataset exist?
         // @todo Figure out a way to find if the identifier exists without
         //   triggering the lifecycle loading of tertiary nodes, etc.
-        $dataset_node = $this->nodeDataFactory->getInstance(
+        $dataset_item = $this->nodeDataFactory->getInstance(
           $route_match->getRawParameter('id') ?? ''
         );
+        // Allow cache invalidation if our dataset item changes at all.
+        // @todo Ideally DKAN would give us an easy way to also get
+        //   cacheability metadata from other related nodes, such as
+        //   distribution.
+        $cacheable_metadata->addCacheableDependency($dataset_item);
       }
       // Handle if the dataset does not exist.
       catch (MissingObjectException) {
-        // Throw an exception that tells Drupal send back a 404. Also enforce
-        // the same caching, so that we won't ever query the DB until the cache
-        // is invalidated.
+        // Throw an exception that tells Drupal send back a 404. Also use the
+        // same caching, so that we won't query the DB about a given known-bad
+        // identifier until after the cache is invalidated.
         throw new CacheableNotFoundHttpException($cacheable_metadata);
       }
     }

--- a/modules/dkan_js_frontend/src/Controller/Page.php
+++ b/modules/dkan_js_frontend/src/Controller/Page.php
@@ -2,9 +2,12 @@
 
 namespace Drupal\dkan_js_frontend\Controller;
 
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Http\Exception\CacheableNotFoundHttpException;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\dkan_js_frontend\Routing\RouteProvider;
@@ -33,13 +36,6 @@ class Page implements ContainerInjectionInterface {
   protected readonly ImmutableConfig $frontendConfig;
 
   /**
-   * Renderer service.
-   *
-   * @var \Drupal\Core\Render\RendererInterface
-   */
-  protected readonly RendererInterface $renderer;
-
-  /**
    * Node data factory service.
    *
    * @var \Drupal\dkan_metastore\NodeWrapper\NodeDataFactory
@@ -52,7 +48,6 @@ class Page implements ContainerInjectionInterface {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
-      $container->get('renderer'),
       $container->get('dkan.metastore.metastore_item_factory'),
     );
   }
@@ -69,11 +64,9 @@ class Page implements ContainerInjectionInterface {
    */
   public function __construct(
     ConfigFactoryInterface $configFactory,
-    RendererInterface $renderer,
     NodeDataFactory $nodeDataFactory,
   ) {
     $this->frontendConfig = $configFactory->get('dkan_js_frontend.config');
-    $this->renderer = $renderer;
     $this->nodeDataFactory = $nodeDataFactory;
   }
 
@@ -93,14 +86,29 @@ class Page implements ContainerInjectionInterface {
    *   identifier.
    */
   public function content(RouteMatchInterface $route_match, Request $request) {
+    $cacheable_metadata = (new CacheableMetadata())
+      // Keep as long as possible. In practice, this will probably be
+      // overridden by other theming elements during render.
+      ->setCacheMaxAge(Cache::PERMANENT)
+      // Allow cache invalidation if we change config for this module.
+      ->addCacheableDependency($this->frontendConfig);
     $dataset_node = NULL;
     // Check for valid dataset identifier on the dataset route.
     // Checking for 404 prevents an infinite loop from the 404 we might cause
     // later.
-    if (($route_match->getRouteName() === RouteProvider::ROUTE_PREFIX . 'dataset') &&
+    // @todo Make the dataset and dataset API routes a special case.
+    if (
+      in_array($route_match->getRouteName(), [
+        RouteProvider::ROUTE_PREFIX . 'dataset',
+        RouteProvider::ROUTE_PREFIX . 'datasetapi'
+      ]) &&
       ($request->query->get('_exception_statuscode') !== 404)
-      ) {
+    ) {
       try {
+        // Allow cache invalidation if our dataset module changes at all.
+        // @todo Ideally DKAN would give us a way to also get cacheability
+        //   metadata from other related nodes, such as distribution.
+        $cacheable_metadata->addCacheableDependency($dataset_node);
         // @todo Figure out a way to find if the identifier exists without
         //   triggering the lifecycle loading of tertiary nodes, etc.
         $dataset_node = $this->nodeDataFactory->getInstance(
@@ -109,18 +117,17 @@ class Page implements ContainerInjectionInterface {
       }
       // Handle if the dataset does not exist.
       catch (MissingObjectException) {
-        // Throw the exception that tells Drupal send back a 404.
-        throw new NotFoundHttpException();
+        // Throw an exception that tells Drupal send back a 404. Also enforce
+        // the same caching, so that we won't ever query the DB until the cache
+        // is invalidated.
+        throw new CacheableNotFoundHttpException($cacheable_metadata);
       }
     }
 
     $build = [
       '#theme' => 'page__dkan_js_frontend',
     ];
-    $this->renderer->addCacheableDependency($build, $this->frontendConfig);
-    if ($dataset_node) {
-      $this->renderer->addCacheableDependency($build, $dataset_node);
-    }
+    $cacheable_metadata->applyTo($build);
 
     return $build;
   }

--- a/modules/dkan_js_frontend/src/Routing/RouteProvider.php
+++ b/modules/dkan_js_frontend/src/Routing/RouteProvider.php
@@ -11,6 +11,8 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class RouteProvider {
 
+  const string ROUTE_PREFIX = 'dkan_js_frontend.';
+
   /**
    * Route-URL pairs, separated by a comma.
    *
@@ -62,10 +64,13 @@ class RouteProvider {
         [
           '_controller' => '\Drupal\dkan_js_frontend\Controller\Page::content',
           'name' => 'dkan_js_frontend',
-        ]
+        ],
       );
       $route->setMethods(['GET']);
-      $routes->add($possible_page[0], $route);
+      $route->addRequirements([
+        '_permission' => 'access content',
+      ]);
+      $routes->add(self::ROUTE_PREFIX . $possible_page[0], $route);
     }
   }
 

--- a/modules/dkan_js_frontend/src/Routing/RouteProvider.php
+++ b/modules/dkan_js_frontend/src/Routing/RouteProvider.php
@@ -48,8 +48,9 @@ class RouteProvider {
   /**
    * Add all the routes specified in configuration.
    *
-   * Routes added here are marked with a default property 'name' with a value
-   * of 'dkan_js_frontend'. This allows for select attachment of libraries.
+   * Routes added here are marked with a default property
+   * '_is_dkan_js_frontend' with a value of 'true'. This allows for select
+   * attachment of libraries.
    *
    * @param \Symfony\Component\Routing\RouteCollection $routes
    *   The collection to add config routes to.
@@ -63,7 +64,7 @@ class RouteProvider {
         '/' . $possible_page[1],
         [
           '_controller' => '\Drupal\dkan_js_frontend\Controller\Page::content',
-          'name' => 'dkan_js_frontend',
+          '_is_dkan_js_frontend' => 'true',
         ],
       );
       $route->setMethods(['GET']);

--- a/modules/dkan_js_frontend/src/Routing/RouteProvider.php
+++ b/modules/dkan_js_frontend/src/Routing/RouteProvider.php
@@ -11,7 +11,7 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class RouteProvider {
 
-  const string ROUTE_PREFIX = 'dkan_js_frontend.';
+  const ROUTE_PREFIX = 'dkan_js_frontend.';
 
   /**
    * Route-URL pairs, separated by a comma.

--- a/modules/dkan_js_frontend/tests/src/Kernel/Controller/PageTest.php
+++ b/modules/dkan_js_frontend/tests/src/Kernel/Controller/PageTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\dkan_js_frontend\Kernel;
 
+use Drupal\Core\Routing\RouteMatch;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\dkan_js_frontend\Routing\RouteProvider;
 use Drupal\KernelTests\KernelTestBase;
@@ -23,22 +24,43 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class PageTest extends KernelTestBase {
 
+  protected static $modules = [
+    'system',
+    'node',
+    'user',
+    'field',
+    'text',
+    'dkan_js_frontend',
+    'dkan_metastore',
+    'dkan_common',
+    'content_moderation',
+    'workflows',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig('system');
+    $this->installConfig('node');
+    $this->installConfig('dkan_common');
+    $this->installConfig('dkan_metastore');
+    $this->installEntitySchema('node');
+    $this->installSchema('node', ['node_access']);
+    $this->installEntitySchema('content_moderation_state');
+    $this->installConfig('field');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('resource_mapping');
+  }
+
   /**
    * @covers ::content
    */
   public function test404OnBadPath() {
-    $metastore_service = $this->getMockBuilder(MetastoreService::class)
+    $route_match = $this->getMockBuilder(RouteMatch::class)
       ->disableOriginalConstructor()
-      ->onlyMethods(['get'])
       ->getMock();
-    $metastore_service->expects($this->once())
-      ->method('get')
-      ->willThrowException(new MissingObjectException());
-
-    $this->container->set('dkan.metastore.service', $metastore_service);
-
-    $route_match = $this->getMockBuilder(RouteMatchInterface::class)
-      ->getMockForAbstractClass();
     $route_match->expects($this->once())
       ->method('getRouteName')
       ->willReturn(RouteProvider::ROUTE_PREFIX . 'dataset');
@@ -52,16 +74,15 @@ class PageTest extends KernelTestBase {
    * @covers ::content
    */
   public function testPathPresent() {
-    // Metastore service does not throw MissingObjectException, so the dataset
-    // exists.
-    $metastore_service = $this->getMockBuilder(MetastoreService::class)
+    $metastore = $this->container->get('dkan.metastore.service');
+    $metadata = $metastore->getValidMetadataFactory()->get(json_encode($this->getDataset('123')), 'dataset');
+    $metastore->post('dataset', $metadata);
+    $item = $this->container->get('dkan.metastore.metastore_item_factory')->getInstance('123');
+    $nid = $item->getEntity()->id();
+
+    $route_match = $this->getMockBuilder(RouteMatch::class)
       ->disableOriginalConstructor()
       ->getMock();
-
-    $this->container->set('dkan.metastore.service', $metastore_service);
-
-    $route_match = $this->getMockBuilder(RouteMatchInterface::class)
-      ->getMockForAbstractClass();
     $route_match->expects($this->once())
       ->method('getRouteName')
       ->willReturn(RouteProvider::ROUTE_PREFIX . 'dataset');
@@ -73,9 +94,38 @@ class PageTest extends KernelTestBase {
     $this->assertEquals(
       [
         '#theme' => 'page__dkan_js_frontend',
+        '#cache' => [
+          'max-age' => -1,
+          'contexts' => [],
+          'tags' => [
+            'config:dkan_js_frontend.config',
+            'node_list:data',
+            'node:' . $nid,
+          ],
+        ],
       ],
       $page->content($route_match, (new Request())),
     );
   }
 
+  protected function getDataset(string $identifier): array {
+    return [
+      'title' => 'Test Dataset',
+      'identifier' => $identifier,
+      'keyword' => ['test'],
+      'description' => 'Test Description',
+      'modified' => '2020-01-01',
+      'accessLevel' => 'public',
+      'distribution' => [
+        [
+          'title' => 'Test Distribution 1',
+          'downloadURL' => 'http://example.com/1.csv',
+        ],
+        [
+          'title' => 'Test Distribution 2',
+          'downloadURL' => 'http://example.com/2.csv',
+        ],
+      ],
+    ];
+  }
 }

--- a/modules/dkan_js_frontend/tests/src/Kernel/Controller/PageTest.php
+++ b/modules/dkan_js_frontend/tests/src/Kernel/Controller/PageTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\dkan_js_frontend\Kernel;
 
-use Drupal\Core\Path\CurrentPathStack;
-use Drupal\dkan_js_frontend\Controller\Page;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\dkan_js_frontend\Routing\RouteProvider;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\dkan_js_frontend\Controller\Page;
 use Drupal\dkan_metastore\Exception\MissingObjectException;
 use Drupal\dkan_metastore\MetastoreService;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -35,52 +37,44 @@ class PageTest extends KernelTestBase {
 
     $this->container->set('dkan.metastore.service', $metastore_service);
 
-    $current_path = $this->getMockBuilder(CurrentPathStack::class)
-      ->disableOriginalConstructor()
-      ->onlyMethods(['getPath'])
-      ->getMock();
-    $current_path->expects($this->once())
-      ->method('getPath')
-      // Always use leading slash.
-      // @see \Symfony\Component\HttpFoundation\Request::getPathInfo()
-      ->willReturn('/dataset/123');
-
-    $this->container->set('path.current', $current_path);
+    $route_match = $this->getMockBuilder(RouteMatchInterface::class)
+      ->getMockForAbstractClass();
+    $route_match->expects($this->once())
+      ->method('getRouteName')
+      ->willReturn(RouteProvider::ROUTE_PREFIX . 'dataset');
 
     $page = Page::create($this->container);
     $this->expectException(NotFoundHttpException::class);
-    $page->content();
+    $page->content($route_match, (new Request()));
   }
 
   /**
    * @covers ::content
    */
   public function testPathPresent() {
-    // Mock
+    // Metastore service does not throw MissingObjectException, so the dataset
+    // exists.
     $metastore_service = $this->getMockBuilder(MetastoreService::class)
       ->disableOriginalConstructor()
       ->getMock();
 
     $this->container->set('dkan.metastore.service', $metastore_service);
 
-    $current_path = $this->getMockBuilder(CurrentPathStack::class)
-      ->disableOriginalConstructor()
-      ->onlyMethods(['getPath'])
-      ->getMock();
-    $current_path->expects($this->once())
-      ->method('getPath')
-      // Always use leading slash.
-      // @see \Symfony\Component\HttpFoundation\Request::getPathInfo()
-      ->willReturn('/dataset/123');
-
-    $this->container->set('path.current', $current_path);
+    $route_match = $this->getMockBuilder(RouteMatchInterface::class)
+      ->getMockForAbstractClass();
+    $route_match->expects($this->once())
+      ->method('getRouteName')
+      ->willReturn(RouteProvider::ROUTE_PREFIX . 'dataset');
+    $route_match->expects($this->once())
+      ->method('getRawParameter')
+      ->willReturn('123');
 
     $page = Page::create($this->container);
     $this->assertEquals(
       [
         '#theme' => 'page__dkan_js_frontend',
       ],
-      $page->content(),
+      $page->content($route_match, (new Request())),
     );
   }
 

--- a/modules/dkan_metastore/src/NodeWrapper/NodeDataFactory.php
+++ b/modules/dkan_metastore/src/NodeWrapper/NodeDataFactory.php
@@ -67,8 +67,12 @@ class NodeDataFactory implements MetastoreEntityItemFactoryInterface {
    *
    * @return \Drupal\dkan_metastore\MetastoreItemInterface
    *   Metastore data node object.
+   *
+   * @throws \Drupal\dkan_metastore\Exception\MissingObjectException
+   *   Thrown when the input is null or otherwise empty.
    */
   public function wrap($input): MetastoreItemInterface {
+    // Check $input so we don't even have to start creating a new Data object.
     if ($input) {
       return new Data($input, $this->entityTypeManager);
     }

--- a/modules/dkan_metastore/src/NodeWrapper/NodeDataFactory.php
+++ b/modules/dkan_metastore/src/NodeWrapper/NodeDataFactory.php
@@ -4,6 +4,7 @@ namespace Drupal\dkan_metastore\NodeWrapper;
 
 use Drupal\Core\Entity\EntityRepository;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\dkan_metastore\Exception\MissingObjectException;
 use Drupal\dkan_metastore\Factory\MetastoreEntityItemFactoryInterface;
 use Drupal\dkan_metastore\MetastoreItemInterface;
 
@@ -54,7 +55,7 @@ class NodeDataFactory implements MetastoreEntityItemFactoryInterface {
    */
   public function getInstance(string $identifier, array $config = []): MetastoreItemInterface {
     return $this->wrap(
-      $this->entityRepository->loadEntityByUuid('node', $identifier)
+      $this->entityRepository->loadEntityByUuid(static::getEntityType(), $identifier)
     );
   }
 
@@ -68,7 +69,10 @@ class NodeDataFactory implements MetastoreEntityItemFactoryInterface {
    *   Metastore data node object.
    */
   public function wrap($input): MetastoreItemInterface {
-    return new Data($input, $this->entityTypeManager);
+    if ($input) {
+      return new Data($input, $this->entityTypeManager);
+    }
+    throw new MissingObjectException();
   }
 
   /**
@@ -89,7 +93,11 @@ class NodeDataFactory implements MetastoreEntityItemFactoryInterface {
    * {@inheritdoc}
    */
   public static function getCacheTags() {
-    return ['node_list:data'];
+    $tags = [];
+    foreach (static::getBundles() as $bundle) {
+      $tags[] = static::getEntityType() . '_list:' . $bundle;
+    }
+    return $tags;
   }
 
   /**


### PR DESCRIPTION
Mainly updates to `dkan_js_frontend`.

- Turns route names like 'about' into `dkan_js_frontend.about`, etc. Try `drush route | grep dkan`
- Refactors the controller render method into less code, using values Drupal has already computed.
- Accepts the typehinted route matcher in the controller method so we can more easily target dataset routes for ID check.
- Adds cache invalidation information for the rendered page.
- Adds 'view content' permission to all our routes.

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
