### PR TITLE
Symfony polyfill workaround

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,31 +273,31 @@ workflows:
     jobs:
       - cypress:
           name: install_test_cypress
-          drupal_core_constraint: "~10.5.0"
+          drupal_core_constraint: "~10.5.10"
       - phpunit:
           name: "Install target (Drupal 10.5, PHP 8.3)"
           report_coverage: true
           matrix:
             parameters:
-              drupal_core_constraint: ["~10.5.0"]
+              drupal_core_constraint: ["~10.5.10"]
               php_version: ["8.3"]
               database_version: ["mysql:5.7"]
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~10.6.0", "~11.2.0", "~11.3.0"]
+              drupal_core_constraint: ["~10.6.9", "~11.2.12", "~11.3.10"]
               php_version: ["8.3"]
               database_version: ["mariadb:10.11"]
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~10.6.0", "~11.2.0", "~11.3.0"]
+              drupal_core_constraint: ["~10.6.9", "~11.2.12", "~11.3.10"]
               php_version: ["8.4"]
               database_version: ["mariadb:10.11"]
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~10.5.0"]
+              drupal_core_constraint: ["~10.5.10"]
               php_version: ["8.1", "8.2", "8.4"]
               database_version: ["mysql:5.7"]
 
@@ -307,4 +307,4 @@ workflows:
       - cypress:
           name: upgrade_test_cypress
           upgrade: true
-          drupal_core_constraint: "~10.5.0"
+          drupal_core_constraint: "~10.5.10"

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "stolt/json-merge-patch": "^2.0"
     },
     "require-dev": {
+        "symfony/polyfill-intl-idn": "1.38.1 as 1.37.0",
         "colinodell/psr-testlogger": "^1.2",
         "drush/drush": "*",
         "getdkan/mock-chain": "~1.4.1",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "stolt/json-merge-patch": "^2.0"
     },
     "require-dev": {
-        "symfony/polyfill-intl-idn": "1.38.1 as 1.37.0",
         "colinodell/psr-testlogger": "^1.2",
         "drush/drush": "*",
         "getdkan/mock-chain": "~1.4.1",
@@ -53,6 +52,11 @@
             "php-http/discovery": true,
             "tbachert/spi": true,
             "drupal/core-composer-scaffold": true
+        },
+        "audit": {
+            "ignore": {
+                "PKSA-dwsq-ppd2-mb1x": "Temporarily ignoring this advisory until core-recommended is updated to bring in symfony/polyfill-intl-idn 1.28."
+            }
         }
     },
     "extra": {


### PR DESCRIPTION
Temporary fix while https://www.drupal.org/project/drupal/issues/3592065 is worked on

Also updated to latest minimum constraints for Drupal, as having too many potential versions to try confuses the error messages. The issue itself is mitigated by having the intl extension installed, which is common for PHP environments. If you are running DKAN w/o intl and use core-recommended as your Drupal core dependency, you should still try to upgrade symfony/polyfill-intl-idn downstream, by requiring `"symfony/polyfill-intl-idn": "1.38.1 as 1.37.0"`.

Will revert the change to composer.json once core-recommended is updated, but our CI will fail in the meantime without this.