### PR TITLE
Add date to filtered csv exports

### DIFF
--- a/modules/dkan_datastore/src/Controller/QueryDownloadController.php
+++ b/modules/dkan_datastore/src/Controller/QueryDownloadController.php
@@ -11,6 +11,7 @@ use RootedData\RootedJsonData;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Drupal\Core\Datetime\DrupalDateTime;
 
 /**
  * Controller providing functionality used to stream datastore queries.
@@ -77,7 +78,9 @@ class QueryDownloadController extends AbstractQueryController {
    *   Return the StreamedResponse object.
    */
   protected function streamCsvResponse(DatastoreQuery $datastoreQuery, RootedJsonData $result) {
-    $response = $this->initStreamedCsvResponse();
+    $date = new DrupalDateTime();
+    $filename = 'data-' . $date->format('m-d-Y_g:ia', NULL) . '.csv';
+    $response = $this->initStreamedCsvResponse($filename);
 
     $response->setCallback(function () use ($result, $datastoreQuery) {
       // Open the stream and send the header.


### PR DESCRIPTION
## Describe your changes
When a user creates a filter on a dataset, they have an option to download the subset to a csv file. Currently that file is named data.csv. This will append a date and time to help differentiate it from other downloads.

## QA Steps

- [ ] Navigate to a dataset with a CSV distribution.
- [ ] Create a filter on the data
- [ ] Hit the download API and confirm the name of the file includes the date and time.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
