### PR TITLE
Return a 503 for specific PDO exceptions, alternate mix

### DIFF
--- a/modules/dkan_common/dkan_common.routing.yml
+++ b/modules/dkan_common/dkan_common.routing.yml
@@ -10,7 +10,8 @@ dkan.common.api:
   path: '/api'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_common\Controller\OpenApiController::getVersions'}
+    _controller: '\Drupal\dkan_common\Controller\OpenApiController::getVersions'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -20,7 +21,8 @@ dkan.common.api.version:
   path: '/api/1'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_common\Controller\OpenApiController::getComplete'}
+    _controller: '\Drupal\dkan_common\Controller\OpenApiController::getComplete'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -31,6 +33,7 @@ dkan.common.api.version.yaml:
   methods: [GET]
   defaults:
     _controller: '\Drupal\dkan_common\Controller\OpenApiController::getComplete'
+    is_dkan_api_route: true
     format: yaml
   requirements:
     _permission: 'access content'

--- a/modules/dkan_common/dkan_common.services.yml
+++ b/modules/dkan_common/dkan_common.services.yml
@@ -69,3 +69,11 @@ services:
   plugin.manager.dkan_api_docs:
     class: \Drupal\dkan_common\Plugin\DkanApiDocsPluginManager
     parent: default_plugin_manager
+
+  dkan_common.exception_subscriber:
+    class: Drupal\dkan_common\EventSubscriber\DkanExceptionSubscriber
+    arguments:
+      - '@logger.factory'
+      - '@current_route_match'
+    tags:
+      - { name: event_subscriber }

--- a/modules/dkan_common/src/EventSubscriber/DkanExceptionSubscriber.php
+++ b/modules/dkan_common/src/EventSubscriber/DkanExceptionSubscriber.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\dkan_common\EventSubscriber;
+
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Send out reasonable responses to DB exceptions.
+ */
+final class DkanExceptionSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Too many connections error.
+   *
+   * @see https://dev.mysql.com/doc/mysql-errors/8.4/en/server-error-reference.html#error_er_too_many_user_connections
+   */
+  protected const int ER_TOO_MANY_USER_CONNECTIONS = 1203;
+
+  /**
+   * How many seconds before the user should try again?
+   */
+  protected const int RETRY_AFTER = 120;
+
+  /**
+   * Current route match service, to find out if it's a DKAN API request.
+   *
+   * @var CurrentRouteMatch
+   */
+  protected CurrentRouteMatch $currentRouteMatch;
+
+  /**
+   * Logger service.
+   *
+   * @var LoggerChannelFactoryInterface
+   */
+  protected LoggerChannelFactoryInterface $logger;
+
+  /**
+   * Constructor.
+   *
+   * @param CurrentRouteMatch $currentRouteMatch
+   *   Current route match service.
+   */
+  public function __construct(
+    LoggerChannelFactoryInterface $logger,
+    CurrentRouteMatch $currentRouteMatch,
+  ) {
+    $this->logger = $logger;
+    $this->currentRouteMatch = $currentRouteMatch;
+  }
+
+  /**
+   * Handle exceptions from the kernel.
+   *
+   * We focus on \PDOException.
+   */
+  public function onKernelException(ExceptionEvent $event): void {
+    // Is this a DKAN API request?
+    if ($this->currentRouteMatch->getRouteObject()->getDefault('is_dkan_api_route') ?? FALSE) {
+      $throwable = $event->getThrowable();
+      // Is this an exception we can handle?
+      if (
+        $throwable instanceof \PDOException &&
+        $throwable->getCode() === self::ER_TOO_MANY_USER_CONNECTIONS
+      ) {
+        // Log the error.
+        $this->logger->get('dkan_api')->error(implode(' ', [
+          $throwable::class,
+          '(code: ' . $throwable->getCode() . ')',
+          $throwable->getMessage(),
+        ]));
+        // Send a response.
+        $response = new JsonResponse(
+          (object) ['message' => 'Try again later after ' . self::RETRY_AFTER . ' seconds.', 'code' => 503],
+          503,
+          ['Retry-After' => self::RETRY_AFTER],
+        );
+        // Setting a response stops propagation.
+        $event->setResponse($response);
+      }
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      KernelEvents::EXCEPTION => ['onKernelException', 60],
+    ];
+  }
+
+}

--- a/modules/dkan_datastore/dkan_datastore.routing.yml
+++ b/modules/dkan_datastore/dkan_datastore.routing.yml
@@ -2,7 +2,8 @@ dkan_datastore.1.datastore:
   path: '/api/1/datastore'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_common\Controller\OpenApiController::getComplete'}
+    _controller: '\Drupal\dkan_common\Controller\OpenApiController::getComplete'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -13,6 +14,7 @@ dkan_datastore.1.imports:
   methods: [GET]
   defaults:
     _controller: '\Drupal\dkan_datastore\Controller\ImportController::list'
+    is_dkan_api_route: true
   requirements:
     _permission: 'datastore_api_import'
   options:
@@ -23,6 +25,7 @@ dkan_datastore.1.imports.post:
   methods: [POST]
   defaults:
     _controller: '\Drupal\dkan_datastore\Controller\ImportController::import'
+    is_dkan_api_route: true
     deferred: false
   requirements:
     _permission: 'datastore_api_import'
@@ -34,6 +37,7 @@ dkan_datastore.1.imports.id:
   methods: [GET]
   defaults:
     _controller: '\Drupal\dkan_datastore\Controller\ImportController::summary'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -44,6 +48,7 @@ dkan_datastore.1.imports.delete:
   methods: [DELETE]
   defaults:
     _controller: '\Drupal\dkan_datastore\Controller\ImportController::deleteMultiple'
+    is_dkan_api_route: true
   requirements:
     _permission: 'datastore_api_drop'
   options:
@@ -54,6 +59,7 @@ dkan_datastore.1.imports.id.delete:
   methods: [DELETE]
   defaults:
     _controller: '\Drupal\dkan_datastore\Controller\ImportController::delete'
+    is_dkan_api_route: true
   requirements:
     _permission: 'datastore_api_drop'
   options:
@@ -64,6 +70,7 @@ dkan_datastore.1.query:
   methods: [GET, POST]
   defaults:
     _controller: '\Drupal\dkan_datastore\Controller\QueryController::query'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -74,6 +81,7 @@ dkan_datastore.1.query.download:
   methods: [GET, POST]
   defaults:
     _controller: '\Drupal\dkan_datastore\Controller\QueryDownloadController::query'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -84,6 +92,7 @@ dkan_datastore.1.query.id:
   methods: [GET, POST]
   defaults:
     _controller: '\Drupal\dkan_datastore\Controller\QueryController::queryResource'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -94,6 +103,7 @@ dkan_datastore.1.query.id.download:
   methods: [GET, POST]
   defaults:
     _controller: '\Drupal\dkan_datastore\Controller\QueryDownloadController::queryResource'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -104,6 +114,7 @@ dkan_datastore.1.query.dataset.index:
   methods: [GET, POST]
   defaults:
     _controller: '\Drupal\dkan_datastore\Controller\QueryController::queryDatasetResource'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -114,6 +125,7 @@ dkan_datastore.1.query.dataset.index.download:
   methods: [GET, POST]
   defaults:
     _controller: '\Drupal\dkan_datastore\Controller\QueryDownloadController::queryDatasetResource'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -124,6 +136,7 @@ dkan_datastore.1.query.schema.get:
   methods: [GET]
   defaults:
     _controller: '\Drupal\dkan_datastore\Controller\QueryController::querySchema'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -133,7 +146,8 @@ dkan_datastore.sql_endpoint.get.api:
   path: '/api/1/datastore/sql'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_datastore\SqlEndpoint\WebServiceApi::runQueryGet'}
+    _controller: '\Drupal\dkan_datastore\SqlEndpoint\WebServiceApi::runQueryGet'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -143,7 +157,8 @@ dkan_datastore.sql_endpoint.post.api:
   path: '/api/1/datastore/sql'
   methods: [POST]
   defaults:
-    { _controller: '\Drupal\dkan_datastore\SqlEndpoint\WebServiceApi::runQueryPost'}
+    _controller: '\Drupal\dkan_datastore\SqlEndpoint\WebServiceApi::runQueryPost'
+    is_dkan_api_route: true
   requirements:
     _access: 'TRUE'
 

--- a/modules/dkan_harvest/dkan_harvest.routing.yml
+++ b/modules/dkan_harvest/dkan_harvest.routing.yml
@@ -2,7 +2,8 @@ dkan.harvest.1.harvest:
   path: '/api/1/harvest'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_common\Controller\OpenApiController::getComplete'}
+    _controller: '\Drupal\dkan_common\Controller\OpenApiController::getComplete'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -12,7 +13,8 @@ dkan.harvest.api.plans:
   path: '/api/1/harvest/plans'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_harvest\WebServiceApi::index'}
+    _controller: '\Drupal\dkan_harvest\WebServiceApi::index'
+    is_dkan_api_route: true
   requirements:
     _permission: 'harvest_api_index'
   options:
@@ -22,7 +24,8 @@ dkan.harvest.api.plans.post:
   path: '/api/1/harvest/plans'
   methods: [POST]
   defaults:
-    { _controller: '\Drupal\dkan_harvest\WebServiceApi::register'}
+    _controller: '\Drupal\dkan_harvest\WebServiceApi::register'
+    is_dkan_api_route: true
   requirements:
     _permission: 'harvest_api_register'
   options:
@@ -32,7 +35,8 @@ dkan.harvest.api.plans_id:
   path: '/api/1/harvest/plans/{identifier}'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_harvest\WebServiceApi::getPlan'}
+    _controller: '\Drupal\dkan_harvest\WebServiceApi::getPlan'
+    is_dkan_api_route: true
   requirements:
     _permission: 'harvest_api_index'
   options:
@@ -42,7 +46,8 @@ dkan.harvest.api.plans_id.delete:
   path: '/api/1/harvest/plans/{identifier}'
   methods: [DELETE]
   defaults:
-    { _controller: '\Drupal\dkan_harvest\WebServiceApi::deregister'}
+    _controller: '\Drupal\dkan_harvest\WebServiceApi::deregister'
+    is_dkan_api_route: true
   requirements:
     _permission: 'harvest_api_run'
   options:
@@ -52,7 +57,8 @@ dkan.harvest.api.runs:
   path: '/api/1/harvest/runs'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_harvest\WebServiceApi::info'}
+    _controller: '\Drupal\dkan_harvest\WebServiceApi::info'
+    is_dkan_api_route: true
   requirements:
     _permission: 'harvest_api_info'
   options:
@@ -62,7 +68,8 @@ dkan.harvest.api.runs.post:
   path: '/api/1/harvest/runs'
   methods: [POST]
   defaults:
-    { _controller: '\Drupal\dkan_harvest\WebServiceApi::run'}
+    _controller: '\Drupal\dkan_harvest\WebServiceApi::run'
+    is_dkan_api_route: true
   requirements:
     _permission: 'harvest_api_run'
   options:
@@ -72,7 +79,8 @@ dkan.harvest.api.runs.delete:
   path: '/api/1/harvest/runs'
   methods: [DELETE]
   defaults:
-    { _controller: '\Drupal\dkan_harvest\WebServiceApi::revert'}
+    _controller: '\Drupal\dkan_harvest\WebServiceApi::revert'
+    is_dkan_api_route: true
   requirements:
     _permission: 'harvest_api_run'
   options:
@@ -82,7 +90,8 @@ dkan.harvest.api.runs_id:
   path: '/api/1/harvest/runs/{identifier}'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_harvest\WebServiceApi::infoRun'}
+    _controller: '\Drupal\dkan_harvest\WebServiceApi::infoRun'
+    is_dkan_api_route: true
   requirements:
     _permission: 'harvest_api_info'
   options:

--- a/modules/dkan_metastore/dkan_metastore.routing.yml
+++ b/modules/dkan_metastore/dkan_metastore.routing.yml
@@ -2,7 +2,8 @@ dkan_metastore.1.metastore:
   path: '/api/1/metastore'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_common\Controller\OpenApiController::getComplete'}
+    _controller: '\Drupal\dkan_common\Controller\OpenApiController::getComplete'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -12,7 +13,8 @@ dkan_metastore.1.metastore.schemas:
   path: '/api/1/metastore/schemas'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::getSchemas'}
+    _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::getSchemas'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -22,7 +24,8 @@ dkan_metastore.1.metastore.schemas.id:
   path: '/api/1/metastore/schemas/{identifier}'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::getSchema'}
+    _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::getSchema'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -32,7 +35,8 @@ dkan_metastore.1.metastore.schemas.id.items:
   path: '/api/1/metastore/schemas/{schema_id}/items'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::getAll'}
+    _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::getAll'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -42,7 +46,8 @@ dkan_metastore.1.metastore.schemas.id.items.post:
   path: '/api/1/metastore/schemas/{schema_id}/items'
   methods: [POST]
   defaults:
-    { _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::post'}
+    _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::post'
+    is_dkan_api_route: true
   requirements:
     _custom_access: '\Drupal\dkan_metastore\Controller\MetastoreAccessManager::canCreate'
   options:
@@ -52,7 +57,8 @@ dkan_metastore.1.metastore.schemas.id.items.id:
   path: '/api/1/metastore/schemas/{schema_id}/items/{identifier}'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::get'}
+    _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::get'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -62,7 +68,8 @@ dkan_metastore.1.metastore.schemas.id.items.id.publish:
   path: '/api/1/metastore/schemas/{schema_id}/items/{identifier}/publish'
   methods: [PUT]
   defaults:
-    { _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::publish'}
+    _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::publish'
+    is_dkan_api_route: true
   requirements:
     _custom_access: '\Drupal\dkan_metastore\Controller\MetastoreAccessManager::canUpdate'
   options:
@@ -72,7 +79,8 @@ dkan_metastore.1.metastore.schemas.id.items.id.put:
   path: '/api/1/metastore/schemas/{schema_id}/items/{identifier}'
   methods: [PUT]
   defaults:
-    { _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::put'}
+    _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::put'
+    is_dkan_api_route: true
   requirements:
     _custom_access: '\Drupal\dkan_metastore\Controller\MetastoreAccessManager::canUpdate'
   options:
@@ -82,7 +90,8 @@ dkan_metastore.1.metastore.schemas.id.items.id.patch:
   path: '/api/1/metastore/schemas/{schema_id}/items/{identifier}'
   methods: [PATCH]
   defaults:
-    { _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::patch'}
+    _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::patch'
+    is_dkan_api_route: true
   requirements:
     _custom_access: '\Drupal\dkan_metastore\Controller\MetastoreAccessManager::canUpdate'
   options:
@@ -92,7 +101,8 @@ dkan_metastore.1.metastore.schemas.id.items.id.delete:
   path: '/api/1/metastore/schemas/{schema_id}/items/{identifier}'
   methods: [DELETE]
   defaults:
-    { _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::delete'}
+    _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::delete'
+    is_dkan_api_route: true
   requirements:
     _custom_access: '\Drupal\dkan_metastore\Controller\MetastoreAccessManager::canDelete'
   options:
@@ -102,7 +112,8 @@ dkan_metastore.1.metastore.schemas.id.items.id.revisions:
   path: '/api/1/metastore/schemas/{schema_id}/items/{identifier}/revisions'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_metastore\Controller\MetastoreRevisionController::getAll'}
+    _controller: '\Drupal\dkan_metastore\Controller\MetastoreRevisionController::getAll'
+    is_dkan_api_route: true
   requirements:
     _custom_access: '\Drupal\dkan_metastore\Controller\MetastoreAccessManager::canViewRevisionList'
   options:
@@ -112,7 +123,8 @@ dkan_metastore.1.metastore.schemas.id.items.id.revisions.id:
   path: '/api/1/metastore/schemas/{schema_id}/items/{identifier}/revisions/{revision_id}'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_metastore\Controller\MetastoreRevisionController::get'}
+    _controller: '\Drupal\dkan_metastore\Controller\MetastoreRevisionController::get'
+    is_dkan_api_route: true
   requirements:
     _custom_access: '\Drupal\dkan_metastore\Controller\MetastoreAccessManager::canViewRevision'
   options:
@@ -122,7 +134,8 @@ dkan_metastore.1.metastore.schemas.id.items.id.revisions.post:
   path: '/api/1/metastore/schemas/{schema_id}/items/{identifier}/revisions'
   methods: [POST]
   defaults:
-    { _controller: '\Drupal\dkan_metastore\Controller\MetastoreRevisionController::post'}
+    _controller: '\Drupal\dkan_metastore\Controller\MetastoreRevisionController::post'
+    is_dkan_api_route: true
   requirements:
     _custom_access: '\Drupal\dkan_metastore\Controller\MetastoreAccessManager::canUpdate'
   options:
@@ -133,7 +146,8 @@ dkan_metastore.1.metastore.schemas.dataset.items.id.docs:
   path: '/api/1/metastore/schemas/dataset/items/{identifier}/docs'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::getDocs'}
+    _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::getDocs'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:
@@ -143,7 +157,8 @@ dkan_metastore.data_json:
   path: '/data.json'
   methods: [GET]
   defaults:
-    { _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::getCatalog'}
+    _controller: '\Drupal\dkan_metastore\Controller\MetastoreController::getCatalog'
+    is_dkan_api_route: true
   requirements:
     _permission: 'access content'
   options:


### PR DESCRIPTION
Fixes [issue#]

## Describe your changes

This is another way to do https://github.com/GetDKAN/dkan/pull/4704 much more generalized.

- Marks DKAN API routes as DKAN API routes in the yml files.
- Adds an exception event subscriber, so we can handle specific exceptions.
- We're handling the case of a `\PDOException` with a code of 1203 (too many connections).
- Always return a `JsonResponse` with a 503 response code for this exception, and a `Retry-After` header of our choosing.

To see it in action, make a local and modify an API controller method to throw the exception. I suggest `Drupal\dkan_datastore\Controller\AbstractQueryController::queryResource`. Throw an exception like this:
```
    throw new \PDOException(
      'AI bots taking over.', 1203
    );
```
Now request: https://dkan.ddev.site/api/1/datastore/query/8701d18a-5792-5451-8700-a621bccc5f6e

See a message like this:
```
{
"message": "Try again later after 120 seconds.",
"code": 503
}
```

Watchdog should show you a message like: "PDOException (code: 1203) AI bots taking over."

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
