### PR TITLE
Add architectural decision records

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/source/adr

--- a/docs/source/adr/0001-record-architecture-decisions.md
+++ b/docs/source/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,23 @@
+# 1. Record architecture decisions
+
+Date: 2026-05-11
+
+## Status
+
+Accepted
+
+## Context
+
+We have decided, with the release of DKAN 4, to record the architectural decisions made on this project. We have suffered in the past from fading memories of why certain non-intuitive decisions were made. DKAN is also becoming more visible with its move to Drupal.org and some renewed interest around it, so being able to refer to ARDs will help the public as well.
+
+There is a considerable amount of technical debt in DKAN that we are in the midst of addressing. Often when we make changes to underlying systems, it can be difficult to find an appropriate place to document the change itself, as the main docs are most effective when they are a concise reference on how the software works _now_.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+We will incorporate these ADRs into the existing Sphinx/readthedocs documentation.
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/docs/source/adr/index.rst
+++ b/docs/source/adr/index.rst
@@ -1,0 +1,10 @@
+.. _adr:
+
+Architecture Decision Records
+=============================
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   *

--- a/docs/source/components/dkan_datastore.rst
+++ b/docs/source/components/dkan_datastore.rst
@@ -29,7 +29,7 @@ and a new import will be triggered.
 
 .. _mysql_import:
 
-.. include:: ../../../modules/dkan_datastore/modules/datastore_mysql_import/README.md
+.. include:: ../../../modules/dkan_datastore/modules/dkan_datastore_mysql_import/README.md
    :parser: myst_parser.sphinx_
 
 Datastore Settings

--- a/docs/source/components/json_form_widget.rst
+++ b/docs/source/components/json_form_widget.rst
@@ -1,7 +1,7 @@
 JSON Form Widget
 ################
 
-As of DKAN 3.0, `JSON Form Widget <https://www.drupal.org/project/json_form_widget>`_ was removed from DKAN's ``modules/`` directory
+As of DKAN 3.0, the `JSON Form Widget module <https://www.drupal.org/project/json_form_widget>`_ was removed from DKAN's ``modules/`` directory
 and released as a standalone module on Drupal.org.
 
 However, that module's `README file <https://git.drupalcode.org/project/json_form_widget/-/blob/1.x/README.md?ref_type=heads>`_

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -3,7 +3,7 @@ Documentation
 
 What follows is a style guide for the DKAN documentation. Use it both to follow the conventions used throughout the site,
 and for your own contributions. DKAN's documentation is written in a combination of `Markdown <https://daringfireball.net/projects/markdown>`_
-and `ReStructuredText (RST) <http://www.sphinx-doc.org/en/stable/rest.html>`_, and built with `Sphinx <http://www.sphinx-doc.org/en/stable/index.html>`_.
+and `ReStructuredText (RST) <http://www.sphinx-doc.org/en/stable/rest.html>`_, and built with the `Sphinx documentation generator <http://www.sphinx-doc.org/en/stable/index.html>`_.
 The docs live in the `/docs/source` folder of the `DKAN Project <https://github.com/GetDKAN/dkan>`_; to suggest modifications,
 submit a pull request as you would for any suggested code change.
 
@@ -189,6 +189,7 @@ instead of ``make``.
 
 First, install ``sphinx-autobuild`` in your virtual environment (we have not 
 added it as an explicit dependency in ``requirements.txt``):
+
   .. prompt:: console $
 
     pip install sphinx-autobuild

--- a/docs/source/contributing/documentation.rst
+++ b/docs/source/contributing/documentation.rst
@@ -97,6 +97,16 @@ This can be achieved in markdown like this:
     **`This text`** will be code-styled and bold
 
 
+Architectural Decision Records
+------------------------------
+
+Major architectural decisions are documented in the :ref:`adr` section of the docs.
+The easiest way to add a new ADR is with the `adr-tools <https://github.com/npryce/adr-tools>`_ command line utility. Install it locally and then run the following command from the root of the repository:
+
+  .. prompt:: console $
+
+    adr new "Title of your ADR"
+
 Building these docs
 -------------------
 If you contribute significantly to this documentation, at some point you will want build them locally
@@ -175,7 +185,15 @@ Autobuilding
 
 You can have the documentation automatically rebuild when you make
 changes to the source files using the ``sphinx-autobuild`` command 
-instead of ``make``:
+instead of ``make``.
+
+First, install ``sphinx-autobuild`` in your virtual environment (we have not 
+added it as an explicit dependency in ``requirements.txt``):
+  .. prompt:: console $
+
+    pip install sphinx-autobuild
+
+Then run the following command from the `/docs` directory:
 
   .. prompt:: console $
 

--- a/docs/source/developer-guide/dev_metastore.rst
+++ b/docs/source/developer-guide/dev_metastore.rst
@@ -1,5 +1,5 @@
 DKAN Metastore
 ==================
 
-.. include:: ../../../modules/metastore/README.md
+.. include:: ../../../modules/dkan_metastore/README.md
     :parser: myst_parser.docutils_

--- a/docs/source/developer-guide/dev_search.rst
+++ b/docs/source/developer-guide/dev_search.rst
@@ -1,7 +1,7 @@
 DKAN Search
 ===========
 
-If you plan to build your data site with a Drupal theme rather than a decoupled frontend the metastore_search module provides a dataset search view that you can use as a starting point.
+If you plan to build your data site with a Drupal theme rather than a decoupled frontend the dkan_metastore_search module provides a dataset search view that you can use as a starting point.
 
-.. include:: ../../../modules/metastore/modules/metastore_facets/README.md
+.. include:: ../../../modules/dkan_metastore/modules/dkanmetastore_facets/README.md
     :parser: myst_parser.docutils_

--- a/docs/source/developer-guide/dev_search.rst
+++ b/docs/source/developer-guide/dev_search.rst
@@ -3,5 +3,5 @@ DKAN Search
 
 If you plan to build your data site with a Drupal theme rather than a decoupled frontend the dkan_metastore_search module provides a dataset search view that you can use as a starting point.
 
-.. include:: ../../../modules/dkan_metastore/modules/dkanmetastore_facets/README.md
+.. include:: ../../../modules/dkan_metastore/modules/dkan_metastore_facets/README.md
     :parser: myst_parser.docutils_

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ DKAN is a Drupal-based open data portal and catalog. Development sponsored by `C
    user-guide/index
    developer-guide/index
    contributing/index
+   adr/index
 
 
 Additional resources


### PR DESCRIPTION
Adds an ADR framework to the docs. Designed around [adr-tools ](https://github.com/npryce/adr-tools).

I don't love how it adds another dotfile to the root but I do like the toolset otherwise. Feedback welcome, not wedded to this solution.

If this is accepted I'll do a new PR with an ADR for the module renaming. I think some of the intro text to the [upgrade guide](https://dkan--4715.org.readthedocs.build/en/4715/upgrade.html) could move in there.

## QA Steps

Review the [ADR section](https://dkan--4715.org.readthedocs.build/en/4715/adr/index.html) of the docs