### PR TITLE
Distribution predelete check resource

### DIFF
--- a/modules/dkan_metastore/dkan_metastore.module
+++ b/modules/dkan_metastore/dkan_metastore.module
@@ -157,21 +157,25 @@ function dkan_metastore_cron() {
         $message = 'No orphaned nodes deleted';
       }
       else {
-        $max_displayed = 20;
-        $count_msg = '';
-        if (count($nids) > $max_displayed) {
-          $count_msg = ' (and ' . count($nids) - $max_displayed . ' more)';
-          $nids = array_slice($nids, 0, 20);
+        $max_displayed = 10;
+        $count_msg = '1 orphaned node was deleted.';
+        $extra = '';
+        if (count($nids) > 1) {
+          $count_msg = count($nids) . ' orphaned nodes were deleted.';
         }
-        $message = 'Orphaned nodes ' . implode(',', $nids) . $count_msg . ' were deleted';
+        if (count($nids) > $max_displayed) {
+          $extra = ' (and ' . count($nids) - $max_displayed . ' more)';
+          $nids = array_slice($nids, 0, 10);
+        }
+        $message = $count_msg . ' Node id(s): ' . implode(', ', $nids) . $extra;
       }
-      \Drupal::logger('metastore')->notice($message);
+      \Drupal::logger('dkan_metastore')->notice($message);
     }
 
     \Drupal::state()->set('orphan_delete.last_run', $request_time);
   }
   catch (Exception $exception) {
-    \Drupal::logger('metastore')->error($exception->getMessage());
+    \Drupal::logger('dkan_metastore')->error($exception->getMessage());
   }
 }
 

--- a/modules/dkan_metastore/src/EventSubscriber/MetastoreSubscriber.php
+++ b/modules/dkan_metastore/src/EventSubscriber/MetastoreSubscriber.php
@@ -4,6 +4,7 @@ namespace Drupal\dkan_metastore\EventSubscriber;
 
 use Drupal\dkan_common\DataResource;
 use Drupal\dkan_common\Events\Event;
+use Drupal\dkan_metastore\LifeCycle\LifeCycle as Dkan_metastoreLifeCycle;
 use Drupal\dkan_metastore\MetastoreService;
 use Drupal\dkan_metastore\Plugin\QueueWorker\OrphanReferenceProcessor;
 use Drupal\dkan_metastore\ReferenceLookupInterface;
@@ -74,11 +75,12 @@ class MetastoreSubscriber implements EventSubscriberInterface {
   public static function getSubscribedEvents(): array {
     $events = [];
     $events[OrphanReferenceProcessor::EVENT_ORPHANING_DISTRIBUTION][] = ['cleanResourceMapperTable'];
+    $events[Dkan_metastoreLifeCycle::EVENT_DELETING_DISTRIBUTION][] = ['cleanResourceMapperTable'];
     return $events;
   }
 
   /**
-   * React to a distribution being orphaned.
+   * React to a distribution being orphaned or deleted.
    *
    * Removes resources associated with the orphaned distribution.
    *

--- a/modules/dkan_metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/dkan_metastore/src/LifeCycle/LifeCycle.php
@@ -35,6 +35,7 @@ class LifeCycle {
 
   const EVENT_DATASET_UPDATE = 'dkan_metastore_dataset_update';
   const EVENT_PRE_REFERENCE = 'dkan_metastore_metadata_pre_reference';
+  const EVENT_DELETING_DISTRIBUTION = 'dkan_metastore_deleting_distribution';
 
   /**
    * Referencer service.
@@ -253,22 +254,9 @@ class LifeCycle {
   protected function distributionPredelete(MetastoreItemInterface $data): void {
     $distributionUuid = $data->getIdentifier();
 
-    $storage = $this->dataFactory->getInstance('distribution');
-    $resource = $storage->retrieve($distributionUuid);
-    $resource = json_decode((string) $resource);
+    $event = new Event($distributionUuid);
+    $this->eventDispatcher->dispatch($event, self::EVENT_DELETING_DISTRIBUTION);
 
-    $id = $resource->data->{'%Ref:downloadURL'}[0]->data->identifier ?? NULL;
-
-    // Ensure a valid resource ID was found since it's required.
-    if (isset($id)) {
-      $perspective = $resource->data->{'%Ref:downloadURL'}[0]->data->perspective ?? NULL;
-      $version = $resource->data->{'%Ref:downloadURL'}[0]->data->version ?? NULL;
-      $this->queueFactory->get('orphan_resource_remover')->createItem([
-        $id,
-        $perspective,
-        $version,
-      ]);
-    }
   }
 
   /**

--- a/modules/dkan_metastore/src/Service/OrphanNodeProcessor.php
+++ b/modules/dkan_metastore/src/Service/OrphanNodeProcessor.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class OrphanNodeProcessor implements ContainerInjectionInterface {
 
-  const SECONDS_PER_DAY = 60 * 60 * 24;
+  const SECONDS_PER_DAY = 30;
 
   /**
    * The datastore.settings config.

--- a/modules/dkan_metastore/src/Service/OrphanNodeProcessor.php
+++ b/modules/dkan_metastore/src/Service/OrphanNodeProcessor.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class OrphanNodeProcessor implements ContainerInjectionInterface {
 
-  const SECONDS_PER_DAY = 30;
+  const SECONDS_PER_DAY = 60 * 60 * 24;
 
   /**
    * The datastore.settings config.


### PR DESCRIPTION
Fixes #4698

## Describe your changes
If you've configured your site to delete orphaned nodes, the resource of any orphaned distribution node should be checked to confirm it is not still in use before being removed from the resource mapper table.

## QA Steps

- [x] Visit /admin/dkan/properties
- [x] Scroll to the bottom and check the "Delete referenced content after a dataset is deleted" box and save
- [x] Edit the SECONDS_PER_DAY in [OrphanNodeProcessor](https://github.com/GetDKAN/dkan/blob/4.x/modules/dkan_metastore/src/Service/OrphanNodeProcessor.php#L16) to make testing easier, 30 works well.
- [x] Create a dataset with a CSV resource, run cron twice
- [x] Edit the dataset, add a title to the distribution, leaving the downloadURL as is and save
- [x] Run cron, the previous distribution will be orphaned. Wait for 30 seconds and run cron again to initiate the deletion.
- [x] Confirm you see a logged message "1 orphaned node has been deleted"
- [x] Go back to /admin/dkan/datasets and click edit for your dataset and confirm the downloadURL is intact.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
