### PR TITLE
Empty datastore error

### DIFF
--- a/modules/dkan_common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/dkan_common/src/Storage/AbstractDatabaseTable.php
@@ -421,6 +421,9 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
    * {@inheritdoc}
    */
   public function tableIsEmpty(): bool {
+    if (!$this->tableExist($this->getTableName())) {
+      return TRUE;
+    }
     $query = $this->connection->select($this->getTableName())
       ->range(0, 1);
     $query->addExpression('1');

--- a/modules/dkan_common/src/Storage/AbstractDatabaseTable.php
+++ b/modules/dkan_common/src/Storage/AbstractDatabaseTable.php
@@ -417,4 +417,14 @@ abstract class AbstractDatabaseTable implements DatabaseTableInterface {
     return substr($md5, 0, 4);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function tableIsEmpty(): bool {
+    $query = $this->connection->select($this->getTableName())
+      ->range(0, 1);
+    $query->addExpression('1');
+    return !(bool) $query->execute()->fetchField();
+  }
+
 }

--- a/modules/dkan_common/src/Storage/DatabaseTableInterface.php
+++ b/modules/dkan_common/src/Storage/DatabaseTableInterface.php
@@ -63,4 +63,12 @@ interface DatabaseTableInterface extends
    */
   public function getTableName();
 
+  /**
+   * Check if the table is empty.
+   *
+   * @return bool
+   *   TRUE if the table is empty, FALSE otherwise.
+   */
+  public function tableIsEmpty(): bool;
+
 }

--- a/modules/dkan_datastore/modules/dkan_datastore_mysql_import/src/Service/MysqlImport.php
+++ b/modules/dkan_datastore/modules/dkan_datastore_mysql_import/src/Service/MysqlImport.php
@@ -62,7 +62,7 @@ class MysqlImport extends ImportJob {
   protected function runIt() {
     // If the storage table already exists, we already performed an import and
     // can stop here.
-    if ($this->dataStorage->hasBeenImported()) {
+    if ($this->dataStorage instanceof ImportedItemInterface && $this->dataStorage->hasBeenImported()) {
       $this->setStatus(Result::DONE);
       return NULL;
     }

--- a/modules/dkan_datastore/modules/dkan_datastore_mysql_import/src/Storage/MySqlDatabaseTable.php
+++ b/modules/dkan_datastore/modules/dkan_datastore_mysql_import/src/Storage/MySqlDatabaseTable.php
@@ -96,4 +96,17 @@ class MySqlDatabaseTable extends DatabaseTable implements ImportedItemInterface 
     }
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * For datastore_mysql_import, at this point we only check if the table exists
+   * in the database and has more than 0 rows. This is because the importer is
+   * assumed to have used LOAD DATA LOCAL INFILE to import the data in one step.
+   *
+   * @see \Drupal\dkan_datastore_mysql_import\Service\MysqlImport::getSqlStatement
+   */
+  public function hasBeenImported(): bool {
+    return !$this->tableIsEmpty();
+  }
+
 }

--- a/modules/dkan_datastore/modules/dkan_datastore_mysql_import/src/Storage/MySqlDatabaseTable.php
+++ b/modules/dkan_datastore/modules/dkan_datastore_mysql_import/src/Storage/MySqlDatabaseTable.php
@@ -96,20 +96,4 @@ class MySqlDatabaseTable extends DatabaseTable implements ImportedItemInterface 
     }
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * For datastore_mysql_import, at this point we only check if the table exists
-   * in the database and has more than 0 rows. This is because the importer is
-   * assumed to have used LOAD DATA LOCAL INFILE to import the data in one step.
-   *
-   * @see \Drupal\dkan_datastore_mysql_import\Service\MysqlImport::getSqlStatement
-   */
-  public function hasBeenImported(): bool {
-    if ($this->tableExist($this->getTableName())) {
-      return $this->count() > 0;
-    }
-    return FALSE;
-  }
-
 }

--- a/modules/dkan_datastore/modules/dkan_datastore_mysql_import/tests/src/Unit/Service/MysqlImportTest.php
+++ b/modules/dkan_datastore/modules/dkan_datastore_mysql_import/tests/src/Unit/Service/MysqlImportTest.php
@@ -92,7 +92,7 @@ class MysqlImportTest extends TestCase {
   protected function getDatabaseTableFactoryMock() {
     return (new Chain($this))
       ->add(DatabaseTableFactory::class, 'getInstance', DatabaseTable::class)
-      ->add(DatabaseTable::class, 'hasBeenImported', TRUE)
+      ->add(DatabaseTable::class, 'tableIsEmpty', TRUE)
       ->add(DatabaseTable::class, 'getTableName', self::TABLE_NAME)
       ->getMock();
   }

--- a/modules/dkan_datastore/modules/dkan_datastore_mysql_import/tests/src/Unit/Service/MysqlImportTest.php
+++ b/modules/dkan_datastore/modules/dkan_datastore_mysql_import/tests/src/Unit/Service/MysqlImportTest.php
@@ -92,7 +92,7 @@ class MysqlImportTest extends TestCase {
   protected function getDatabaseTableFactoryMock() {
     return (new Chain($this))
       ->add(DatabaseTableFactory::class, 'getInstance', DatabaseTable::class)
-      ->add(DatabaseTable::class, 'count', 4)
+      ->add(DatabaseTable::class, 'hasBeenImported', TRUE)
       ->add(DatabaseTable::class, 'getTableName', self::TABLE_NAME)
       ->getMock();
   }

--- a/modules/dkan_datastore/src/Controller/AbstractQueryController.php
+++ b/modules/dkan_datastore/src/Controller/AbstractQueryController.php
@@ -7,6 +7,7 @@ use Drupal\dkan_common\JsonResponseTrait;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\State\StateInterface;
+use Drupal\dkan_datastore\Exception\EmptyResourceException;
 use Drupal\dkan_datastore\Service\DatastoreQuery;
 use Drupal\dkan_datastore\Service\Query as QueryService;
 use Drupal\dkan_metastore\MetastoreApiResponse;
@@ -280,6 +281,9 @@ abstract class AbstractQueryController implements ContainerInjectionInterface {
     }
     catch (HttpException $e) {
       return $this->getResponseFromException($e, $e->getStatusCode());
+    }
+    catch (EmptyResourceException $e) {
+      return $this->getResponseFromException($e, 404);
     }
     catch (\Exception $e) {
       $code = (str_contains($e->getMessage(), "Error retrieving")) ? 404 : 400;

--- a/modules/dkan_datastore/src/Exception/EmptyResourceException.php
+++ b/modules/dkan_datastore/src/Exception/EmptyResourceException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\dkan_datastore\Exception;
+
+/**
+ * Exception for empty datastore resources.
+ */
+class EmptyResourceException extends \Exception {
+
+  /**
+   * Constructor.
+   *
+   * @param string $resourceId
+   *   The unique identifier for the resource that is empty.
+   */
+  public function __construct(string $resourceId) {
+    parent::__construct('The resource ' . $resourceId . ' does not contain any data.');
+  }
+
+}

--- a/modules/dkan_datastore/src/Plugin/QueueWorker/ImportJob.php
+++ b/modules/dkan_datastore/src/Plugin/QueueWorker/ImportJob.php
@@ -186,6 +186,9 @@ class ImportJob extends AbstractPersistentJob {
 
   /**
    * Get the storage object.
+   *
+   * @return \Drupal\dkan_datastore\Storage\DatabaseTable
+   *   A datastore table.
    */
   public function getStorage() {
     return $this->dataStorage;

--- a/modules/dkan_datastore/src/Service/Query.php
+++ b/modules/dkan_datastore/src/Service/Query.php
@@ -101,10 +101,10 @@ class Query implements ContainerInjectionInterface {
    * @param \Drupal\dkan_datastore\Service\DatastoreQuery $datastoreQuery
    *   DatastoreQuery object.
    *
-   * @return array
+   * @return \Drupal\dkan_datastore\Storage\DatabaseTable[]
    *   Array of storage objects, keyed to resource aliases.
    */
-  public function getQueryStorageMap(DatastoreQuery $datastoreQuery) {
+  public function getQueryStorageMap(DatastoreQuery $datastoreQuery): array {
     $storageMap = [];
     foreach ($datastoreQuery->{"$.resources"} as $resource) {
       [$identifier, $version] = DataResource::getIdentifierAndVersion($resource["id"]);

--- a/modules/dkan_datastore/src/Storage/DatabaseTable.php
+++ b/modules/dkan_datastore/src/Storage/DatabaseTable.php
@@ -5,9 +5,6 @@ namespace Drupal\dkan_datastore\Storage;
 use Drupal\Core\Database\Connection;
 use Drupal\dkan_common\DataResource;
 use Drupal\dkan_common\Storage\AbstractDatabaseTable;
-use Drupal\dkan_common\Storage\ImportedItemInterface;
-use Drupal\dkan_common\Storage\Query;
-use Drupal\dkan_datastore\Exception\EmptyResourceException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -20,7 +17,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * actually MySQL-specific. In the future it should probably be a base class
  * with a MySQL-specific subclass.
  */
-class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable, ImportedItemInterface {
+class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
 
   /**
    * Datastore resource object.
@@ -124,34 +121,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable, 
   }
 
   /**
-   * {@inheritdoc}
-   */
-  public function query(Query $query, string $alias = 't', $fetch = TRUE) {
-    $this->setTable();
-    // Check if the table has any rows. For empty tables in the datastore, we
-    // want to throw an exception instead of just returning an empty result.
-    if (!$this->hasBeenImported()) {
-      throw new EmptyResourceException($this->resource->getUniqueIdentifier());
-    }
-    return parent::query($query, $alias, $fetch);
-  }
-
-  /**
-   * Check if the table has been imported -- ie, if it has any rows.
-   */
-  public function hasBeenImported(): bool {
-    if (!$this->tableExist($this->getTableName())) {
-      return FALSE;
-    }
-
-    $query = $this->connection->select($this->getTableName())
-      ->range(0, 1);
-    $query->addExpression('1');
-    return (bool) $query->execute()->fetchField();
-  }
-
-  /**
-   * {@inheritdoc}
+   * Protected.
    */
   public function primaryKey() {
     return 'record_number';

--- a/modules/dkan_datastore/src/Storage/DatabaseTable.php
+++ b/modules/dkan_datastore/src/Storage/DatabaseTable.php
@@ -5,6 +5,8 @@ namespace Drupal\dkan_datastore\Storage;
 use Drupal\Core\Database\Connection;
 use Drupal\dkan_common\DataResource;
 use Drupal\dkan_common\Storage\AbstractDatabaseTable;
+use Drupal\dkan_common\Storage\Query;
+use Drupal\dkan_datastore\Exception\EmptyResourceException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -121,7 +123,20 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
   }
 
   /**
-   * Protected.
+   * {@inheritdoc}
+   */
+  public function query(Query $query, string $alias = 't', $fetch = TRUE) {
+    $this->setTable();
+    // Check if the table has any rows. For empty tables in the datastore, we
+    // want to throw an exception instead of just returning an empty result.
+    if ($this->count() == 0) {
+      throw new EmptyResourceException($this->resource->getUniqueIdentifier());
+    }
+    return parent::query($query, $alias, $fetch);
+  }
+
+  /**
+   * {@inheritdoc}
    */
   public function primaryKey() {
     return 'record_number';

--- a/modules/dkan_datastore/src/Storage/DatabaseTable.php
+++ b/modules/dkan_datastore/src/Storage/DatabaseTable.php
@@ -129,10 +129,20 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     $this->setTable();
     // Check if the table has any rows. For empty tables in the datastore, we
     // want to throw an exception instead of just returning an empty result.
-    if ($this->count() == 0) {
+    if ($this->tableIsEmpty()) {
       throw new EmptyResourceException($this->resource->getUniqueIdentifier());
     }
     return parent::query($query, $alias, $fetch);
+  }
+
+  /**
+   * Check if the table is empty.
+   */
+  protected function tableIsEmpty(): bool {
+    $query = $this->connection->select($this->getTableName())
+      ->range(0, 1);
+    $query->addExpression('1');
+    return !(bool) $query->execute()->fetchField();
   }
 
   /**

--- a/modules/dkan_datastore/src/Storage/DatabaseTable.php
+++ b/modules/dkan_datastore/src/Storage/DatabaseTable.php
@@ -130,7 +130,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable, 
     $this->setTable();
     // Check if the table has any rows. For empty tables in the datastore, we
     // want to throw an exception instead of just returning an empty result.
-    if ($this->hasBeenImported()) {
+    if (!$this->hasBeenImported()) {
       throw new EmptyResourceException($this->resource->getUniqueIdentifier());
     }
     return parent::query($query, $alias, $fetch);
@@ -147,7 +147,7 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable, 
     $query = $this->connection->select($this->getTableName())
       ->range(0, 1);
     $query->addExpression('1');
-    return !(bool) $query->execute()->fetchField();
+    return (bool) $query->execute()->fetchField();
   }
 
   /**

--- a/modules/dkan_datastore/src/Storage/DatabaseTable.php
+++ b/modules/dkan_datastore/src/Storage/DatabaseTable.php
@@ -5,6 +5,8 @@ namespace Drupal\dkan_datastore\Storage;
 use Drupal\Core\Database\Connection;
 use Drupal\dkan_common\DataResource;
 use Drupal\dkan_common\Storage\AbstractDatabaseTable;
+use Drupal\dkan_common\Storage\Query;
+use Drupal\dkan_datastore\Exception\EmptyResourceException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -118,6 +120,19 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
       throw new \Exception('Import for ' . $id . ' returned an error when preparing table header: ' . $data);
     }
     return $decoded;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query(Query $query, string $alias = 't', $fetch = TRUE) {
+    $this->setTable();
+    // Check if the table has any rows. For empty tables in the datastore, we
+    // want to throw an exception instead of just returning an empty result.
+    if ($this->tableIsEmpty()) {
+      throw new EmptyResourceException($this->resource->getUniqueIdentifier());
+    }
+    return parent::query($query, $alias, $fetch);
   }
 
   /**

--- a/modules/dkan_datastore/src/Storage/DatabaseTable.php
+++ b/modules/dkan_datastore/src/Storage/DatabaseTable.php
@@ -5,6 +5,7 @@ namespace Drupal\dkan_datastore\Storage;
 use Drupal\Core\Database\Connection;
 use Drupal\dkan_common\DataResource;
 use Drupal\dkan_common\Storage\AbstractDatabaseTable;
+use Drupal\dkan_common\Storage\ImportedItemInterface;
 use Drupal\dkan_common\Storage\Query;
 use Drupal\dkan_datastore\Exception\EmptyResourceException;
 use Psr\Log\LoggerInterface;
@@ -19,7 +20,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * actually MySQL-specific. In the future it should probably be a base class
  * with a MySQL-specific subclass.
  */
-class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
+class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable, ImportedItemInterface {
 
   /**
    * Datastore resource object.
@@ -129,16 +130,20 @@ class DatabaseTable extends AbstractDatabaseTable implements \JsonSerializable {
     $this->setTable();
     // Check if the table has any rows. For empty tables in the datastore, we
     // want to throw an exception instead of just returning an empty result.
-    if ($this->tableIsEmpty()) {
+    if ($this->hasBeenImported()) {
       throw new EmptyResourceException($this->resource->getUniqueIdentifier());
     }
     return parent::query($query, $alias, $fetch);
   }
 
   /**
-   * Check if the table is empty.
+   * Check if the table has been imported -- ie, if it has any rows.
    */
-  protected function tableIsEmpty(): bool {
+  public function hasBeenImported(): bool {
+    if (!$this->tableExist($this->getTableName())) {
+      return FALSE;
+    }
+
     $query = $this->connection->select($this->getTableName())
       ->range(0, 1);
     $query->addExpression('1');

--- a/modules/dkan_datastore/tests/src/Unit/Plugin/QueueWorker/TestMemStorage.php
+++ b/modules/dkan_datastore/tests/src/Unit/Plugin/QueueWorker/TestMemStorage.php
@@ -134,4 +134,8 @@ class TestMemStorage implements DatabaseTableInterface, \JsonSerializable
         return "test_mem_storage";
     }
 
-  }
+    public function tableIsEmpty(): bool {
+        throw new \Exception('Not implemented');
+    }
+
+}

--- a/modules/dkan_datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -350,6 +350,7 @@ class DatabaseTableTest extends TestCase {
    *
    * @covers ::query()
    * @covers ::tableIsEmpty()
+   * @covers \Drupal\dkan_datastore\Exception\EmptyResourceException
    */
   public function testQueryCountZero() {
     $query = new Query();
@@ -440,7 +441,8 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
-   *
+   * @covers ::prepareData()
+   * @covers ::store()
    */
   public function testPrepareDataNonArray() {
     $connectionChain = $this->getConnectionChain()
@@ -465,7 +467,7 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
-   *
+   * @covers ::query()
    */
   public function testQuery() {
     $query = new Query();
@@ -489,7 +491,7 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
-   *
+   * @covers ::query()
    */
   public function testQueryExceptionDatabaseInternalError() {
     $query = new Query();
@@ -517,7 +519,7 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
-   *
+   * @covers ::query()
    */
   public function testQueryColumnNotFound() {
     $query = new Query();
@@ -540,7 +542,8 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
-   *
+   * @covers ::query()
+   * @covers \Drupal\dkan_common\Storage\AbstractDatabaseTable::sanitizedErrorMessage()
    */
   public function testNoFulltextIndexFound() {
     $query = new Query();

--- a/modules/dkan_datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -349,7 +349,7 @@ class DatabaseTableTest extends TestCase {
    * Test that an empty table will throw an exception.
    *
    * @covers ::query()
-   * @covers ::tableIsEmpty()
+   * @covers ::hasBeenImported()
    * @covers \Drupal\dkan_datastore\Exception\EmptyResourceException
    */
   public function testQueryCountZero() {

--- a/modules/dkan_datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -9,6 +9,7 @@ use Drupal\Core\Database\Query\Insert;
 use Drupal\Core\Database\Query\Select;
 use Drupal\dkan_common\Storage\Query;
 use Drupal\Core\Database\StatementInterface;
+use Drupal\dkan_datastore\Exception\EmptyResourceException;
 use Drupal\dkan_datastore\Storage\DatabaseTable;
 use Drupal\mysql\Driver\Database\mysql\Schema;
 use MockChain\Chain;
@@ -122,7 +123,7 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
-   *
+   * @covers ::__construct()
    */
   public function testConstruction() {
 
@@ -136,7 +137,7 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
-   *
+   * @covers ::getSchema()
    */
   public function testGetSchema() {
     $connectionChain = $this->getConnectionChain();
@@ -187,7 +188,7 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
-   *
+   * @covers ::retrieveAll()
    */
   public function testRetrieveAll() {
 
@@ -217,7 +218,7 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
-   *
+   * @covers ::store()
    */
   public function testStore() {
     $connectionChain = $this->getConnectionChain()
@@ -241,7 +242,7 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
-   *
+   * @covers ::store()
    */
   public function testStoreFieldCountException() {
     $connectionChain = $this->getConnectionChain()
@@ -266,7 +267,7 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
-   *
+   * @covers ::storeMultiple()
    */
   public function testStoreMultiple() {
     $connectionChain = $this->getConnectionChain()
@@ -295,7 +296,7 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
-   *
+   * @covers ::storeMultiple()
    */
   public function testStoreMultipleFieldCountException() {
     $connectionChain = $this->getConnectionChain()
@@ -325,7 +326,7 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
-   *
+   * @covers ::count()
    */
   public function testCount() {
     $connectionChain = $this->getConnectionChain()
@@ -345,7 +346,32 @@ class DatabaseTableTest extends TestCase {
   }
 
   /**
+   * Test that an empty table will throw an exception.
    *
+   * @covers ::query()
+   */
+  public function testQueryCountZero() {
+    $query = new Query();
+
+    $connectionChain = $this->getConnectionChain()
+      ->add(Connection::class, 'select', Select::class, 'select_1')
+      ->add(Select::class, 'fields', Select::class)
+      ->add(Select::class, 'countQuery', Select::class)
+      ->add(Select::class, 'execute', StatementInterface::class)
+      ->add(StatementInterface::class, 'fetchField', 0);
+
+    $databaseTable = new DatabaseTable(
+      $connectionChain->getMock(),
+      $this->getResource(),
+      $this->createStub(LoggerInterface::class),
+      $this->createStub(EventDispatcherInterface::class)
+    );
+    $this->expectException(EmptyResourceException::class);
+    $databaseTable->query($query);
+  }
+
+  /**
+   * @covers ::getSummary
    */
   public function testGetSummary() {
     $connectionChain = $this->getConnectionChain()

--- a/modules/dkan_datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -356,8 +356,6 @@ class DatabaseTableTest extends TestCase {
 
     $connectionChain = $this->getConnectionChain()
       ->add(Connection::class, 'select', Select::class, 'select_1')
-      ->add(Select::class, 'fields', Select::class)
-      ->add(Select::class, 'countQuery', Select::class)
       ->add(Select::class, 'execute', StatementInterface::class)
       ->add(StatementInterface::class, 'fetchField', 0);
 
@@ -477,6 +475,7 @@ class DatabaseTableTest extends TestCase {
       ->add(Select::class, 'fields', Select::class)
       ->add(Select::class, 'condition', Select::class)
       ->add(Select::class, 'execute', StatementInterface::class)
+      ->add(StatementInterface::class, 'fetchField', 1)
       ->add(StatementInterface::class, 'fetchAll', []);
 
     $databaseTable = new DatabaseTable(
@@ -495,11 +494,16 @@ class DatabaseTableTest extends TestCase {
   public function testQueryExceptionDatabaseInternalError() {
     $query = new Query();
 
+    $executeSequence = (new Sequence())
+      ->add(StatementInterface::class)
+      ->add(new DatabaseExceptionWrapper("Integrity constraint violation"));
+
     $connectionChain = $this->getConnectionChain()
       ->add(Connection::class, 'select', Select::class, 'select_1')
       ->add(Select::class, 'fields', Select::class)
       ->add(Select::class, 'condition', Select::class)
-      ->add(Select::class, 'execute', new DatabaseExceptionWrapper("Integrity constraint violation"));
+      ->add(Select::class, 'execute', $executeSequence)
+      ->add(StatementInterface::class, 'fetchField', 1);
 
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),
@@ -541,11 +545,16 @@ class DatabaseTableTest extends TestCase {
   public function testNoFulltextIndexFound() {
     $query = new Query();
 
+    $executeSequence = (new Sequence())
+      ->add(StatementInterface::class)
+      ->add(new DatabaseExceptionWrapper("SQLSTATE[HY000]: General error: 1191 Can't find FULLTEXT index matching the column list..."));
+
     $connectionChain = $this->getConnectionChain()
       ->add(Connection::class, 'select', Select::class, 'select_1')
       ->add(Select::class, 'fields', Select::class)
       ->add(Select::class, 'condition', Select::class)
-      ->add(Select::class, 'execute', new DatabaseExceptionWrapper("SQLSTATE[HY000]: General error: 1191 Can't find FULLTEXT index matching the column list..."));
+      ->add(Select::class, 'execute', $executeSequence)
+      ->add(StatementInterface::class, 'fetchField', 1);
 
     $databaseTable = new DatabaseTable(
       $connectionChain->getMock(),

--- a/modules/dkan_datastore/tests/src/Unit/Storage/DatabaseTableTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Storage/DatabaseTableTest.php
@@ -349,6 +349,7 @@ class DatabaseTableTest extends TestCase {
    * Test that an empty table will throw an exception.
    *
    * @covers ::query()
+   * @covers ::tableIsEmpty()
    */
   public function testQueryCountZero() {
     $query = new Query();

--- a/modules/dkan_harvest/src/Storage/HarvestHashesEntityDatabaseTable.php
+++ b/modules/dkan_harvest/src/Storage/HarvestHashesEntityDatabaseTable.php
@@ -274,4 +274,17 @@ class HarvestHashesEntityDatabaseTable implements DatabaseTableInterface {
     throw new \RuntimeException(__METHOD__ . ' not yet implemented.');
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function tableIsEmpty(): bool {
+    // Check if there are any entities at all in the table.
+    $ids = $this->entityStorage->getQuery()
+      ->condition('harvest_plan_id', $this->planId)
+      ->range(0, 1)
+      ->accessCheck(FALSE)
+      ->execute();
+    return empty($ids);
+  }
+
 }

--- a/modules/dkan_harvest/tests/src/Kernel/Storage/HarvestHashesEntityDatabaseTableTest.php
+++ b/modules/dkan_harvest/tests/src/Kernel/Storage/HarvestHashesEntityDatabaseTableTest.php
@@ -100,4 +100,22 @@ class HarvestHashesEntityDatabaseTableTest extends KernelTestBase {
     $this->assertEquals(0, $table->count());
   }
 
+  public function testTableIsEmpty() {
+    $harvest_plan_id = 'test_harvest';
+    /** @var \Drupal\dkan_harvest\Storage\HarvestHashesEntityDatabaseTable $table */
+    $table = $this->container
+      ->get('dkan.harvest.storage.hashes_database_table')
+      ->getInstance($harvest_plan_id);
+
+    $this->assertTrue($table->tableIsEmpty());
+
+    $dataset_uuid = '9110349C-65CB-4187-984C-E33A0F27DA39';
+    $hash_data = [
+      'harvest_plan_id' => $harvest_plan_id,
+      'hash' => 'yuck',
+    ];
+    $table->store(json_encode($hash_data), $dataset_uuid);
+    $this->assertFalse($table->tableIsEmpty());
+  }
+
 }


### PR DESCRIPTION
Throws a specific exception when a table has been created but not populated.

After significant back-and-forth and debate I settled on 404 as the HTTP error code, but this is still negotiable.

## QA Steps

1. Build and load sample content
2. Use drush dkan:dataset-info to get the table name of an imported resource
3. Run `drush sqlc`, and then run `TRUNCATE [table-name]`
4. Do a datastore query against that resource (using any endpoint)
5. Confirm 404 error with with appropriate message.