### PR TITLE
Fix Opis v2 warnings, add schema validator service

### DIFF
--- a/modules/dkan_metastore/dkan_metastore.install
+++ b/modules/dkan_metastore/dkan_metastore.install
@@ -7,11 +7,6 @@
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Opis\JsonSchema\Exceptions\SchemaException;
-use Opis\JsonSchema\Info\SchemaInfo;
-use Opis\JsonSchema\Parsers\SchemaParser;
-use Opis\JsonSchema\SchemaLoader;
-use Opis\JsonSchema\Schemas\ExceptionSchema;
 
 /**
  * Update hook to uninstall the legacy metastore module.
@@ -44,196 +39,6 @@ function dkan_metastore_update_11301() {
 }
 
 /**
- * Validate a JSON Schema document under opis/json-schema v2.
- *
- * Opis defers sub-schema parsing (LazySchema), and validating trivial data only
- * reaches schema positions a given instance walks into — so buried draft-04 or
- * structural errors (e.g. in properties, $defs, items, or short-circuited
- * allOf/anyOf/then/else branches) go unnoticed. This walks every genuine schema
- * position and forces each through opis's throwing parse path.
- *
- * @param string $json
- *   Schema JSON string.
- *
- * @return string|null
- *   NULL on success; an error message string if the schema cannot be parsed.
- */
-function _dkan_metastore_validate_schema_json(string $json): ?string {
-  $decoded = json_decode($json, FALSE);
-  if ($decoded === NULL && json_last_error() !== JSON_ERROR_NONE) {
-    return 'Schema is not valid JSON: ' . json_last_error_msg();
-  }
-  if (!is_object($decoded) && !is_bool($decoded)) {
-    return 'Schema must be a JSON object or boolean.';
-  }
-  if (is_bool($decoded)) {
-    return NULL;
-  }
-
-  // Opis's public parseSchema() swallows SchemaException into an
-  // ExceptionSchema whose wrapped exception is private; this subclass exposes
-  // the throwing path so we can report the real message. Default construction
-  // inherits opis's registered drafts and formats.
-  $parser = new class() extends SchemaParser {
-
-    /**
-     * Re-parse a node through the throwing path to surface its error.
-     */
-    public function parseStrict(SchemaInfo $info): void {
-      $this->parseSchemaObject($info);
-    }
-
-  };
-  $loader = new SchemaLoader($parser);
-
-  // Build and cache the full lazy schema tree once. This throws eagerly only
-  // for root-level structural errors raised by parseRootSchema() (non-string
-  // $schema, non-absolute or duplicate $id). Ordinary keyword parse errors are
-  // deferred and surfaced by the walk below.
-  try {
-    $loader->loadObjectSchema($decoded);
-  }
-  catch (SchemaException $e) {
-    return $e->getMessage();
-  }
-
-  // Visit every genuine schema position (root first) and resolve it against
-  // the cached tree, which preserves each node's draft/base/root/$ref context.
-  // A bad node resolves to an ExceptionSchema; re-parse it for the message.
-  $nodes = [];
-  _dkan_metastore_collect_schema_nodes($decoded, '#', $nodes);
-  foreach ($nodes as [$node, $pointer]) {
-    if (!($loader->loadObjectSchema($node) instanceof ExceptionSchema)) {
-      continue;
-    }
-    try {
-      $parser->parseStrict($loader->loadObjectSchema($node)->info());
-      $message = 'cannot be parsed under opis/json-schema v2.';
-    }
-    catch (SchemaException $e) {
-      $message = $e->getMessage();
-    }
-    return $pointer === '#' ? $message : "Sub-schema at {$pointer}: {$message}";
-  }
-
-  return NULL;
-}
-
-/**
- * Collect every genuine JSON Schema position in a decoded schema document.
- *
- * Descends only through applicator keywords, so non-schema containers (the
- * properties map, default/const values, a property literally named "format")
- * are never mistaken for schemas.
- *
- * @param mixed $node
- *   Current node. Only objects are schema positions worth checking; booleans
- *   are valid schemas with nothing to descend into; anything else is ignored.
- * @param string $pointer
- *   JSON pointer of $node, for error reporting.
- * @param array $out
- *   Accumulator of [object $node, string $pointer] pairs.
- */
-function _dkan_metastore_collect_schema_nodes($node, string $pointer, array &$out): void {
-  if (!is_object($node)) {
-    return;
-  }
-  $out[] = [$node, $pointer];
-
-  // Keywords whose value is a single sub-schema.
-  $schema_valued = [
-    'additionalProperties', 'additionalItems', 'unevaluatedProperties',
-    'unevaluatedItems', 'contains', 'propertyNames', 'not', 'if', 'then',
-    'else', 'contentSchema',
-  ];
-  foreach ($schema_valued as $kw) {
-    if (isset($node->$kw)) {
-      _dkan_metastore_collect_schema_nodes($node->$kw, "{$pointer}/{$kw}", $out);
-    }
-  }
-
-  // Keywords whose value is a map of name => sub-schema.
-  $schema_map = [
-    'properties', 'patternProperties', '$defs', 'definitions',
-    'dependentSchemas',
-  ];
-  foreach ($schema_map as $kw) {
-    if (isset($node->$kw) && is_object($node->$kw)) {
-      foreach ($node->$kw as $name => $sub) {
-        _dkan_metastore_collect_schema_nodes($sub, "{$pointer}/{$kw}/{$name}", $out);
-      }
-    }
-  }
-
-  // Keywords whose value is a list of sub-schemas.
-  $schema_list = ['allOf', 'anyOf', 'oneOf', 'prefixItems'];
-  foreach ($schema_list as $kw) {
-    if (isset($node->$kw) && is_array($node->$kw)) {
-      foreach ($node->$kw as $i => $sub) {
-        _dkan_metastore_collect_schema_nodes($sub, "{$pointer}/{$kw}/{$i}", $out);
-      }
-    }
-  }
-
-  // items: a single schema (object/bool) or a tuple (array of schemas).
-  if (isset($node->items)) {
-    if (is_array($node->items)) {
-      foreach ($node->items as $i => $sub) {
-        _dkan_metastore_collect_schema_nodes($sub, "{$pointer}/items/{$i}", $out);
-      }
-    }
-    else {
-      _dkan_metastore_collect_schema_nodes($node->items, "{$pointer}/items", $out);
-    }
-  }
-
-  // The dependencies keyword (draft 6/7): an object/bool value is a sub-schema;
-  // an array value is a list of property names — not a schema, so skip it.
-  if (isset($node->dependencies) && is_object($node->dependencies)) {
-    foreach ($node->dependencies as $name => $sub) {
-      if (is_object($sub) || is_bool($sub)) {
-        _dkan_metastore_collect_schema_nodes($sub, "{$pointer}/dependencies/{$name}", $out);
-      }
-    }
-  }
-
-  // The $slots opis extension (allowSlots defaults on): object/bool fallbacks
-  // are sub-schemas; string fallbacks are slot names — skip those.
-  if (isset($node->{'$slots'}) && is_object($node->{'$slots'})) {
-    foreach ($node->{'$slots'} as $name => $fallback) {
-      if (is_object($fallback) || is_bool($fallback)) {
-        _dkan_metastore_collect_schema_nodes($fallback, "{$pointer}/\$slots/{$name}", $out);
-      }
-    }
-  }
-}
-
-/**
- * Collect schema-parse problems across the metastore's registered schema IDs.
- *
- * @return array
- *   Map of schema id => error message. Empty when all schemas are clean.
- */
-function _dkan_metastore_check_schemas(): array {
-  /** @var \Drupal\dkan_metastore\SchemaRetriever $retriever */
-  $retriever = \Drupal::service('dkan.metastore.schema_retriever');
-  $problems = [];
-  foreach ($retriever->getAllIds() as $id) {
-    try {
-      $json = $retriever->retrieve($id);
-    }
-    catch (\Throwable $e) {
-      $problems[$id] = 'Could not retrieve schema: ' . $e->getMessage();
-      continue;
-    }
-    if ($error = _dkan_metastore_validate_schema_json($json)) {
-      $problems[$id] = $error;
-    }
-  }
-  return $problems;
-}
-
-/**
  * Implements hook_requirements().
  *
  * Surfaces draft-04 (or otherwise unparseable) metastore schemas on
@@ -243,7 +48,7 @@ function dkan_metastore_requirements(string $phase): array {
   if ($phase !== 'runtime') {
     return [];
   }
-  $problems = _dkan_metastore_check_schemas();
+  $problems = \Drupal::service('dkan.metastore.schema_validator')->checkAllSchemas();
   if (empty($problems)) {
     return [];
   }
@@ -269,7 +74,7 @@ function dkan_metastore_requirements(string $phase): array {
  * output. hook_requirements keeps the warning visible until resolved.
  */
 function dkan_metastore_update_11302(): TranslatableMarkup {
-  $problems = _dkan_metastore_check_schemas();
+  $problems = \Drupal::service('dkan.metastore.schema_validator')->checkAllSchemas();
   if (empty($problems)) {
     return t('All metastore schemas parse cleanly under opis/json-schema v2.');
   }

--- a/modules/dkan_metastore/dkan_metastore.install
+++ b/modules/dkan_metastore/dkan_metastore.install
@@ -35,7 +35,7 @@ function dkan_metastore_update_11301() {
     $message = t('The legacy metastore module has been uninstalled.');
     $config->delete();
   }
-  return $message;
+  return $message ?? NULL;
 }
 
 /**

--- a/modules/dkan_metastore/dkan_metastore.install
+++ b/modules/dkan_metastore/dkan_metastore.install
@@ -58,8 +58,11 @@ function dkan_metastore_requirements(string $phase): array {
       'severity' => REQUIREMENT_WARNING,
       'value' => t('@n schema(s) cannot be parsed', ['@n' => count($problems)]),
       'description' => t(
-        'The following metastore schemas could not be parsed under opis/json-schema v2: @list. They will fail at runtime when used. See the DKAN upgrade docs for the draft-04 → draft-07 migration steps.',
-        ['@list' => implode(', ', array_keys($problems))]
+        'The following metastore schemas could not be parsed under opis/json-schema v2: @list. They will fail at runtime when used. See <a href=":change_record_url">DKAN change record</a> for the draft-04 -> draft-07 migration steps.',
+        [
+          '@list' => implode(', ', array_keys($problems)),
+          ':change_record_url' => 'https://www.drupal.org/node/3593097',
+        ]
       ),
     ],
   ];

--- a/modules/dkan_metastore/dkan_metastore.install
+++ b/modules/dkan_metastore/dkan_metastore.install
@@ -8,7 +8,10 @@
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Opis\JsonSchema\Exceptions\SchemaException;
-use Opis\JsonSchema\Validator;
+use Opis\JsonSchema\Info\SchemaInfo;
+use Opis\JsonSchema\Parsers\SchemaParser;
+use Opis\JsonSchema\SchemaLoader;
+use Opis\JsonSchema\Schemas\ExceptionSchema;
 
 /**
  * Update hook to uninstall the legacy metastore module.
@@ -43,6 +46,12 @@ function dkan_metastore_update_11301() {
 /**
  * Validate a JSON Schema document under opis/json-schema v2.
  *
+ * Opis defers sub-schema parsing (LazySchema), and validating trivial data only
+ * reaches schema positions a given instance walks into — so buried draft-04 or
+ * structural errors (e.g. in properties, $defs, items, or short-circuited
+ * allOf/anyOf/then/else branches) go unnoticed. This walks every genuine schema
+ * position and forces each through opis's throwing parse path.
+ *
  * @param string $json
  *   Schema JSON string.
  *
@@ -60,18 +69,143 @@ function _dkan_metastore_validate_schema_json(string $json): ?string {
   if (is_bool($decoded)) {
     return NULL;
   }
+
+  // Opis's public parseSchema() swallows SchemaException into an
+  // ExceptionSchema whose wrapped exception is private; this subclass exposes
+  // the throwing path so we can report the real message. Default construction
+  // inherits opis's registered drafts and formats.
+  $parser = new class() extends SchemaParser {
+
+    /**
+     * Re-parse a node through the throwing path to surface its error.
+     */
+    public function parseStrict(SchemaInfo $info): void {
+      $this->parseSchemaObject($info);
+    }
+
+  };
+  $loader = new SchemaLoader($parser);
+
+  // Build and cache the full lazy schema tree once. This throws eagerly only
+  // for root-level structural errors raised by parseRootSchema() (non-string
+  // $schema, non-absolute or duplicate $id). Ordinary keyword parse errors are
+  // deferred and surfaced by the walk below.
   try {
-    // Force eager parse — catches root-level structural errors (non-string
-    // $schema, non-absolute $id, etc.).
-    (new Validator())->loader()->loadObjectSchema($decoded);
-    // Force LazySchema resolution by validating trivial data — opis defers
-    // sub-schema parsing until the validator walks into them.
-    (new Validator())->validate(NULL, $decoded);
+    $loader->loadObjectSchema($decoded);
   }
   catch (SchemaException $e) {
     return $e->getMessage();
   }
+
+  // Visit every genuine schema position (root first) and resolve it against
+  // the cached tree, which preserves each node's draft/base/root/$ref context.
+  // A bad node resolves to an ExceptionSchema; re-parse it for the message.
+  $nodes = [];
+  _dkan_metastore_collect_schema_nodes($decoded, '#', $nodes);
+  foreach ($nodes as [$node, $pointer]) {
+    if (!($loader->loadObjectSchema($node) instanceof ExceptionSchema)) {
+      continue;
+    }
+    try {
+      $parser->parseStrict($loader->loadObjectSchema($node)->info());
+      $message = 'cannot be parsed under opis/json-schema v2.';
+    }
+    catch (SchemaException $e) {
+      $message = $e->getMessage();
+    }
+    return $pointer === '#' ? $message : "Sub-schema at {$pointer}: {$message}";
+  }
+
   return NULL;
+}
+
+/**
+ * Collect every genuine JSON Schema position in a decoded schema document.
+ *
+ * Descends only through applicator keywords, so non-schema containers (the
+ * properties map, default/const values, a property literally named "format")
+ * are never mistaken for schemas.
+ *
+ * @param mixed $node
+ *   Current node. Only objects are schema positions worth checking; booleans
+ *   are valid schemas with nothing to descend into; anything else is ignored.
+ * @param string $pointer
+ *   JSON pointer of $node, for error reporting.
+ * @param array $out
+ *   Accumulator of [object $node, string $pointer] pairs.
+ */
+function _dkan_metastore_collect_schema_nodes($node, string $pointer, array &$out): void {
+  if (!is_object($node)) {
+    return;
+  }
+  $out[] = [$node, $pointer];
+
+  // Keywords whose value is a single sub-schema.
+  $schema_valued = [
+    'additionalProperties', 'additionalItems', 'unevaluatedProperties',
+    'unevaluatedItems', 'contains', 'propertyNames', 'not', 'if', 'then',
+    'else', 'contentSchema',
+  ];
+  foreach ($schema_valued as $kw) {
+    if (isset($node->$kw)) {
+      _dkan_metastore_collect_schema_nodes($node->$kw, "{$pointer}/{$kw}", $out);
+    }
+  }
+
+  // Keywords whose value is a map of name => sub-schema.
+  $schema_map = [
+    'properties', 'patternProperties', '$defs', 'definitions',
+    'dependentSchemas',
+  ];
+  foreach ($schema_map as $kw) {
+    if (isset($node->$kw) && is_object($node->$kw)) {
+      foreach ($node->$kw as $name => $sub) {
+        _dkan_metastore_collect_schema_nodes($sub, "{$pointer}/{$kw}/{$name}", $out);
+      }
+    }
+  }
+
+  // Keywords whose value is a list of sub-schemas.
+  $schema_list = ['allOf', 'anyOf', 'oneOf', 'prefixItems'];
+  foreach ($schema_list as $kw) {
+    if (isset($node->$kw) && is_array($node->$kw)) {
+      foreach ($node->$kw as $i => $sub) {
+        _dkan_metastore_collect_schema_nodes($sub, "{$pointer}/{$kw}/{$i}", $out);
+      }
+    }
+  }
+
+  // items: a single schema (object/bool) or a tuple (array of schemas).
+  if (isset($node->items)) {
+    if (is_array($node->items)) {
+      foreach ($node->items as $i => $sub) {
+        _dkan_metastore_collect_schema_nodes($sub, "{$pointer}/items/{$i}", $out);
+      }
+    }
+    else {
+      _dkan_metastore_collect_schema_nodes($node->items, "{$pointer}/items", $out);
+    }
+  }
+
+  // The dependencies keyword (draft 6/7): an object/bool value is a sub-schema;
+  // an array value is a list of property names — not a schema, so skip it.
+  if (isset($node->dependencies) && is_object($node->dependencies)) {
+    foreach ($node->dependencies as $name => $sub) {
+      if (is_object($sub) || is_bool($sub)) {
+        _dkan_metastore_collect_schema_nodes($sub, "{$pointer}/dependencies/{$name}", $out);
+      }
+    }
+  }
+
+  // The $slots opis extension (allowSlots defaults on): object/bool fallbacks
+  // are sub-schemas; string fallbacks are slot names — skip those.
+  if (isset($node->{'$slots'}) && is_object($node->{'$slots'})) {
+    foreach ($node->{'$slots'} as $name => $fallback) {
+      if (is_object($fallback) || is_bool($fallback)) {
+        _dkan_metastore_collect_schema_nodes($fallback, "{$pointer}/\$slots/{$name}", $out);
+      }
+    }
+  }
 }
 
 /**

--- a/modules/dkan_metastore/dkan_metastore.services.yml
+++ b/modules/dkan_metastore/dkan_metastore.services.yml
@@ -132,3 +132,8 @@ services:
       - '@dkan.metastore.service'
       - '@dkan.metastore.reference_lookup'
       - '@dkan.metastore.url_generator'
+
+  dkan.metastore.schema_validator:
+    class: \Drupal\dkan_metastore\SchemaValidator
+    arguments:
+      - '@dkan.metastore.schema_retriever'

--- a/modules/dkan_metastore/src/SchemaRetriever.php
+++ b/modules/dkan_metastore/src/SchemaRetriever.php
@@ -8,21 +8,19 @@ use Drupal\Core\Extension\ModuleExtensionList;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class.
+ * DKAN schema retriever service.
  */
 class SchemaRetriever implements RetrieverInterface, ContainerInjectionInterface {
 
   /**
-   * Directory.
+   * Directory where schema files are stored.
    *
    * @var string
    */
   protected $directory;
 
   /**
-   * Inherited.
-   *
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
     $appRoot = $container->getParameter('app.root');
@@ -32,14 +30,24 @@ class SchemaRetriever implements RetrieverInterface, ContainerInjectionInterface
   }
 
   /**
-   * Public.
+   * Constructor.
+   *
+   * @param string $appRoot
+   *   Drupal app root, for locating schema directory.
+   * @param \Drupal\Core\Extension\ModuleExtensionList $extensionList
+   *   Drupal extension list.
    */
   public function __construct($appRoot, ModuleExtensionList $extensionList) {
     $this->findSchemaDirectory($appRoot, $extensionList);
   }
 
   /**
-   * Public.
+   * Get all available schema IDs.
+   *
+   * @todo Make this dynamic.
+   *
+   * @return array
+   *   List of schema IDs.
    */
   public function getAllIds() {
     return [
@@ -59,14 +67,26 @@ class SchemaRetriever implements RetrieverInterface, ContainerInjectionInterface
   }
 
   /**
-   * Public.
+   * Get the directory where schema files are stored.
+   *
+   * @return string
+   *   Directory path.
    */
   public function getSchemaDirectory() {
     return $this->directory;
   }
 
   /**
-   * Public.
+   * Retrieve a schema by ID.
+   *
+   * @param string $id
+   *   Schema ID.
+   *
+   * @return string|null
+   *   Schema content or null if not found.
+   *
+   * @throws \Exception
+   *   If the schema is not found.
    */
   public function retrieve(string $id): ?string {
 
@@ -81,7 +101,15 @@ class SchemaRetriever implements RetrieverInterface, ContainerInjectionInterface
   }
 
   /**
-   * Private.
+   * Find the schema directory.
+   *
+   * @param string $appRoot
+   *   Drupal app root.
+   * @param \Drupal\Core\Extension\ModuleExtensionList $extensionList
+   *   Drupal extension list.
+   *
+   * @throws \Exception
+   *   If no schema directory is found.
    */
   protected function findSchemaDirectory($appRoot, $extensionList) {
 

--- a/modules/dkan_metastore/src/SchemaValidator.php
+++ b/modules/dkan_metastore/src/SchemaValidator.php
@@ -165,6 +165,13 @@ class SchemaValidator {
 
   /**
    * Collect single-value sub-schema keywords.
+   *
+   * @param object $node
+   *   Current node.
+   * @param string $pointer
+   *   JSON pointer of $node, for error reporting.
+   * @param array $out
+   *   Accumulator of [object $node, string $pointer] pairs.
    */
   protected function collectSchemaValuedNodes(object $node, string $pointer, array &$out): void {
     // Keywords whose value is a single sub-schema.
@@ -190,6 +197,13 @@ class SchemaValidator {
 
   /**
    * Collect object-map sub-schema keywords.
+   *
+   * @param object $node
+   *   Current node.
+   * @param string $pointer
+   *   JSON pointer of $node, for error reporting.
+   * @param array $out
+   *   Accumulator of [object $node, string $pointer] pairs.
    */
   protected function collectSchemaMapNodes(object $node, string $pointer, array &$out): void {
     // Keywords whose value is a map of name => sub-schema.
@@ -211,6 +225,13 @@ class SchemaValidator {
 
   /**
    * Collect list-of-sub-schema keywords.
+   *
+   * @param object $node
+   *   Current node.
+   * @param string $pointer
+   *   JSON pointer of $node, for error reporting.
+   * @param array $out
+   *   Accumulator of [object $node, string $pointer] pairs.
    */
   protected function collectSchemaListNodes(object $node, string $pointer, array &$out): void {
     // Keywords whose value is a list of sub-schemas.
@@ -228,6 +249,13 @@ class SchemaValidator {
 
   /**
    * Collect item sub-schemas.
+   *
+   * @param object $node
+   *   Current node.
+   * @param string $pointer
+   *   JSON pointer of $node, for error reporting.
+   * @param array $out
+   *   Accumulator of [object $node, string $pointer] pairs.
    */
   protected function collectItemsNodes(object $node, string $pointer, array &$out): void {
     // items: a single schema (object/bool) or an array of schemas.
@@ -245,6 +273,13 @@ class SchemaValidator {
 
   /**
    * Collect dependency sub-schemas.
+   *
+   * @param object $node
+   *   Current node.
+   * @param string $pointer
+   *   JSON pointer of $node, for error reporting.
+   * @param array $out
+   *   Accumulator of [object $node, string $pointer] pairs.
    */
   protected function collectDependenciesNodes(object $node, string $pointer, array &$out): void {
     // The dependencies keyword (draft 6/7): an object/bool value is a schema;
@@ -262,6 +297,13 @@ class SchemaValidator {
 
   /**
    * Collect $slots fallback sub-schemas.
+   *
+   * @param object $node
+   *   Current node.
+   * @param string $pointer
+   *   JSON pointer of $node, for error reporting.
+   * @param array $out
+   *   Accumulator of [object $node, string $pointer] pairs.
    */
   protected function collectSlotsNodes(object $node, string $pointer, array &$out): void {
     // The $slots opis extension (allowSlots defaults on): object/bool fallbacks

--- a/modules/dkan_metastore/src/SchemaValidator.php
+++ b/modules/dkan_metastore/src/SchemaValidator.php
@@ -128,13 +128,12 @@ class SchemaValidator {
         continue;
       }
       try {
-        $error = $schema->validate($this->genericContext);
-        $message = $error ? $error->message() : 'Could not parse schema at ' . $pointer;
+        $schema->validate($this->genericContext);
       }
       catch (SchemaException $e) {
         $message = $e->getMessage();
       }
-      return $message;
+      return $message ?? NULL;
     }
 
     return NULL;

--- a/modules/dkan_metastore/src/SchemaValidator.php
+++ b/modules/dkan_metastore/src/SchemaValidator.php
@@ -131,7 +131,7 @@ class SchemaValidator {
         $schema->validate($this->genericContext);
       }
       catch (SchemaException $e) {
-        $message = $e->getMessage();
+        $message = $pointer . ': ' . $e->getMessage();
       }
       return $message ?? NULL;
     }
@@ -267,7 +267,7 @@ class SchemaValidator {
       $this->collectNodes($node->items, "{$pointer}/items", $out);
       return;
     }
-    // We collect this despite knowing it will fail, as items arrays are a 
+    // We collect this despite knowing it will fail, as items arrays are a
     // common draft-04 -> v2 migration pain point.
     foreach ($node->items as $i => $sub) {
       $this->collectNodes($sub, "{$pointer}/items/{$i}", $out);

--- a/modules/dkan_metastore/src/SchemaValidator.php
+++ b/modules/dkan_metastore/src/SchemaValidator.php
@@ -138,6 +138,18 @@ class SchemaValidator {
     }
     $out[] = [$node, $pointer];
 
+    $this->collectSchemaValuedNodes($node, $pointer, $out);
+    $this->collectSchemaMapNodes($node, $pointer, $out);
+    $this->collectSchemaListNodes($node, $pointer, $out);
+    $this->collectItemsNodes($node, $pointer, $out);
+    $this->collectDependenciesNodes($node, $pointer, $out);
+    $this->collectSlotsNodes($node, $pointer, $out);
+  }
+
+  /**
+   * Collect single-value sub-schema keywords.
+   */
+  protected function collectSchemaValuedNodes(object $node, string $pointer, array &$out): void {
     // Keywords whose value is a single sub-schema.
     $schema_valued = [
       'additionalProperties',
@@ -157,7 +169,12 @@ class SchemaValidator {
         $this->collectNodes($node->$kw, "{$pointer}/{$kw}", $out);
       }
     }
+  }
 
+  /**
+   * Collect object-map sub-schema keywords.
+   */
+  protected function collectSchemaMapNodes(object $node, string $pointer, array &$out): void {
     // Keywords whose value is a map of name => sub-schema.
     $schema_map = [
       'properties',
@@ -173,7 +190,12 @@ class SchemaValidator {
         }
       }
     }
+  }
 
+  /**
+   * Collect list-of-sub-schema keywords.
+   */
+  protected function collectSchemaListNodes(object $node, string $pointer, array &$out): void {
     // Keywords whose value is a list of sub-schemas.
     $schema_list = ['allOf', 'anyOf', 'oneOf', 'prefixItems'];
     foreach ($schema_list as $kw) {
@@ -183,7 +205,12 @@ class SchemaValidator {
         }
       }
     }
+  }
 
+  /**
+   * Collect item sub-schemas.
+   */
+  protected function collectItemsNodes(object $node, string $pointer, array &$out): void {
     // items: a single schema (object/bool) or an array of schemas.
     if (isset($node->items)) {
       if (is_array($node->items)) {
@@ -195,7 +222,12 @@ class SchemaValidator {
         $this->collectNodes($node->items, "{$pointer}/items", $out);
       }
     }
+  }
 
+  /**
+   * Collect dependency sub-schemas.
+   */
+  protected function collectDependenciesNodes(object $node, string $pointer, array &$out): void {
     // The dependencies keyword (draft 6/7): an object/bool value is a schema;
     // an array value is a list of property names — not a schema, so skip it.
     if (isset($node->dependencies) && is_object($node->dependencies)) {
@@ -205,7 +237,12 @@ class SchemaValidator {
         }
       }
     }
+  }
 
+  /**
+   * Collect $slots fallback sub-schemas.
+   */
+  protected function collectSlotsNodes(object $node, string $pointer, array &$out): void {
     // The $slots opis extension (allowSlots defaults on): object/bool fallbacks
     // are sub-schemas; string fallbacks are slot names — skip those.
     if (isset($node->{'$slots'}) && is_object($node->{'$slots'})) {

--- a/modules/dkan_metastore/src/SchemaValidator.php
+++ b/modules/dkan_metastore/src/SchemaValidator.php
@@ -13,7 +13,11 @@ use Opis\JsonSchema\ValidationContext;
  * Tool to validate a JSON schema recursively.
  *
  * Compensates for the fact that opis/json-schema v2's SchemaLoader only reports
- * validation errors at the root level.
+ * validation errors at the root level. Recurses through entire JSON Schema
+ * document to find every "node" (usually a nested object) that behaves like a
+ * schema and validates it.
+ *
+ * This may be worth releasing as a standalone library some day.
  */
 class SchemaValidator {
 
@@ -103,6 +107,19 @@ class SchemaValidator {
     // the cached tree, which preserves each node's draft/base/root/$ref.
     $nodes = [];
     $this->collectNodes($decoded, '#', $nodes);
+    return $this->validateCollectedNodes($nodes);
+  }
+
+  /**
+   * Validate collected schema nodes and return the first parse failure.
+   *
+   * @param array $nodes
+   *   Collected [object $node, string $pointer] pairs.
+   *
+   * @return string|null
+   *   First parse error found, or NULL when all nodes are valid.
+   */
+  protected function validateCollectedNodes(array $nodes): ?string {
     foreach ($nodes as [$node, $pointer]) {
       $schema = $this->loader->loadObjectSchema($node);
       if (!($schema instanceof ExceptionSchema)) {
@@ -164,9 +181,9 @@ class SchemaValidator {
       'else',
       'contentSchema',
     ];
-    foreach ($schema_valued as $kw) {
-      if (isset($node->$kw)) {
-        $this->collectNodes($node->$kw, "{$pointer}/{$kw}", $out);
+    foreach ($schema_valued as $keyword) {
+      if (isset($node->$keyword)) {
+        $this->collectNodes($node->$keyword, "{$pointer}/{$keyword}", $out);
       }
     }
   }
@@ -183,10 +200,10 @@ class SchemaValidator {
       'definitions',
       'dependentSchemas',
     ];
-    foreach ($schema_map as $kw) {
-      if (isset($node->$kw) && is_object($node->$kw)) {
-        foreach ($node->$kw as $name => $sub) {
-          $this->collectNodes($sub, "{$pointer}/{$kw}/{$name}", $out);
+    foreach ($schema_map as $keyword) {
+      if (isset($node->$keyword) && is_object($node->$keyword)) {
+        foreach ($node->$keyword as $name => $sub) {
+          $this->collectNodes($sub, "{$pointer}/{$keyword}/{$name}", $out);
         }
       }
     }
@@ -198,11 +215,13 @@ class SchemaValidator {
   protected function collectSchemaListNodes(object $node, string $pointer, array &$out): void {
     // Keywords whose value is a list of sub-schemas.
     $schema_list = ['allOf', 'anyOf', 'oneOf', 'prefixItems'];
-    foreach ($schema_list as $kw) {
-      if (isset($node->$kw) && is_array($node->$kw)) {
-        foreach ($node->$kw as $i => $sub) {
-          $this->collectNodes($sub, "{$pointer}/{$kw}/{$i}", $out);
-        }
+    foreach ($schema_list as $keyword) {
+      $sub_schemas = $node->$keyword ?? NULL;
+      if (!is_array($sub_schemas)) {
+        continue;
+      }
+      foreach ($sub_schemas as $i => $sub) {
+        $this->collectNodes($sub, "{$pointer}/{$keyword}/{$i}", $out);
       }
     }
   }
@@ -212,15 +231,15 @@ class SchemaValidator {
    */
   protected function collectItemsNodes(object $node, string $pointer, array &$out): void {
     // items: a single schema (object/bool) or an array of schemas.
-    if (isset($node->items)) {
-      if (is_array($node->items)) {
-        foreach ($node->items as $i => $sub) {
-          $this->collectNodes($sub, "{$pointer}/items/{$i}", $out);
-        }
-      }
-      else {
-        $this->collectNodes($node->items, "{$pointer}/items", $out);
-      }
+    if (!isset($node->items)) {
+      return;
+    }
+    if (!is_array($node->items)) {
+      $this->collectNodes($node->items, "{$pointer}/items", $out);
+      return;
+    }
+    foreach ($node->items as $i => $sub) {
+      $this->collectNodes($sub, "{$pointer}/items/{$i}", $out);
     }
   }
 
@@ -230,11 +249,13 @@ class SchemaValidator {
   protected function collectDependenciesNodes(object $node, string $pointer, array &$out): void {
     // The dependencies keyword (draft 6/7): an object/bool value is a schema;
     // an array value is a list of property names — not a schema, so skip it.
-    if (isset($node->dependencies) && is_object($node->dependencies)) {
-      foreach ($node->dependencies as $name => $sub) {
-        if (is_object($sub) || is_bool($sub)) {
-          $this->collectNodes($sub, "{$pointer}/dependencies/{$name}", $out);
-        }
+    $dependencies = $node->dependencies ?? NULL;
+    if (!is_object($dependencies)) {
+      return;
+    }
+    foreach ($dependencies as $name => $sub) {
+      if (is_object($sub) || is_bool($sub)) {
+        $this->collectNodes($sub, "{$pointer}/dependencies/{$name}", $out);
       }
     }
   }
@@ -245,11 +266,13 @@ class SchemaValidator {
   protected function collectSlotsNodes(object $node, string $pointer, array &$out): void {
     // The $slots opis extension (allowSlots defaults on): object/bool fallbacks
     // are sub-schemas; string fallbacks are slot names — skip those.
-    if (isset($node->{'$slots'}) && is_object($node->{'$slots'})) {
-      foreach ($node->{'$slots'} as $name => $fallback) {
-        if (is_object($fallback) || is_bool($fallback)) {
-          $this->collectNodes($fallback, "{$pointer}/\$slots/{$name}", $out);
-        }
+    $slots = $node->{'$slots'} ?? NULL;
+    if (!is_object($slots)) {
+      return;
+    }
+    foreach ($slots as $name => $fallback) {
+      if (is_object($fallback) || is_bool($fallback)) {
+        $this->collectNodes($fallback, "{$pointer}/\$slots/{$name}", $out);
       }
     }
   }

--- a/modules/dkan_metastore/src/SchemaValidator.php
+++ b/modules/dkan_metastore/src/SchemaValidator.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Drupal\dkan_metastore;
+
+use Opis\JsonSchema\Exceptions\ParseException;
+use Opis\JsonSchema\Exceptions\SchemaException;
+use Opis\JsonSchema\Parsers\SchemaParser;
+use Opis\JsonSchema\SchemaLoader;
+use Opis\JsonSchema\Schemas\ExceptionSchema;
+use Opis\JsonSchema\ValidationContext;
+
+/**
+ * Tool to validate a JSON schema recursively.
+ *
+ * Compensates for the fact that opis/json-schema v2's SchemaLoader only reports
+ * validation errors at the root level.
+ */
+class SchemaValidator {
+
+  /**
+   * Schema retriever service.
+   */
+  protected SchemaRetriever $retriever;
+
+
+  /**
+   * Opis Schema Parser.
+   */
+  protected SchemaParser $parser;
+
+  /**
+   * Generic Opis validation context, used for all validations.
+   */
+  protected ValidationContext $genericContext;
+
+  /**
+   * Opis Schema Loader, used to resolve every schema node.
+   */
+  protected SchemaLoader $loader;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\dkan_metastore\SchemaRetriever $retriever
+   *   Service to retrieve schema JSON by ID, for checkAllSchemas().
+   */
+  public function __construct(SchemaRetriever $retriever) {
+    $this->retriever = $retriever;
+    $this->parser = new SchemaParser();
+    $this->loader = new SchemaLoader($this->parser);
+    $this->genericContext = new ValidationContext([], $this->loader);
+  }
+
+  /**
+   * Validate a schema by ID.
+   *
+   * @param string $id
+   *   Metastore Schema ID (e.g. "dataset") to validate.
+   *
+   * @return string|null
+   *   NULL on success; an error message string if the schema cannot be parsed.
+   */
+  public function validateSchemaId(string $id): ?string {
+    try {
+      $json = $this->retriever->retrieve($id);
+    }
+    catch (\Throwable $e) {
+      return 'Could not retrieve schema: ' . $e->getMessage();
+    }
+    return $this->validateSchemaJson($json);
+  }
+
+  /**
+   * Validate a JSON Schema document under opis/json-schema v2.
+   *
+   * @param string $json
+   *   Schema JSON string.
+   *
+   * @return string|null
+   *   NULL on success; an error message string if the schema cannot be parsed.
+   */
+  public function validateSchemaJson(string $json): ?string {
+    $decoded = json_decode($json, FALSE);
+    if ($decoded === NULL && json_last_error() !== JSON_ERROR_NONE) {
+      return 'Schema is not valid JSON: ' . json_last_error_msg();
+    }
+    if (!is_object($decoded) && !is_bool($decoded)) {
+      return 'Schema must be a JSON object or boolean.';
+    }
+    if (is_bool($decoded)) {
+      return NULL;
+    }
+
+    try {
+      $schema = $this->loader->loadObjectSchema($decoded);
+      $schema->validate($this->genericContext);
+    }
+    catch (SchemaException | ParseException $e) {
+      return $e->getMessage();
+    }
+
+    // Visit every genuine schema position (root first) and resolve it against
+    // the cached tree, which preserves each node's draft/base/root/$ref.
+    $nodes = [];
+    $this->collectNodes($decoded, '#', $nodes);
+    foreach ($nodes as [$node, $pointer]) {
+      $schema = $this->loader->loadObjectSchema($node);
+      if (!($schema instanceof ExceptionSchema)) {
+        continue;
+      }
+      try {
+        $error = $schema->validate($this->genericContext);
+        $message = $error ? $error->message() : 'Could not parse schema at ' . $pointer;
+      }
+      catch (SchemaException $e) {
+        $message = $e->getMessage();
+      }
+      return $message;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Collect every genuine JSON Schema position in a decoded schema document.
+   *
+   * @param mixed $node
+   *   Current node. Only objects are schema positions worth checking; booleans
+   *   are valid schemas with nothing to descend into; anything else is ignored.
+   * @param string $pointer
+   *   JSON pointer of $node, for error reporting.
+   * @param array $out
+   *   Accumulator of [object $node, string $pointer] pairs.
+   */
+  protected function collectNodes($node, string $pointer, array &$out): void {
+    if (!is_object($node)) {
+      return;
+    }
+    $out[] = [$node, $pointer];
+
+    // Keywords whose value is a single sub-schema.
+    $schema_valued = [
+      'additionalProperties',
+      'additionalItems',
+      'unevaluatedProperties',
+      'unevaluatedItems',
+      'contains',
+      'propertyNames',
+      'not',
+      'if',
+      'then',
+      'else',
+      'contentSchema',
+    ];
+    foreach ($schema_valued as $kw) {
+      if (isset($node->$kw)) {
+        $this->collectNodes($node->$kw, "{$pointer}/{$kw}", $out);
+      }
+    }
+
+    // Keywords whose value is a map of name => sub-schema.
+    $schema_map = [
+      'properties',
+      'patternProperties',
+      '$defs',
+      'definitions',
+      'dependentSchemas',
+    ];
+    foreach ($schema_map as $kw) {
+      if (isset($node->$kw) && is_object($node->$kw)) {
+        foreach ($node->$kw as $name => $sub) {
+          $this->collectNodes($sub, "{$pointer}/{$kw}/{$name}", $out);
+        }
+      }
+    }
+
+    // Keywords whose value is a list of sub-schemas.
+    $schema_list = ['allOf', 'anyOf', 'oneOf', 'prefixItems'];
+    foreach ($schema_list as $kw) {
+      if (isset($node->$kw) && is_array($node->$kw)) {
+        foreach ($node->$kw as $i => $sub) {
+          $this->collectNodes($sub, "{$pointer}/{$kw}/{$i}", $out);
+        }
+      }
+    }
+
+    // items: a single schema (object/bool) or an array of schemas.
+    if (isset($node->items)) {
+      if (is_array($node->items)) {
+        foreach ($node->items as $i => $sub) {
+          $this->collectNodes($sub, "{$pointer}/items/{$i}", $out);
+        }
+      }
+      else {
+        $this->collectNodes($node->items, "{$pointer}/items", $out);
+      }
+    }
+
+    // The dependencies keyword (draft 6/7): an object/bool value is a schema;
+    // an array value is a list of property names — not a schema, so skip it.
+    if (isset($node->dependencies) && is_object($node->dependencies)) {
+      foreach ($node->dependencies as $name => $sub) {
+        if (is_object($sub) || is_bool($sub)) {
+          $this->collectNodes($sub, "{$pointer}/dependencies/{$name}", $out);
+        }
+      }
+    }
+
+    // The $slots opis extension (allowSlots defaults on): object/bool fallbacks
+    // are sub-schemas; string fallbacks are slot names — skip those.
+    if (isset($node->{'$slots'}) && is_object($node->{'$slots'})) {
+      foreach ($node->{'$slots'} as $name => $fallback) {
+        if (is_object($fallback) || is_bool($fallback)) {
+          $this->collectNodes($fallback, "{$pointer}/\$slots/{$name}", $out);
+        }
+      }
+    }
+  }
+
+  /**
+   * Fetch all registered schemas and check for validation failures.
+   *
+   * @return array
+   *   Map of schema id => error message. Empty when all schemas are clean.
+   */
+  public function checkAllSchemas(): array {
+    /** @var \Drupal\dkan_metastore\SchemaRetriever $retriever */
+    $problems = [];
+    foreach ($this->retriever->getAllIds() as $id) {
+      if ($error = $this->validateSchemaId($id)) {
+        $problems[$id] = $error;
+      }
+    }
+    return $problems;
+  }
+
+}

--- a/modules/dkan_metastore/src/SchemaValidator.php
+++ b/modules/dkan_metastore/src/SchemaValidator.php
@@ -268,6 +268,8 @@ class SchemaValidator {
       $this->collectNodes($node->items, "{$pointer}/items", $out);
       return;
     }
+    // We collect this despite knowing it will fail, as items arrays are a 
+    // common draft-04 -> v2 migration pain point.
     foreach ($node->items as $i => $sub) {
       $this->collectNodes($sub, "{$pointer}/items/{$i}", $out);
     }

--- a/modules/dkan_metastore/src/SchemaValidator.php
+++ b/modules/dkan_metastore/src/SchemaValidator.php
@@ -84,9 +84,11 @@ class SchemaValidator {
    *   NULL on success; an error message string if the schema cannot be parsed.
    */
   public function validateSchemaJson(string $json): ?string {
-    $decoded = json_decode($json, FALSE);
-    if ($decoded === NULL && json_last_error() !== JSON_ERROR_NONE) {
-      return 'Schema is not valid JSON: ' . json_last_error_msg();
+    try {
+      $decoded = json_decode($json, FALSE, 512, JSON_THROW_ON_ERROR);
+    }
+    catch (\JsonException $e) {
+      return 'Schema is not valid JSON: ' . $e->getMessage();
     }
     if (!is_object($decoded) && !is_bool($decoded)) {
       return 'Schema must be a JSON object or boolean.';

--- a/modules/dkan_metastore/tests/src/Kernel/SchemaValidatorTest.php
+++ b/modules/dkan_metastore/tests/src/Kernel/SchemaValidatorTest.php
@@ -29,8 +29,8 @@ class SchemaCheckTest extends KernelTestBase {
   public function testBundledSchemasParseCleanly(): void {
     $module_path = \Drupal::service('extension.list.module')->getPath('dkan_metastore');
     require_once DRUPAL_ROOT . '/' . $module_path . '/dkan_metastore.install';
-    $problems = _dkan_metastore_check_schemas();
-    $this->assertSame([], $problems, 'Bundled DKAN schemas all parse under opis/json-schema v2');
+    $problems = \Drupal::service('dkan.metastore.schema_validator')->checkAllSchemas();
+    $this->assertSame([], $problems);
   }
 
 }

--- a/modules/dkan_metastore/tests/src/Kernel/SchemaValidatorTest.php
+++ b/modules/dkan_metastore/tests/src/Kernel/SchemaValidatorTest.php
@@ -11,7 +11,7 @@ use Drupal\KernelTests\KernelTestBase;
  * @group dkan_metastore
  * @group kernel
  */
-class SchemaCheckTest extends KernelTestBase {
+class SchemaValidatorTest extends KernelTestBase {
 
   protected static $modules = [
     'dkan',

--- a/modules/dkan_metastore/tests/src/Kernel/SchemaValidatorTest.php
+++ b/modules/dkan_metastore/tests/src/Kernel/SchemaValidatorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\dkan_metastore\Kernel\Install;
+namespace Drupal\Tests\dkan_metastore\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 

--- a/modules/dkan_metastore/tests/src/Unit/Install/SchemaCheckHelperTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/Install/SchemaCheckHelperTest.php
@@ -51,17 +51,14 @@ class SchemaCheckHelperTest extends TestCase {
   }
 
   /**
-   * $schema must be a string; opis throws ParseException eagerly at the
-   * root-level parse step (loadObjectSchema).
+   * Non-string $schema throws eagerly at the root parse step.
    */
   public function testRootLevelStructuralErrorReturnsError(): void {
     $this->assertNotNull(_dkan_metastore_validate_schema_json('{"$schema": 42}'));
   }
 
   /**
-   * Sub-schema errors are deferred by opis's LazySchema and surface during
-   * the validate() phase. The helper covers this with the trivial validate
-   * call.
+   * A root-level keyword parse error is caught by strict-parsing the root node.
    */
   public function testDeepStructuralErrorReturnsError(): void {
     $this->assertNotNull(
@@ -70,14 +67,65 @@ class SchemaCheckHelperTest extends TestCase {
   }
 
   /**
-   * Draft-04 declaration — opis v2 rejects (only draft-06+ supported).
-   * This is the headline failure mode this hook exists to detect.
+   * Draft-04 declaration — opis v2 supports only draft-06+.
    */
   public function testDraft04SchemaReturnsError(): void {
     $msg = _dkan_metastore_validate_schema_json(
       '{"$schema": "http://json-schema.org/draft-04/schema#", "type": "object"}'
     );
     $this->assertNotNull($msg);
+  }
+
+  /**
+   * Draft-04 or structural errors buried in sub-schemas must be reported.
+   *
+   * @dataProvider buriedErrorProvider
+   */
+  public function testBuriedErrorReturnsError(string $json): void {
+    $this->assertNotNull(_dkan_metastore_validate_schema_json($json));
+  }
+
+  public static function buriedErrorProvider(): array {
+    $d04 = '{"$schema":"http://json-schema.org/draft-04/schema#"}';
+    $d7 = 'http://json-schema.org/draft-07/schema#';
+    return [
+      'properties' => ['{"type":"object","properties":{"foo":' . $d04 . '}}'],
+      '$defs' => ['{"$defs":{"thing":' . $d04 . '}}'],
+      'items (object form)' => ['{"items":' . $d04 . '}'],
+      'dependentSchemas' => ['{"dependentSchemas":{"a":' . $d04 . '}}'],
+      'dependencies (object value)' => ['{"dependencies":{"a":' . $d04 . '}}'],
+      'structural error in properties' => ['{"properties":{"foo":{"type":"array","items":42}}}'],
+      // Short-circuited branches validate(NULL) would not have parsed fully.
+      'allOf[1] behind null-failing allOf[0]' => [
+        '{"$schema":"' . $d7 . '","allOf":[{"type":"string"},' . $d04 . ']}',
+      ],
+      'non-matching anyOf branch' => [
+        '{"$schema":"' . $d7 . '","anyOf":[{"type":"null"},' . $d04 . ']}',
+      ],
+      'unselected else branch' => [
+        '{"$schema":"' . $d7 . '","if":{"type":"null"},"then":{},"else":' . $d04 . '}',
+      ],
+    ];
+  }
+
+  /**
+   * Genuine schema positions only — non-schema containers must not be flagged.
+   *
+   * @dataProvider noFalsePositiveProvider
+   */
+  public function testNoFalsePositive(string $json): void {
+    $this->assertNull(_dkan_metastore_validate_schema_json($json));
+  }
+
+  public static function noFalsePositiveProvider(): array {
+    return [
+      // The properties map contains a key named "format"; it must not be read
+      // as the format keyword.
+      'property named format' => ['{"type":"object","properties":{"format":{"type":"string"}}}'],
+      // Dependencies array values are property-name lists, not schemas.
+      'dependencies array form' => ['{"dependencies":{"a":["b","c"]}}'],
+      'nested clean properties' => ['{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"integer"}}}'],
+    ];
   }
 
 }

--- a/modules/dkan_metastore/tests/src/Unit/SchemaValidatorTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/SchemaValidatorTest.php
@@ -1,51 +1,72 @@
 <?php
 
-namespace Drupal\Tests\dkan_metastore\Unit\Install;
+namespace Drupal\Tests\dkan_metastore\Unit;
 
+use Drupal\dkan_metastore\SchemaRetriever;
+use Drupal\dkan_metastore\SchemaValidator;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Covers the pure schema-parse helper in dkan_metastore.install.
+ * Covers SchemaValidator schema-parse behavior.
  *
  * @group dkan
  * @group dkan_metastore
  * @group unit
  */
-class SchemaCheckHelperTest extends TestCase {
+class SchemaValidatorTest extends TestCase {
+
+  protected SchemaValidator $validator;
 
   protected function setUp(): void {
     parent::setUp();
-    // The install file's helper functions aren't autoloaded; pull them in
-    // explicitly. Path: tests/src/Unit/Install -> module root is ../../../..
-    require_once __DIR__ . '/../../../../dkan_metastore.install';
+
+    $datasetSchemaPath = realpath(__DIR__ . '/../docs/dataset.json');
+    $this->assertNotFalse($datasetSchemaPath, 'Could not resolve dataset schema path.');
+    $datasetSchema = file_get_contents($datasetSchemaPath);
+    $this->assertNotFalse($datasetSchema, 'Could not read dataset schema JSON.');
+
+    $retriever = $this->getMockBuilder(SchemaRetriever::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['getAllIds', 'retrieve'])
+      ->getMock();
+
+    $retriever->method('getAllIds')->willReturn(['dataset']);
+    $retriever->method('retrieve')->willReturnCallback(function (string $id) use ($datasetSchema): string {
+      if ($id !== 'dataset') {
+        throw new \Exception("Schema {$id} not found.");
+      }
+      return $datasetSchema;
+    });
+
+    $this->validator = new SchemaValidator($retriever);
   }
 
   public function testValidObjectSchemaReturnsNull(): void {
-    $this->assertNull(_dkan_metastore_validate_schema_json('{"type":"object"}'));
+    $this->assertNull($this->validator->validateSchemaJson('{"type":"object"}'));
   }
 
   public function testBooleanSchemaTrueReturnsNull(): void {
-    $this->assertNull(_dkan_metastore_validate_schema_json('true'));
+    $this->assertNull($this->validator->validateSchemaJson('true'));
   }
 
   public function testBooleanSchemaFalseReturnsNull(): void {
-    $this->assertNull(_dkan_metastore_validate_schema_json('false'));
+    $this->assertNull($this->validator->validateSchemaJson('false'));
   }
 
   public function testMalformedJsonReturnsError(): void {
-    $msg = _dkan_metastore_validate_schema_json('{not json');
+    $msg = $this->validator->validateSchemaJson('{not json');
     $this->assertNotNull($msg);
     $this->assertStringContainsString('not valid JSON', $msg);
   }
 
   public function testStringSchemaReturnsError(): void {
-    $msg = _dkan_metastore_validate_schema_json('"hello"');
+    $msg = $this->validator->validateSchemaJson('"hello"');
     $this->assertNotNull($msg);
     $this->assertStringContainsString('object or boolean', $msg);
   }
 
   public function testNumberSchemaReturnsError(): void {
-    $msg = _dkan_metastore_validate_schema_json('42');
+    $msg = $this->validator->validateSchemaJson('42');
     $this->assertNotNull($msg);
     $this->assertStringContainsString('object or boolean', $msg);
   }
@@ -54,7 +75,7 @@ class SchemaCheckHelperTest extends TestCase {
    * Non-string $schema throws eagerly at the root parse step.
    */
   public function testRootLevelStructuralErrorReturnsError(): void {
-    $this->assertNotNull(_dkan_metastore_validate_schema_json('{"$schema": 42}'));
+    $this->assertNotNull($this->validator->validateSchemaJson('{"$schema": 42}'));
   }
 
   /**
@@ -62,7 +83,7 @@ class SchemaCheckHelperTest extends TestCase {
    */
   public function testDeepStructuralErrorReturnsError(): void {
     $this->assertNotNull(
-      _dkan_metastore_validate_schema_json('{"type":"object","properties":"not-an-object"}')
+      $this->validator->validateSchemaJson('{"type":"object","properties":"not-an-object"}')
     );
   }
 
@@ -70,7 +91,7 @@ class SchemaCheckHelperTest extends TestCase {
    * Draft-04 declaration — opis v2 supports only draft-06+.
    */
   public function testDraft04SchemaReturnsError(): void {
-    $msg = _dkan_metastore_validate_schema_json(
+    $msg = $this->validator->validateSchemaJson(
       '{"$schema": "http://json-schema.org/draft-04/schema#", "type": "object"}'
     );
     $this->assertNotNull($msg);
@@ -82,7 +103,7 @@ class SchemaCheckHelperTest extends TestCase {
    * @dataProvider buriedErrorProvider
    */
   public function testBuriedErrorReturnsError(string $json): void {
-    $this->assertNotNull(_dkan_metastore_validate_schema_json($json));
+    $this->assertNotNull($this->validator->validateSchemaJson($json));
   }
 
   public static function buriedErrorProvider(): array {
@@ -114,7 +135,7 @@ class SchemaCheckHelperTest extends TestCase {
    * @dataProvider noFalsePositiveProvider
    */
   public function testNoFalsePositive(string $json): void {
-    $this->assertNull(_dkan_metastore_validate_schema_json($json));
+    $this->assertNull($this->validator->validateSchemaJson($json));
   }
 
   public static function noFalsePositiveProvider(): array {
@@ -126,6 +147,21 @@ class SchemaCheckHelperTest extends TestCase {
       'dependencies array form' => ['{"dependencies":{"a":["b","c"]}}'],
       'nested clean properties' => ['{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"integer"}}}'],
     ];
+  }
+
+  public function testOldsDatasetSchemaThrowsDraft04Error(): void {
+    $this->assertEquals('Unsupported draft-04', $this->validator->validateSchemaId('dataset'));
+  }
+
+  public function testNonexistentSchemaIdReturnsError(): void {
+    $this->assertStringContainsString('Could not retrieve schema', $this->validator->validateSchemaId('nonexistent'));
+  }
+
+  public function testCheckAllSchemas(): void {
+    $problems = $this->validator->checkAllSchemas();
+    $this->assertIsArray($problems);
+    $this->assertArrayHasKey('dataset', $problems);
+    $this->assertStringContainsString('Unsupported draft-04', $problems['dataset']);
   }
 
 }

--- a/modules/dkan_metastore/tests/src/Unit/SchemaValidatorTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/SchemaValidatorTest.php
@@ -45,6 +45,82 @@ class SchemaValidatorTest extends TestCase {
     $this->assertNull($this->validator->validateSchemaJson('{"type":"object"}'));
   }
 
+  public function testSchemaKeywordSubSchemas(): void {
+    $schema = [
+      'type' => 'object',
+      'properties' => [
+        'foo' => [
+          'type' => 'object',
+          'properties' => [
+            'bar' => ['type' => 'string'],
+          ],
+          'additionalProperties' => [
+            'type' => 'object',
+            'properties' => [
+              'bar' => [
+                'type' => 'integer',
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+    $this->assertNull($this->validator->validateSchemaJson(json_encode($schema)));
+
+    // A structural error in a sub-schema must be reported.
+    $schema['properties']['foo']['additionalProperties']['properties']['bar']['type'] = 42;
+    $msg = $this->validator->validateSchemaJson(json_encode($schema));
+    $this->assertStringContainsString('type can only be a string or an array of string', $msg);
+  }
+
+  public function testNestedItemsSchema(): void {
+    $schema = [
+      'type' => 'object',
+      'properties' => [
+        'foo' => [
+          'type' => 'array',
+          'items' => [
+            [
+              'type' => 'object',
+              'properties' => [
+                'bar' => ['type' => 'string'],
+              ],
+            ],
+            [
+              'type' => 'object',
+              'properties' => [
+                'bar' => ['type' => 'integer'],
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+    // Items can no longer be an array of schemas; prefixItems must be used.
+    $msg = $this->validator->validateSchemaJson(json_encode($schema));
+    $this->assertStringContainsString('items must contain a valid json schema', $msg);
+  }
+
+  public function testSlotsSchemaValidation(): void {
+    $schema = [
+      'type' => 'object',
+      '$slots' => [
+        'foo' => [
+          'type' => 'object',
+          'properties' => [
+            'bar' => ['type' => 'string'],
+          ],
+        ],
+      ],
+    ];
+    $this->assertNull($this->validator->validateSchemaJson(json_encode($schema)));
+
+    // A structural error in a $slots sub-schema must be reported.
+    $schema['$slots']['foo']['properties']['bar']['type'] = 42;
+    $msg = $this->validator->validateSchemaJson(json_encode($schema));
+    $this->assertStringContainsString('type can only be a string or an array of string', $msg);
+  }
+
   public function testBooleanSchemaTrueReturnsNull(): void {
     $this->assertNull($this->validator->validateSchemaJson('true'));
   }

--- a/modules/dkan_metastore/tests/src/Unit/SchemaValidatorTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/SchemaValidatorTest.php
@@ -70,7 +70,8 @@ class SchemaValidatorTest extends TestCase {
     // A structural error in a sub-schema must be reported.
     $schema['properties']['foo']['additionalProperties']['properties']['bar']['type'] = 42;
     $msg = $this->validator->validateSchemaJson(json_encode($schema));
-    $this->assertStringContainsString('type can only be a string or an array of string', $msg);
+    $expected = '#/properties/foo/additionalProperties/properties/bar: type can only be a string or an array of string';
+    $this->assertEquals($expected, $msg);
   }
 
   public function testNestedItemsSchema(): void {
@@ -98,7 +99,7 @@ class SchemaValidatorTest extends TestCase {
     ];
     // Items can no longer be an array of schemas; prefixItems must be used.
     $msg = $this->validator->validateSchemaJson(json_encode($schema));
-    $this->assertStringContainsString('items must contain a valid json schema', $msg);
+    $this->assertEquals('#/properties/foo: items must contain a valid json schema', $msg);
   }
 
   public function testSlotsSchemaValidation(): void {
@@ -118,7 +119,8 @@ class SchemaValidatorTest extends TestCase {
     // A structural error in a $slots sub-schema must be reported.
     $schema['$slots']['foo']['properties']['bar']['type'] = 42;
     $msg = $this->validator->validateSchemaJson(json_encode($schema));
-    $this->assertStringContainsString('type can only be a string or an array of string', $msg);
+    $expected = '#/$slots/foo/properties/bar: type can only be a string or an array of string';
+    $this->assertEquals($expected, $msg);
   }
 
   public function testBooleanSchemaTrueReturnsNull(): void {
@@ -132,19 +134,19 @@ class SchemaValidatorTest extends TestCase {
   public function testMalformedJsonReturnsError(): void {
     $msg = $this->validator->validateSchemaJson('{not json');
     $this->assertNotNull($msg);
-    $this->assertStringContainsString('not valid JSON', $msg);
+    $this->assertEquals('Schema is not valid JSON: Syntax error', $msg);
   }
 
   public function testStringSchemaReturnsError(): void {
     $msg = $this->validator->validateSchemaJson('"hello"');
     $this->assertNotNull($msg);
-    $this->assertStringContainsString('object or boolean', $msg);
+    $this->assertEquals('Schema must be a JSON object or boolean.', $msg);
   }
 
   public function testNumberSchemaReturnsError(): void {
     $msg = $this->validator->validateSchemaJson('42');
     $this->assertNotNull($msg);
-    $this->assertStringContainsString('object or boolean', $msg);
+    $this->assertEquals('Schema must be a JSON object or boolean.', $msg);
   }
 
   /**
@@ -226,7 +228,7 @@ class SchemaValidatorTest extends TestCase {
   }
 
   public function testOldsDatasetSchemaThrowsDraft04Error(): void {
-    $this->assertEquals('Unsupported draft-04', $this->validator->validateSchemaId('dataset'));
+    $this->assertEquals('#/properties/publisher: Unsupported draft-04', $this->validator->validateSchemaId('dataset'));
   }
 
   public function testNonexistentSchemaIdReturnsError(): void {
@@ -237,7 +239,7 @@ class SchemaValidatorTest extends TestCase {
     $problems = $this->validator->checkAllSchemas();
     $this->assertIsArray($problems);
     $this->assertArrayHasKey('dataset', $problems);
-    $this->assertStringContainsString('Unsupported draft-04', $problems['dataset']);
+    $this->assertEquals('#/properties/publisher: Unsupported draft-04', $problems['dataset']);
   }
 
 }

--- a/modules/dkan_metastore/tests/src/docs/dataset.json
+++ b/modules/dkan_metastore/tests/src/docs/dataset.json
@@ -1,0 +1,321 @@
+{
+  "id": "http://dkan/api/v1/schema/dataset",
+  "title": "Project Open Data Dataset",
+  "description": "The metadata format for all federal open data. Validates a single JSON object entry (as opposed to entire Data.json catalog).",
+  "type": "object",
+  "required": [
+    "title",
+    "description",
+    "identifier",
+    "accessLevel",
+    "modified",
+    "keyword"
+  ],
+  "properties": {
+    "@type": {
+      "title": "Metadata Context",
+      "type": "string",
+      "description": "IRI for the JSON-LD data type. This should be dcat:Dataset for each Dataset.",
+      "default": "dcat:Dataset"
+    },
+    "title": {
+      "title": "Title",
+      "description": "Human-readable name of the asset. Should be in plain English and include sufficient detail to facilitate search and discovery.",
+      "type": "string",
+      "minLength": 1
+    },
+    "identifier": {
+      "title": "Unique Identifier",
+      "description": "A unique identifier for the dataset or API as maintained within an Agency catalog or database.",
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "title": "Description",
+      "description": "Human-readable description (e.g., an abstract) with sufficient detail to enable a user to quickly understand whether the asset is of interest.",
+      "type": "string",
+      "minLength": 1
+    },
+    "accessLevel": {
+      "description": "The degree to which this dataset could be made publicly-available, regardless of whether it has been made available. Choices: public (Data asset is or could be made publicly available to all without restrictions), restricted public (Data asset is available under certain use restrictions), or non-public (Data asset is not available to members of the public).",
+      "title": "Public Access Level",
+      "type": "string",
+      "enum": [
+        "public",
+        "restricted public",
+        "non-public"
+      ],
+      "default": "public"
+    },
+    "accrualPeriodicity": {
+      "title": "Frequency",
+      "description": "Frequency with which dataset is published.",
+      "type": "string",
+      "enum": [
+        "R/P10Y",
+        "R/P4Y",
+        "R/P1Y",
+        "R/P2M",
+        "R/P3.5D",
+        "R/P1D",
+        "R/P2W",
+        "R/P6M",
+        "R/P2Y",
+        "R/P3Y",
+        "R/P0.33W",
+        "R/P0.33M",
+        "R/PT1S",
+        "R/P1M",
+        "R/P3M",
+        "R/P0.5M",
+        "R/P4M",
+        "R/P1W",
+        "R/PT1H",
+        "irregular"
+      ],
+      "enumNames": [
+        "Decennial",
+        "Quadrennial",
+        "Annual",
+        "Bimonthly",
+        "Semiweekly",
+        "Daily",
+        "Biweekly",
+        "Semiannual",
+        "Biennial",
+        "Triennial",
+        "Three times a week",
+        "Three times a month",
+        "Continuously updated",
+        "Monthly",
+        "Quarterly",
+        "Semimonthly",
+        "Three times a year",
+        "Weekly",
+        "Hourly",
+        "Irregular"
+      ]
+    },
+    "describedBy": {
+      "title": "Data Dictionary",
+      "description": "URL to the data dictionary for the dataset or API. Note that documentation other than a data dictionary can be referenced using Related Documents as shown in the expanded fields.",
+      "type": "string",
+      "format": "uri"
+    },
+    "describedByType": {
+      "title": "Data Dictionary Type",
+      "description": "The machine-readable file format (IANA Media Type or MIME Type) of the distribution’s describedBy URL.",
+      "type": "string"
+    },
+    "issued": {
+      "title": "Release Date",
+      "description": "Date of formal issuance.",
+      "type": "string"
+    },
+    "modified": {
+      "title": "Last Update",
+      "description": "Most recent date on which the dataset was changed, updated or modified.",
+      "type": "string"
+    },
+    "license": {
+      "title": "License",
+      "description": "The license dataset or API is published with. See <a href=\"https://resources.data.gov/open-licenses/\">Open Licenses</a> for more information.",
+      "type": "string",
+      "format": "uri"
+    },
+    "spatial": {
+      "title": "Spatial",
+      "description": "The <a href=\"https://project-open-data.cio.gov/v1.1/schema/#spatial\">spatial coverage</a> of the dataset. Could include a spatial region like a bounding box or a named place.",
+      "type": "string",
+      "minLength": 1
+    },
+    "temporal": {
+      "title": "Temporal",
+      "description": "The <a href=\"https://project-open-data.cio.gov/v1.1/schema/#temporal\">start and end dates</a> for which the dataset is applicable, separated by a \"/\" (i.e., 2000-01-15T00:45:00Z/2010-01-15T00:06:00Z).",
+      "type": "string"
+    },
+    "isPartOf": {
+      "title": "Collection",
+      "description": "The collection of which the dataset is a subset.",
+      "type": "string",
+      "minLength": 1
+    },
+    "publisher": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
+      "title": "Organization",
+      "description": "A Dataset Publisher Organization.",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "@type": {
+          "title": "Metadata Context",
+          "description": "IRI for the JSON-LD data type. This should be org:Organization for each publisher",
+          "type": "string",
+          "default": "org:Organization"
+        },
+        "name": {
+          "title": "Publisher Name",
+          "description": "",
+          "type": "string",
+          "minLength": 1
+        },
+        "subOrganizationOf": {
+          "title": "Parent Organization",
+          "type": "string"
+        }
+      }
+    },
+    "contactPoint": {
+      "id": "https://project-open-data.cio.gov/v1.1/schema/vcard.json#",
+      "title": "Project Open Data ContactPoint vCard",
+      "description": "A Dataset ContactPoint as a vCard object.",
+      "type": "object",
+      "required": [
+        "fn",
+        "hasEmail"
+      ],
+      "properties": {
+        "@type": {
+          "title": "Metadata Context",
+          "description": "IRI for the JSON-LD data type. This should be vcard:Contact for contactPoint.",
+          "enum": [
+            "vcard:Contact"
+          ],
+          "type": "string"
+        },
+        "fn": {
+          "title": "Contact Name",
+          "description": "A full formatted name, e.g. Firstname Lastname.",
+          "type": "string",
+          "minLength": 1
+        },
+        "hasEmail": {
+          "title": "Email",
+          "description": "Email address for the contact name.",
+          "pattern": "^mailto:[\\w\\_\\~\\!\\$\\&\\'\\(\\)\\*\\+\\,\\;\\=\\:.-]+@[\\w.-]+\\.[\\w.-]+?$|[\\w\\_\\~\\!\\$\\&\\'\\(\\)\\*\\+\\,\\;\\=\\:.-]+@[\\w.-]+\\.[\\w.-]+?$",
+          "type": "string"
+        }
+      }
+    },
+    "theme": {
+      "title": "Category",
+      "description": "Main thematic category of the dataset.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "title": "Category",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "keyword": {
+      "title": "Tags",
+      "description": "Tags (or keywords) help users discover your dataset; please include terms that would be used by technical and non-technical users.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "title": "Tag",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "distribution": {
+      "title": "Distribution",
+      "description": "A distribution is a container for the metadata specific to the data resource being shared. Each distribution should contain one <strong>Access URL</strong> or <strong>Download URL</strong>. When providing a Download URL, also include the format of the file. A distribution containing a Download URL to a csv or tsv file will generate queues that will import the data into a database table, this is referred to as a datastore. The datastore provides an API endpoint for users to run queries against the data.",
+      "type": "array",
+      "items": {
+        "title": "Data File",
+        "type": "object",
+        "properties": {
+          "@type": {
+            "title": "Metadata Context",
+            "description": "IRI for the JSON-LD data type. This should be dcat:Distribution for each Distribution.",
+            "default": "dcat:Distribution",
+            "type": "string",
+            "readOnly": true
+          },
+          "title": {
+            "title": "Title",
+            "description": "Human-readable name of the file.",
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "title": "Description",
+            "description": "Human-readable description of the file.",
+            "type": "string",
+            "minLength": 1
+          },
+          "format": {
+            "title": "Format",
+            "description": "A human-readable description of the file format of a distribution (i.e. csv, pdf, xml, kml, etc.).",
+            "type": "string",
+            "examples": [
+              "arcgis",
+              "csv",
+              "esri rest",
+              "geojson",
+              "json",
+              "kml",
+              "pdf",
+              "tsv",
+              "xls",
+              "xlsx",
+              "xml",
+              "zip"
+            ]
+          },
+          "mediaType": {
+            "title": "Media Type",
+            "description": "The machine-readable file format (<a href=\"https://www.iana.org/assignments/media-types/media-types.xhtml\">IANA Media Type or MIME Type</a>) of the distribution’s downloadURL.",
+            "type": "string"
+          },
+          "downloadURL": {
+            "title": "Download URL",
+            "description": "URL providing direct access to a downloadable file of a dataset.",
+            "type": "string",
+            "format": "uri"
+          },
+          "accessURL": {
+            "title": "Access URL",
+            "description": "URL providing indirect access to a dataset.",
+            "type": "string",
+            "format": "uri"
+          },
+          "conformsTo": {
+            "title": "Data Standard",
+            "description": "URI used to identify a standardized specification the distribution conforms to.",
+            "type": "string",
+            "format": "uri"
+          },
+          "describedBy": {
+            "title": "Data Dictionary",
+            "description": "URL to the data dictionary for the distribution found at the downloadURL.",
+            "type": "string",
+            "format": "uri"
+          },
+          "describedByType": {
+            "title": "Data Dictionary Type",
+            "description": "The machine-readable file format (IANA Media Type or MIME Type) of the distribution’s describedBy URL.",
+            "pattern": "^[a-z\\/\\.\\+]+?$",
+            "type": "string"
+          }
+        },
+        "uniqueItems": true
+      },
+      "minItems": 1
+    },
+    "references": {
+      "title": "Related Documents",
+      "description": "Related documents such as technical information about a dataset, developer documentation, etc.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Re-working of #4729 by @dcgoodwin2112: Fixes warnings for broken schemas from Opis v2 upgrade, and significantly refactors the schema validator logic into its own service.

Also took the opportunity to clean up SchemaRetriever docs.

## QA Steps

- Replace `schema/collections/dataset.json` with the contents of this file: https://github.com/GetDKAN/dkan/blob/cea733db3c589636a1d6702710b3dc3f44d2d4d9/schema/collections/dataset.json
- Clear cache.
- Check the Drupal status page. You should see a message like this: "1 schema(s) cannot be parsed
- The following metastore schemas could not be parsed under opis/json-schema v2: dataset. They will fail at runtime when used. See [DKAN change record](https://www.drupal.org/node/3593097) for the draft-04 -> draft-07 migration steps."
- Revert the file and this message should not appear.