### PR TITLE
#4655 Add link to node/123 to dataset import status table.

### DIFF
--- a/modules/dkan_datastore/dkan_datastore.module
+++ b/modules/dkan_datastore/dkan_datastore.module
@@ -15,6 +15,7 @@ function dkan_datastore_theme($existing, $type, $theme, $path) {
         'uuid' => NULL,
         'title' => NULL,
         'url' => NULL,
+        'node_id' => NULL,
       ],
     ],
     'dkan_datastore_dashboard_revision_cell' => [

--- a/modules/dkan_datastore/src/Form/DashboardForm.php
+++ b/modules/dkan_datastore/src/Form/DashboardForm.php
@@ -503,6 +503,7 @@ class DashboardForm extends FormBase {
     if ($moderation_class == 'hidden') {
       $moderation_class = 'published-hidden';
     }
+
     return [
       [
         'rowspan' => $resourceCount,
@@ -511,6 +512,7 @@ class DashboardForm extends FormBase {
           '#uuid' => $rev['uuid'],
           '#title' => $rev['title'],
           '#url' => Url::fromUri("internal:/dataset/$rev[uuid]"),
+          '#node_id' => $rev['node_id'],
         ],
       ],
       [

--- a/modules/dkan_datastore/templates/dkan-datastore-dashboard-dataset-cell.html.twig
+++ b/modules/dkan_datastore/templates/dkan-datastore-dashboard-dataset-cell.html.twig
@@ -1,2 +1,8 @@
-<div class="datastore-status-dataset-uuid">{{ uuid }}</div>
-<div class="datastore-status-dataset-link">{{ link(title, url) }}</div>
+  <div class="datastore-status-dataset-link">
+    {{title}} <a href="{{ path('entity.node.canonical', {'node': node_id}) }}" aria-label="{{ 'admin'|t }}: {{title}}">{{ 'admin'|t }}</a>
+    {% if url is not empty %}
+      {% set link_attributes = create_attribute({'aria-label': 'view: @title'|t({'@title': title})}) %}
+        | {{ link('view', url, {'attributes': link_attributes}) }}
+      {% endif %}
+  </div>
+  <div class="datastore-status-dataset-uuid">{{ uuid }}</div>

--- a/modules/dkan_datastore/tests/src/Unit/Form/DashboardFormTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/Form/DashboardFormTest.php
@@ -2,8 +2,12 @@
 
 namespace Drupal\Tests\dkan_datastore\Unit\Form;
 
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\DependencyInjection\Container;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Form\FormState;
 use Drupal\Core\Pager\Pager;
 use Drupal\Core\Pager\PagerManagerInterface;
@@ -11,27 +15,23 @@ use Drupal\Core\Path\PathValidator;
 use Drupal\Core\StreamWrapper\PublicStream;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
 use Drupal\Core\StringTranslation\TranslationManager;
-use Drupal\Tests\dkan_metastore\Unit\MetastoreServiceTest;
+use Drupal\dkan_common\DataResource;
 use Drupal\dkan_common\DatasetInfo;
-use Drupal\Core\Database\Connection;
 use Drupal\dkan_datastore\Form\DashboardForm;
+use Drupal\dkan_datastore\PostImportResult;
+use Drupal\dkan_datastore\PostImportResultFactory;
 use Drupal\dkan_datastore\Service\PostImport;
 use Drupal\dkan_harvest\Entity\HarvestRunRepository;
 use Drupal\dkan_harvest\HarvestService;
 use Drupal\dkan_metastore\MetastoreService;
+use Drupal\dkan_metastore\ResourceMapper;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\dkan_metastore\Unit\MetastoreServiceTest;
 use MockChain\Chain;
 use MockChain\Options;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Drupal\dkan_metastore\ResourceMapper;
-use Drupal\dkan_datastore\PostImportResult;
-use Drupal\dkan_datastore\PostImportResultFactory;
-use Drupal\dkan_common\DataResource;
-use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\Query\QueryInterface;
-use Drupal\node\NodeInterface;
 
 /**
  * @group dkan
@@ -110,6 +110,7 @@ class DashboardFormTest extends TestCase {
       'moderation_state' => 'published',
       'modified_date_metadata' => '2020-01-15',
       'modified_date_dkan' => '2021-02-11',
+      'node_id' => 1,
     ];
     $distribution = [
       'distribution_uuid' => 'dist-1',
@@ -154,6 +155,7 @@ class DashboardFormTest extends TestCase {
     $this->assertEquals('NEW', $form['table']['#rows'][0][2]['data']);
     $this->assertEquals('done', $form['table']['#rows'][0][6]['data']['#status']);
     $this->assertEquals(NULL, $form['table']['#rows'][0][6]['data']['#error']);
+    $this->assertEquals(1, $form['table']['#rows'][0][0]['data']['#node_id']);
   }
 
   /**
@@ -167,6 +169,7 @@ class DashboardFormTest extends TestCase {
       'moderation_state' => 'published',
       'modified_date_metadata' => '2020-01-15',
       'modified_date_dkan' => '2021-02-11',
+      'node_id' => 2,
     ];
     $distribution = [
       'distribution_uuid' => 'dist-1',
@@ -222,6 +225,7 @@ class DashboardFormTest extends TestCase {
     $this->assertEquals('NEW', $form['table']['#rows'][0][2]['data']);
     $this->assertEquals('done', $form['table']['#rows'][0][6]['data']['#status']);
     $this->assertEquals(NULL, $form['table']['#rows'][0][6]['data']['#error']);
+    $this->assertEquals(2, $form['table']['#rows'][0][0]['data']['#node_id']);
   }
 
   /**
@@ -235,6 +239,7 @@ class DashboardFormTest extends TestCase {
       'moderation_state' => 'published',
       'modified_date_metadata' => '2020-01-15',
       'modified_date_dkan' => '2021-02-11',
+      'node_id' => 3,
     ];
     $distribution = [
       'distribution_uuid' => 'dist-1',
@@ -295,6 +300,7 @@ class DashboardFormTest extends TestCase {
         'title' => 'Dataset 1',
         'modified_date_metadata' => '2019-08-12',
         'modified_date_dkan' => '2021-07-08',
+        'node_id' => 3,
         'distributions' => [
           [
             'distribution_uuid' => 'dist-1',
@@ -320,6 +326,7 @@ class DashboardFormTest extends TestCase {
         'title' => 'Non-Harvest Dataset',
         'modified_date_metadata' => '2019-08-12',
         'modified_date_dkan' => '2021-07-08',
+        'node_id' => 3,
         'distributions' => [
           [
             'distribution_uuid' => 'dist-2',
@@ -395,6 +402,7 @@ class DashboardFormTest extends TestCase {
         'modified_date_metadata' => '2019-08-12',
         'modified_date_dkan' => '2021-07-08',
         'distributions' => ['Not found'],
+        'node_id' => 1,
       ],
     ];
 
@@ -421,6 +429,7 @@ class DashboardFormTest extends TestCase {
         'title' => 'Dataset 1',
         'modified_date_metadata' => '2019-08-12',
         'modified_date_dkan' => '2021-07-08',
+        'node_id' => 5,
         'distributions' => [
           [
             'distribution_uuid' => 'dist-1',
@@ -510,6 +519,7 @@ class DashboardFormTest extends TestCase {
     $this->assertEquals('done', $form["table"]["#rows"][1][3]["data"]["#status"]);
     // The second row post import class is correct.
     $this->assertEquals('done', $form["table"]["#rows"][1][3]["class"][0]);
+    $this->assertEquals(5, $form['table']['#rows'][0][0]['data']['#node_id']);
   }
 
   /**
@@ -524,6 +534,7 @@ class DashboardFormTest extends TestCase {
         'title' => 'Dataset 1',
         'modified_date_metadata' => '2019-08-12',
         'modified_date_dkan' => '2021-07-08',
+        'node_id' => 7,
         'distributions' => [
           [
             'distribution_uuid' => 'dist-1',


### PR DESCRIPTION
Fixes #4655 

## Describe your changes
This is a repeat of #4656 but applied to 4.x

## QA Steps

- [ ] git checkout 4655-add-node-link-to-import-status-4
- [ ] drush cr to pick up twig changes
- [ ] visit /dashboard/datastore
- [ ] validate that the dataset identifier comes after/below the title
- [ ] validate that the dataset title has no link
- [ ] validate the "view" links to the FE version of the dataset page
- [ ] validate the "admin" links to the node version of the dataset page
- [ ] inspect the source and validate that the "admin" link has an aria-label that reads "admin: <dataset title>"
- [ ] inspect the source and validate that the "view" link has an aria-label that reads "view: <dataset title>"
## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [x] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
