### PR TITLE
Post import cache invalidate

### DIFF
--- a/modules/dkan_datastore/src/Controller/AbstractQueryController.php
+++ b/modules/dkan_datastore/src/Controller/AbstractQueryController.php
@@ -12,6 +12,7 @@ use Drupal\dkan_metastore\MetastoreApiResponse;
 use JsonSchema\Validator;
 use RootedData\RootedJsonData;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -93,16 +94,16 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     catch (\Exception $e) {
       return $this->getResponseFromException($e, 400);
     }
-    try {
-      $result = $this->queryService->runQuery($datastoreQuery);
-    }
-    catch (\Exception $e) {
-      $code = (str_contains($e->getMessage(), "Error retrieving")) ? 404 : 400;
-      return $this->getResponseFromException($e, $code);
-    }
+    $result = $this->runDatastoreQuery($datastoreQuery);
 
-    $dependencies = $this->extractMetastoreDependencies($datastoreQuery);
-    return $this->formatResponse($datastoreQuery, $result, $dependencies, $request->query);
+    return ($result instanceof JsonResponse)
+      ? $result
+      : $this->formatResponse(
+        $datastoreQuery,
+        $result,
+        $this->extractMetastoreDependencies($datastoreQuery),
+        $request->query
+      );
   }
 
   /**
@@ -123,15 +124,16 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     catch (\Exception $e) {
       return $this->getResponseFromException($e, 400);
     }
-    try {
-      $result = $this->queryService->runQuery($datastoreQuery);
-    }
-    catch (\Exception $e) {
-      $code = (str_contains($e->getMessage(), "Error retrieving")) ? 404 : 400;
-      return $this->getResponseFromException($e, $code);
-    }
+    $result = $this->runDatastoreQuery($datastoreQuery);
 
-    return $this->formatResponse($datastoreQuery, $result, ['distribution' => [$identifier]], $request->query);
+    return ($result instanceof JsonResponse)
+      ? $result
+      : $this->formatResponse(
+        $datastoreQuery,
+        $result,
+        ['distribution' => [$identifier]],
+        $request->query
+      );
   }
 
   /**
@@ -149,10 +151,11 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
    */
   public function queryDatasetResource(string $dataset, string $index, Request $request) {
     $distribution_uuid = $this->datasetInfo->getDistributionUuid($dataset, $index);
-
     if (empty($distribution_uuid)) {
       return $this->getResponse((object) ['message' => "No resource found for dataset $dataset at index $index"], 404);
     }
+
+    $dependencies = ['distribution' => [$distribution_uuid], 'dataset' => [$dataset]];
 
     try {
       $datastoreQuery = $this->buildDatastoreQuery($request, $distribution_uuid);
@@ -160,20 +163,16 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     catch (\Exception $e) {
       return $this->getResponseFromException($e, 400);
     }
-    try {
-      $result = $this->queryService->runQuery($datastoreQuery);
-    }
-    catch (\Exception $e) {
-      $code = (str_contains($e->getMessage(), "Error retrieving")) ? 404 : 400;
-      return $this->getResponseFromException($e, $code);
-    }
 
-    $dependencies = [
-      'distribution' => [$distribution_uuid],
-      'dataset' => [$dataset],
-    ];
-
-    return $this->formatResponse($datastoreQuery, $result, $dependencies, $request->query);
+    $result = $this->runDatastoreQuery($datastoreQuery);
+    return ($result instanceof JsonResponse) 
+      ? $result 
+      : $this->formatResponse(
+        $datastoreQuery,
+        $result,
+        $dependencies,
+        $request->query
+      );
   }
 
   /**
@@ -242,6 +241,25 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
       $data->schema = TRUE;
     }
     return new DatastoreQuery(json_encode($data), $this->getRowsLimit());
+  }
+
+  /**
+   * Run a datastore query with standard error handling.
+   *
+   * @param \Drupal\dkan_datastore\Service\DatastoreQuery $datastoreQuery
+   *   The datastore query object.
+   *
+   * @return \RootedData\RootedJsonData|\Symfony\Component\HttpFoundation\JsonResponse
+   *   The query result or an error response.
+   */
+  protected function runDatastoreQuery(DatastoreQuery $datastoreQuery) {
+    try {
+      return $this->queryService->runQuery($datastoreQuery);
+    }
+    catch (\Exception $e) {
+      $code = (str_contains($e->getMessage(), "Error retrieving")) ? 404 : 400;
+      return $this->getResponseFromException($e, $code);
+    }
   }
 
   /**

--- a/modules/dkan_datastore/src/Controller/AbstractQueryController.php
+++ b/modules/dkan_datastore/src/Controller/AbstractQueryController.php
@@ -165,8 +165,8 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     }
 
     $result = $this->runDatastoreQuery($datastoreQuery);
-    return ($result instanceof JsonResponse) 
-      ? $result 
+    return ($result instanceof JsonResponse)
+      ? $result
       : $this->formatResponse(
         $datastoreQuery,
         $result,

--- a/modules/dkan_datastore/src/Controller/AbstractQueryController.php
+++ b/modules/dkan_datastore/src/Controller/AbstractQueryController.php
@@ -154,7 +154,26 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
       return $this->getResponse((object) ['message' => "No resource found for dataset $dataset at index $index"], 404);
     }
 
-    return $this->queryResource($distribution_uuid, $request);
+    try {
+      $datastoreQuery = $this->buildDatastoreQuery($request, $distribution_uuid);
+    }
+    catch (\Exception $e) {
+      return $this->getResponseFromException($e, 400);
+    }
+    try {
+      $result = $this->queryService->runQuery($datastoreQuery);
+    }
+    catch (\Exception $e) {
+      $code = (str_contains($e->getMessage(), "Error retrieving")) ? 404 : 400;
+      return $this->getResponseFromException($e, $code);
+    }
+
+    $dependencies = [
+      'distribution' => [$distribution_uuid],
+      'dataset' => [$dataset],
+    ];
+
+    return $this->formatResponse($datastoreQuery, $result, $dependencies, $request->query);
   }
 
   /**

--- a/modules/dkan_datastore/src/Service/ImportService.php
+++ b/modules/dkan_datastore/src/Service/ImportService.php
@@ -255,6 +255,10 @@ class ImportService {
    */
   protected function invalidateCacheTags(mixed $resourceId) {
     $this->referenceLookup->invalidateReferencerCacheTags('distribution', $resourceId, 'downloadURL');
+    $distributionIds = $this->referenceLookup->getReferencers('distribution', $resourceId, 'downloadURL');
+    foreach ($distributionIds as $id) {
+      $this->referenceLookup->invalidateReferencerCacheTags('dataset', $id, 'distribution');
+    }
   }
 
 }

--- a/modules/dkan_datastore/tests/data/1.csv
+++ b/modules/dkan_datastore/tests/data/1.csv
@@ -1,0 +1,3 @@
+one
+un
+uno

--- a/modules/dkan_datastore/tests/data/2.csv
+++ b/modules/dkan_datastore/tests/data/2.csv
@@ -1,0 +1,3 @@
+one,two
+un,deux
+uno,dos

--- a/modules/dkan_datastore/tests/src/Functional/ImportCacheInvalidationTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/ImportCacheInvalidationTest.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Drupal\Tests\dkan_metastore\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
+use GuzzleHttp\RequestOptions;
+use Psr\Http\Message\ResponseInterface;
+use RootedData\RootedJsonData;
+
+/**
+ * Test cache invalidation behavior for datastore endpoints.
+ *
+ * @group dkan
+ * @group dkan_datastore
+ * @group functional2
+ */
+class ImportCacheInvalidationTest extends BrowserTestBase {
+
+  use QueueRunnerTrait;
+
+  protected static $modules = [
+    'dkan_common',
+    'dkan_datastore',
+    'dynamic_page_cache',
+    'dkan_harvest',
+    'dkan_metastore',
+    'node',
+  ];
+
+  protected $defaultTheme = 'stark';
+
+  /**
+   * The HTTP client.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected $httpClient;
+
+  private const S3_PREFIX = 'https://dkan-default-content-files.s3.amazonaws.com/phpunit';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    // Ensure the proper triggering properties are set for datastore comparison.
+    $this->config('dkan_datastore.settings')
+      ->set('triggering_properties', ['modified'])
+      ->save();
+
+    // Set up a Guzzle client using our service.
+    $this->httpClient = $this->container->get('http_client_factory')
+      ->fromOptions([
+        'base_uri' => $this->baseUrl,
+        'http_errors' => FALSE,
+        'timeout' => 600,
+      ]);
+  }
+
+  /**
+   * Make an API request, using method, path, and query.
+   *
+   * @param string $method
+   *   HTTP method.
+   * @param string $path
+   *   Request path.
+   * @param array $query
+   *   Request query as an array. Example: '?foo' would be ['foo' => TRUE].
+   *
+   * @return \Psr\Http\Message\ResponseInterface
+   *   Response object from Guzzle.
+   */
+  protected function apiRequest(string $method, string $path, array $query = []): ResponseInterface {
+    return $this->httpClient->request(
+      $method,
+      $this->buildUrl($path),
+      [RequestOptions::QUERY => $query]
+    );
+  }
+
+  /**
+   * Test dataset page caching.
+   */
+  public function testDatasetApiPageCache() {
+    $identifier = '111';
+
+    // Before we've done anything, GET should yield a 404.
+    $response = $this->apiRequest('GET', 'api/1/metastore/schemas/dataset/items/' . $identifier);
+    $this->assertEquals(404, $response->getStatusCode(), $response->getBody());
+
+    $datasetRootedJsonData = $this->getData($identifier, '1', ['1.csv']);
+
+    // Post dataset.
+    $this->assertEquals(
+      $identifier,
+      $this->httpVerbHandler('post', $datasetRootedJsonData, json_decode($datasetRootedJsonData))
+    );
+
+    // Request datastore; should fail, as the import queue hasn't run yet.
+    $response = $this->apiRequest('GET', 'api/1/datastore/query/' . $identifier . '/0');
+    $this->assertEquals(400, $response->getStatusCode(), $response->getBody());
+
+    $queues = [
+      'localize_import',
+      'datastore_import',
+      'resource_purger',
+      // 'orphan_reference_processor',
+      // 'orphan_resource_remover',
+    ];
+
+    // Importing the datastore should invalidate the cache.
+    $this->runQueues($queues);
+    // Re-render the dataset nodes using the render service.
+    $this->renderDatasetNodesForCache();
+
+    // Request once, should not return a cached version (it's a novel request).
+    $response = $this->apiRequest('GET', 'api/1/datastore/query/' . $identifier . '/0');
+    $this->assertEquals(200, $response->getStatusCode(), $response->getBody());
+    $this->assertEquals('MISS', $response->getHeaders()['X-Drupal-Cache'][0] ?? '', $response->getBody());
+
+    // Request again, confirm it's now a hit.
+    $response = $this->apiRequest('GET', 'api/1/datastore/query/' . $identifier . '/0');
+    $this->assertEquals(200, $response->getStatusCode(), $response->getBody());
+    $this->assertEquals('HIT', $response->getHeaders()['X-Drupal-Cache'][0] ?? '', $response->getBody());
+
+    // Now let's patch the dataset and switch the download URL.
+    $datasetRootedJsonData = $this->getData($identifier, '1', ['2.csv']);
+    $this->assertEquals(
+      $identifier,
+      $this->httpVerbHandler('put', $datasetRootedJsonData, json_decode($datasetRootedJsonData))
+    );
+
+    $this->runQueues($queues);
+
+    $response = $this->apiRequest('GET', 'api/1/datastore/query/' . $identifier . '/0');
+    $this->assertEquals(200, $response->getStatusCode(), $response->getBody());
+    $this->assertEquals('MISS', $response->getHeaders()['X-Drupal-Cache'][0] ?? '', $response->getBody());
+
+  }
+
+  /**
+   * Generate dataset metadata, possibly with multiple distributions.
+   *
+   * @param string $identifier
+   *   Dataset identifier.
+   * @param string $title
+   *   Dataset title.
+   * @param array $filenames
+   *   Array of resource files URLs for this dataset.
+   *
+   * @return \RootedData\RootedJsonData
+   *   RootedJsonData object containing the dataset metadata.
+   */
+  private function getData(string $identifier, string $title, array $filenames): RootedJsonData {
+
+    $data = new \stdClass();
+    $data->title = $title;
+    $data->description = 'Some description.';
+    $data->identifier = $identifier;
+    $data->accessLevel = 'public';
+    $data->modified = '06-04-2020';
+    $data->keyword = ['some keyword'];
+    $data->distribution = [];
+
+    foreach ($filenames as $key => $filename) {
+      $distribution = new \stdClass();
+      $distribution->title = 'Distribution #' . $key . ' for ' . $identifier;
+      $distribution->downloadURL = $this->getPublicCsvUrl($filename);
+      $distribution->mediaType = 'text/csv';
+
+      $data->distribution[] = $distribution;
+    }
+
+    $valid_metadata_factory = $this->container->get('dkan.metastore.valid_metadata');
+    return $valid_metadata_factory->get(json_encode($data), 'dataset');
+  }
+
+  /**
+   * Render all the dataset nodes to address cache.
+   */
+  private function renderDatasetNodesForCache() {
+    $renderer = $this->container->get('renderer');
+    $entityTypeManager = $this->container->get('entity_type.manager');
+    $database_service = $this->container->get('database');
+
+    $query = $database_service->select('node', 'n');
+    $query->addField('n', 'nid');
+    $nids = $query->execute()->fetchCol();
+
+    $node_storage = $entityTypeManager->getStorage('node');
+    $node_render = $entityTypeManager->getViewBuilder('node');
+    foreach ($node_storage->loadMultiple($nids) as $node) {
+      $build = $node_render->view($node);
+      $renderer->renderPlain($build);
+    }
+  }
+
+  /**
+   * Handle HTTP verbs for dataset operations.
+   */
+  private function httpVerbHandler(string $method, RootedJsonData $json, $dataset) {
+    $metastore_service = $this->container->get('dkan.metastore.service');
+
+    if ($method == 'post') {
+      $identifier = $metastore_service->post('dataset', $json);
+    }
+    // PUT for now, refactor later if more verbs are needed.
+    else {
+      $id = $dataset->identifier;
+      $info = $metastore_service->put('dataset', $id, $json);
+      $identifier = $info['identifier'];
+    }
+
+    return $identifier;
+  }
+
+  /**
+   * Copy file from the data folder to public:// and produce a URL.
+   *
+   * @param string $filename
+   *   Filename. Must be in the module's tests/data folder.
+   *
+   * @return string
+   *   Absolute URL to the copied file.
+   */
+  private function getPublicCsvUrl(string $filename): string {
+    $source = dirname(__DIR__, 2) . '/data/' . $filename;
+    $destination = 'public://' . $filename;
+    $this->container->get('file_system')->copy($source, $destination, TRUE);
+    return $this->container->get('file_url_generator')->generateAbsoluteString($destination);
+  }
+
+}

--- a/modules/dkan_datastore/tests/src/Functional/ImportCacheInvalidationTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/ImportCacheInvalidationTest.php
@@ -37,8 +37,6 @@ class ImportCacheInvalidationTest extends BrowserTestBase {
    */
   protected $httpClient;
 
-  private const S3_PREFIX = 'https://dkan-default-content-files.s3.amazonaws.com/phpunit';
-
   /**
    * {@inheritdoc}
    */

--- a/modules/dkan_datastore/tests/src/Functional/ImportCacheInvalidationTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/ImportCacheInvalidationTest.php
@@ -87,8 +87,8 @@ class ImportCacheInvalidationTest extends BrowserTestBase {
     $identifier = '111';
 
     // Before we've done anything, GET should yield a 404.
-    $response = $this->apiRequest('GET', 'api/1/metastore/schemas/dataset/items/' . $identifier);
-    $this->assertEquals(404, $response->getStatusCode(), $response->getBody());
+    $metastoreResponse = $this->apiRequest('GET', 'api/1/metastore/schemas/dataset/items/' . $identifier);
+    $this->assertEquals(404, $metastoreResponse->getStatusCode(), $metastoreResponse->getBody());
 
     $datasetRootedJsonData = $this->getData($identifier, '1', ['1.csv']);
 
@@ -102,13 +102,7 @@ class ImportCacheInvalidationTest extends BrowserTestBase {
     $response = $this->apiRequest('GET', 'api/1/datastore/query/' . $identifier . '/0');
     $this->assertEquals(400, $response->getStatusCode(), $response->getBody());
 
-    $queues = [
-      'localize_import',
-      'datastore_import',
-      'resource_purger',
-      // 'orphan_reference_processor',
-      // 'orphan_resource_remover',
-    ];
+    $queues = ['localize_import', 'datastore_import'];
 
     // Importing the datastore should invalidate the cache.
     $this->runQueues($queues);
@@ -132,12 +126,16 @@ class ImportCacheInvalidationTest extends BrowserTestBase {
       $this->httpVerbHandler('put', $datasetRootedJsonData, json_decode($datasetRootedJsonData))
     );
 
+    // We haven't run an import yet, the dataset query should return error.
+    $response = $this->apiRequest('GET', 'api/1/datastore/query/' . $identifier . '/0');
+    $this->assertEquals(400, $response->getStatusCode(), $response->getBody());
+
     $this->runQueues($queues);
 
+    // Now we should get a 200 and a cache MISS.
     $response = $this->apiRequest('GET', 'api/1/datastore/query/' . $identifier . '/0');
     $this->assertEquals(200, $response->getStatusCode(), $response->getBody());
     $this->assertEquals('MISS', $response->getHeaders()['X-Drupal-Cache'][0] ?? '', $response->getBody());
-
   }
 
   /**

--- a/modules/dkan_metastore/tests/src/Functional/MetastoreApiPageCacheTest.php
+++ b/modules/dkan_metastore/tests/src/Functional/MetastoreApiPageCacheTest.php
@@ -192,8 +192,8 @@ class MetastoreApiPageCacheTest extends BrowserTestBase {
    * @param array $downloadUrls
    *   Array of resource files URLs for this dataset.
    *
-   * @return string|false
-   *   Json encoded string of this dataset's metadata, or FALSE if error.
+   * @return \RootedData\RootedJsonData
+   *   RootedJsonData object containing the dataset metadata.
    */
   private function getData(string $identifier, string $title, array $downloadUrls): RootedJsonData {
 


### PR DESCRIPTION
The dataset query endpoint for the datastore api (/api/1/datastore/query/[dataset_id]/[index]) does not get a cache tag for the dataset ID, just the distribution. This causes the cache to get stuck in many situations, because the distribution IDs change over time. If a distribution ID changes in the parent dataset, invalidating caches based on the old distribution ID no longer works. Tagging URLs that contain a dataset ID with that dataset's node cache tag, plus directly invalidating both cache tags when an import is finished, result in much more predictable cache behavior.

## Notes

* Copied approach from MetastoreApiPageCacheTest but implemented local files for the tests. In a separate PR will apply that approach to the original test file. I didn't realize we still had S3 dependencies in our tests; would like to finally eliminate all of those.
* The different methods in AbstractQueryControler are similar but couldn't be condensed as much as I'd hoped, at least not in a way I could see that would preserve the signatures. I think what I did makes it a little less redundant and more readable?
* We could probably create a trait or base class for both tests since they share several functions
* I don't understand what the `::renderDatasetNodesForCache()` function does exactly, or why its needed. Is this an accurate simulation of the real-world behavior?

## QA Steps

### Reproduce old behavior

1. Build on 4.x
2. Create a dataset with a CSV upload resource. You can use one of the csvs in modules/dkan_datastore/tests/data
3. Run queues/cron. Confirm that /api/1/datastore/query/[dataset-id]/0 shows expected results.
4. Edit dataset. Replace CSV with a new CSV.
5. Refresh the datastore API URL from 3. Confirm that it still shows the old data.
6. Run the localize_import and datastore_import queues
7. Confirm that datastore API is still stuck on the same response as #3.
8. Run the orphan_reference_processor queue. 
9. Now the datastore endpoint should finally show the new data when refreshed, because the orphan reference processor modified the old distribution, causing the distribution cache tag to invalidate.

### Demonstrate fix

1. Build on `post-import-cache-invalidate`
2. Create a dataset with a CSV upload resource. You can use one of the csvs in modules/dkan_datastore/tests/data
3. Run queues/cron. Confirm that /api/1/datastore/query/[dataset-id]/0 shows expected results.
4. Edit dataset. Replace CSV with a new CSV.
5. Refresh the datastore API URL from 3. It should now show a 400 error, as there has been a new file added but it's not yet imported
6. Run the localize_import queue
7. Refresh datastore, confirm there is still a 400 error
8. Run the datastore_import queue
9. Refresh the datastore endpoint. Confirm you now see the new expected data.
