### PR TITLE
Migrate to opis/json-schema v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "getdkan/file-fetcher": "^5.1.0",
         "getdkan/pdlt": "^0.1.7",
         "getdkan/procrastinator": "^5.0.3",
-        "getdkan/rooted-json-data": "dev-opis-v2-migration as 0.2.4",
+        "getdkan/rooted-json-data": "^1.0",
         "guzzlehttp/guzzle": "^7.5",
         "ilbee/csv-response": "^1.2.0",
         "justinrainbow/json-schema": "^5.2 || ^6.6.1",

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,7 @@
         "drush/drush": "*",
         "getdkan/mock-chain": "~1.4.1",
         "osteel/openapi-httpfoundation-testing": "^0.13",
-        "drupal/admin_toolbar": "^3.0",
-        "phpunit/phpunit": "^9.6"
+        "drupal/admin_toolbar": "^3.0"
     },
     "repositories": {
         "drupal": {

--- a/composer.json
+++ b/composer.json
@@ -45,10 +45,6 @@
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
-        },
-        "rooted-json-data-fork": {
-            "type": "vcs",
-            "url": "https://github.com/GetDKAN/RootedJsonData"
         }
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,11 @@
         "getdkan/file-fetcher": "^5.1.0",
         "getdkan/pdlt": "^0.1.7",
         "getdkan/procrastinator": "^5.0.3",
-        "getdkan/rooted-json-data": "^0.2.2",
+        "getdkan/rooted-json-data": "dev-opis-v2-migration as 0.2.4",
         "guzzlehttp/guzzle": "^7.5",
         "ilbee/csv-response": "^1.2.0",
         "justinrainbow/json-schema": "^5.2 || ^6.6.1",
-        "m1x0n/opis-json-schema-error-presenter": "^0.5.3",
+        "opis/json-schema": "^2.4",
         "ramsey/uuid": "^3.8.0 || ^4",
         "stolt/json-merge-patch": "^2.0"
     },
@@ -39,14 +39,21 @@
         "drush/drush": "*",
         "getdkan/mock-chain": "~1.4.1",
         "osteel/openapi-httpfoundation-testing": "^0.13",
-        "drupal/admin_toolbar": "^3.0"
+        "drupal/admin_toolbar": "^3.0",
+        "phpunit/phpunit": "^9.6"
     },
     "repositories": {
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        "rooted-json-data-fork": {
+            "type": "vcs",
+            "url": "https://github.com/GetDKAN/RootedJsonData"
         }
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "php-http/discovery": true,

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -239,7 +239,7 @@ have another opportunity to inspect what changed before committing.
     this in production. Still, if anything goes wrong, be prepared to roll back
     both the code and the database to a previous tag and backup, respectively.
 
-Step 8: DKAN 4.0
+Step 8: DKAN 4
 ################
 
 The newly namespaced modules are now enabled, the legacy modules disabled, and
@@ -253,3 +253,23 @@ must also be updated:
 
 While there should be no pending database updates at this point, it is always a
 good idea to run ``drush update:db`` after any change to ``composer.json``.
+
+A note on DKAN 4.1
+******************
+
+By the time you read this, DKAN 4.1 may already be out. You may wish to upgrade
+directly to 4.1 instead of 4.0. DKAN 4.1 introduces 
+`breaking changes <https://github.com/GetDKAN/dkan/pull/4706>`_ to JSON
+validation, so make sure to read the release notes for that version before
+upgrading (they will be linked directly in a future version of this document).
+It is possible that you will need to make some minor adjustments to your
+metastore schemas to ensure they are compatible with JSON Schema draft-07 or
+later.
+
+To upgrade to 4.1, simply change the composer command in step 8 to:
+
+.. prompt:: bash $
+
+    composer require drupal/dkan:~4.1.0
+
+Or use a loser constraint like ``^4`` to allow for any 4.x release.

--- a/modules/dkan_common/src/JsonResponseTrait.php
+++ b/modules/dkan_common/src/JsonResponseTrait.php
@@ -14,7 +14,17 @@ trait JsonResponseTrait {
   use CacheableResponseTrait;
 
   /**
-   * Private.
+   * Get a JSON response from a message, code, and headers.
+   *
+   * @param string|object|array $message
+   *   The message to include in the response body.
+   * @param int $code
+   *   The HTTP status code for the response.
+   * @param array $headers
+   *   An array of headers to include in the response.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   A Symfony JSON response.
    */
   protected function getResponse($message, int $code = 200, array $headers = []): JsonResponse {
     $response = new JsonResponse($message, $code, $headers);
@@ -66,10 +76,7 @@ trait JsonResponseTrait {
         while (!empty($subs = $error->subErrors())) {
           $error = $subs[0];
         }
-        // Emit the historical v1/m1x0n shape so existing downstream
-        // consumers (frontend, external API clients) parse the response
-        // unchanged across the opis v1 -> v2 migration. Message wording
-        // comes from opis v2 templates and may differ slightly from v1.
+        // Normalize and simplify the error shape.
         $formatter = new ErrorFormatter();
         return [
           'keyword' => $error->keyword(),

--- a/modules/dkan_common/src/JsonResponseTrait.php
+++ b/modules/dkan_common/src/JsonResponseTrait.php
@@ -60,8 +60,21 @@ trait JsonResponseTrait {
     if ($e instanceof ValidationException) {
       $error = $e->getResult()->error();
       if ($error) {
+        // Walk to a leaf — v2's root error is a container keyword (e.g.
+        // `properties`); the actionable error lives at a leaf.
+        while (!empty($subs = $error->subErrors())) {
+          $error = $subs[0];
+        }
+        // Emit the historical v1/m1x0n shape so existing downstream
+        // consumers (frontend, external API clients) parse the response
+        // unchanged across the opis v1 -> v2 migration. Message wording
+        // comes from opis v2 templates and may differ slightly from v1.
         $formatter = new ErrorFormatter();
-        return $formatter->format($error);
+        return [
+          'keyword' => $error->keyword(),
+          'pointer' => implode('/', $error->data()->fullPath()),
+          'message' => $formatter->formatErrorMessage($error),
+        ];
       }
     }
 

--- a/modules/dkan_common/src/JsonResponseTrait.php
+++ b/modules/dkan_common/src/JsonResponseTrait.php
@@ -58,8 +58,9 @@ trait JsonResponseTrait {
    */
   protected function getExceptionData(\Exception $e) {
     if ($e instanceof ValidationException) {
-      $error = $e->getResult()->error();
-      if ($error) {
+      $result = $e->getResult();
+      if ($result->hasError()) {
+        $error = $result->error();
         // Walk to a leaf — v2's root error is a container keyword (e.g.
         // `properties`); the actionable error lives at a leaf.
         while (!empty($subs = $error->subErrors())) {

--- a/modules/dkan_common/src/JsonResponseTrait.php
+++ b/modules/dkan_common/src/JsonResponseTrait.php
@@ -2,12 +2,9 @@
 
 namespace Drupal\dkan_common;
 
-use Symfony\Component\HttpFoundation\JsonResponse;
-use OpisErrorPresenter\Implementation\MessageFormatterFactory;
-use OpisErrorPresenter\Implementation\PresentedValidationErrorFactory;
-use OpisErrorPresenter\Implementation\Strategies\BestMatchError;
-use OpisErrorPresenter\Implementation\ValidationErrorPresenter;
+use Opis\JsonSchema\Errors\ErrorFormatter;
 use RootedData\Exception\ValidationException;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
@@ -61,15 +58,11 @@ trait JsonResponseTrait {
    */
   protected function getExceptionData(\Exception $e) {
     if ($e instanceof ValidationException) {
-      $errors = $e->getResult()->getErrors();
-      $presenter = new ValidationErrorPresenter(
-        new PresentedValidationErrorFactory(
-          new MessageFormatterFactory()
-        ),
-        new BestMatchError()
-      );
-      $presented = $presenter->present(...$errors);
-      return $presented[0];
+      $error = $e->getResult()->error();
+      if ($error) {
+        $formatter = new ErrorFormatter();
+        return $formatter->format($error);
+      }
     }
 
     return FALSE;

--- a/modules/dkan_common/tests/src/Functional/Api1TestBase.php
+++ b/modules/dkan_common/tests/src/Functional/Api1TestBase.php
@@ -6,7 +6,6 @@ use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
-use Opis\JsonSchema\Schema;
 use Opis\JsonSchema\Validator;
 use Osteel\OpenApi\Testing\ValidatorBuilder;
 
@@ -99,10 +98,12 @@ abstract class Api1TestBase extends BrowserTestBase {
   }
 
   protected function assertJsonIsValid($schema, $json) {
-    $opiSchema = is_string($schema) ? Schema::fromJsonString($schema) : new Schema($schema);
-    $validator = new Validator();
+    // Opis v2: Schema::fromJsonString is gone (Schema is an interface).
+    // Validator::validate() accepts a decoded schema (object/bool) directly.
+    $decodedSchema = is_string($schema) ? json_decode($schema, FALSE) : $schema;
     $data = is_string($json) ? json_decode($json) : $json;
-    $result = $validator->schemaValidation($data, $opiSchema);
+    $validator = new Validator();
+    $result = $validator->validate($data, $decodedSchema);
     $this->assertTrue($result->isValid());
   }
 

--- a/modules/dkan_common/tests/src/Functional/Api1TestBase.php
+++ b/modules/dkan_common/tests/src/Functional/Api1TestBase.php
@@ -98,7 +98,6 @@ abstract class Api1TestBase extends BrowserTestBase {
   }
 
   protected function assertJsonIsValid($schema, $json) {
-    // Opis v2: Schema::fromJsonString is gone (Schema is an interface).
     // Validator::validate() accepts a decoded schema (object/bool) directly.
     $decodedSchema = is_string($schema) ? json_decode($schema, FALSE) : $schema;
     $data = is_string($json) ? json_decode($json) : $json;

--- a/modules/dkan_common/tests/src/Unit/JsonResponseTraitTest.php
+++ b/modules/dkan_common/tests/src/Unit/JsonResponseTraitTest.php
@@ -19,13 +19,8 @@ class JsonResponseTraitTest extends TestCase {
   /**
    * @covers ::getExceptionData
    *
-   * Locks down the historical v1/m1x0n response shape:
-   *   { "keyword": <string>, "pointer": <string>, "message": <string> }
-   *
-   * The v2 migration preserves this shape (the values are sourced from
-   * opis v2's API instead of m1x0n, and message wording may differ
-   * slightly, but the keys and types match) so downstream consumers
-   * parsing validation errors keep working unchanged.
+   * Makes sure that getExceptionData returns an array with the expected shape
+   * when a ValidationException is passed.
    */
   public function testGetExceptionDataReturnsV1CompatibleShape(): void {
     $schema = (object) [

--- a/modules/dkan_common/tests/src/Unit/JsonResponseTraitTest.php
+++ b/modules/dkan_common/tests/src/Unit/JsonResponseTraitTest.php
@@ -19,12 +19,15 @@ class JsonResponseTraitTest extends TestCase {
   /**
    * @covers ::getExceptionData
    *
-   * Verifies the v2 ErrorFormatter::format() shape — array keyed by JSON
-   * pointer, values are arrays of message strings. This is the BC-impacting
-   * shape change downstream consumers parsing validation error responses
-   * need to be aware of.
+   * Locks down the historical v1/m1x0n response shape:
+   *   { "keyword": <string>, "pointer": <string>, "message": <string> }
+   *
+   * The v2 migration preserves this shape (the values are sourced from
+   * opis v2's API instead of m1x0n, and message wording may differ
+   * slightly, but the keys and types match) so downstream consumers
+   * parsing validation errors keep working unchanged.
    */
-  public function testGetExceptionDataReturnsPointerKeyedShape(): void {
+  public function testGetExceptionDataReturnsV1CompatibleShape(): void {
     $schema = (object) [
       'type' => 'object',
       'properties' => (object) [
@@ -40,16 +43,16 @@ class JsonResponseTraitTest extends TestCase {
     $data = (new ClassUsingJsonResponseTrait())->callGetExceptionData($exception);
 
     $this->assertIsArray($data);
-    $this->assertNotEmpty($data);
-    foreach ($data as $pointer => $messages) {
-      $this->assertIsString($pointer, 'response keys are JSON pointers');
-      $this->assertIsArray($messages, 'response values are arrays of strings');
-      $this->assertNotEmpty($messages);
-      foreach ($messages as $message) {
-        $this->assertIsString($message);
-        $this->assertNotEmpty($message);
-      }
-    }
+    $this->assertSame(['keyword', 'pointer', 'message'], array_keys($data));
+    $this->assertIsString($data['keyword']);
+    $this->assertNotEmpty($data['keyword']);
+    $this->assertIsString($data['pointer']);
+    $this->assertIsString($data['message']);
+    $this->assertNotEmpty($data['message']);
+    // Pointer should reference the failing field.
+    $this->assertStringContainsString('title', $data['pointer']);
+    // Keyword should name the failing constraint.
+    $this->assertSame('minLength', $data['keyword']);
   }
 
   /**

--- a/modules/dkan_common/tests/src/Unit/JsonResponseTraitTest.php
+++ b/modules/dkan_common/tests/src/Unit/JsonResponseTraitTest.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\Tests\dkan_common\Unit;
 
-use Drupal\dkan_common\JsonResponseTrait;
+use Drupal\Tests\dkan_common\Unit\Mocks\ClassUsingJsonResponseTrait;
 use Opis\JsonSchema\Validator;
 use PHPUnit\Framework\TestCase;
 use RootedData\Exception\ValidationException;
@@ -81,20 +81,6 @@ class JsonResponseTraitTest extends TestCase {
     $this->assertFalse(
       (new ClassUsingJsonResponseTrait())->callGetExceptionData($exception)
     );
-  }
-
-}
-
-/**
- * Stub exposing the protected trait method for tests.
- *
- * Mirrors the pattern in CacheableResponseTraitTest.
- */
-class ClassUsingJsonResponseTrait {
-  use JsonResponseTrait;
-
-  public function callGetExceptionData(\Exception $e) {
-    return $this->getExceptionData($e);
   }
 
 }

--- a/modules/dkan_common/tests/src/Unit/JsonResponseTraitTest.php
+++ b/modules/dkan_common/tests/src/Unit/JsonResponseTraitTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Drupal\Tests\dkan_common\Unit;
+
+use Drupal\dkan_common\JsonResponseTrait;
+use Opis\JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
+use RootedData\Exception\ValidationException;
+
+/**
+ * @coversDefaultClass \Drupal\dkan_common\JsonResponseTrait
+ *
+ * @group dkan
+ * @group dkan_common
+ * @group unit
+ */
+class JsonResponseTraitTest extends TestCase {
+
+  /**
+   * @covers ::getExceptionData
+   *
+   * Verifies the v2 ErrorFormatter::format() shape — array keyed by JSON
+   * pointer, values are arrays of message strings. This is the BC-impacting
+   * shape change downstream consumers parsing validation error responses
+   * need to be aware of.
+   */
+  public function testGetExceptionDataReturnsPointerKeyedShape(): void {
+    $schema = (object) [
+      'type' => 'object',
+      'properties' => (object) [
+        'title' => (object) ['type' => 'string', 'minLength' => 1],
+      ],
+      'required' => ['title'],
+    ];
+    $invalid = (object) ['title' => ''];
+    $result = (new Validator())->validate($invalid, $schema);
+    $this->assertTrue($result->hasError());
+
+    $exception = new ValidationException('invalid', $result);
+    $data = (new ClassUsingJsonResponseTrait())->callGetExceptionData($exception);
+
+    $this->assertIsArray($data);
+    $this->assertNotEmpty($data);
+    foreach ($data as $pointer => $messages) {
+      $this->assertIsString($pointer, 'response keys are JSON pointers');
+      $this->assertIsArray($messages, 'response values are arrays of strings');
+      $this->assertNotEmpty($messages);
+      foreach ($messages as $message) {
+        $this->assertIsString($message);
+        $this->assertNotEmpty($message);
+      }
+    }
+  }
+
+  /**
+   * @covers ::getExceptionData
+   */
+  public function testGetExceptionDataReturnsFalseForNonValidationException(): void {
+    $this->assertFalse(
+      (new ClassUsingJsonResponseTrait())->callGetExceptionData(new \RuntimeException('nope'))
+    );
+  }
+
+  /**
+   * @covers ::getExceptionData
+   *
+   * Edge case: ValidationException whose result has no error (unusual but
+   * possible if callers misuse the exception). Should return FALSE rather
+   * than crashing.
+   */
+  public function testGetExceptionDataReturnsFalseWhenResultHasNoError(): void {
+    $schema = (object) ['type' => 'object'];
+    $valid = (object) [];
+    $result = (new Validator())->validate($valid, $schema);
+    $this->assertFalse($result->hasError());
+
+    $exception = new ValidationException('no-error', $result);
+    $this->assertFalse(
+      (new ClassUsingJsonResponseTrait())->callGetExceptionData($exception)
+    );
+  }
+
+}
+
+/**
+ * Stub exposing the protected trait method for tests.
+ *
+ * Mirrors the pattern in CacheableResponseTraitTest.
+ */
+class ClassUsingJsonResponseTrait {
+  use JsonResponseTrait;
+
+  public function callGetExceptionData(\Exception $e) {
+    return $this->getExceptionData($e);
+  }
+
+}

--- a/modules/dkan_common/tests/src/Unit/Mocks/ClassUsingJsonResponseTrait.php
+++ b/modules/dkan_common/tests/src/Unit/Mocks/ClassUsingJsonResponseTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\Tests\dkan_common\Unit\Mocks;
+
+use Drupal\dkan_common\JsonResponseTrait;
+
+/**
+ * Trait host for JsonResponseTraitTest.
+ *
+ * Exposes the protected getExceptionData method via a public proxy. Kept in
+ * its own file (no inline class) per #4706 review feedback:
+ * https://github.com/GetDKAN/dkan/pull/4706#discussion_r3274833176
+ */
+class ClassUsingJsonResponseTrait {
+  use JsonResponseTrait;
+
+  public function callGetExceptionData(\Exception $e) {
+    return $this->getExceptionData($e);
+  }
+
+}

--- a/modules/dkan_harvest/schema/schema.json
+++ b/modules/dkan_harvest/schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "harvest-plan",
+  "$id": "https://schemas.getdkan.com/harvest-plan.json",
   "type": "object",
   "title": "Harvest Plan",
   "required": [

--- a/modules/dkan_harvest/schema/schema.json
+++ b/modules/dkan_harvest/schema/schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "harvest-plan",
   "type": "object",
   "title": "Harvest Plan",
   "required": [

--- a/modules/dkan_harvest/schema/schema.json
+++ b/modules/dkan_harvest/schema/schema.json
@@ -1,6 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.getdkan.com/harvest-plan.json",
   "type": "object",
   "title": "Harvest Plan",
   "required": [

--- a/modules/dkan_harvest/schema/schema.json
+++ b/modules/dkan_harvest/schema/schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "id": "harvest-plan",
   "type": "object",
   "title": "Harvest Plan",
   "required": [

--- a/modules/dkan_harvest/src/ETL/Factory.php
+++ b/modules/dkan_harvest/src/ETL/Factory.php
@@ -142,12 +142,18 @@ class Factory {
 
     $path_to_schema = __DIR__ . "/../../schema/schema.json";
     $json_schema = file_get_contents($path_to_schema);
-
+    if ($json_schema === FALSE) {
+      throw new \Exception("Harvest plan schema not readable at: {$path_to_schema}");
+    }
     // Opis v2: Validator::validate() accepts a JSON-string schema; pre-decode
     // to bypass v2's URI-first parse path.
+    $schema = json_decode($json_schema, FALSE);
+    if ($schema === NULL && json_last_error() !== JSON_ERROR_NONE) {
+      throw new \Exception("Harvest plan schema is not valid JSON: " . json_last_error_msg());
+    }
     $data = $harvest_plan;
     $validator = new Validator();
-    $result = $validator->validate($data, json_decode($json_schema, FALSE));
+    $result = $validator->validate($data, $schema);
 
     if (!$result->isValid()) {
       // Walk to a leaf — v2's root is a container (e.g. `properties`); the

--- a/modules/dkan_harvest/src/ETL/Factory.php
+++ b/modules/dkan_harvest/src/ETL/Factory.php
@@ -79,7 +79,7 @@ class Factory {
    */
   public function get(string $type) {
     switch ($type) {
-      case  "extract":
+      case "extract":
         $class = $this->harvestPlan->extract->type;
         $this->validateClass($class);
 

--- a/modules/dkan_harvest/src/ETL/Factory.php
+++ b/modules/dkan_harvest/src/ETL/Factory.php
@@ -3,7 +3,6 @@
 namespace Drupal\dkan_harvest\ETL;
 
 use GuzzleHttp\ClientInterface;
-use Opis\JsonSchema\Schema;
 use Opis\JsonSchema\Validator;
 
 /**
@@ -144,19 +143,22 @@ class Factory {
     $path_to_schema = __DIR__ . "/../../schema/schema.json";
     $json_schema = file_get_contents($path_to_schema);
 
+    // Opis v2: Validator::validate() accepts a JSON-string schema; pre-decode
+    // to bypass v2's URI-first parse path.
     $data = $harvest_plan;
-    $schema = Schema::fromJsonString($json_schema);
     $validator = new Validator();
-
-    /** @var ValidationResult $result */
-    $result = $validator->schemaValidation($data, $schema);
+    $result = $validator->validate($data, json_decode($json_schema, FALSE));
 
     if (!$result->isValid()) {
-      /** @var ValidationError $error */
-      $error = $result->getFirstError();
+      // Walk to a leaf — v2's root is a container (e.g. `properties`); the
+      // actionable error (path + args like `missing`) lives at a leaf.
+      $error = $result->error();
+      while (!empty($subs = $error->subErrors())) {
+        $error = $subs[0];
+      }
       throw new \Exception(
-            "Invalid harvest plan. " . implode("->", $error->dataPointer()) .
-            " " . json_encode($error->keywordArgs())
+            "Invalid harvest plan. " . implode("->", $error->data()->fullPath()) .
+            " " . json_encode($error->args())
         );
     }
 

--- a/modules/dkan_harvest/src/ETL/Factory.php
+++ b/modules/dkan_harvest/src/ETL/Factory.php
@@ -145,19 +145,12 @@ class Factory {
     if ($json_schema === FALSE) {
       throw new \Exception("Harvest plan schema not readable at: {$path_to_schema}");
     }
-    // Opis v2: Validator::validate() accepts a JSON-string schema; pre-decode
-    // to bypass v2's URI-first parse path.
-    $schema = json_decode($json_schema, FALSE);
-    if ($schema === NULL && json_last_error() !== JSON_ERROR_NONE) {
-      throw new \Exception("Harvest plan schema is not valid JSON: " . json_last_error_msg());
-    }
-    $data = $harvest_plan;
+
+    $schema = json_decode($json_schema, FALSE, 512, JSON_THROW_ON_ERROR);
     $validator = new Validator();
-    $result = $validator->validate($data, $schema);
+    $result = $validator->validate($harvest_plan, $schema);
 
     if (!$result->isValid()) {
-      // Walk to a leaf — v2's root is a container (e.g. `properties`); the
-      // actionable error (path + args like `missing`) lives at a leaf.
       $error = $result->error();
       while (!empty($subs = $error->subErrors())) {
         $error = $subs[0];

--- a/modules/dkan_harvest/tests/src/Kernel/Commands/HarvestCommandsTest.php
+++ b/modules/dkan_harvest/tests/src/Kernel/Commands/HarvestCommandsTest.php
@@ -108,7 +108,7 @@ class HarvestCommandsTest extends KernelTestBase {
   public static function providePlanOpts(): array {
     return [
       'no identifier key' => [
-        'Invalid harvest plan.  {"missing":"identifier"}', [
+        'Invalid harvest plan.  {"missing":["identifier"]}', [
           'extract-type' => DataJson::class,
           'extract-uri' => 'uri',
           'transform' => [],
@@ -116,7 +116,7 @@ class HarvestCommandsTest extends KernelTestBase {
         ],
       ],
       'no identifier' => [
-        'Invalid harvest plan.  {"missing":"identifier"}', [
+        'Invalid harvest plan.  {"missing":["identifier"]}', [
           'identifier' => '',
           'extract-type' => DataJson::class,
           'extract-uri' => 'uri',
@@ -125,7 +125,7 @@ class HarvestCommandsTest extends KernelTestBase {
         ],
       ],
       'no extract-type' => [
-        'Invalid harvest plan. extract {"missing":"type"}', [
+        'Invalid harvest plan. extract {"missing":["type"]}', [
           'identifier' => 'id',
           'extract-uri' => '',
           'extract-type' => '',
@@ -134,7 +134,7 @@ class HarvestCommandsTest extends KernelTestBase {
         ],
       ],
       'no extract-uri' => [
-        'Invalid harvest plan. extract {"missing":"uri"}', [
+        'Invalid harvest plan. extract {"missing":["uri"]}', [
           'identifier' => 'id',
           'extract-uri' => '',
           'extract-type' => DataJson::class,
@@ -143,7 +143,7 @@ class HarvestCommandsTest extends KernelTestBase {
         ],
       ],
       'no load' => [
-        'Invalid harvest plan. load {"missing":"type"}', [
+        'Invalid harvest plan. load {"missing":["type"]}', [
           'identifier' => 'id',
           'extract-type' => DataJson::class,
           'extract-uri' => 'uri',

--- a/modules/dkan_harvest/tests/src/Unit/HarvesterTest.php
+++ b/modules/dkan_harvest/tests/src/Unit/HarvesterTest.php
@@ -13,7 +13,8 @@ use Drupal\Tests\dkan_harvest\MemStore;
 class HarvesterTest extends TestCase {
 
   public function testPlanValidation(): void {
-    $this->expectExceptionMessage("Invalid harvest plan. load {\"missing\":\"type\"}");
+    // opis v2 represents missing required fields as an array.
+    $this->expectExceptionMessage("Invalid harvest plan. load {\"missing\":[\"type\"]}");
     $plan = $this->getPlan("badplan");
     $this->getHarvester($plan, new MemStore(), new MemStore());
   }

--- a/modules/dkan_metastore/dkan_metastore.install
+++ b/modules/dkan_metastore/dkan_metastore.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Config\FileStorage;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Update hook to uninstall the legacy metastore module.
@@ -35,4 +36,117 @@ function dkan_metastore_update_11301() {
     $config->delete();
   }
   return $message;
+}
+
+/**
+ * Validate a JSON Schema document under opis/json-schema v2.
+ *
+ * @param string $json
+ *   Schema JSON string.
+ *
+ * @return string|null
+ *   NULL on success; an error message string if the schema cannot be parsed.
+ */
+function _dkan_metastore_validate_schema_json(string $json): ?string {
+  $decoded = json_decode($json, FALSE);
+  if ($decoded === NULL && json_last_error() !== JSON_ERROR_NONE) {
+    return 'Schema is not valid JSON: ' . json_last_error_msg();
+  }
+  if (!is_object($decoded) && !is_bool($decoded)) {
+    return 'Schema must be a JSON object or boolean.';
+  }
+  // Booleans are trivially valid JSON Schemas (per spec) and don't require
+  // structural parsing — loadObjectSchema's signature would reject them.
+  if (is_bool($decoded)) {
+    return NULL;
+  }
+  try {
+    // Force eager parse — catches root-level structural errors (non-string
+    // $schema, non-absolute $id, etc.).
+    (new \Opis\JsonSchema\Validator())->loader()->loadObjectSchema($decoded);
+    // Force LazySchema resolution by validating trivial data — opis defers
+    // sub-schema parsing until the validator walks into them.
+    (new \Opis\JsonSchema\Validator())->validate(NULL, $decoded);
+  }
+  catch (\Opis\JsonSchema\Exceptions\SchemaException $e) {
+    return $e->getMessage();
+  }
+  return NULL;
+}
+
+/**
+ * Collect schema-parse problems across the metastore's registered schema IDs.
+ *
+ * @return array
+ *   Map of schema id => error message. Empty when all schemas are clean.
+ */
+function _dkan_metastore_check_schemas(): array {
+  /** @var \Drupal\dkan_metastore\SchemaRetriever $retriever */
+  $retriever = \Drupal::service('dkan.metastore.schema_retriever');
+  $problems = [];
+  foreach ($retriever->getAllIds() as $id) {
+    try {
+      $json = $retriever->retrieve($id);
+    }
+    catch (\Throwable $e) {
+      $problems[$id] = 'Could not retrieve schema: ' . $e->getMessage();
+      continue;
+    }
+    if ($error = _dkan_metastore_validate_schema_json($json)) {
+      $problems[$id] = $error;
+    }
+  }
+  return $problems;
+}
+
+/**
+ * Implements hook_requirements().
+ *
+ * Surfaces draft-04 (or otherwise opis-v2-unparseable) metastore schemas on
+ * the status report. Added with the opis/json-schema v2 migration so sites
+ * that have overridden DKAN's bundled schemas see broken ones rather than
+ * encountering opaque runtime errors.
+ */
+function dkan_metastore_requirements(string $phase): array {
+  if ($phase !== 'runtime') {
+    return [];
+  }
+  $problems = _dkan_metastore_check_schemas();
+  if (empty($problems)) {
+    return [];
+  }
+  return [
+    'dkan_metastore_schema_parse' => [
+      'title' => t('DKAN metastore schemas'),
+      'severity' => REQUIREMENT_WARNING,
+      'value' => t('@n schema(s) cannot be parsed', ['@n' => count($problems)]),
+      'description' => t(
+        'The following metastore schemas could not be parsed under opis/json-schema v2: @list. They will fail at runtime when used. See the DKAN upgrade docs for the draft-04 → draft-07 migration steps.',
+        ['@list' => implode(', ', array_keys($problems))]
+      ),
+    ],
+  ];
+}
+
+/**
+ * One-shot opis/json-schema v2 compatibility report for metastore schemas.
+ *
+ * Reports on any metastore schema that can no longer be parsed (typically
+ * site-overridden schemas still declaring JSON Schema draft-04). Does not
+ * block the upgrade — sites can fix offending schemas after seeing this
+ * output. hook_requirements keeps the warning visible until resolved.
+ */
+function dkan_metastore_update_11302(): TranslatableMarkup {
+  $problems = _dkan_metastore_check_schemas();
+  if (empty($problems)) {
+    return t('All metastore schemas parse cleanly under opis/json-schema v2.');
+  }
+  $lines = [];
+  foreach ($problems as $id => $msg) {
+    $lines[] = "- {$id}: {$msg}";
+  }
+  return t(
+    "Some metastore schemas could not be parsed under opis/json-schema v2:\n@list\nThese schemas will fail at runtime when used. See the DKAN upgrade docs for the draft-04 → draft-07 migration steps.",
+    ['@list' => implode("\n", $lines)]
+  );
 }

--- a/modules/dkan_metastore/dkan_metastore.install
+++ b/modules/dkan_metastore/dkan_metastore.install
@@ -7,6 +7,8 @@
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Opis\JsonSchema\Exceptions\SchemaException;
+use Opis\JsonSchema\Validator;
 
 /**
  * Update hook to uninstall the legacy metastore module.
@@ -55,20 +57,18 @@ function _dkan_metastore_validate_schema_json(string $json): ?string {
   if (!is_object($decoded) && !is_bool($decoded)) {
     return 'Schema must be a JSON object or boolean.';
   }
-  // Booleans are trivially valid JSON Schemas (per spec) and don't require
-  // structural parsing — loadObjectSchema's signature would reject them.
   if (is_bool($decoded)) {
     return NULL;
   }
   try {
     // Force eager parse — catches root-level structural errors (non-string
     // $schema, non-absolute $id, etc.).
-    (new \Opis\JsonSchema\Validator())->loader()->loadObjectSchema($decoded);
+    (new Validator())->loader()->loadObjectSchema($decoded);
     // Force LazySchema resolution by validating trivial data — opis defers
     // sub-schema parsing until the validator walks into them.
-    (new \Opis\JsonSchema\Validator())->validate(NULL, $decoded);
+    (new Validator())->validate(NULL, $decoded);
   }
-  catch (\Opis\JsonSchema\Exceptions\SchemaException $e) {
+  catch (SchemaException $e) {
     return $e->getMessage();
   }
   return NULL;
@@ -102,10 +102,8 @@ function _dkan_metastore_check_schemas(): array {
 /**
  * Implements hook_requirements().
  *
- * Surfaces draft-04 (or otherwise opis-v2-unparseable) metastore schemas on
- * the status report. Added with the opis/json-schema v2 migration so sites
- * that have overridden DKAN's bundled schemas see broken ones rather than
- * encountering opaque runtime errors.
+ * Surfaces draft-04 (or otherwise unparseable) metastore schemas on
+ * the status report.
  */
 function dkan_metastore_requirements(string $phase): array {
   if ($phase !== 'runtime') {
@@ -146,7 +144,7 @@ function dkan_metastore_update_11302(): TranslatableMarkup {
     $lines[] = "- {$id}: {$msg}";
   }
   return t(
-    "Some metastore schemas could not be parsed under opis/json-schema v2:\n@list\nThese schemas will fail at runtime when used. See the DKAN upgrade docs for the draft-04 → draft-07 migration steps.",
+    "DKAN's JSON Validator has been updated, and some metastore schemas could not be parsed under opis/json-schema v2:\n@list\nThese schemas will fail at runtime when used. Please update your schemas to ensure they are compatible with JSON Schema draft-07 or later.",
     ['@list' => implode("\n", $lines)]
   );
 }

--- a/modules/dkan_metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
+++ b/modules/dkan_metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
@@ -99,19 +99,14 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
         $errors = $this->getValidationErrorsMessages($result->error());
       }
     }
-    catch (InvalidArgumentException $e) {
+    catch (\InvalidArgumentException $e) {
       $errors[] = $e->getMessage();
     }
     return $errors;
   }
 
   /**
-   * Flatten the v2 validation error tree into one message per leaf.
-   *
-   * Uses ErrorFormatter::formatKeyed() to walk leaves only (avoiding the
-   * redundancy of formatFlat() which also includes container errors), then
-   * collapses the pointer-keyed groups into the array<string> shape that
-   * addViolation() expects.
+   * Flatten the validation error tree into one message per leaf.
    *
    * @param \Opis\JsonSchema\Errors\ValidationError $error
    *   Root validation error to flatten.

--- a/modules/dkan_metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
+++ b/modules/dkan_metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
@@ -94,9 +94,9 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
       $this->validMetadataFactory->get($item->value, $schema_id);
     }
     catch (ValidationException $e) {
-      $rootError = $e->getResult()->error();
-      if ($rootError) {
-        $errors = $this->getValidationErrorsMessages($rootError);
+      $result = $e->getResult();
+      if ($result->hasError()) {
+        $errors = $this->getValidationErrorsMessages($result->error());
       }
     }
     catch (InvalidArgumentException $e) {
@@ -112,6 +112,12 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
    * redundancy of formatFlat() which also includes container errors), then
    * collapses the pointer-keyed groups into the array<string> shape that
    * addViolation() expects.
+   *
+   * @param \Opis\JsonSchema\Errors\ValidationError $error
+   *   Root validation error to flatten.
+   *
+   * @return array
+   *   Per-leaf message strings ready to pass to addViolation().
    */
   private function getValidationErrorsMessages(ValidationError $error): array {
     $formatter = new ErrorFormatter();

--- a/modules/dkan_metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
+++ b/modules/dkan_metastore/src/Plugin/Validation/Constraint/ProperJsonValidator.php
@@ -4,9 +4,8 @@ namespace Drupal\dkan_metastore\Plugin\Validation\Constraint;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\dkan_metastore\ValidMetadataFactory;
-use OpisErrorPresenter\Implementation\MessageFormatterFactory;
-use OpisErrorPresenter\Implementation\PresentedValidationErrorFactory;
-use OpisErrorPresenter\Implementation\ValidationErrorPresenter;
+use Opis\JsonSchema\Errors\ErrorFormatter;
+use Opis\JsonSchema\Errors\ValidationError;
 use RootedData\Exception\ValidationException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraint;
@@ -25,13 +24,6 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
   protected $validMetadataFactory;
 
   /**
-   * ValidationErrorPresenter.
-   *
-   * @var \OpisErrorPresenter\Implementation\ValidationErrorPresenter
-   */
-  protected $presenter;
-
-  /**
    * ProperJsonValidator constructor.
    *
    * @param \Drupal\dkan_metastore\ValidMetadataFactory $valid_metadata_factory
@@ -39,11 +31,6 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
    */
   public function __construct(ValidMetadataFactory $valid_metadata_factory) {
     $this->validMetadataFactory = $valid_metadata_factory;
-    $this->presenter = new ValidationErrorPresenter(
-      new PresentedValidationErrorFactory(
-        new MessageFormatterFactory()
-      )
-    );
   }
 
   /**
@@ -107,7 +94,10 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
       $this->validMetadataFactory->get($item->value, $schema_id);
     }
     catch (ValidationException $e) {
-      $errors = $this->getValidationErrorsMessages($e->getResult()->getErrors());
+      $rootError = $e->getResult()->error();
+      if ($rootError) {
+        $errors = $this->getValidationErrorsMessages($rootError);
+      }
     }
     catch (InvalidArgumentException $e) {
       $errors[] = $e->getMessage();
@@ -116,22 +106,22 @@ class ProperJsonValidator extends ConstraintValidator implements ContainerInject
   }
 
   /**
-   * Presents errors.
+   * Flatten the v2 validation error tree into one message per leaf.
    *
-   * @param array $errors
-   *   Validation errors array.
-   *
-   * @return array
-   *   Presented errors array.
+   * Uses ErrorFormatter::formatKeyed() to walk leaves only (avoiding the
+   * redundancy of formatFlat() which also includes container errors), then
+   * collapses the pointer-keyed groups into the array<string> shape that
+   * addViolation() expects.
    */
-  private function getValidationErrorsMessages(array $errors): array {
-    $presented = $this->presenter->present(...$errors);
-    return array_map(
-      function ($presented_error) {
-        return $presented_error->message();
-      },
-      $presented
-    );
+  private function getValidationErrorsMessages(ValidationError $error): array {
+    $formatter = new ErrorFormatter();
+    $messages = [];
+    foreach ($formatter->formatKeyed($error) as $errs) {
+      foreach ($errs as $msg) {
+        $messages[] = $msg;
+      }
+    }
+    return $messages;
   }
 
   /**

--- a/modules/dkan_metastore/tests/src/Kernel/Install/SchemaCheckTest.php
+++ b/modules/dkan_metastore/tests/src/Kernel/Install/SchemaCheckTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\Tests\dkan_metastore\Kernel\Install;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Covers _dkan_metastore_check_schemas() against the running site's schemas.
+ *
+ * @group dkan
+ * @group dkan_metastore
+ * @group kernel
+ */
+class SchemaCheckTest extends KernelTestBase {
+
+  protected static $modules = [
+    'dkan',
+    'dkan_common',
+    'dkan_metastore',
+    'system',
+  ];
+
+  /**
+   * Bundled DKAN schemas must all parse cleanly under opis v2.
+   *
+   * Regression guard so we don't ship a draft-04 (or otherwise broken)
+   * schema with future PRs.
+   */
+  public function testBundledSchemasParseCleanly(): void {
+    $module_path = \Drupal::service('extension.list.module')->getPath('dkan_metastore');
+    require_once DRUPAL_ROOT . '/' . $module_path . '/dkan_metastore.install';
+    $problems = _dkan_metastore_check_schemas();
+    $this->assertSame([], $problems, 'Bundled DKAN schemas all parse under opis/json-schema v2');
+  }
+
+}

--- a/modules/dkan_metastore/tests/src/Unit/Install/SchemaCheckHelperTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/Install/SchemaCheckHelperTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\Tests\dkan_metastore\Unit\Install;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the pure schema-parse helper in dkan_metastore.install.
+ *
+ * @group dkan
+ * @group dkan_metastore
+ * @group unit
+ */
+class SchemaCheckHelperTest extends TestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    // The install file's helper functions aren't autoloaded; pull them in
+    // explicitly. Path: tests/src/Unit/Install -> module root is ../../../..
+    require_once __DIR__ . '/../../../../dkan_metastore.install';
+  }
+
+  public function testValidObjectSchemaReturnsNull(): void {
+    $this->assertNull(_dkan_metastore_validate_schema_json('{"type":"object"}'));
+  }
+
+  public function testBooleanSchemaTrueReturnsNull(): void {
+    $this->assertNull(_dkan_metastore_validate_schema_json('true'));
+  }
+
+  public function testBooleanSchemaFalseReturnsNull(): void {
+    $this->assertNull(_dkan_metastore_validate_schema_json('false'));
+  }
+
+  public function testMalformedJsonReturnsError(): void {
+    $msg = _dkan_metastore_validate_schema_json('{not json');
+    $this->assertNotNull($msg);
+    $this->assertStringContainsString('not valid JSON', $msg);
+  }
+
+  public function testStringSchemaReturnsError(): void {
+    $msg = _dkan_metastore_validate_schema_json('"hello"');
+    $this->assertNotNull($msg);
+    $this->assertStringContainsString('object or boolean', $msg);
+  }
+
+  public function testNumberSchemaReturnsError(): void {
+    $msg = _dkan_metastore_validate_schema_json('42');
+    $this->assertNotNull($msg);
+    $this->assertStringContainsString('object or boolean', $msg);
+  }
+
+  /**
+   * $schema must be a string; opis throws ParseException eagerly at the
+   * root-level parse step (loadObjectSchema).
+   */
+  public function testRootLevelStructuralErrorReturnsError(): void {
+    $this->assertNotNull(_dkan_metastore_validate_schema_json('{"$schema": 42}'));
+  }
+
+  /**
+   * Sub-schema errors are deferred by opis's LazySchema and surface during
+   * the validate() phase. The helper covers this with the trivial validate
+   * call.
+   */
+  public function testDeepStructuralErrorReturnsError(): void {
+    $this->assertNotNull(
+      _dkan_metastore_validate_schema_json('{"type":"object","properties":"not-an-object"}')
+    );
+  }
+
+  /**
+   * Draft-04 declaration — opis v2 rejects (only draft-06+ supported).
+   * This is the headline failure mode this hook exists to detect.
+   */
+  public function testDraft04SchemaReturnsError(): void {
+    $msg = _dkan_metastore_validate_schema_json(
+      '{"$schema": "http://json-schema.org/draft-04/schema#", "type": "object"}'
+    );
+    $this->assertNotNull($msg);
+  }
+
+}

--- a/modules/dkan_metastore/tests/src/Unit/Plugin/Validation/Constraint/ProperJsonValidatorTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/Plugin/Validation/Constraint/ProperJsonValidatorTest.php
@@ -99,7 +99,15 @@ class ProperJsonValidatorTest extends TestCase {
 
     $validator = ProperJsonValidator::create($this->container);
 
-    $this->context->expects($this->once())->method("addViolation");
+    // Assert addViolation is invoked with a non-empty string referencing the
+    // failing field. This catches regressions where ErrorFormatter output
+    // becomes empty or malformed.
+    $this->context->expects($this->once())
+      ->method('addViolation')
+      ->with($this->logicalAnd(
+        $this->isType('string'),
+        $this->stringContains('number')
+      ));
 
     $validator->initialize($this->context);
 

--- a/modules/dkan_metastore/tests/src/Unit/ValidMetadataFactoryTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/ValidMetadataFactoryTest.php
@@ -11,7 +11,9 @@ use PHPUnit\Framework\TestCase;
 use RootedData\Exception\ValidationException;
 
 /**
- *
+ * @group unit
+ * @group dkan_metastore
+ * @coversDefaultClass \Drupal\dkan_metastore\ValidMetadataFactory
  */
 class ValidMetadataFactoryTest extends TestCase {
 
@@ -39,7 +41,8 @@ class ValidMetadataFactoryTest extends TestCase {
    */
   public function testInvalidJson() {
     $validMetadataFactory = ValidMetadataFactory::create($this->getCommonMockChain()->getMock());
-    $this->expectExceptionMessage("Invalid JSON: Syntax error");
+    $this->expectException(\JsonException::class);
+    $this->expectExceptionMessage("Syntax error");
     $validMetadataFactory->get('{"foo": "bar",}');
   }
 

--- a/schema/collections/dataset.json
+++ b/schema/collections/dataset.json
@@ -141,8 +141,6 @@
       "minLength": 1
     },
     "publisher": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
       "title": "Organization",
       "description": "A Dataset Publisher Organization.",
       "type": "object",
@@ -169,8 +167,6 @@
       }
     },
     "contactPoint": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "https://project-open-data.cio.gov/v1.1/schema/vcard.json#",
       "title": "Project Open Data ContactPoint vCard",
       "description": "A Dataset ContactPoint as a vCard object.",
       "type": "object",

--- a/schema/collections/dataset.json
+++ b/schema/collections/dataset.json
@@ -141,8 +141,8 @@
       "minLength": 1
     },
     "publisher": {
-      "$schema": "http://json-schema.org/draft-04/schema#",
-      "id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
       "title": "Organization",
       "description": "A Dataset Publisher Organization.",
       "type": "object",
@@ -169,8 +169,8 @@
       }
     },
     "contactPoint": {
-      "$schema": "http://json-schema.org/draft-04/schema#",
-      "id": "https://project-open-data.cio.gov/v1.1/schema/vcard.json#",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://project-open-data.cio.gov/v1.1/schema/vcard.json#",
       "title": "Project Open Data ContactPoint vCard",
       "description": "A Dataset ContactPoint as a vCard object.",
       "type": "object",

--- a/schema/collections/dataset.json
+++ b/schema/collections/dataset.json
@@ -141,6 +141,7 @@
       "minLength": 1
     },
     "publisher": {
+      "id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
       "title": "Organization",
       "description": "A Dataset Publisher Organization.",
       "type": "object",
@@ -167,6 +168,7 @@
       }
     },
     "contactPoint": {
+      "id": "https://project-open-data.cio.gov/v1.1/schema/vcard.json#",
       "title": "Project Open Data ContactPoint vCard",
       "description": "A Dataset ContactPoint as a vCard object.",
       "type": "object",

--- a/schema/collections/publisher.json
+++ b/schema/collections/publisher.json
@@ -12,6 +12,7 @@
       "type": "string"
     },
     "data": {
+      "id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
       "title": "Organization",
       "description": "A Dataset Publisher Organization.",
       "type": "object",

--- a/schema/collections/publisher.json
+++ b/schema/collections/publisher.json
@@ -12,8 +12,8 @@
       "type": "string"
     },
     "data": {
-      "$schema": "http://json-schema.org/draft-04/schema#",
-      "id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
       "title": "Organization",
       "description": "A Dataset Publisher Organization.",
       "type": "object",

--- a/schema/collections/publisher.json
+++ b/schema/collections/publisher.json
@@ -12,8 +12,6 @@
       "type": "string"
     },
     "data": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
       "title": "Organization",
       "description": "A Dataset Publisher Organization.",
       "type": "object",


### PR DESCRIPTION
Migrates DKAN from `opis/json-schema` v1 to v2 (`^2.4`) and drops the unmaintained `m1x0n/opis-json-schema-error-presenter` add-on in favor of opis v2's built-in `ErrorFormatter`. Coordinates with [GetDKAN/RootedJsonData#24](https://github.com/GetDKAN/RootedJsonData/pull/24).

**Validation error response shape is preserved** — `JsonResponseTrait::getExceptionData()` returns the same `{keyword, pointer, message}` shape downstream consumers expect, sourced from opis v2's API. Only the message wording differs slightly (opis v2 templates vs m1x0n templates).

### Dependency changes

- **Add**: `opis/json-schema: ^2.4` (direct require)
- **Drop**: `m1x0n/opis-json-schema-error-presenter` (opis v1-only; no v2 equivalent needed)
- **Bump**: `getdkan/rooted-json-data` to `^0.2.4` (currently pinned via inline alias `dev-opis-v2-migration as 0.2.4` until upstream tags; revert that alias + `minimum-stability: dev` once tagged)

### Schema changes

| File | Change |
|---|---|
| `modules/dkan_harvest/schema/schema.json` | Set absolute `$id` (`https://schemas.getdkan.com/harvest-plan.json`) — v2 rejects relative URIs. |
| `schema/collections/dataset.json`, `schema/collections/publisher.json` | Bumped nested sub-schemas (publisher, contactPoint, publisher.data) from JSON Schema **draft-04 → draft-07**; renamed bare `id` → `$id` per draft-06+ conventions. |

### Test changes

| File | Change |
|---|---|
| `modules/dkan_harvest/tests/src/Unit/HarvesterTest.php` | Update `testPlanValidation` expectation from v1's string-form `args["missing"]: "x"` to v2's array-form `args["missing"]: ["x"]`. |
| `modules/dkan_harvest/tests/src/Kernel/Commands/HarvestCommandsTest.php` | Same array-form update across 5 data-provider entries. |
| **New: `modules/dkan_common/tests/src/Unit/JsonResponseTraitTest.php`** | Locks down the v1-compatible response shape (`{keyword, pointer, message}` with string values) so the bridge can't silently regress. Also covers the non-`ValidationException` pass-through and the no-error edge case. |
| `modules/dkan_metastore/tests/src/Unit/Plugin/Validation/Constraint/ProperJsonValidatorTest.php` | Tighten `testValidationFailure` to assert `addViolation` is called with a non-empty string referencing the failing field (was previously asserting only on call count). |

### Breaking changes for downstream consumers

| Change | Impact | Mitigation |
|---|---|---|
| Validation error message wording | Slight wording differences from m1x0n templates (e.g. `"minLength: must be at least 1 characters long"` → `"Minimum string length is 1, found 0"`) — same field, same constraint name, just different prose. | None required for typical consumers; update test fixtures asserting on exact strings |
| Custom schemas declaring draft-04 | Will throw `ParseException` at validation time | See JSON Schema migration notes below |
| Custom code importing `m1x0n\\OpisJsonSchemaErrorPresenter\\*` | Class-not-found at runtime | Port to `Opis\JsonSchema\Errors\ErrorFormatter` |
| Custom code calling v1-only opis API (`Schema::fromJsonString`, `getFirstError()`, `keywordArgs()`, `dataPointer()`) | Method/class-not-found | Port to v2 API (`Validator::validate()`, `error()`, `args()`, `data()->fullPath()`) |

### JSON Schema draft-04 → draft-07 notes

opis v2 ships parsers for **draft-06, draft-07, 2019-09, 2020-12**. **Draft-04 is not supported.** Three nested sub-schemas in DKAN's metadata schemas were on draft-04 and have been migrated.

The migration steps for any custom downstream schemas:

1. Bump `"$schema"` declaration to `"http://json-schema.org/draft-07/schema#"`
2. Rename `"id"` → `"$id"` (renamed at the draft-04 → draft-06 boundary)
3. Use absolute URIs for `$id` values (v2 rejects relative URIs at the schema root)
4. If using `exclusiveMinimum` / `exclusiveMaximum` as boolean modifiers, switch to numeric values (draft-06+ semantics)

DKAN has long had a bit of an issue with being based on DCAT-US 1.1 (despite supporting a lot of schema customization) but using a validator that does not support draft 4, which is what DCAT-US 1.1 is based on. While none of the DCAT-US schema properties conflict with later drafts, they do declare draft 4 and use the old `schema` (rather than `$schema`) keyword format. This has always necessitated slightly modifying the original schemas from their original form; now additional modifications will be needed at the sub-schema level.

Looking ahead, DCAT-US 1.1 is also out of date, as [DCAT-US 3.0](https://resources.data.gov/resources/dcat-us3/) is now the recommended schema, and it is [defined in draft 2022-12](https://github.com/GSA/dcat-us/blob/main/jsonschema/definitions/Catalog.json#L2C45-L2C52). DKAN should move to adopt 3.0 as its default schema as soon as possible.

## QA Steps

The response-shape preservation is locked down by `JsonResponseTraitTest`; the QA below verifies end-to-end behavior in the test site.

- [ ] **Composer install resolves cleanly**
  - `ddev composer install` succeeds without errors
  - `ddev composer why opis/json-schema` shows ^2.4 (and no v1 reference remains)
  - `ddev composer why m1x0n/opis-json-schema-error-presenter` shows it is no longer required
- [ ] **POST a valid dataset succeeds**
  - `curl -X POST -u admin:admin -H "Content-Type: application/json" -d @valid-dataset.json https://<site>/api/1/metastore/schemas/dataset/items` returns 201
- [ ] **POST an invalid dataset returns the v1-compatible error shape**
  - POST a dataset with `"title": ""` (or any spec-violating field)
  - Verify response `data` field has shape `{"keyword": "...", "pointer": "...", "message": "..."}` — keys, types, and pointer/keyword values match v1; only message wording may differ
  - Example expected: `{"keyword": "minLength", "pointer": "title", "message": "Minimum string length is 1, found 0"}`
- [ ] **Submit a malformed harvest plan**
  - `ddev drush dkan-harvest:register --identifier=test-bad --plan='{"identifier":"test-bad"}'` (missing required fields)
  - Verify exception message includes a path (e.g. `extract`) and JSON-encoded args (e.g. `{"missing":["type"]}`)
- [ ] **Frontend (`data-catalog-app`) continues to display field-level validation errors** correctly when a dataset edit fails validation
- [ ] **Watchdog clean**
  - `ddev drush watchdog:show --severity=Error --count=20` after performing the above QA steps shows no opis-v2-related fatals

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
  - `HarvesterTest::testPlanValidation` and 5 entries in `HarvestCommandsTest::providePlanOpts` updated for the v2 error-arg shape
  - New `JsonResponseTraitTest` locks down the v1-compatible response shape
  - `ProperJsonValidatorTest::testValidationFailure` tightened to assert message content, not just call count
- [ ] I have updated or added documentation
  - Release notes for downstream consumers are pending (Phase 3b — not blocking this PR but should land before tagging a release)

## Related

- Upstream library PR: [GetDKAN/RootedJsonData#24](https://github.com/GetDKAN/RootedJsonData/pull/24)
- opis/json-schema v2 docs: https://docs.opis.io/json-schema/2.x/

Co-authored-by: Copilot <copilot@github.com>