### PR TITLE
Validate buried sub-schemas in metastore schema check

### DIFF
--- a/modules/dkan_metastore/dkan_metastore.install
+++ b/modules/dkan_metastore/dkan_metastore.install
@@ -8,7 +8,10 @@
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Opis\JsonSchema\Exceptions\SchemaException;
-use Opis\JsonSchema\Validator;
+use Opis\JsonSchema\Info\SchemaInfo;
+use Opis\JsonSchema\Parsers\SchemaParser;
+use Opis\JsonSchema\SchemaLoader;
+use Opis\JsonSchema\Schemas\ExceptionSchema;
 
 /**
  * Update hook to uninstall the legacy metastore module.
@@ -43,6 +46,12 @@ function dkan_metastore_update_11301() {
 /**
  * Validate a JSON Schema document under opis/json-schema v2.
  *
+ * Opis defers sub-schema parsing (LazySchema), and validating trivial data only
+ * reaches schema positions a given instance walks into — so buried draft-04 or
+ * structural errors (e.g. in properties, $defs, items, or short-circuited
+ * allOf/anyOf/then/else branches) go unnoticed. This walks every genuine schema
+ * position and forces each through opis's throwing parse path.
+ *
  * @param string $json
  *   Schema JSON string.
  *
@@ -60,18 +69,143 @@ function _dkan_metastore_validate_schema_json(string $json): ?string {
   if (is_bool($decoded)) {
     return NULL;
   }
+
+  // Opis's public parseSchema() swallows SchemaException into an
+  // ExceptionSchema whose wrapped exception is private; this subclass exposes
+  // the throwing path so we can report the real message. Default construction
+  // inherits opis's registered drafts and formats.
+  $parser = new class() extends SchemaParser {
+
+    /**
+     * Re-parse a node through the throwing path to surface its error.
+     */
+    public function parseStrict(SchemaInfo $info): void {
+      $this->parseSchemaObject($info);
+    }
+
+  };
+  $loader = new SchemaLoader($parser);
+
+  // Build and cache the full lazy schema tree once. This throws eagerly only
+  // for root-level structural errors raised by parseRootSchema() (non-string
+  // $schema, non-absolute or duplicate $id). Ordinary keyword parse errors are
+  // deferred and surfaced by the walk below.
   try {
-    // Force eager parse — catches root-level structural errors (non-string
-    // $schema, non-absolute $id, etc.).
-    (new Validator())->loader()->loadObjectSchema($decoded);
-    // Force LazySchema resolution by validating trivial data — opis defers
-    // sub-schema parsing until the validator walks into them.
-    (new Validator())->validate(NULL, $decoded);
+    $loader->loadObjectSchema($decoded);
   }
   catch (SchemaException $e) {
     return $e->getMessage();
   }
+
+  // Visit every genuine schema position (root first) and resolve it against
+  // the cached tree, which preserves each node's draft/base/root/$ref context.
+  // A bad node resolves to an ExceptionSchema; re-parse it for the message.
+  $nodes = [];
+  _dkan_metastore_collect_schema_nodes($decoded, '#', $nodes);
+  foreach ($nodes as [$node, $pointer]) {
+    if (!($loader->loadObjectSchema($node) instanceof ExceptionSchema)) {
+      continue;
+    }
+    try {
+      $parser->parseStrict($loader->loadObjectSchema($node)->info());
+      $message = 'cannot be parsed under opis/json-schema v2.';
+    }
+    catch (SchemaException $e) {
+      $message = $e->getMessage();
+    }
+    return $pointer === '#' ? $message : "Sub-schema at {$pointer}: {$message}";
+  }
+
   return NULL;
+}
+
+/**
+ * Collect every genuine JSON Schema position in a decoded schema document.
+ *
+ * Descends only through applicator keywords, so non-schema containers (the
+ * properties map, default/const values, a property literally named "format")
+ * are never mistaken for schemas.
+ *
+ * @param mixed $node
+ *   Current node. Only objects are schema positions worth checking; booleans
+ *   are valid schemas with nothing to descend into; anything else is ignored.
+ * @param string $pointer
+ *   JSON pointer of $node, for error reporting.
+ * @param array $out
+ *   Accumulator of [object $node, string $pointer] pairs.
+ */
+function _dkan_metastore_collect_schema_nodes($node, string $pointer, array &$out): void {
+  if (!is_object($node)) {
+    return;
+  }
+  $out[] = [$node, $pointer];
+
+  // Keywords whose value is a single sub-schema.
+  $schema_valued = [
+    'additionalProperties', 'additionalItems', 'unevaluatedProperties',
+    'unevaluatedItems', 'contains', 'propertyNames', 'not', 'if', 'then',
+    'else', 'contentSchema',
+  ];
+  foreach ($schema_valued as $kw) {
+    if (isset($node->$kw)) {
+      _dkan_metastore_collect_schema_nodes($node->$kw, "{$pointer}/{$kw}", $out);
+    }
+  }
+
+  // Keywords whose value is a map of name => sub-schema.
+  $schema_map = [
+    'properties', 'patternProperties', '$defs', 'definitions',
+    'dependentSchemas',
+  ];
+  foreach ($schema_map as $kw) {
+    if (isset($node->$kw) && is_object($node->$kw)) {
+      foreach ($node->$kw as $name => $sub) {
+        _dkan_metastore_collect_schema_nodes($sub, "{$pointer}/{$kw}/{$name}", $out);
+      }
+    }
+  }
+
+  // Keywords whose value is a list of sub-schemas.
+  $schema_list = ['allOf', 'anyOf', 'oneOf', 'prefixItems'];
+  foreach ($schema_list as $kw) {
+    if (isset($node->$kw) && is_array($node->$kw)) {
+      foreach ($node->$kw as $i => $sub) {
+        _dkan_metastore_collect_schema_nodes($sub, "{$pointer}/{$kw}/{$i}", $out);
+      }
+    }
+  }
+
+  // items: a single schema (object/bool) or a tuple (array of schemas).
+  if (isset($node->items)) {
+    if (is_array($node->items)) {
+      foreach ($node->items as $i => $sub) {
+        _dkan_metastore_collect_schema_nodes($sub, "{$pointer}/items/{$i}", $out);
+      }
+    }
+    else {
+      _dkan_metastore_collect_schema_nodes($node->items, "{$pointer}/items", $out);
+    }
+  }
+
+  // The dependencies keyword (draft 6/7): an object/bool value is a sub-schema;
+  // an array value is a list of property names — not a schema, so skip it.
+  if (isset($node->dependencies) && is_object($node->dependencies)) {
+    foreach ($node->dependencies as $name => $sub) {
+      if (is_object($sub) || is_bool($sub)) {
+        _dkan_metastore_collect_schema_nodes($sub, "{$pointer}/dependencies/{$name}", $out);
+      }
+    }
+  }
+
+  // The $slots opis extension (allowSlots defaults on): object/bool fallbacks
+  // are sub-schemas; string fallbacks are slot names — skip those.
+  if (isset($node->{'$slots'}) && is_object($node->{'$slots'})) {
+    foreach ($node->{'$slots'} as $name => $fallback) {
+      if (is_object($fallback) || is_bool($fallback)) {
+        _dkan_metastore_collect_schema_nodes($fallback, "{$pointer}/\$slots/{$name}", $out);
+      }
+    }
+  }
 }
 
 /**

--- a/modules/dkan_metastore/tests/src/Unit/Install/SchemaCheckHelperTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/Install/SchemaCheckHelperTest.php
@@ -51,17 +51,14 @@ class SchemaCheckHelperTest extends TestCase {
   }
 
   /**
-   * $schema must be a string; opis throws ParseException eagerly at the
-   * root-level parse step (loadObjectSchema).
+   * Non-string $schema throws eagerly at the root parse step.
    */
   public function testRootLevelStructuralErrorReturnsError(): void {
     $this->assertNotNull(_dkan_metastore_validate_schema_json('{"$schema": 42}'));
   }
 
   /**
-   * Sub-schema errors are deferred by opis's LazySchema and surface during
-   * the validate() phase. The helper covers this with the trivial validate
-   * call.
+   * A root-level keyword parse error is caught by strict-parsing the root node.
    */
   public function testDeepStructuralErrorReturnsError(): void {
     $this->assertNotNull(
@@ -70,14 +67,65 @@ class SchemaCheckHelperTest extends TestCase {
   }
 
   /**
-   * Draft-04 declaration — opis v2 rejects (only draft-06+ supported).
-   * This is the headline failure mode this hook exists to detect.
+   * Draft-04 declaration — opis v2 supports only draft-06+.
    */
   public function testDraft04SchemaReturnsError(): void {
     $msg = _dkan_metastore_validate_schema_json(
       '{"$schema": "http://json-schema.org/draft-04/schema#", "type": "object"}'
     );
     $this->assertNotNull($msg);
+  }
+
+  /**
+   * Draft-04 or structural errors buried in sub-schemas must be reported.
+   *
+   * @dataProvider buriedErrorProvider
+   */
+  public function testBuriedErrorReturnsError(string $json): void {
+    $this->assertNotNull(_dkan_metastore_validate_schema_json($json));
+  }
+
+  public static function buriedErrorProvider(): array {
+    $d04 = '{"$schema":"http://json-schema.org/draft-04/schema#"}';
+    $d7 = 'http://json-schema.org/draft-07/schema#';
+    return [
+      'properties' => ['{"type":"object","properties":{"foo":' . $d04 . '}}'],
+      '$defs' => ['{"$defs":{"thing":' . $d04 . '}}'],
+      'items (object form)' => ['{"items":' . $d04 . '}'],
+      'dependentSchemas' => ['{"dependentSchemas":{"a":' . $d04 . '}}'],
+      'dependencies (object value)' => ['{"dependencies":{"a":' . $d04 . '}}'],
+      'structural error in properties' => ['{"properties":{"foo":{"type":"array","items":42}}}'],
+      // Short-circuited branches validate(NULL) would not have parsed fully.
+      'allOf[1] behind null-failing allOf[0]' => [
+        '{"$schema":"' . $d7 . '","allOf":[{"type":"string"},' . $d04 . ']}',
+      ],
+      'non-matching anyOf branch' => [
+        '{"$schema":"' . $d7 . '","anyOf":[{"type":"null"},' . $d04 . ']}',
+      ],
+      'unselected else branch' => [
+        '{"$schema":"' . $d7 . '","if":{"type":"null"},"then":{},"else":' . $d04 . '}',
+      ],
+    ];
+  }
+
+  /**
+   * Genuine schema positions only — non-schema containers must not be flagged.
+   *
+   * @dataProvider noFalsePositiveProvider
+   */
+  public function testNoFalsePositive(string $json): void {
+    $this->assertNull(_dkan_metastore_validate_schema_json($json));
+  }
+
+  public static function noFalsePositiveProvider(): array {
+    return [
+      // The properties map contains a key named "format"; it must not be read
+      // as the format keyword.
+      'property named format' => ['{"type":"object","properties":{"format":{"type":"string"}}}'],
+      // Dependencies array values are property-name lists, not schemas.
+      'dependencies array form' => ['{"dependencies":{"a":["b","c"]}}'],
+      'nested clean properties' => ['{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"integer"}}}'],
+    ];
   }
 
 }


### PR DESCRIPTION
## Describe your changes

`_dkan_metastore_validate_schema_json()` only reliably validated the schema root: opis defers sub-schema parsing (`LazySchema`) and `validate(NULL, …)` never reaches `properties`/`$defs`/`items`/etc. or short-circuited `allOf`/`anyOf`/`then`/`else` branches, so buried draft-04 or structural errors passed silently.

- Replaced the root-only check with a recursive walk over genuine schema positions (applicator keywords + opis `$slots`), resolving each node against a single cached load (preserves draft/base/`$ref` context).
- Recover precise messages via a `SchemaParser` subclass exposing the throwing parse path (`parseSchema()` swallows errors into `ExceptionSchema`); reports the JSON pointer of the offending node.
- Non-schema positions (the `properties` map, a property named `format`, `dependencies` property-name arrays) are skipped — no false positives.

## QA Steps

- [ ] `drush cr`, then visit `/admin/reports/status` — no DKAN metastore schema warning on a clean site.
- [ ] Override a metastore schema with a buried draft-04 sub-schema (e.g. under `properties.*`); confirm the status report (and `drush updatedb` / `dkan_metastore_update_11302`) reports it with its pointer.
- [ ] Restore the schema; confirm the warning clears.
- [ ] `phpunit modules/dkan_metastore/tests/src/{Unit,Kernel}/Install/` passes.

## Checklist before requesting review

- [x] I have updated or added tests to cover my code — added buried/short-circuit/false-positive cases to `SchemaCheckHelperTest`; existing `SchemaCheckTest` guards real schemas.
- [ ] I have updated or added documentation — n/a; no behavior change beyond broader detection (upgrade docs already cover the draft-04 → draft-07 migration).

Co-authored by GitHub Copilot