### PR TITLE
Degraded performance mode

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -36,7 +36,7 @@ threshold = 4
 threshold = 5
 
 [smells.duplication]
-threshold = 22
+nodes_threshold = 22
 
 [[source]]
 name = "default"
@@ -45,3 +45,6 @@ default = true
 [[plugin]]
 name = "php-codesniffer"
 package_file = ".qlty/configs/composer.json"
+
+[runtimes.enabled]
+php = "8.4"

--- a/docs/source/drush_commands.rst
+++ b/docs/source/drush_commands.rst
@@ -130,11 +130,11 @@ dkan:datastore:reimport
 dkan:datastore:degraded-mode
 ----------------------------
 
-    Toggle degraded service mode for the datastore. Blocks requests to the datastore API that contain conditions, joins, groupings, sorts, and offsets.
+    Turn degraded service mode on or off for the datastore. Blocks requests to the datastore API that contain conditions, joins, groupings, sorts, and offsets.
 
     **Arguments**
 
-    - **state** The state of the degraded mode (1 to turn on, 0 to turn off).
+    - **state** The state of the degraded mode (1 to turn on, 0 to turn off, leave blank to see current state).
 
 ~~~~~~
 

--- a/docs/source/drush_commands.rst
+++ b/docs/source/drush_commands.rst
@@ -127,6 +127,17 @@ dkan:datastore:reimport
 
 ~~~~~~
 
+dkan:datastore:degraded-mode
+----------------------------
+
+    Toggle degraded service mode for the datastore. Blocks requests to the datastore API that contain conditions, joins, groupings, sorts, and offsets.
+
+    **Arguments**
+
+    - **state** The state of the degraded mode (1 to turn on, 0 to turn off).
+
+~~~~~~
+
 dkan:harvest:archive
 ---------------------
 

--- a/docs/source/user-guide/guide_datastore_settings.rst
+++ b/docs/source/user-guide/guide_datastore_settings.rst
@@ -22,3 +22,18 @@ can select other "triggers" to ensure that the old datastore is dropped and a ne
 For example, if you select "Last Update (modified)", any change to this value will add
 jobs to the queue when the dataset is saved. These jobs will drop the existing datastore
 table and generate a new datastore when cron runs or when the queue is run directly.
+
+Degraded service mode
+----------------------
+Degraded service mode blocks requests to the datastore API that contain conditions,
+joins, groupings, sorts, and offsets. The datastore API allows people to make potentially
+very complex and expensive queries against the database. Partiularly when a DKAN
+site become the target of a large amount of bot traffic, even when not intentionally
+malicious, MySQL servers can become overwhelmed. Placing the site in degraded
+service mode can help the server to "cool down", and return to a state where
+the database can be responsive, without having to take the site offline entirely.
+
+Toggle degraded service mode on the datastore settings page, or use the Drush command
+``drush dkan:datastore:degraded-mode 1`` to turn on, and 
+``drush dkan:datastore:degraded-mode 0`` to turn off. Run 
+``drush dkan:datastore:degraded-mode`` with no arguments to check the current status.

--- a/modules/dkan_common/src/JsonResponseTrait.php
+++ b/modules/dkan_common/src/JsonResponseTrait.php
@@ -8,6 +8,7 @@ use OpisErrorPresenter\Implementation\PresentedValidationErrorFactory;
 use OpisErrorPresenter\Implementation\Strategies\BestMatchError;
 use OpisErrorPresenter\Implementation\ValidationErrorPresenter;
 use RootedData\Exception\ValidationException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
  * Json Response Trait.
@@ -18,8 +19,8 @@ trait JsonResponseTrait {
   /**
    * Private.
    */
-  protected function getResponse($message, int $code = 200): JsonResponse {
-    $response = new JsonResponse($message, $code, []);
+  protected function getResponse($message, int $code = 200, array $headers = []): JsonResponse {
+    $response = new JsonResponse($message, $code, $headers);
     return $this->addCacheHeaders($response);
   }
 
@@ -43,7 +44,8 @@ trait JsonResponseTrait {
     if ($data = $this->getExceptionData($e)) {
       $body['data'] = $data;
     }
-    return $this->getResponse((object) $body, $code);
+    $headers = ($e instanceof HttpException) ? $e->getHeaders() : [];
+    return $this->getResponse((object) $body, $code, $headers);
   }
 
   /**

--- a/modules/dkan_datastore/docs/openapi_spec.json
+++ b/modules/dkan_datastore/docs/openapi_spec.json
@@ -85,6 +85,33 @@
                         }
                     }
                 }
+            },
+            "503ServiceUnavailable": {
+                "description": "Service unavailable. Datastore queries are temporarily limited due to high server load.",
+                "headers": {
+                    "Retry-After": {
+                        "description": "Seconds to tell client to wait until retrying",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "example": 120
+                    }
+                },
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "required": ["message"],
+                            "properties": {
+                                "message": {
+                                    "type": "string",
+                                    "description": "Human-readable error message",
+                                    "example": "Datastore queries are temporarily limited due to high server load. Remove conditions, joins, groupings, sorts, and offsets to retry."
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     },
@@ -247,7 +274,8 @@
                 },
                 "responses": {
                     "200": { "$ref": "#/components/responses/200JsonOrCsvQueryOk" },
-                    "400": { "$ref": "#/components/responses/400BadJson" }
+                    "400": { "$ref": "#/components/responses/400BadJson" },
+                    "503": { "$ref": "#/components/responses/503ServiceUnavailable" }
                 }
             },
             "get": {
@@ -258,7 +286,8 @@
                 "parameters": [],
                 "responses": {
                     "200": { "$ref": "#/components/responses/200JsonOrCsvQueryOk"},
-                    "400": { "$ref": "#/components/responses/400BadJson" }
+                    "400": { "$ref": "#/components/responses/400BadJson" },
+                    "503": { "$ref": "#/components/responses/503ServiceUnavailable" }
                 }
             }
         },
@@ -278,7 +307,8 @@
                 "responses": {
                     "200": { "$ref": "#/components/responses/200DatastoreCsvOk" },
                     "400": { "$ref": "#/components/responses/400BadJson" },
-                    "404": { "$ref": "#/components/responses/404IdNotFound" }
+                    "404": { "$ref": "#/components/responses/404IdNotFound" },
+                    "503": { "$ref": "#/components/responses/503ServiceUnavailable" }
                 }
             },
             "get": {
@@ -290,7 +320,8 @@
                 "responses": {
                     "200": { "$ref": "#/components/responses/200DatastoreCsvOk" },
                     "400": { "$ref": "#/components/responses/400BadJson" },
-                    "404": { "$ref": "#/components/responses/404IdNotFound" }
+                    "404": { "$ref": "#/components/responses/404IdNotFound" },
+                    "503": { "$ref": "#/components/responses/503ServiceUnavailable" }
                 }
             }
         },
@@ -315,7 +346,8 @@
                 "responses": {
                     "200": { "$ref": "#/components/responses/200JsonOrCsvQueryOk"},
                     "400": { "$ref": "#/components/responses/400BadJson" },
-                    "404": { "$ref": "#/components/responses/404IdNotFound" }
+                    "404": { "$ref": "#/components/responses/404IdNotFound" },
+                    "503": { "$ref": "#/components/responses/503ServiceUnavailable" }
                 }
             },
             "get": {
@@ -331,7 +363,8 @@
                 "responses": {
                     "200": { "$ref": "#/components/responses/200JsonOrCsvQueryOk"},
                     "400": { "$ref": "#/components/responses/400BadJson" },
-                    "404": { "$ref": "#/components/responses/404IdNotFound" }
+                    "404": { "$ref": "#/components/responses/404IdNotFound" },
+                    "503": { "$ref": "#/components/responses/503ServiceUnavailable" }
                 }
             }
         },
@@ -359,7 +392,8 @@
                 "responses": {
                     "200": { "$ref": "#/components/responses/200JsonOrCsvQueryOk"},
                     "400": { "$ref": "#/components/responses/400BadJson" },
-                    "404": { "$ref": "#/components/responses/404IdNotFound" }
+                    "404": { "$ref": "#/components/responses/404IdNotFound" },
+                    "503": { "$ref": "#/components/responses/503ServiceUnavailable" }
                 }
             },
             "get": {
@@ -378,7 +412,8 @@
                 "responses": {
                     "200": { "$ref": "#/components/responses/200JsonOrCsvQueryOk"},
                     "400": { "$ref": "#/components/responses/400BadJson" },
-                    "404": { "$ref": "#/components/responses/404IdNotFound" }
+                    "404": { "$ref": "#/components/responses/404IdNotFound" },
+                    "503": { "$ref": "#/components/responses/503ServiceUnavailable" }
                 }
             }
         },
@@ -407,7 +442,8 @@
                 "responses": {
                     "200": { "$ref": "#/components/responses/200DatastoreCsvOk"},
                     "400": { "$ref": "#/components/responses/400BadJson" },
-                    "404": { "$ref": "#/components/responses/404IdNotFound" }
+                    "404": { "$ref": "#/components/responses/404IdNotFound" },
+                    "503": { "$ref": "#/components/responses/503ServiceUnavailable" }
                 }
             }
         },
@@ -439,7 +475,8 @@
                 "responses": {
                     "200": { "$ref": "#/components/responses/200DatastoreCsvOk"},
                     "400": { "$ref": "#/components/responses/400BadJson" },
-                    "404": { "$ref": "#/components/responses/404IdNotFound" }
+                    "404": { "$ref": "#/components/responses/404IdNotFound" },
+                    "503": { "$ref": "#/components/responses/503ServiceUnavailable" }
                 }
             }
         },

--- a/modules/dkan_datastore/drush.services.yml
+++ b/modules/dkan_datastore/drush.services.yml
@@ -26,3 +26,9 @@ services:
       - '@dkan.datastore.logger_channel'
     tags:
       - { name: drush.command }
+  dkan_datastore.degraded_mode.commands:
+    class: \Drupal\dkan_datastore\Commands\DegradedModeCommands
+    arguments:
+      - '@state'
+    tags:
+      - { name: drush.command }

--- a/modules/dkan_datastore/drush.services.yml
+++ b/modules/dkan_datastore/drush.services.yml
@@ -9,6 +9,7 @@ services:
       - '@dkan.datastore.import_info_list'
       - '@dkan.datastore.post_import_result_factory'
       - '@dkan.datastore.lookup'
+      - '@state'
     tags:
       - { name: drush.command }
   dkan_datastore.purger.commands:

--- a/modules/dkan_datastore/src/Commands/DegradedModeCommands.php
+++ b/modules/dkan_datastore/src/Commands/DegradedModeCommands.php
@@ -7,6 +7,8 @@ use Drush\Commands\DrushCommands;
 
 /**
  * Datastore-related Drush commands.
+ *
+ * @codeCoverageIgnore
  */
 class DegradedModeCommands extends DrushCommands {
 

--- a/modules/dkan_datastore/src/Commands/DegradedModeCommands.php
+++ b/modules/dkan_datastore/src/Commands/DegradedModeCommands.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\dkan_datastore\Commands;
+
+use Drupal\Core\State\StateInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Datastore-related Drush commands.
+ *
+ * @codeCoverageIgnore
+ */
+class DegradedModeCommands extends DrushCommands {
+
+  /**
+   * State service.
+   */
+  protected StateInterface $state;
+
+  /**
+   * DegradedModeCommands constructor.
+   *
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state service.
+   */
+  public function __construct(StateInterface $state) {
+    parent::__construct();
+    $this->state = $state;
+  }
+
+  /**
+   * Enable or disable degraded datastore query mode.
+   *
+   * @param string|null $state
+   *   Optional state: 1 or 0. If omitted, current status shown.
+   *
+   * @command dkan:datastore:degraded-mode
+   */
+  public function degradedMode(?string $state = NULL) {
+    $current = (bool) $this->state->get('dkan_datastore.degraded_performance', FALSE);
+
+    if ($state === NULL) {
+      $this->output()->writeln('Datastore degraded performance mode: ' . ($current ? 'enabled' : 'disabled'));
+      return DrushCommands::EXIT_SUCCESS;
+    }
+
+    if ($state !== '1' && $state !== '0') {
+      $this->output()->writeln('Invalid value. Use 1 or 0.');
+      return DrushCommands::EXIT_FAILURE;
+    }
+
+    $value = $state === '1';
+    $this->state->set('dkan_datastore.degraded_performance', $value);
+    $this->output()->writeln('Datastore degraded performance mode ' . ($value ? 'enabled' : 'disabled') . '.');
+    return DrushCommands::EXIT_SUCCESS;
+  }
+
+}

--- a/modules/dkan_datastore/src/Commands/DegradedModeCommands.php
+++ b/modules/dkan_datastore/src/Commands/DegradedModeCommands.php
@@ -7,8 +7,6 @@ use Drush\Commands\DrushCommands;
 
 /**
  * Datastore-related Drush commands.
- *
- * @codeCoverageIgnore
  */
 class DegradedModeCommands extends DrushCommands {
 

--- a/modules/dkan_datastore/src/Controller/AbstractQueryController.php
+++ b/modules/dkan_datastore/src/Controller/AbstractQueryController.php
@@ -305,16 +305,16 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     if (!empty($data->conditions)) {
       $blocked = TRUE;
     }
-    elseif (!empty($data->joins)) {
+    if (!empty($data->joins)) {
       $blocked = TRUE;
     }
-    elseif (!empty($data->groupings)) {
+    if (!empty($data->groupings)) {
       $blocked = TRUE;
     }
-    elseif (!empty($data->sorts)) {
+    if (!empty($data->sorts)) {
       $blocked = TRUE;
     }
-    elseif ((int) ($data->offset ?? 0) !== 0) {
+    if ((int) ($data->offset ?? 0) !== 0) {
       $blocked = TRUE;
     }
 

--- a/modules/dkan_datastore/src/Controller/AbstractQueryController.php
+++ b/modules/dkan_datastore/src/Controller/AbstractQueryController.php
@@ -6,6 +6,7 @@ use Drupal\dkan_common\DatasetInfo;
 use Drupal\dkan_common\JsonResponseTrait;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\State\StateInterface;
 use Drupal\dkan_datastore\Service\DatastoreQuery;
 use Drupal\dkan_datastore\Service\Query as QueryService;
 use Drupal\dkan_metastore\MetastoreApiResponse;
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 /**
  * Abstract Controller providing base functionality used to query datastores.
@@ -45,6 +48,11 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
   protected MetastoreApiResponse $metastoreApiResponse;
 
   /**
+   * State service.
+   */
+  protected StateInterface $state;
+
+  /**
    * Default API rows limit.
    *
    * @var int
@@ -59,11 +67,13 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     DatasetInfo $datasetInfo,
     MetastoreApiResponse $metastoreApiResponse,
     ConfigFactoryInterface $configFactory,
+    StateInterface $state,
   ) {
     $this->queryService = $queryService;
     $this->datasetInfo = $datasetInfo;
     $this->metastoreApiResponse = $metastoreApiResponse;
     $this->configFactory = $configFactory;
+    $this->state = $state;
   }
 
   /**
@@ -74,7 +84,8 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
       $container->get('dkan.datastore.query'),
       $container->get('dkan.common.dataset_info'),
       $container->get('dkan.metastore.api_response'),
-      $container->get('config.factory')
+      $container->get('config.factory'),
+      $container->get('state'),
     );
   }
 
@@ -231,6 +242,7 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
   protected function buildDatastoreQuery(Request $request, mixed $identifier = NULL) {
     $json = static::getPayloadJson($request);
     $data = json_decode($json);
+    $this->assertDegradedModeAllowed($data);
     $this->additionalPayloadValidation($data, $identifier);
     if ($identifier) {
       $resource = (object) ["id" => $identifier, "alias" => "t"];
@@ -256,9 +268,51 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     try {
       return $this->queryService->runQuery($datastoreQuery);
     }
+    catch (HttpExceptionInterface $e) {
+      return $this->getResponseFromException($e, $e->getStatusCode());
+    }
     catch (\Exception $e) {
       $code = (str_contains($e->getMessage(), "Error retrieving")) ? 404 : 400;
       return $this->getResponseFromException($e, $code);
+    }
+  }
+
+  /**
+   * Block expensive queries when degraded performance mode is enabled.
+   *
+   * @param object $data
+   *   The decoded request data.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+   *   When a blocked query is detected.
+   */
+  protected function assertDegradedModeAllowed(object $data): void {
+    if (!$this->state->get('dkan_datastore.degraded_performance', FALSE)) {
+      return;
+    }
+
+    $blocked = FALSE;
+    if (!empty($data->conditions)) {
+      $blocked = TRUE;
+    }
+    elseif (!empty($data->joins)) {
+      $blocked = TRUE;
+    }
+    elseif (!empty($data->groupings)) {
+      $blocked = TRUE;
+    }
+    elseif (!empty($data->sorts)) {
+      $blocked = TRUE;
+    }
+    elseif ((int) ($data->offset ?? 0) !== 0) {
+      $blocked = TRUE;
+    }
+
+    if ($blocked) {
+      throw new HttpException(
+        503,
+        'Datastore queries are temporarily limited due to high server load. Remove conditions, joins, groupings, sorts, and offsets to retry.'
+      );
     }
   }
 

--- a/modules/dkan_datastore/src/Controller/AbstractQueryController.php
+++ b/modules/dkan_datastore/src/Controller/AbstractQueryController.php
@@ -27,6 +27,8 @@ use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 abstract class AbstractQueryController implements ContainerInjectionInterface {
   use JsonResponseTrait;
 
+  const DEGRADE_MODE_RETRY_AFTER = 120;
+
   /**
    * Datastore query service.
    */
@@ -318,7 +320,7 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
 
     if ($blocked) {
       throw new ServiceUnavailableHttpException(
-        60,
+        static::DEGRADE_MODE_RETRY_AFTER,
         'Datastore queries are temporarily limited due to high server load. Remove conditions, joins, groupings, sorts, and offsets to retry.'
       );
     }

--- a/modules/dkan_datastore/src/Controller/AbstractQueryController.php
+++ b/modules/dkan_datastore/src/Controller/AbstractQueryController.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 /**
  * Abstract Controller providing base functionality used to query datastores.
@@ -102,6 +102,9 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     try {
       $datastoreQuery = $this->buildDatastoreQuery($request);
     }
+    catch (HttpException $e) {
+      return $this->getResponseFromException($e, $e->getStatusCode());
+    }
     catch (\Exception $e) {
       return $this->getResponseFromException($e, 400);
     }
@@ -131,6 +134,9 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
   public function queryResource(string $identifier, Request $request) {
     try {
       $datastoreQuery = $this->buildDatastoreQuery($request, $identifier);
+    }
+    catch (HttpException $e) {
+      return $this->getResponseFromException($e, $e->getStatusCode());
     }
     catch (\Exception $e) {
       return $this->getResponseFromException($e, 400);
@@ -165,11 +171,13 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     if (empty($distribution_uuid)) {
       return $this->getResponse((object) ['message' => "No resource found for dataset $dataset at index $index"], 404);
     }
-
     $dependencies = ['distribution' => [$distribution_uuid], 'dataset' => [$dataset]];
 
     try {
       $datastoreQuery = $this->buildDatastoreQuery($request, $distribution_uuid);
+    }
+    catch (HttpException $e) {
+      return $this->getResponseFromException($e, $e->getStatusCode());
     }
     catch (\Exception $e) {
       return $this->getResponseFromException($e, 400);
@@ -268,7 +276,7 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     try {
       return $this->queryService->runQuery($datastoreQuery);
     }
-    catch (HttpExceptionInterface $e) {
+    catch (HttpException $e) {
       return $this->getResponseFromException($e, $e->getStatusCode());
     }
     catch (\Exception $e) {
@@ -309,8 +317,8 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     }
 
     if ($blocked) {
-      throw new HttpException(
-        503,
+      throw new ServiceUnavailableHttpException(
+        60,
         'Datastore queries are temporarily limited due to high server load. Remove conditions, joins, groupings, sorts, and offsets to retry.'
       );
     }

--- a/modules/dkan_datastore/src/Controller/QueryDownloadController.php
+++ b/modules/dkan_datastore/src/Controller/QueryDownloadController.php
@@ -3,6 +3,7 @@
 namespace Drupal\dkan_datastore\Controller;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\State\StateInterface;
 use Drupal\dkan_common\DatasetInfo;
 use Drupal\dkan_datastore\Service\DatastoreQuery;
 use Drupal\dkan_datastore\Service\Query as QueryService;
@@ -11,6 +12,7 @@ use RootedData\RootedJsonData;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
  * Controller providing functionality used to stream datastore queries.
@@ -22,8 +24,24 @@ class QueryDownloadController extends AbstractQueryController {
   /**
    * {@inheritDoc}
    */
-  public function __construct(QueryService $queryService, DatasetInfo $datasetInfo, MetastoreApiResponse $metastoreApiResponse, ConfigFactoryInterface $configFactory) {
-    parent::__construct($queryService, $datasetInfo, $metastoreApiResponse, $configFactory);
+  public function __construct(
+    QueryService $queryService,
+    DatasetInfo $datasetInfo,
+    MetastoreApiResponse $metastoreApiResponse,
+    ConfigFactoryInterface $configFactory,
+    StateInterface $state,
+  ) {
+    parent::__construct($queryService, $datasetInfo, $metastoreApiResponse, $configFactory, $state);
+    // Throw 503 error immediately if in degraded service mode, as all streaming
+    // responses are blocked.
+    $blocked = $state->get('dkan_datastore.degraded_service_mode', FALSE);
+    if ($blocked) {
+      throw new HttpException(
+        503,
+        'Datastore downloads are temporarily limited due to high server load. All streaming responses are currently unavailable.'
+      );
+    }
+
     // We do not want to cache streaming CSV content internally in Drupal,
     // because datasets can be very large. However, we do want CDNs to be able
     // to cache the CSV stream for a reasonable amount of time.

--- a/modules/dkan_datastore/src/Controller/QueryDownloadController.php
+++ b/modules/dkan_datastore/src/Controller/QueryDownloadController.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 /**
  * Controller providing functionality used to stream datastore queries.
@@ -32,16 +33,6 @@ class QueryDownloadController extends AbstractQueryController {
     StateInterface $state,
   ) {
     parent::__construct($queryService, $datasetInfo, $metastoreApiResponse, $configFactory, $state);
-    // Throw 503 error immediately if in degraded service mode, as all streaming
-    // responses are blocked.
-    $blocked = $state->get('dkan_datastore.degraded_service_mode', FALSE);
-    if ($blocked) {
-      throw new HttpException(
-        503,
-        'Datastore downloads are temporarily limited due to high server load. All streaming responses are currently unavailable.'
-      );
-    }
-
     // We do not want to cache streaming CSV content internally in Drupal,
     // because datasets can be very large. However, we do want CDNs to be able
     // to cache the CSV stream for a reasonable amount of time.
@@ -74,6 +65,7 @@ class QueryDownloadController extends AbstractQueryController {
   protected function buildDatastoreQuery($request, $identifier = NULL) {
     $json = static::getPayloadJson($request);
     $data = json_decode($json);
+    $this->assertDegradedModeAllowed($data);
     $this->additionalPayloadValidation($data);
     if ($identifier) {
       $resource = (object) ["id" => $identifier, "alias" => "t"];
@@ -81,6 +73,18 @@ class QueryDownloadController extends AbstractQueryController {
     }
     $data->results = FALSE;
     return new DatastoreQuery(json_encode($data));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertDegradedModeAllowed(object $data): void {
+    if ($this->state->get('dkan_datastore.degraded_performance', FALSE)) {
+      throw new ServiceUnavailableHttpException(
+        static::DEGRADE_MODE_RETRY_AFTER,
+        'Datastore downloads are temporarily limited due to high server load. All streaming responses are currently unavailable.'
+      );
+    }
   }
 
   /**

--- a/modules/dkan_datastore/src/Controller/QueryDownloadController.php
+++ b/modules/dkan_datastore/src/Controller/QueryDownloadController.php
@@ -12,7 +12,6 @@ use RootedData\RootedJsonData;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\StreamedJsonResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 /**

--- a/modules/dkan_datastore/src/Drush.php
+++ b/modules/dkan_datastore/src/Drush.php
@@ -7,7 +7,6 @@ use Consolidation\OutputFormatters\StructuredData\UnstructuredListData;
 use Drupal\dkan_common\DataResource;
 use Drupal\Component\Utility\DeprecationHelper;
 use Drupal\Core\StringTranslation\ByteSizeMarkup;
-use Drupal\Core\State\StateInterface;
 use Drupal\dkan_datastore\Service\Info\ImportInfoList;
 use Drupal\dkan_datastore\Service\ResourceLocalizer;
 use Drupal\dkan_metastore\MetastoreService;
@@ -64,13 +63,6 @@ class Drush extends DrushCommands {
   protected DatastoreLookupInterface $datastoreLookup;
 
   /**
-   * State service.
-   *
-   * @var \Drupal\Core\State\StateInterface
-   */
-  protected StateInterface $state;
-
-  /**
    * Database connection service.
    *
    * @var \Drupal\Core\Database\Connection
@@ -88,7 +80,6 @@ class Drush extends DrushCommands {
     ImportInfoList $importInfoList,
     PostImportResultFactory $postImportResultFactory,
     DatastoreLookupInterface $datastoreLookup,
-    StateInterface $state,
   ) {
     parent::__construct();
     $this->metastoreService = $metastoreService;
@@ -98,7 +89,6 @@ class Drush extends DrushCommands {
     $this->importInfoList = $importInfoList;
     $this->postImportResultFactory = $postImportResultFactory;
     $this->datastoreLookup = $datastoreLookup;
-    $this->state = $state;
   }
 
   /**

--- a/modules/dkan_datastore/src/Drush.php
+++ b/modules/dkan_datastore/src/Drush.php
@@ -7,6 +7,7 @@ use Consolidation\OutputFormatters\StructuredData\UnstructuredListData;
 use Drupal\dkan_common\DataResource;
 use Drupal\Component\Utility\DeprecationHelper;
 use Drupal\Core\StringTranslation\ByteSizeMarkup;
+use Drupal\Core\State\StateInterface;
 use Drupal\dkan_datastore\Service\Info\ImportInfoList;
 use Drupal\dkan_datastore\Service\ResourceLocalizer;
 use Drupal\dkan_metastore\MetastoreService;
@@ -63,6 +64,13 @@ class Drush extends DrushCommands {
   protected DatastoreLookupInterface $datastoreLookup;
 
   /**
+   * State service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected StateInterface $state;
+
+  /**
    * Database connection service.
    *
    * @var \Drupal\Core\Database\Connection
@@ -80,6 +88,7 @@ class Drush extends DrushCommands {
     ImportInfoList $importInfoList,
     PostImportResultFactory $postImportResultFactory,
     DatastoreLookupInterface $datastoreLookup,
+    StateInterface $state,
   ) {
     parent::__construct();
     $this->metastoreService = $metastoreService;
@@ -89,6 +98,7 @@ class Drush extends DrushCommands {
     $this->importInfoList = $importInfoList;
     $this->postImportResultFactory = $postImportResultFactory;
     $this->datastoreLookup = $datastoreLookup;
+    $this->state = $state;
   }
 
   /**
@@ -358,6 +368,33 @@ class Drush extends DrushCommands {
     }
     $this->output()->writeln('Can not map datastore table to dataset: ' . $table_name);
     return DrushCommands::EXIT_FAILURE;
+  }
+
+  /**
+   * Enable or disable degraded datastore query mode.
+   *
+   * @param string|null $state
+   *   Optional state: 1 or 0. If omitted, current status shown.
+   *
+   * @command dkan:datastore:degraded-mode
+   */
+  public function degradedMode(?string $state = NULL) {
+    $current = (bool) $this->state->get('dkan_datastore.degraded_performance', FALSE);
+
+    if ($state === NULL) {
+      $this->output()->writeln('Datastore degraded performance mode: ' . ($current ? 'enabled' : 'disabled'));
+      return DrushCommands::EXIT_SUCCESS;
+    }
+
+    if ($state !== '1' && $state !== '0') {
+      $this->output()->writeln('Invalid value. Use 1 or 0.');
+      return DrushCommands::EXIT_FAILURE;
+    }
+
+    $value = $state === '1';
+    $this->state->set('dkan_datastore.degraded_performance', $value);
+    $this->output()->writeln('Datastore degraded performance mode ' . ($value ? 'enabled' : 'disabled') . '.');
+    return DrushCommands::EXIT_SUCCESS;
   }
 
 }

--- a/modules/dkan_datastore/src/Drush.php
+++ b/modules/dkan_datastore/src/Drush.php
@@ -370,31 +370,4 @@ class Drush extends DrushCommands {
     return DrushCommands::EXIT_FAILURE;
   }
 
-  /**
-   * Enable or disable degraded datastore query mode.
-   *
-   * @param string|null $state
-   *   Optional state: 1 or 0. If omitted, current status shown.
-   *
-   * @command dkan:datastore:degraded-mode
-   */
-  public function degradedMode(?string $state = NULL) {
-    $current = (bool) $this->state->get('dkan_datastore.degraded_performance', FALSE);
-
-    if ($state === NULL) {
-      $this->output()->writeln('Datastore degraded performance mode: ' . ($current ? 'enabled' : 'disabled'));
-      return DrushCommands::EXIT_SUCCESS;
-    }
-
-    if ($state !== '1' && $state !== '0') {
-      $this->output()->writeln('Invalid value. Use 1 or 0.');
-      return DrushCommands::EXIT_FAILURE;
-    }
-
-    $value = $state === '1';
-    $this->state->set('dkan_datastore.degraded_performance', $value);
-    $this->output()->writeln('Datastore degraded performance mode ' . ($value ? 'enabled' : 'disabled') . '.');
-    return DrushCommands::EXIT_SUCCESS;
-  }
-
 }

--- a/modules/dkan_datastore/src/Form/DatastoreSettingsForm.php
+++ b/modules/dkan_datastore/src/Form/DatastoreSettingsForm.php
@@ -36,6 +36,8 @@ class DatastoreSettingsForm extends ConfigFormBase {
    *
    * @param \Drupal\dkan_metastore\SchemaPropertiesHelper $schemaHelper
    *   The schema properties helper service.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state service.
    */
   public function __construct(SchemaPropertiesHelper $schemaHelper, StateInterface $state) {
     $this->schemaHelper = $schemaHelper;

--- a/modules/dkan_datastore/src/Form/DatastoreSettingsForm.php
+++ b/modules/dkan_datastore/src/Form/DatastoreSettingsForm.php
@@ -4,6 +4,7 @@ namespace Drupal\dkan_datastore\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\State\StateInterface;
 use Drupal\dkan_datastore\Controller\QueryController;
 use Drupal\dkan_metastore\SchemaPropertiesHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -24,13 +25,21 @@ class DatastoreSettingsForm extends ConfigFormBase {
   private $schemaHelper;
 
   /**
+   * State service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  private StateInterface $state;
+
+  /**
    * Constructs form.
    *
    * @param \Drupal\dkan_metastore\SchemaPropertiesHelper $schemaHelper
    *   The schema properties helper service.
    */
-  public function __construct(SchemaPropertiesHelper $schemaHelper) {
+  public function __construct(SchemaPropertiesHelper $schemaHelper, StateInterface $state) {
     $this->schemaHelper = $schemaHelper;
+    $this->state = $state;
   }
 
   /**
@@ -39,6 +48,7 @@ class DatastoreSettingsForm extends ConfigFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('dkan.metastore.schema_properties_helper'),
+      $container->get('state'),
     );
   }
 
@@ -78,6 +88,13 @@ class DatastoreSettingsForm extends ConfigFormBase {
       '#description' => $this->t('Set the cache max-age for streaming CSV responses, in seconds. Default: 3600 (1 hour).'),
     ];
 
+    $form['datastore_degraded_performance'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable degraded datastore query mode'),
+      '#default_value' => $this->state->get('dkan_datastore.degraded_performance', FALSE),
+      '#description' => $this->t('When enabled, datastore query endpoints reject requests with conditions, joins, groupings, sorts, offsets, or limits above the configured rows limit.'),
+    ];
+
     $form['triggering_properties'] = [
       '#type' => 'checkboxes',
       '#title' => $this->t('Datastore triggering properties'),
@@ -98,6 +115,10 @@ class DatastoreSettingsForm extends ConfigFormBase {
       ->set('response_stream_max_age', $form_state->getValue('response_stream_max_age'))
       ->set('triggering_properties', $form_state->getValue('triggering_properties'))
       ->save();
+    $this->state->set(
+      'dkan_datastore.degraded_performance',
+      (bool) $form_state->getValue('datastore_degraded_performance')
+    );
     parent::submitForm($form, $form_state);
   }
 

--- a/modules/dkan_datastore/tests/src/Functional/Api1/DatastoreQueryApiTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/Api1/DatastoreQueryApiTest.php
@@ -71,4 +71,48 @@ use GuzzleHttp\RequestOptions;
     $this->validator->validate($response, "/api/1/datastore/query/{datasetId}/{index}", 'get');
   }
 
-}
+  /**
+   * Test that we get a 503 and retry-after header when in degraded mode.
+   */
+  public function testDegradedMode() {
+    \Drupal::state()->set('dkan_datastore.degraded_performance', TRUE);
+
+    $dataset = $this->getSampleDataset();
+    $this->post($dataset, FALSE);
+    $dataset_id = $dataset->identifier;
+
+    $dataset_info = \Drupal::service('dkan.common.dataset_info')->gather($dataset_id);
+    $resource_id = $dataset_info['latest_revision']['distributions'][0]['resource_id'];
+    \Drupal::service('dkan.datastore.service')->import($resource_id, FALSE);
+
+    $query = [
+      'format' => 'json',
+      'conditions' => [
+        [
+          'property' => 'id',
+          'operator' => '=',
+          'value' => 1,
+        ],
+      ],
+    ];
+
+    $response = $this->httpClient->get("api/1/datastore/query/$dataset_id/0", [
+      RequestOptions::QUERY => $query,
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(503, $response->getStatusCode());
+    $this->assertEquals(120, $response->getHeaderLine('Retry-After'));
+    $this->assertStringContainsString('Datastore queries are temporarily limited due to high server load', (string) $response->getBody());
+    $this->validator->validate($response, "/api/1/datastore/query/{datasetId}/{index}", 'get');
+
+    $response = $this->httpClient->get("api/1/datastore/query/$dataset_id/0/download", [
+      RequestOptions::QUERY => $query,
+      RequestOptions::HTTP_ERRORS => FALSE,
+    ]);
+    $this->assertEquals(503, $response->getStatusCode());
+    $this->assertEquals(120, $response->getHeaderLine('Retry-After'));
+    $this->assertStringContainsString('Datastore downloads are temporarily limited due to high server load', (string) $response->getBody());
+    $this->validator->validate($response, "/api/1/datastore/query/{datasetId}/{index}", 'get');
+  }
+
+  }

--- a/modules/dkan_datastore/tests/src/Functional/Api1/DatastoreQueryApiTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/Api1/DatastoreQueryApiTest.php
@@ -8,6 +8,8 @@ use GuzzleHttp\RequestOptions;
 /**
  * Tests the Datastore Query API.
  *
+ * @covers \Drupal\dkan_datastore\Controller\QueryController
+ * @coversDefaultClass \Drupal\dkan_datastore\Controller\QueryController
  * @group dkan
  * @group datastore
  * @group api1

--- a/modules/dkan_datastore/tests/src/Functional/Commands/DegradedModeCommandsTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/Commands/DegradedModeCommandsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\Tests\dkan_datastore\Functional\Commands;
+
+use Drupal\Tests\BrowserTestBase;
+use Drush\TestTraits\DrushTestTrait;
+
+/**
+ * Tests for degraded mode Drush commands.
+ *
+ * @covers \Drupal\dkan_datastore\Commands\DegradedModeCommands
+ * @coversDefaultClass \Drupal\dkan_datastore\Commands\DegradedModeCommands
+ * @group dkan_datastore
+ * @group functional
+ * @group btb
+ * @group functional2
+ */
+class DegradedModeCommandsTest extends BrowserTestBase {
+  use DrushTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['dkan_datastore'];
+
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Tests the dkan:datastore:degraded-mode command.
+   */
+  public function testDegradedModeCommand() {
+    // Check initial state is disabled.
+    $this->drush('dkan:datastore:degraded-mode');
+    $this->assertStringContainsString('Datastore degraded performance mode: disabled', $this->getSimplifiedOutput());
+
+    // Enable degraded mode.
+    $this->drush('dkan:datastore:degraded-mode', ['1']);
+    $this->assertStringContainsString('Datastore degraded performance mode enabled.', $this->getSimplifiedOutput());
+
+    // Check state is enabled.
+    $this->drush('dkan:datastore:degraded-mode');
+    $this->assertStringContainsString('Datastore degraded performance mode: enabled', $this->getSimplifiedOutput());
+
+    // Disable degraded mode.
+    $this->drush('dkan:datastore:degraded-mode', ['0']);
+    $this->assertStringContainsString('Datastore degraded performance mode disabled.', $this->getSimplifiedOutput());
+  }
+}

--- a/modules/dkan_datastore/tests/src/Unit/Controller/AbstractQueryControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/AbstractQueryControllerTest.php
@@ -25,7 +25,7 @@ class AbstractQueryControllerTest extends TestCase {
   }
 
   /**
-   * Make sure we get what we expect with a POST
+   * Make sure we get what we expect with a POST.
    */
   public function testPostNormalizer() {
     $sampleJson = $this->getSampleJson();
@@ -36,7 +36,7 @@ class AbstractQueryControllerTest extends TestCase {
   }
 
   /**
-   * Make sure we get what we expect with a PATCH
+   * Make sure we get what we expect with a PATCH.
    */
   public function testPatchNormalizer() {
     $sampleJson = $this->getSampleJson();
@@ -48,7 +48,7 @@ class AbstractQueryControllerTest extends TestCase {
   }
 
   /**
-   * Make sure we get what we expect with a DELETE
+   * Make sure we get what we expect with a DELETE.
    */
   public function testDeleteNormalizer() {
     $this->expectExceptionMessage("Only POST, PUT, PATCH and GET requests can be normalized");
@@ -59,7 +59,7 @@ class AbstractQueryControllerTest extends TestCase {
   }
 
   /**
-   * Make sure we get what we expect with a PUT
+   * Make sure we get what we expect with a PUT.
    */
   public function testPutNormalizer() {
     $sampleJson = $this->getSampleJson();

--- a/modules/dkan_datastore/tests/src/Unit/Controller/AbstractQueryControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/AbstractQueryControllerTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
+ * @covers \Drupal\dkan_datastore\Controller\AbstractQueryController
+ * @coversDefaultClass \Drupal\dkan_datastore\Controller\AbstractQueryController
  * @group dkan
  * @group datastore
  * @group unit

--- a/modules/dkan_datastore/tests/src/Unit/Controller/AbstractQueryControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/AbstractQueryControllerTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 class AbstractQueryControllerTest extends TestCase {
 
   /**
-   * Make sure we get what we expect with a GET
+   * Make sure we get what we expect with a GET.
    */
   public function testGetNormalizer() {
     $queryString = "conditions[0][property]=state&conditions[0][value]=AL&conditions[0][operator]==&conditions[1][property]=record_number&conditions[1][value]=%1%&conditions[1][operator]=LIKE&sort[0][property]=record_number&sort[0][order]=asc&sort[1][property]=state&sort[1][order]=desc&limit=50&offset=25&results=true";

--- a/modules/dkan_datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -5,9 +5,11 @@ namespace Drupal\Tests\dkan_datastore\Unit\Controller;
 use Drupal\Core\Cache\Context\CacheContextsManager;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\State\State;
 use Drupal\dkan_common\DataResource;
 use Drupal\dkan_common\DatasetInfo;
 use Drupal\dkan_datastore\Controller\QueryController;
+use Drupal\dkan_datastore\Controller\QueryDownloadController;
 use Drupal\dkan_datastore\DatastoreService;
 use Drupal\dkan_datastore\Service\Query;
 use Drupal\dkan_datastore\Storage\SqliteDatabaseTable;
@@ -90,10 +92,12 @@ class QueryControllerTest extends TestCase {
 
     $options = (new Options())
       ->add("dkan.metastore.storage", DataFactory::class)
+      ->add("state", State::class)
       ->index(0);
     $container = (new Chain($this))
       ->add(Container::class, "get", $options)
       ->add(DataFactory::class, 'getInstance', MockStorage::class)
+      ->add(State::class, 'get', FALSE)
       ->getMock();
     \Drupal::setContainer($container);
 
@@ -493,6 +497,7 @@ class QueryControllerTest extends TestCase {
       ->add('config.factory', ConfigFactoryInterface::class)
       ->add('dkan.metastore.metastore_item_factory', NodeDataFactory::class)
       ->add('dkan.metastore.api_response', MetastoreApiResponse::class)
+      ->add("state", State::class)
       ->index(0);
 
     $chain = (new Chain($this))
@@ -505,13 +510,75 @@ class QueryControllerTest extends TestCase {
       ->add(Data::class, 'getCacheTags', ['node:1'])
       ->add(Data::class, 'getCacheMaxAge', 0)
       ->add(ConfigFactoryInterface::class, 'get', ImmutableConfig::class)
-      ->add(ImmutableConfig::class, 'get', 500);
+      ->add(ImmutableConfig::class, 'get', 500)
+      ->add(State::class, 'get', FALSE);
 
     if ($mockMap) {
       $chain->add(Query::class, "getQueryStorageMap", ['t' => $this->mockDatastoreTable()]);
     }
 
     return $chain;
+  }
+
+  /**
+   * Make sure degraded service mode causes resource query to fail.
+   *
+   * 503 error if there are conditions.
+   */
+  public function testDegradedServiceModeQuery() {
+    $container = $this->getQueryContainer()
+      ->add(State::class, 'get', TRUE)
+      ->add(DatasetInfo::class, "getDistributionUuid", "456")
+      ->getMock();
+
+    \Drupal::setContainer($container);
+    $webServiceApi = QueryController::create($container);
+
+    $data = json_encode([
+      "results" => TRUE,
+      "conditions" => [
+        [
+          "resource" => "t",
+          "property" => "state",
+          "operator" => "=",
+          "value" => "Alabama",
+        ],
+      ],
+    ]);
+
+    // Test resource query.
+    $request = $this->mockRequest($data);
+    $result = $webServiceApi->query($request);
+    $this->assertTrue($result instanceof JsonResponse);
+    $this->assertEquals(503, $result->getStatusCode());
+    $this->assertStringContainsString('Datastore queries are temporarily limited due to high server load', $result->getContent());
+
+    // Test resource query.
+    $request = $this->mockRequest($data);
+    $result = $webServiceApi->queryResource($this->resource->getIdentifier(), $request);
+    $this->assertTrue($result instanceof JsonResponse);
+    $this->assertEquals(503, $result->getStatusCode());
+    $this->assertStringContainsString('Datastore queries are temporarily limited due to high server load', $result->getContent());
+
+    // Test dataset query.
+    $result = $webServiceApi->queryDatasetResource("abc", 0, $request);
+    $this->assertTrue($result instanceof JsonResponse);
+    $this->assertEquals(503, $result->getStatusCode());
+    $this->assertStringContainsString('Datastore queries are temporarily limited due to high server load', $result->getContent());
+
+  }
+
+  /**
+   * Make sure degraded service mode causes downloads to fail with 503.
+   */
+  public function testDegradedServiceModeDownloads() {
+    $container = $this->getQueryContainer()
+      ->add(State::class, 'get', TRUE)
+      ->getMock();
+    \Drupal::setContainer($container);
+
+    $this->expectExceptionMessage("Datastore downloads are temporarily limited due to high server load. All streaming responses are currently unavailable.");
+    QueryDownloadController::create($container);
   }
 
   /**

--- a/modules/dkan_datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -9,7 +9,6 @@ use Drupal\Core\State\State;
 use Drupal\dkan_common\DataResource;
 use Drupal\dkan_common\DatasetInfo;
 use Drupal\dkan_datastore\Controller\QueryController;
-use Drupal\dkan_datastore\Controller\QueryDownloadController;
 use Drupal\dkan_datastore\DatastoreService;
 use Drupal\dkan_datastore\Service\Query;
 use Drupal\dkan_datastore\Storage\SqliteDatabaseTable;

--- a/modules/dkan_datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -48,7 +48,7 @@ class QueryControllerTest extends TestCase {
   protected function setUp(): void {
     parent::setUp();
     // Set cache services.
-    $options = (new Options)
+    $options = (new Options())
       ->add('cache_contexts_manager', CacheContextsManager::class)
       ->add('event_dispatcher', EventDispatcher::class)
       ->index(0);
@@ -198,7 +198,6 @@ class QueryControllerTest extends TestCase {
     $this->assertEquals(400, $result->getStatusCode());
   }
 
-
   public function testResourceQueryInvalidJson() {
     $data = "{[";
 
@@ -324,7 +323,7 @@ class QueryControllerTest extends TestCase {
   }
 
   private function getQueryResult($data, $id = NULL, $index = NULL, $info = []) {
-    $container = $this->getQueryContainer($info, true)->getMock();
+    $container = $this->getQueryContainer($info, TRUE)->getMock();
     $webServiceApi = QueryController::create($container);
     $request = $this->mockRequest($data);
     if ($id === NULL && $index === NULL) {

--- a/modules/dkan_datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -545,6 +545,33 @@ class QueryControllerTest extends TestCase {
           "value" => "Alabama",
         ],
       ],
+      "joins" => [
+        [
+          "resource" => "r",
+          "condition" => [
+            "resource" => "t",
+            "property" => "record_number",
+            "value" => [
+              "resource" => "t",
+              "property" => "record_number",
+            ],
+          ],
+        ],
+      ],
+      "groupings" => [
+        [
+          "resource" => "t",
+          "property" => "state",
+        ],
+      ],
+      "sorts" => [
+        [
+          "resource" => "t",
+          "property" => "state",
+          "order" => "desc",
+        ],
+      ],
+      "offset" => 1,
     ]);
 
     // Test resource query.

--- a/modules/dkan_datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -32,6 +32,8 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
+ * @covers \Drupal\dkan_datastore\Controller\QueryController
+ * @coversDefaultClass \Drupal\dkan_datastore\Controller\QueryController
  * @group dkan
  * @group datastore
  * @group unit
@@ -565,19 +567,6 @@ class QueryControllerTest extends TestCase {
     $this->assertEquals(503, $result->getStatusCode());
     $this->assertStringContainsString('Datastore queries are temporarily limited due to high server load', $result->getContent());
 
-  }
-
-  /**
-   * Make sure degraded service mode causes downloads to fail with 503.
-   */
-  public function testDegradedServiceModeDownloads() {
-    $container = $this->getQueryContainer()
-      ->add(State::class, 'get', TRUE)
-      ->getMock();
-    \Drupal::setContainer($container);
-
-    $this->expectExceptionMessage("Datastore downloads are temporarily limited due to high server load. All streaming responses are currently unavailable.");
-    QueryDownloadController::create($container);
   }
 
   /**

--- a/modules/dkan_datastore/tests/src/Unit/Controller/QueryControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/QueryControllerTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @covers \Drupal\dkan_datastore\Controller\QueryController
  * @coversDefaultClass \Drupal\dkan_datastore\Controller\QueryController
+ * @covers \Drupal\dkan_datastore\Controller\AbstractQueryController
  * @group dkan
  * @group datastore
  * @group unit

--- a/modules/dkan_datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -81,11 +81,11 @@ class QueryDownloadControllerTest extends TestCase {
    */
   private function queryResultCompareCsv($data, $resource = NULL) {
     $request = $this->mockRequest($data);
-    $qController = QueryController::create($this->getQueryContainer(500));
+    $qController = QueryController::create($this->getQueryContainer(500)->getMock());
     $response = $resource ? $qController->queryResource($resource, $request) : $qController->query($request);
     $csv = $response->getContent() ?? '';
 
-    $dController = QueryDownloadController::create($this->getQueryContainer(25));
+    $dController = QueryDownloadController::create($this->getQueryContainer(25)->getMock());
     ob_start(self::getBuffer(...));
     $streamResponse = $resource ? $dController->queryResource($resource, $request) : $dController->query($request);
     $streamResponse->sendContent();
@@ -101,11 +101,11 @@ class QueryDownloadControllerTest extends TestCase {
    */
   private function queryResultCompareJson($data, $resource = NULL) {
     $request = $this->mockRequest($data);
-    $qController = QueryController::create($this->getQueryContainer(500));
+    $qController = QueryController::create($this->getQueryContainer(500)->getMock());
     $response = $resource ? $qController->queryResource($resource, $request) : $qController->query($request);
     $json = $response->getContent() ?? '';
 
-    $dController = QueryDownloadController::create($this->getQueryContainer(25));
+    $dController = QueryDownloadController::create($this->getQueryContainer(25)->getMock());
     ob_start(self::getBuffer(...));
     $streamResponse = $resource ? $dController->queryResource($resource, $request) : $dController->query($request);
     $streamResponse->sendContent();
@@ -289,7 +289,7 @@ class QueryDownloadControllerTest extends TestCase {
       "limit" => $queryLimit,
     ]);
     // Set the row limit to 50 even though we're requesting 1000.
-    $container = $this->getQueryContainer($pageLimit, $responseStreamMaxAge);
+    $container = $this->getQueryContainer($pageLimit, $responseStreamMaxAge)->getMock();
     $downloadController = QueryDownloadController::create($container);
     $request = $this->mockRequest($data);
     ob_start(self::getBuffer(...));
@@ -386,7 +386,7 @@ class QueryDownloadControllerTest extends TestCase {
       "format" => "csv",
     ];
     $request = $this->mockRequest($data);
-    $dController = QueryDownloadController::create($this->getQueryContainer(25));
+    $dController = QueryDownloadController::create($this->getQueryContainer(25)->getMock());
     ob_start(self::getBuffer(...));
     $streamResponse = $dController->query($request);
     $streamResponse->sendContent();
@@ -409,6 +409,19 @@ class QueryDownloadControllerTest extends TestCase {
   }
 
   /**
+   * Make sure degraded service mode causes downloads to fail with 503.
+   */
+  public function testDegradedServiceModeDownloads() {
+    $container = $this->getQueryContainer(25)
+      ->add(State::class, 'get', TRUE)
+      ->getMock();
+    \Drupal::setContainer($container);
+
+    $this->expectExceptionMessage("Datastore downloads are temporarily limited due to high server load. All streaming responses are currently unavailable.");
+    QueryDownloadController::create($container);
+  }
+
+  /**
    * Create a mock chain for the main container passed to the controller.
    *
    * @param int $rowLimit
@@ -416,8 +429,8 @@ class QueryDownloadControllerTest extends TestCase {
    * @param int|null $responseStreamMaxAge
    *   The max age for the response stream in cache, or NULL to use the default.
    *
-   * @return \PHPUnit\Framework\MockObject\MockObject
-   *   MockChain mock object.
+   * @return \MockChain\Chain
+   *   MockChain (needs getMock() before use).
    */
   private function getQueryContainer(int $rowLimit, ?int $responseStreamMaxAge = NULL) {
     $pdo = match(TRUE) {
@@ -495,7 +508,7 @@ class QueryDownloadControllerTest extends TestCase {
       ->add(ImmutableConfig::class, 'get', $responseStreamMaxAge)
       ->add(State::class, 'get', FALSE);
 
-    return $chain->getMock();
+    return $chain;
   }
 
   /**

--- a/modules/dkan_datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -417,8 +418,13 @@ class QueryDownloadControllerTest extends TestCase {
       ->getMock();
     \Drupal::setContainer($container);
 
-    $this->expectExceptionMessage("Datastore downloads are temporarily limited due to high server load. All streaming responses are currently unavailable.");
-    QueryDownloadController::create($container);
+    $request = $this->mockRequest('{}');
+    $dController = QueryDownloadController::create($container);
+    $result = $dController->query($request);
+    $this->assertTrue($result instanceof JsonResponse);
+    $this->assertEquals(503, $result->getStatusCode());
+    $this->assertStringContainsString('Datastore downloads are temporarily limited due to high server load.', $result->getContent());
+
   }
 
   /**

--- a/modules/dkan_datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -31,6 +31,8 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
+ * @covers \Drupal\dkan_datastore\Controller\QueryDownloadController
+ * @coversDefaultClass \Drupal\dkan_datastore\Controller\QueryDownloadController
  * @group dkan
  * @group datastore
  * @group unit

--- a/modules/dkan_datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @covers \Drupal\dkan_datastore\Controller\QueryDownloadController
  * @coversDefaultClass \Drupal\dkan_datastore\Controller\QueryDownloadController
+ * @covers \Drupal\dkan_datastore\Controller\AbstractQueryController
  * @group dkan
  * @group datastore
  * @group unit

--- a/modules/dkan_datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Controller/QueryDownloadControllerTest.php
@@ -6,6 +6,7 @@ use Drupal\dkan_common\DataResource;
 use Drupal\Core\Cache\Context\CacheContextsManager;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\State\State;
 use Drupal\dkan_common\DatasetInfo;
 use Drupal\dkan_datastore\Controller\QueryController;
 use Drupal\dkan_datastore\Controller\QueryDownloadController;
@@ -432,6 +433,7 @@ class QueryDownloadControllerTest extends TestCase {
       ->add('config.factory', ConfigFactoryInterface::class)
       ->add('dkan.metastore.metastore_item_factory', NodeDataFactory::class)
       ->add('dkan.metastore.api_response', MetastoreApiResponse::class)
+      ->add('state', State::class)
       ->index(0);
 
     $schema2 = [
@@ -490,7 +492,8 @@ class QueryDownloadControllerTest extends TestCase {
       ->add(DatastoreService::class, 'getDataDictionaryFields', NULL)
       // @todo Use an Options or Sequence return here; this will only work for one arg at a time.
       ->add(ImmutableConfig::class, 'get', $rowLimit)
-      ->add(ImmutableConfig::class, 'get', $responseStreamMaxAge);
+      ->add(ImmutableConfig::class, 'get', $responseStreamMaxAge)
+      ->add(State::class, 'get', FALSE);
 
     return $chain->getMock();
   }


### PR DESCRIPTION
This adds a Drupal state setting that prevents the datastore endpoint from accepting queries with conditions, sorts or joins. This is primarily to make it easier to recover from situations when traffic has overwhelmed the database and we need to "cool" it down to restore functionality.

## QA Steps

- Import sample content
- Try datastore request:
```httpd
﻿﻿POST https://dkan.ddev.site/api/1/datastore/query/cedcd327-4e5d-43f9-8eb1-c11850fa7c55/0 HTTP/1.1

{
  "conditions": [
    {
      "property": "objectid",
      "value": "2049"
    }
  ]
}
```
- Go to admin/dkan/datastore
- Enable degraded service query mode
- Try the query again, confirm you get an error
- Try the Drush command:
  - `drush dkan:datastore:degraded-mode`
  - `drush dkan:datastore:degraded-mode 1`
  - `drush dkan:datastore:degraded-mode 0`
