### PR TITLE
#4710: Metastore Search - check for empty facet from content

### DIFF
--- a/modules/dkan_metastore/modules/dkan_metastore_search/src/FacetsFromContentTrait.php
+++ b/modules/dkan_metastore/modules/dkan_metastore_search/src/FacetsFromContentTrait.php
@@ -130,11 +130,13 @@ trait FacetsFromContentTrait {
 
         $facet = isset($field) ? $facet->{"$.data." . $field} : $facet->{"$.data"};
 
-        $facets["{$type}:{$facet}"] = (object) [
-          'type' => $type,
-          'name' => $facet,
-          'total' => 0,
-        ];
+        if (!empty($facet)) {
+          $facets["{$type}:{$facet}"] = (object) [
+            'type' => $type,
+            'name' => $facet,
+            'total' => 0,
+          ];
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #4710 
