### PR TITLE
Send back 503 on query requests if the database is otherwise occupied.

### DIFF
--- a/modules/dkan_common/src/JsonResponseTrait.php
+++ b/modules/dkan_common/src/JsonResponseTrait.php
@@ -9,7 +9,6 @@ use OpisErrorPresenter\Implementation\Strategies\BestMatchError;
 use OpisErrorPresenter\Implementation\ValidationErrorPresenter;
 use RootedData\Exception\ValidationException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 /**
  * Json Response Trait.

--- a/modules/dkan_common/src/JsonResponseTrait.php
+++ b/modules/dkan_common/src/JsonResponseTrait.php
@@ -8,6 +8,7 @@ use OpisErrorPresenter\Implementation\PresentedValidationErrorFactory;
 use OpisErrorPresenter\Implementation\Strategies\BestMatchError;
 use OpisErrorPresenter\Implementation\ValidationErrorPresenter;
 use RootedData\Exception\ValidationException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 /**
  * Json Response Trait.
@@ -43,7 +44,11 @@ trait JsonResponseTrait {
     if ($data = $this->getExceptionData($e)) {
       $body['data'] = $data;
     }
-    return $this->getResponse((object) $body, $code);
+    $response = $this->getResponse((object) $body, $code);
+    if ($e instanceof HttpExceptionInterface) {
+      $response->headers->add($e->getHeaders());
+    }
+    return $response;
   }
 
   /**

--- a/modules/dkan_datastore/src/Controller/AbstractQueryController.php
+++ b/modules/dkan_datastore/src/Controller/AbstractQueryController.php
@@ -2,12 +2,10 @@
 
 namespace Drupal\dkan_datastore\Controller;
 
-use Drupal\Core\Cache\CacheableMetadata;
-use Drupal\Core\Http\Exception\CacheableTooManyRequestsHttpException;
-use Drupal\dkan_common\DatasetInfo;
-use Drupal\dkan_common\JsonResponseTrait;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\dkan_common\DatasetInfo;
+use Drupal\dkan_common\JsonResponseTrait;
 use Drupal\dkan_datastore\Service\DatastoreQuery;
 use Drupal\dkan_datastore\Service\Query as QueryService;
 use Drupal\dkan_metastore\MetastoreApiResponse;
@@ -17,7 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 /**
  * Abstract Controller providing base functionality used to query datastores.
@@ -26,6 +24,11 @@ use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
  */
 abstract class AbstractQueryController implements ContainerInjectionInterface {
   use JsonResponseTrait;
+
+  /**
+   * Wait time for new request if the DB server reports busy.
+   */
+  protected const int BUSY_RETRY_AFTER = 60;
 
   /**
    * Datastore query service.
@@ -263,10 +266,8 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
       switch ($e->getCode()) {
         // @see https://dev.mysql.com/doc/mysql-errors/8.4/en/server-error-reference.html#error_er_too_many_user_connections
         case 1203:
-          // @todo Use CacheableTooManyRequestsHttpException when
-          //   getResponseFromException() can handle caching.
-          $too_many = new TooManyRequestsHttpException(60, $e->getMessage());
-          return $this->getResponseFromException($e, $too_many->getStatusCode());
+          $http_exception = new ServiceUnavailableHttpException(self::BUSY_RETRY_AFTER, $e->getMessage());
+          return $this->getResponseFromException($http_exception, $http_exception->getStatusCode());
 
         default:
           throw $e;

--- a/modules/dkan_datastore/src/Controller/AbstractQueryController.php
+++ b/modules/dkan_datastore/src/Controller/AbstractQueryController.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\dkan_datastore\Controller;
 
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Http\Exception\CacheableTooManyRequestsHttpException;
 use Drupal\dkan_common\DatasetInfo;
 use Drupal\dkan_common\JsonResponseTrait;
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -15,6 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 
 /**
  * Abstract Controller providing base functionality used to query datastores.
@@ -255,6 +258,19 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
   protected function runDatastoreQuery(DatastoreQuery $datastoreQuery) {
     try {
       return $this->queryService->runQuery($datastoreQuery);
+    }
+    catch (\PDOException $e) {
+      switch ($e->getCode()) {
+        // @see https://dev.mysql.com/doc/mysql-errors/8.4/en/server-error-reference.html#error_er_too_many_user_connections
+        case 1203:
+          // @todo Use CacheableTooManyRequestsHttpException when
+          //   getResponseFromException() can handle caching.
+          $too_many = new TooManyRequestsHttpException(60, $e->getMessage());
+          return $this->getResponseFromException($e, $too_many->getStatusCode());
+
+        default:
+          throw $e;
+      }
     }
     catch (\Exception $e) {
       $code = (str_contains($e->getMessage(), "Error retrieving")) ? 404 : 400;

--- a/modules/dkan_datastore/tests/src/Unit/Controller/AbstractQueryControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/AbstractQueryControllerTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\dkan_common\Unit\Controller;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\State\StateInterface;
 use Drupal\dkan_common\DatasetInfo;
 use Drupal\dkan_datastore\Controller\AbstractQueryController;
 use Drupal\dkan_datastore\Service\DatastoreQuery;
@@ -129,6 +130,7 @@ class AbstractQueryControllerTest extends TestCase {
         $this->createMock(DatasetInfo::class),
         $this->createMock(MetastoreApiResponse::class),
         $this->createMock(ConfigFactoryInterface::class),
+        $this->createMock(StateInterface::class),
       ],
     );
 
@@ -142,7 +144,7 @@ class AbstractQueryControllerTest extends TestCase {
 
     // Did we get a 503 with the message we added?
     $this->assertSame(503, $result->getStatusCode());
-    $this->assertSame('60', $result->headers->get('retry-after'));
+    $this->assertSame('120', $result->headers->get('retry-after'));
     $this->assertStringContainsString($message, $result->getContent());
   }
 

--- a/modules/dkan_datastore/tests/src/Unit/Controller/AbstractQueryControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/AbstractQueryControllerTest.php
@@ -139,8 +139,9 @@ class AbstractQueryControllerTest extends TestCase {
       [$this->createMock(DatastoreQuery::class)]
     );
 
-    // Did we get a 429 with the message we added?
-    $this->assertSame(429, $result->getStatusCode());
+    // Did we get a 503 with the message we added?
+    $this->assertSame(503, $result->getStatusCode());
+    $this->assertSame('60', $result->headers->get('retry-after'));
     $this->assertStringContainsString($message, $result->getContent());
   }
 

--- a/modules/dkan_datastore/tests/src/Unit/Controller/AbstractQueryControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/AbstractQueryControllerTest.php
@@ -1,12 +1,19 @@
 <?php
 
-namespace Drupal\Tests\dkan_common\Unit\Util;
+namespace Drupal\Tests\dkan_common\Unit\Controller;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\dkan_common\DatasetInfo;
 use Drupal\dkan_datastore\Controller\AbstractQueryController;
+use Drupal\dkan_datastore\Service\DatastoreQuery;
+use Drupal\dkan_datastore\Service\Query;
+use Drupal\dkan_metastore\MetastoreApiResponse;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
+ * @coversDefaultClass \Drupal\dkan_datastore\Controller\AbstractQueryController
+ *
  * @group dkan
  * @group datastore
  * @group unit
@@ -14,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 class AbstractQueryControllerTest extends TestCase {
 
   /**
-   * Make sure we get what we expect with a GET
+   * Make sure we get what we expect with a GET.
    */
   public function testGetNormalizer() {
     $queryString = "conditions[0][property]=state&conditions[0][value]=AL&conditions[0][operator]==&conditions[1][property]=record_number&conditions[1][value]=%1%&conditions[1][operator]=LIKE&sort[0][property]=record_number&sort[0][order]=asc&sort[1][property]=state&sort[1][order]=desc&limit=50&offset=25&results=true";
@@ -25,7 +32,7 @@ class AbstractQueryControllerTest extends TestCase {
   }
 
   /**
-   * Make sure we get what we expect with a POST
+   * Make sure we get what we expect with a POST.
    */
   public function testPostNormalizer() {
     $sampleJson = $this->getSampleJson();
@@ -36,7 +43,7 @@ class AbstractQueryControllerTest extends TestCase {
   }
 
   /**
-   * Make sure we get what we expect with a PATCH
+   * Make sure we get what we expect with a PATCH.
    */
   public function testPatchNormalizer() {
     $sampleJson = $this->getSampleJson();
@@ -48,7 +55,7 @@ class AbstractQueryControllerTest extends TestCase {
   }
 
   /**
-   * Make sure we get what we expect with a DELETE
+   * Make sure we get what we expect with a DELETE.
    */
   public function testDeleteNormalizer() {
     $this->expectExceptionMessage("Only POST, PUT, PATCH and GET requests can be normalized");
@@ -59,7 +66,7 @@ class AbstractQueryControllerTest extends TestCase {
   }
 
   /**
-   * Make sure we get what we expect with a PUT
+   * Make sure we get what we expect with a PUT.
    */
   public function testPutNormalizer() {
     $sampleJson = $this->getSampleJson();
@@ -92,6 +99,49 @@ class AbstractQueryControllerTest extends TestCase {
 
   private function getSampleSchema() {
     return file_get_contents(__DIR__ . "/../../../data/querySchema.json");
+  }
+
+  /**
+   * @covers ::runDatastoreQuery
+   */
+  public function testTooManyRequests() {
+    $message = 'The AI bots have taken over!';
+
+    // @see https://dev.mysql.com/doc/mysql-errors/8.4/en/server-error-reference.html#error_er_too_many_user_connections
+    $exception = new \PDOException($message, 1203);
+
+    // Query service always throws the 1203 exception.
+    $query_service = $this->getMockBuilder(Query::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['runQuery'])
+      ->getMock();
+    $query_service->expects($this->once())
+      ->method('runQuery')
+      ->willThrowException($exception);
+
+    // Get a controller to test.
+    $controller = $this->getMockForAbstractClass(
+      AbstractQueryController::class,
+      [
+        $query_service,
+        // These dependencies are unused, so we just mock them.
+        $this->createMock(DatasetInfo::class),
+        $this->createMock(MetastoreApiResponse::class),
+        $this->createMock(ConfigFactoryInterface::class),
+      ],
+    );
+
+    // Let ourselves run the method we want to test.
+    $ref_run_datastore_query = new \ReflectionMethod($controller, 'runDatastoreQuery');
+    /** @var \Symfony\Component\HttpFoundation\JsonResponse $result */
+    $result = $ref_run_datastore_query->invokeArgs(
+      $controller,
+      [$this->createMock(DatastoreQuery::class)]
+    );
+
+    // Did we get a 429 with the message we added?
+    $this->assertSame(429, $result->getStatusCode());
+    $this->assertStringContainsString($message, $result->getContent());
   }
 
 }


### PR DESCRIPTION
Fixes [issue#]

## Describe your changes

On a client project, we got some interesting watchdog logs, sorting them by frequency. The log represented a week of data.
The top entry is this one:
```
[HY000] [1203] User u0hFhL5uTb1qLmLI already has more than 'max_user_connections' active connections in Drupal\common\Storage\AbstractDatabaseConnectionFactory->getConnection() (line 81 of /var/www/html/docroot/modules/contrib/dkan/modules/common/src/Storage/AbstractDatabaseConnectionFactory.php).
```
This had 4,285 occurrences within a week, which is 612 a day.

This means we can handle this error better, and turn it into a useful 429 response.

This PR handles this within the `AbstractQueryController`, which is where it is most likely to occur (at least on our site).

We could place similar catch blocks on other controllers as well, or figure out a more centralized way to handle this.

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
