### PR TITLE
Remove metastore_resource_mapper_new_revision

### DIFF
--- a/modules/dkan_datastore/src/EventSubscriber/DatastoreSubscriber.php
+++ b/modules/dkan_datastore/src/EventSubscriber/DatastoreSubscriber.php
@@ -23,11 +23,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class DatastoreSubscriber implements EventSubscriberInterface {
 
   /**
-   * Drupal Config Factory.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   * Config factory service.
    */
-  protected $configFactory;
+  private ConfigFactoryInterface $configFactory;
 
   /**
    * Datastore logger channel service.
@@ -59,7 +57,7 @@ class DatastoreSubscriber implements EventSubscriberInterface {
   /**
    * Inherited.
    *
-   * @{inheritdocs}
+  * @inheritdoc
    */
   public static function create(ContainerInterface $container) {
     return new static(
@@ -75,8 +73,8 @@ class DatastoreSubscriber implements EventSubscriberInterface {
   /**
    * Constructor.
    *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   A ConfigFactory service instance.
+    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+    *   Config factory.
    * @param \Psr\Log\LoggerInterface $loggerChannel
    *   Logger channel.
    * @param \Drupal\dkan_datastore\DatastoreService $service
@@ -89,14 +87,14 @@ class DatastoreSubscriber implements EventSubscriberInterface {
    *   The event dispatcher service.
    */
   public function __construct(
-    ConfigFactoryInterface $config_factory,
+    ConfigFactoryInterface $configFactory,
     LoggerInterface $loggerChannel,
     DatastoreService $service,
     ResourcePurger $resourcePurger,
     ImportJobStoreFactory $importJobStoreFactory,
     EventDispatcherInterface $eventDispatcher,
   ) {
-    $this->configFactory = $config_factory;
+    $this->configFactory = $configFactory;
     $this->logger = $loggerChannel;
     $this->datastoreService = $service;
     $this->resourcePurger = $resourcePurger;
@@ -196,30 +194,58 @@ class DatastoreSubscriber implements EventSubscriberInterface {
    * React to a preReference to check if datastore update should be triggered.
    *
    * @param \Drupal\dkan_common\Events\Event $event
-   *   The event object containing the resource uuid.
+   *   The event object containing pre-reference context.
    */
   public function onPreReference(Event $event) {
-    // Attempt to retrieve new and original revisions of metadata object.
-    $data = $event->getData();
-    $original = $data->getLatestRevision();
-    // Retrieve a list of metadata properties which, when changed, should
-    // trigger a new metadata resource revision.
-    $datastore_settings = $this->configFactory->get('dkan_datastore.settings');
-    $triggers = array_filter($datastore_settings->get('triggering_properties') ?? []);
-    // Ensure at least one trigger has been selected in datastore settings, and
-    // that a valid MetastoreItem data object was found for the previous version
-    // of the wrapped node.
-    // If a change was found in one of the triggering elements, change the
-    // "new revision" flag to true in order to trigger a datastore update.
-    $rev = &drupal_static('metastore_resource_mapper_new_revision');
-    if (!empty($triggers) && $original instanceof MetastoreItemInterface &&
-      $this->lazyDiffObject($original->getMetadata(), $data->getMetadata(), $triggers)) {
-      // Update static to reflect that a new resource is needed.
-      $rev = 1;
+    $eventData = $event->getData();
+    $item = NULL;
+
+    // New explicit form passes a payload object with the item and decision.
+    if (is_object($eventData) && isset($eventData->item) && $eventData->item instanceof MetastoreItemInterface) {
+      $item = $eventData->item;
     }
-    else {
-      // Set static back to default value of false.
-      $rev = 0;
+    // Backward compatibility for direct MetastoreItem event payloads.
+    elseif ($eventData instanceof MetastoreItemInterface) {
+      $item = $eventData;
+    }
+
+    if (!$item) {
+      return;
+    }
+
+    $triggers = array_filter($this->configFactory->get('dkan_datastore.settings')->get('triggering_properties') ?? []);
+    if (empty($triggers)) {
+      return;
+    }
+
+    $baseline = NULL;
+    if (method_exists($item, 'getLatestRevision')) {
+      $latest = $item->getLatestRevision();
+      if ($latest instanceof MetastoreItemInterface) {
+        $baseline = $latest->getMetadata();
+      }
+    }
+
+    if (!is_object($baseline)) {
+      $baseline = $item->getRawMetadata();
+    }
+
+    if (!is_object($baseline)) {
+      return;
+    }
+
+    $shouldCreateNewResourceVersion = FALSE;
+    $metadata = $item->getMetadata();
+    foreach ($triggers as $property) {
+      if (($baseline->{$property} ?? NULL) != ($metadata->{$property} ?? NULL)) {
+        $shouldCreateNewResourceVersion = TRUE;
+        break;
+      }
+    }
+
+    if (is_object($eventData)) {
+      $eventData->createNewResourceVersion = $shouldCreateNewResourceVersion;
+      $event->setData($eventData);
     }
   }
 
@@ -242,31 +268,6 @@ class DatastoreSubscriber implements EventSubscriberInterface {
       TRUE,
       $data['version'] ?? NULL
     );
-  }
-
-  /**
-   * Determine differences in the supplied objects in the given property scope.
-   *
-   * @param object $a
-   *   The first object being compared.
-   * @param object $b
-   *   The second object being compared.
-   * @param array $scope
-   *   Shared object properties being compared.
-   *
-   * @returns bool
-   *   Whether any differences were found in the scoped two objects.
-   */
-  protected function lazyDiffObject($a, $b, array $scope): bool {
-    $changed = FALSE;
-    foreach ($scope as $property) {
-      if ($a->{$property} != $b->{$property}) {
-        $changed = TRUE;
-        break;
-      }
-    }
-
-    return $changed;
   }
 
 }

--- a/modules/dkan_metastore/dkan_metastore.module
+++ b/modules/dkan_metastore/dkan_metastore.module
@@ -56,13 +56,6 @@ function dkan_metastore_entity_bundle_field_info_alter(&$fields, EntityTypeInter
 }
 
 /**
- * Helper method to retrieve the static value for a resource's revisioning.
- */
-function resource_mapper_new_revision() {
-  return drupal_static('dkan_metastore_resource_mapper_new_revision', 0);
-}
-
-/**
  * Send some entities into their life cycle.
  *
  * @param \Drupal\Core\Entity\EntityInterface[] $entities

--- a/modules/dkan_metastore/src/LifeCycle/LifeCycle.php
+++ b/modules/dkan_metastore/src/LifeCycle/LifeCycle.php
@@ -342,18 +342,28 @@ class LifeCycle {
    * @throws \Exception
    */
   protected function referenceMetadata(MetastoreItemInterface $data): void {
-    $metadata = $data->getMetadata();
+    $createNewResourceVersion = FALSE;
 
     // Trigger datastore import if applicable.
     // Needs to happen before updating references.
     if ($data instanceof MetastoreItemInterface) {
-      $event = new Event($data);
+      $event = new Event((object) [
+        'item' => $data,
+        'createNewResourceVersion' => FALSE,
+      ]);
       $this->eventDispatcher->dispatch($event, self::EVENT_PRE_REFERENCE);
+
+      $eventData = $event->getData();
+      if (is_object($eventData) && isset($eventData->createNewResourceVersion)) {
+        $createNewResourceVersion = (bool) $eventData->createNewResourceVersion;
+      }
     }
+
+    $metadata = $data->getMetadata();
 
     // Convert references in metadata to uuids.
     // Create new reference entities if they do not exist.
-    $metadata = $this->referencer->reference($metadata);
+    $metadata = $this->referencer->reference($metadata, $createNewResourceVersion);
 
     // Re-add metadata to data object with uuids.
     $data->setMetadata($metadata);
@@ -451,23 +461,9 @@ class LifeCycle {
   protected function distributionPresave(MetastoreItemInterface $data): void {
     $metadata = $data->getMetaData();
 
-    // If updating an existing distribution, re-reference it.
-    if (!$data->isNew()) {
-      $distributionUuid = $data->getIdentifier();
-      $storage = $this->dataFactory->getInstance('distribution');
-      $resource = $storage->retrieve($distributionUuid);
-      $resource = json_decode((string) $resource);
-
-      $resourceId = $resource->data->{'%Ref:downloadURL'}[0]->data->identifier ?? NULL;
-
-      // Replace download url with the resource reference ID again.
-      if (isset($resourceId)) {
-        $perspective = $resource->data->{'%Ref:downloadURL'}[0]->data->perspective ?? NULL;
-        $version = $resource->data->{'%Ref:downloadURL'}[0]->data->version ?? NULL;
-        $metadata->data->downloadURL = $resourceId . '__' . $version . '__' . $perspective;
-        unset($metadata->data->{'%Ref:downloadURL'});
-      }
-    }
+    // A distribution save by itself should not force resource re-versioning.
+    // Re-versioning decisions are made at dataset pre-reference time.
+    $this->referencer->distributionHandling($metadata->data, FALSE);
     $data->setMetadata($metadata);
   }
 

--- a/modules/dkan_metastore/src/Reference/Referencer.php
+++ b/modules/dkan_metastore/src/Reference/Referencer.php
@@ -98,14 +98,14 @@ class Referencer {
    * @return object
    *   Json object modified with references to some of its properties' values.
    */
-  public function reference($data) {
+  public function reference($data, bool $createNewResourceVersion = FALSE) {
     if (!is_object($data)) {
       throw new \Exception('data must be an object.');
     }
     // Cycle through the dataset properties we seek to reference.
     foreach ($this->getPropertyList() as $property_id) {
       if (isset($data->{$property_id})) {
-        $data->{$property_id} = $this->referenceProperty($property_id, $data->{$property_id});
+        $data->{$property_id} = $this->referenceProperty($property_id, $data->{$property_id}, $createNewResourceVersion);
 
         // Remove de-referenced info from metadata.
         unset($data->{'%Ref:' . $property_id});
@@ -125,13 +125,13 @@ class Referencer {
    * @return string|array
    *   Single reference, or an array of references.
    */
-  protected function referenceProperty(string $property_id, mixed $data) {
+  protected function referenceProperty(string $property_id, mixed $data, bool $createNewResourceVersion = FALSE) {
     if (is_array($data)) {
-      return $this->referenceMultiple($property_id, $data);
+      return $this->referenceMultiple($property_id, $data, $createNewResourceVersion);
     }
     else {
       // Case for $data being an object or a string.
-      return $this->referenceSingle($property_id, $data);
+      return $this->referenceSingle($property_id, $data, $createNewResourceVersion);
     }
   }
 
@@ -146,10 +146,10 @@ class Referencer {
    * @return array
    *   The array of uuid references.
    */
-  protected function referenceMultiple(string $property_id, array $values) : array {
+  protected function referenceMultiple(string $property_id, array $values, bool $createNewResourceVersion = FALSE) : array {
     $result = [];
     foreach ($values as $value) {
-      $data = $this->referenceSingle($property_id, $value);
+      $data = $this->referenceSingle($property_id, $value, $createNewResourceVersion);
       if (NULL !== $data) {
         $result[] = $data;
       }
@@ -168,9 +168,9 @@ class Referencer {
    * @return string|null
    *   The Uuid reference, or NULL on failure.
    */
-  protected function referenceSingle(string $property_id, $value) {
+  protected function referenceSingle(string $property_id, $value, bool $createNewResourceVersion = FALSE) {
     if ($property_id == 'distribution') {
-      $value = $this->distributionHandling($value);
+      $value = $this->distributionHandling($value, $createNewResourceVersion);
     }
 
     $uuid = $this->checkExistingReference($property_id, $value);
@@ -203,7 +203,7 @@ class Referencer {
    * @return object
    *   The supplied distribution with an updated resource download URL.
    */
-  public function distributionHandling($distribution): object {
+  public function distributionHandling($distribution, bool $createNewResourceVersion = FALSE): object {
     // Ensure the supplied distribution has a valid resource before attempting
     // to register it with the resource mapper.
     if (isset($distribution->downloadURL)) {
@@ -211,7 +211,10 @@ class Referencer {
       // replace the download URL with a unique ID registered in the resource
       // mapper.
       $distribution->downloadURL = $this->registerWithResourceMapper(
-        UrlHostTokenResolver::hostify($distribution->downloadURL), $this->getMimeType($distribution));
+        UrlHostTokenResolver::hostify($distribution->downloadURL),
+        $this->getMimeType($distribution),
+        $createNewResourceVersion
+      );
     }
 
     // If there is a describedBy value, convert to dkan:// URL if appropriate.
@@ -258,7 +261,7 @@ class Referencer {
    * @return string
    *   A unique ID for the resource generated using the supplied details.
    */
-  protected function registerWithResourceMapper(string $downloadUrl, string $mimeType): string {
+  protected function registerWithResourceMapper(string $downloadUrl, string $mimeType, bool $createNewResourceVersion = FALSE): string {
     try {
       // Create a new resource using the supplied resource details.
       $resource = new DataResource($downloadUrl, $mimeType);
@@ -280,7 +283,7 @@ class Referencer {
           $entity->get('identifier')->getString(),
           DataResource::DEFAULT_SOURCE_PERSPECTIVE
         );
-        $downloadUrl = $this->handleExistingResource($stored, $mimeType);
+        $downloadUrl = $this->handleExistingResource($stored, $mimeType, $createNewResourceVersion);
       }
     }
     return $downloadUrl;
@@ -297,10 +300,10 @@ class Referencer {
    * @return string
    *   The download URL.
    */
-  protected function handleExistingResource(DataResource $existing, string $mimeType): string {
+  protected function handleExistingResource(DataResource $existing, string $mimeType, bool $createNewResourceVersion = FALSE): string {
     if (
       $existing->getPerspective() == DataResource::DEFAULT_SOURCE_PERSPECTIVE &&
-      (ResourceMapper::newRevision() == 1 || $existing->getMimeType() != $mimeType)
+      ($createNewResourceVersion || $existing->getMimeType() != $mimeType)
     ) {
       $new = $existing->createNewVersion();
       // Update the MIME type, since this may be updated by the user.

--- a/modules/dkan_metastore/src/ResourceMapper.php
+++ b/modules/dkan_metastore/src/ResourceMapper.php
@@ -58,16 +58,6 @@ class ResourceMapper {
   }
 
   /**
-   * Helper method to retrieve the static value for a resource's display.
-   *
-   * @return string
-   *   A resource perspective.
-   */
-  public static function newRevision() {
-    return \drupal_static('metastore_resource_mapper_new_revision', 0);
-  }
-
-  /**
    * Register a new url for mapping.
    */
   public function register(DataResource $resource): bool {

--- a/modules/dkan_metastore/tests/src/Functional/OnPreReferenceTest.php
+++ b/modules/dkan_metastore/tests/src/Functional/OnPreReferenceTest.php
@@ -60,6 +60,7 @@ class OnPreReferenceTest extends BrowserTestBase {
     $metastore = $this->container->get('dkan.metastore.service');
     $dataset = $metastore->getValidMetadataFactory()->get($data, 'dataset');
     $metastore->post('dataset', $dataset);
+    $beforeRef = $this->getDistributionDownloadUrlReference('123');
 
     $decoded = json_decode((string) $data);
     $decoded->modified = '06-04-2021';
@@ -68,8 +69,40 @@ class OnPreReferenceTest extends BrowserTestBase {
     $dataset = $metastore->getValidMetadataFactory()->get($edited, 'dataset');
     $metastore->patch('dataset', '123', $dataset);
 
-    $rev = drupal_static('metastore_resource_mapper_new_revision');
-    $this->assertEquals(1, $rev);
+    $afterRef = $this->getDistributionDownloadUrlReference('123');
+    $this->assertNotSame($beforeRef, $afterRef);
+  }
+
+  /**
+   * Get the raw downloadURL reference stored on a dataset's first distribution.
+   */
+  private function getDistributionDownloadUrlReference(string $datasetUuid): string {
+    $storage = $this->container->get('entity_type.manager')->getStorage('node');
+
+    $result = $storage->loadByProperties(['type' => 'data', 'uuid' => $datasetUuid]);
+    $datasetNode = reset($result);
+    $this->assertNotFalse($datasetNode);
+
+    $query = $this->container->get('database')->query(
+      'SELECT field_json_metadata_value FROM {node__field_json_metadata} WHERE entity_id = :entity_id',
+      [':entity_id' => $datasetNode->id()]
+    );
+    $datasetRaw = json_decode($query->fetchField(), TRUE);
+
+    $distributionUuid = $datasetRaw['distribution'][0] ?? NULL;
+    $this->assertNotNull($distributionUuid);
+
+    $result = $storage->loadByProperties(['type' => 'data', 'uuid' => $distributionUuid]);
+    $distributionNode = reset($result);
+    $this->assertNotFalse($distributionNode);
+
+    $query = $this->container->get('database')->query(
+      'SELECT field_json_metadata_value FROM {node__field_json_metadata} WHERE entity_id = :entity_id',
+      [':entity_id' => $distributionNode->id()]
+    );
+    $distributionRaw = json_decode($query->fetchField(), TRUE);
+
+    return $distributionRaw['data']['downloadURL'] ?? '';
   }
 
 }


### PR DESCRIPTION
Bookmarking an attempt to change revision logic to remove static flag `metastore_resource_mapper_new_revision`. Result of work with copilot and not at all ready for human consumption - will come back to this, full review, test, rewrite for consistency etc. 

Copilot's explanation of what it did:

Implemented the explicit-parameter form end-to-end and validated it with focused tests.

What changed:
1. Explicit new-version intent now flows through lifecycle and referencer calls (no static flag dependency).
- LifeCycle.php
- Referencer.php

2. Pre-reference decisioning was moved to event payload mutation in the datastore subscriber.
- Subscriber now reads triggering properties and sets createNewResourceVersion on event data.
- DatastoreSubscriber.php

3. Legacy static helpers were removed.
- ResourceMapper.php
- dkan_metastore.module

4. Distribution presave uses explicit behavior directly.
- LifeCycle.php

5. Functional regression coverage was updated to a deterministic signal.
- Instead of queue-depth checks, test now compares stored distribution downloadURL reference before/after patch.
- OnPreReferenceTest.php

Validation run:
1. dkan_datastore subscriber unit tests: OK (6 tests, 7 assertions)
2. metastore referencer unit tests: OK (12 tests, 16 assertions)
3. OnPreReference functional test: OK (1 test, 9 assertions)
4. LifeCycle distribution load kernel test: OK (1 test, 20 assertions)