### PR TITLE
Unset downloadURL if empty string

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,13 +285,13 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~10.6.0", "~11.2.0", "11.3.0"]
+              drupal_core_constraint: ["~10.6.0", "~11.2.0", "~11.3.0"]
               php_version: ["8.3"]
               database_version: ["mariadb:10.11"]
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["10.6.0", "~11.2.0", "~11.3.0"]
+              drupal_core_constraint: ["~10.6.0", "~11.2.0", "~11.3.0"]
               php_version: ["8.4"]
               database_version: ["mariadb:10.11"]
       - phpunit:

--- a/modules/dkan_metastore/config/schema/dkan_metastore.schema.yml
+++ b/modules/dkan_metastore/config/schema/dkan_metastore.schema.yml
@@ -42,3 +42,6 @@ dkan_metastore.settings:
         retain_for:
           type: integer
           label: 'Number of days to keep referenced content before deletion'
+    unset_download_url_if_empty:
+      type: boolean
+      label: 'Unset download URL if empty'

--- a/modules/dkan_metastore/src/Form/DkanDataSettingsForm.php
+++ b/modules/dkan_metastore/src/Form/DkanDataSettingsForm.php
@@ -82,6 +82,12 @@ class DkanDataSettingsForm extends ConfigFormBase {
 
     $form['description'] = $this->getDescriptionMarkup();
     $form['redirect_to_datasets'] = $this->getRedirectCheckbox($config);
+    $form['unset_download_url_if_empty'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Unset download URL if empty'),
+      '#default_value' => $config->get('unset_download_url_if_empty') ?? 0,
+      '#description' => $this->t('If enabled, and a dataset contains a distribution[].downloadURL property, the property will be unset if it is empty. For DCAT-US dataset schemas, this prevents a validation error in rare cases when a resource mapper entity is inadvertently deleted, leaving an empty downloadURL that fails validation. Leave this unchecked unless you are experiencing fatal validation errors on dataset load.'),
+    ];
     $form['html_allowed_properties'] = $this->getHtmlAllowedProperties($config);
     $form['html_allowed_html'] = $this->getHtmlAllowedHtml($config);
     $form['property_list'] = $this->getPropertyList($config);
@@ -223,6 +229,7 @@ class DkanDataSettingsForm extends ConfigFormBase {
 
     $this->config('dkan_metastore.settings')
       ->set('redirect_to_datasets', $form_state->getValue('redirect_to_datasets'))
+      ->set('unset_download_url_if_empty', $form_state->getValue('unset_download_url_if_empty'))
       ->set('property_list', $form_state->getValue('property_list'))
       ->set('html_allowed_properties', $form_state->getValue('html_allowed_properties'))
       ->set('html_allowed_html', $form_state->getValue('html_allowed_html'))

--- a/modules/dkan_metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/dkan_metastore/src/LifeCycle/LifeCycle.php
@@ -231,7 +231,14 @@ class LifeCycle {
     if (is_string($downloadUrl)) {
       $downloadUrl = UrlHostTokenResolver::resolve($downloadUrl);
     }
-    $metadata->data->downloadURL = $downloadUrl;
+
+    $unset_downloadUrl = $this->configFactory->get('dkan_metastore.settings')->get('unset_download_url_if_empty') ?? FALSE;
+    if (!$downloadUrl && $unset_downloadUrl) {
+      unset($metadata->data->downloadURL);
+    }
+    else {
+      $metadata->data->downloadURL = $downloadUrl;
+    }
 
     // If describedBy contains dkan:// URI, convert to absolute URL.
     if (StreamWrapperManager::getScheme($metadata->data->describedBy ?? '') == MetastoreUrlGenerator::DKAN_SCHEME) {

--- a/modules/dkan_metastore/tests/src/Kernel/LifeCycle/LifeCycleTest.php
+++ b/modules/dkan_metastore/tests/src/Kernel/LifeCycle/LifeCycleTest.php
@@ -10,6 +10,8 @@ use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
 use RootedData\Exception\ValidationException;
 
 /**
+ * Some tests for LifeCycle hooks.
+ *
  * @group dkan
  * @group dkan_metastore
  * @group kernel
@@ -73,10 +75,6 @@ class LifeCycleTest extends KernelTestBase {
     $this->installConfig('field');
     $this->installEntitySchema('user');
     $this->installEntitySchema('resource_mapping');
-
-    // $config = $this->config('dkan_metastore.settings');
-    // $config->set('orphan.delete', TRUE);
-    // $config->save();
   }
 
   /**
@@ -139,6 +137,16 @@ class LifeCycleTest extends KernelTestBase {
     catch (ValidationException $e) {
       $this->assertEquals('JSON Schema validation failed.', $e->getMessage());
     }
+
+    // Enable the unset_download_url_if_empty setting and try again.
+    $config = $this->container->get('config.factory')->getEditable('dkan_metastore.settings');
+    $config->set('unset_download_url_if_empty', TRUE);
+    $config->save();
+    $this->container->get('config.factory')->reset('dkan_metastore.settings');
+    $this->container->get('entity_type.manager')->getStorage('node')->resetCache();
+
+    $dataset = $metastore->get('dataset', $identifier);
+    $this->assertArrayNotHasKey('downloadURL', $dataset->{"$.distribution[0]"});
   }
 
 }

--- a/modules/dkan_metastore/tests/src/Kernel/LifeCycle/LifeCycleTest.php
+++ b/modules/dkan_metastore/tests/src/Kernel/LifeCycle/LifeCycleTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\dkan_metastore\LifeCycle;
+
+use Drupal\dkan_common\DataResource;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
+
+/**
+ * @group dkan
+ * @group dkan_metastore
+ * @group kernel
+ *
+ * @covers \Drupal\dkan_metastore\LifeCycle\LifeCycle
+ * @coversDefaultClass \Drupal\dkan_metastore\LifeCycle\LifeCycle
+ */
+class LifeCycleTest extends KernelTestBase {
+  use QueueRunnerTrait;
+
+  protected const DATASET_DATA = [
+    'title' => 'Test Dataset',
+    'identifier' => '123',
+    'description' => 'Test Description',
+    'modified' => '2026-01-01',
+    'accessLevel' => 'public',
+    'keyword' => ['test'],
+    'distribution' => [
+      [
+        'title' => 'Test Distribution 1',
+        'downloadURL' => 'http://example.com/1.csv',
+      ],
+    ],
+    "publisher" => [
+      "@type" => "org:Organization",
+      "name" => "Test Org",
+    ],
+    "theme" => [
+      "Tag 1",
+      "Tag 2",
+    ],
+  ];
+
+
+  public static $modules = [
+    'system',
+    'node',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'dkan_metastore',
+    'dkan_common',
+    'dkan',
+    'content_moderation',
+    'workflows',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig('system');
+    $this->installConfig('node');
+    $this->installConfig('dkan_common');
+    $this->installConfig('dkan_metastore');
+    $this->installEntitySchema('node');
+    $this->installSchema('node', ['node_access']);
+    $this->installEntitySchema('content_moderation_state');
+    $this->installConfig('field');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('resource_mapping');
+
+    $config = $this->config('dkan_metastore.settings');
+    $config->set('orphan.delete', TRUE);
+    $config->save();
+  }
+
+  /**
+   * Make sure that distributionLoad properly creates references.
+   */
+  public function testDistributionLoad() {
+    /**
+     * @var \Drupal\dkan_metastore\MetastoreService $metastore
+     */
+    $metastore = $this->container->get('dkan.metastore.service');
+    $metadata = $metastore->getValidMetadataFactory()->get(json_encode(self::DATASET_DATA), 'dataset');
+    $identifier = $metastore->post('dataset', $metadata);
+    $result = $this->container->get('entity_type.manager')
+      ->getStorage('node')
+      ->loadByProperties(['type' => 'data', 'uuid' => $identifier]);
+    $node = reset($result);
+    // Get the raw value from the database for field_json_metadata.
+    $query = $this->container->get('database')->query(
+      'SELECT field_json_metadata_value FROM {node__field_json_metadata} WHERE entity_id = :entity_id',
+      [':entity_id' => $node->id()]
+    );
+    $json_raw = $query->fetchField();
+    $dataset_raw = json_decode($json_raw, TRUE);
+    $distribution_id = $dataset_raw['distribution'][0];
+    $result = $this->container->get('entity_type.manager')
+      ->getStorage('node')
+      ->loadByProperties(['type' => 'data', 'uuid' => $distribution_id]);
+    $distribution_node = reset($result);
+    $query = $this->container->get('database')->query(
+      'SELECT field_json_metadata_value FROM {node__field_json_metadata} WHERE entity_id = :entity_id',
+      [':entity_id' => $distribution_node->id()]
+    );
+    $json_raw = $query->fetchField();
+    $distribution_raw = json_decode($json_raw, TRUE);
+    $download_url_ref = $distribution_raw['data']['downloadURL'];
+    $resource_parts = DataResource::parseUniqueIdentifier($download_url_ref);
+    $resource_identifier = $resource_parts['identifier'];
+    $resource_version = $resource_parts['version'];
+    $resource_perspective = $resource_parts['perspective'];
+
+    // Delete the resource mapping entity.
+    $storage = $this->container->get('entity_type.manager')->getStorage('resource_mapping');
+    $entities = $storage->loadByProperties([
+      'identifier' => $resource_identifier,
+      'version' => $resource_version,
+      'perspective' => $resource_perspective,
+    ]);
+    foreach ($entities as $entity) {
+      $entity->delete();
+    }
+    $this->assertEmpty(
+      $storage->loadByProperties([
+        'identifier' => $resource_identifier,
+        'version' => $resource_version,
+        'perspective' => $resource_perspective,
+      ]),
+      'Resource mapping entities should be deleted before reload.'
+    );
+
+    // Clear the node cache.
+    $this->container->get('cache.entity')->deleteAll();
+
+    // Reset node storage static cache for this request.
+    $this->container->get('entity_type.manager')->getStorage('node')->resetCache();
+
+    // Clear the resource_mapping static cache for this request.
+    $this->container->get('entity_type.manager')->getStorage('resource_mapping')->resetCache();
+
+    // Re-load the original dataset via the metastore service
+    $dataset = $metastore->get('dataset', $identifier);
+    $retrieved = json_decode((string) $dataset);
+    $download_url = $retrieved->distribution[0]->downloadURL ?? NULL;
+    $this->assertSame(
+      '',
+      $download_url,
+      'Expected empty downloadURL when resource mapping is missing.'
+    );
+  }
+
+}

--- a/modules/dkan_metastore/tests/src/Kernel/LifeCycle/LifeCycleTest.php
+++ b/modules/dkan_metastore/tests/src/Kernel/LifeCycle/LifeCycleTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\dkan_metastore\LifeCycle;
 use Drupal\dkan_common\DataResource;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
+use RootedData\Exception\ValidationException;
 
 /**
  * @group dkan
@@ -73,9 +74,9 @@ class LifeCycleTest extends KernelTestBase {
     $this->installEntitySchema('user');
     $this->installEntitySchema('resource_mapping');
 
-    $config = $this->config('dkan_metastore.settings');
-    $config->set('orphan.delete', TRUE);
-    $config->save();
+    // $config = $this->config('dkan_metastore.settings');
+    // $config->set('orphan.delete', TRUE);
+    // $config->save();
   }
 
   /**
@@ -92,6 +93,7 @@ class LifeCycleTest extends KernelTestBase {
       ->getStorage('node')
       ->loadByProperties(['type' => 'data', 'uuid' => $identifier]);
     $node = reset($result);
+
     // Get the raw value from the database for field_json_metadata.
     $query = $this->container->get('database')->query(
       'SELECT field_json_metadata_value FROM {node__field_json_metadata} WHERE entity_id = :entity_id',
@@ -104,6 +106,8 @@ class LifeCycleTest extends KernelTestBase {
       ->getStorage('node')
       ->loadByProperties(['type' => 'data', 'uuid' => $distribution_id]);
     $distribution_node = reset($result);
+
+    // Get the raw value for the distribution JSON from the DB.
     $query = $this->container->get('database')->query(
       'SELECT field_json_metadata_value FROM {node__field_json_metadata} WHERE entity_id = :entity_id',
       [':entity_id' => $distribution_node->id()]
@@ -112,47 +116,29 @@ class LifeCycleTest extends KernelTestBase {
     $distribution_raw = json_decode($json_raw, TRUE);
     $download_url_ref = $distribution_raw['data']['downloadURL'];
     $resource_parts = DataResource::parseUniqueIdentifier($download_url_ref);
-    $resource_identifier = $resource_parts['identifier'];
-    $resource_version = $resource_parts['version'];
-    $resource_perspective = $resource_parts['perspective'];
 
     // Delete the resource mapping entity.
     $storage = $this->container->get('entity_type.manager')->getStorage('resource_mapping');
     $entities = $storage->loadByProperties([
-      'identifier' => $resource_identifier,
-      'version' => $resource_version,
-      'perspective' => $resource_perspective,
+      'identifier' => $resource_parts['identifier'],
+      'version' => $resource_parts['version'],
+      'perspective' => $resource_parts['perspective'],
     ]);
     foreach ($entities as $entity) {
       $entity->delete();
     }
-    $this->assertEmpty(
-      $storage->loadByProperties([
-        'identifier' => $resource_identifier,
-        'version' => $resource_version,
-        'perspective' => $resource_perspective,
-      ]),
-      'Resource mapping entities should be deleted before reload.'
-    );
 
-    // Clear the node cache.
-    $this->container->get('cache.entity')->deleteAll();
-
-    // Reset node storage static cache for this request.
+    // Avoid reusing the already-loaded distribution entity with a resolved URL.
     $this->container->get('entity_type.manager')->getStorage('node')->resetCache();
 
-    // Clear the resource_mapping static cache for this request.
-    $this->container->get('entity_type.manager')->getStorage('resource_mapping')->resetCache();
-
-    // Re-load the original dataset via the metastore service
-    $dataset = $metastore->get('dataset', $identifier);
-    $retrieved = json_decode((string) $dataset);
-    $download_url = $retrieved->distribution[0]->downloadURL ?? NULL;
-    $this->assertSame(
-      '',
-      $download_url,
-      'Expected empty downloadURL when resource mapping is missing.'
-    );
+    // Re-load the original dataset via the metastore service.
+    try {
+      $metastore->get('dataset', $identifier);
+      $this->fail('Expected a ValidationException to be thrown due to the missing resource mapping.');
+    }
+    catch (ValidationException $e) {
+      $this->assertEquals('JSON Schema validation failed.', $e->getMessage());
+    }
   }
 
 }

--- a/modules/dkan_metastore/tests/src/Kernel/LifeCycle/LifeCycleTest.php
+++ b/modules/dkan_metastore/tests/src/Kernel/LifeCycle/LifeCycleTest.php
@@ -6,7 +6,6 @@ namespace Drupal\Tests\dkan_metastore\LifeCycle;
 
 use Drupal\dkan_common\DataResource;
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
 use RootedData\Exception\ValidationException;
 
 /**
@@ -20,8 +19,6 @@ use RootedData\Exception\ValidationException;
  * @coversDefaultClass \Drupal\dkan_metastore\LifeCycle\LifeCycle
  */
 class LifeCycleTest extends KernelTestBase {
-  use QueueRunnerTrait;
-
   protected const DATASET_DATA = [
     'title' => 'Test Dataset',
     'identifier' => '123',

--- a/modules/dkan_metastore/tests/src/Kernel/Service/OrphanNodeProcessorTest.php
+++ b/modules/dkan_metastore/tests/src/Kernel/Service/OrphanNodeProcessorTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\dkan_metastore\Kernel\Service;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
+
+/**
+ * @group dkan
+ * @group dkan_metastore
+ * @group kernel
+ *
+ * @covers \Drupal\dkan_metastore\Service\OrphanNodeProcessor
+ * @coversDefaultClass \Drupal\dkan_metastore\Service\OrphanNodeProcessor
+ */
+class OrphanNodeProcessorTest extends KernelTestBase {
+  use QueueRunnerTrait;
+
+  protected const DATASET_DATA = [
+    'title' => 'Test Dataset',
+    'identifier' => '123',
+    'description' => 'Test Description',
+    'modified' => '2026-01-01',
+    'accessLevel' => 'public',
+    'keyword' => ['test'],
+    'distribution' => [
+      [
+        'title' => 'Test Distribution 1',
+        'downloadURL' => 'http://example.com/1.csv',
+      ],
+    ],
+    "publisher" => [
+      "@type" => "org:Organization",
+      "name" => "Test Org",
+    ],
+    "theme" => [
+      "Tag 1",
+      "Tag 2",
+    ],
+  ];
+
+
+  public static $modules = [
+    'system',
+    'node',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'dkan_metastore',
+    'dkan_common',
+    'dkan',
+    'content_moderation',
+    'workflows',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig('system');
+    $this->installConfig('node');
+    $this->installConfig('dkan_common');
+    $this->installConfig('dkan_metastore');
+    $this->installEntitySchema('node');
+    $this->installSchema('node', ['node_access']);
+    $this->installEntitySchema('content_moderation_state');
+    $this->installConfig('field');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('resource_mapping');
+
+    $config = $this->config('dkan_metastore.settings');
+    $config->set('orphan.delete', TRUE);
+    $config->save();
+  }
+
+  /**
+   * Make sure that deleteOutdatedOrphans() removes all orphaned nodes.
+   */
+  public function testOrphanNodeDeletion() {
+    /**
+     * @var \Drupal\dkan_metastore\MetastoreService $metastore
+     */
+    $metastore = $this->container->get('dkan.metastore.service');
+    $metadata = $metastore->getValidMetadataFactory()->get(json_encode(self::DATASET_DATA), 'dataset');
+    $metastore->post('dataset', $metadata);
+    $this->assertEquals($this->getRelatedItemCount() + 1, $this->getDataNodeCount());
+
+    $metastore->delete('dataset', '123');
+    $this->assertEquals($this->getRelatedItemCount(), $this->getDataNodeCount());
+
+    $this->runQueues(['orphan_reference_processor']);
+    /** @var \Drupal\dkan_metastore\Service\OrphanNodeProcessor $processor */
+    $processor = $this->container->get('dkan.metastore.orphan_node_processor');
+    $deleted_nids = $processor->deleteOutdatedOrphans();
+    $this->assertEquals($this->getRelatedItemCount(), count($deleted_nids));
+    $this->assertEquals(0, $this->getDataNodeCount());
+  }
+
+  protected function getRelatedItemCount() {
+    // There can only be one publisher and it's stored as an array.
+    $publisher = count(self::DATASET_DATA['publisher']) ? 1 : 0;
+    return count(self::DATASET_DATA['keyword'])
+      + count(self::DATASET_DATA['distribution'])
+      + $publisher
+      + count(self::DATASET_DATA['theme']);
+  }
+
+  protected function getDataNodeCount() {
+    return $this->container->get('entity_type.manager')->getStorage('node')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', 'data')
+      ->count()
+      ->execute();
+  }
+
+}


### PR DESCRIPTION
This adds a setting to the metastore to remove the downloadURL property from a distribution, if it is set to an empty string. This may be desirable because a) removing a resource referenced in downloadURL results in an empty string, and b) downloadURL is not required, but must be a URL if present. When a dataset already saved in the datastore becomes invalid, it can no longer be loaded, even to correct it.

Note this also restores the OrphanNodeProcessorTest, which appears to have been removed accidentally during the big refactor.

## QA Steps

- [ ] Build site, and load sample content
- [ ] `drush dkan:dataset-info cedcd327-4e5d-43f9-8eb1-c11850fa7c55`
- [ ] Copy resource_id (should be `3a187a87dc6cd47c48b6b4c4785224b7`)
- [ ] `drush sqlc`
- [ ] `DELETE FROM dkan_metastore_resource_mapper WHERE identifier = '3a187a87dc6cd47c48b6b4c4785224b7' AND perspective = 'source';`
- [ ] `exit`
- [ ] `drush cr`
- [ ] Load https://dkan.ddev.site/api/1/metastore/schemas/dataset/items/cedcd327-4e5d-43f9-8eb1-c11850fa7c55
- [ ] Confirm JSON validation error
- [ ] Visit https://dkan.ddev.site/admin/dkan/properties
- [ ] Check "Unset download URL if empty" and Save
- [ ] Re-load https://dkan.ddev.site/api/1/metastore/schemas/dataset/items/cedcd327-4e5d-43f9-8eb1-c11850fa7c55
- [ ] Confirm it loads correctly, and does not have a downloadURL in the distribution
