### PR TITLE
#4621 Add revision time on presave.

### DIFF
--- a/modules/dkan_metastore/dkan_metastore.module
+++ b/modules/dkan_metastore/dkan_metastore.module
@@ -5,10 +5,11 @@
  */
 
 use Drupal\Core\Database\Query\AlterableInterface;
-use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\dkan_metastore\Factory\MetastoreEntityItemFactoryInterface;
 use Drupal\dkan_metastore\NodeWrapper\Data;
 use Drupal\dkan_metastore\MetastoreService;
 use Drupal\dkan_metastore\Service\OrphanNodeProcessor;
@@ -27,6 +28,15 @@ function dkan_metastore_entity_load(array $entities) {
  * Implements hook_entity_presave().
  */
 function dkan_metastore_entity_presave(EntityInterface $entity) {
+  // Check if the entity is a data entity and a new revision is being created.
+  /** @var MetastoreEntityItemFactoryInterface $storage */
+  $metastore_service = \Drupal::service('dkan.metastore.metastore_item_factory');
+  if ($entity->getEntityTypeId() === $metastore_service::getEntityType() && in_array($entity->bundle(), $metastore_service::getBundles()) && $entity->isNewRevision()) {
+    // Set revision creation time to the current time because programmatically
+    // saved revisions will reuse the previous revision's timestamp if not
+    // explicitly set.
+    $entity->setRevisionCreationTime(\Drupal::time()->getCurrentTime());
+  }
   dkan_metastore_data_lifecycle([$entity], "presave");
 }
 

--- a/modules/dkan_metastore/tests/src/Functional/RevisionCreationTimeOnPresaveTest.php
+++ b/modules/dkan_metastore/tests/src/Functional/RevisionCreationTimeOnPresaveTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\Tests\dkan_metastore\Functional;
+
+use Drupal\Core\Entity\RevisionLogInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\dkan_common\Traits\GetDataTrait;
+use Drupal\node\NodeInterface;
+
+/**
+ * @group dkan
+ * @group metastore
+ * @group functional
+ * @group btb
+ * @group functional1
+ */
+class RevisionCreationTimeOnPresaveTest extends BrowserTestBase {
+  use GetDataTrait;
+
+  protected static $modules = [
+    'dkan_datastore',
+    'dkan_metastore',
+    'node',
+  ];
+
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Ensures new revisions get a fresh revision creation timestamp.
+   */
+  public function test() {
+    /** @var \Drupal\dkan_metastore\MetastoreService $metastore */
+    $metastore = $this->container->get('dkan.metastore.service');
+    $metadata = $metastore->getValidMetadataFactory()->get(
+      $this->getDataset('revision-time-test', 'Revision Time Test', ['district_centerpoints_small.csv']),
+      'dataset'
+    );
+    $identifier = $metastore->post('dataset', $metadata);
+
+    /** @var \Drupal\dkan_metastore\Storage\DataFactory $storage_factory */
+    $storage_factory = $this->container->get('dkan.metastore.storage');
+    /** @var \Drupal\dkan_metastore\Storage\MetastoreEntityStorageInterface $storage */
+    $storage = $storage_factory->getInstance('dataset');
+
+    $entity = $storage->getEntityLatestRevision($identifier);
+    $this->assertNotEmpty($entity, 'Dataset entity is available for revision testing.');
+    $this->assertInstanceOf(NodeInterface::class, $entity);
+    $this->assertInstanceOf(RevisionLogInterface::class, $entity);
+    /** @var \Drupal\node\NodeInterface&\Drupal\Core\Entity\RevisionLogInterface $entity */
+
+    $past_timestamp = 1000;
+    $entity->setRevisionCreationTime($past_timestamp);
+    $entity->save();
+
+    $entity = $storage->getEntityLatestRevision($identifier);
+    $this->assertInstanceOf(NodeInterface::class, $entity);
+    $this->assertInstanceOf(RevisionLogInterface::class, $entity);
+    /** @var \Drupal\node\NodeInterface&\Drupal\Core\Entity\RevisionLogInterface $entity */
+    $previous_revision_id = $entity->getRevisionId();
+
+    $entity->setNewRevision();
+    $entity->setRevisionLogMessage('Create a new revision in functional test.');
+    $entity->setTitle('Revision Time Test Updated');
+    $save_start = \Drupal::time()->getCurrentTime();
+    $entity->save();
+
+    $latest_revision = $storage->getEntityLatestRevision($identifier);
+    $this->assertInstanceOf(RevisionLogInterface::class, $latest_revision);
+    /** @var \Drupal\Core\Entity\RevisionLogInterface $latest_revision */
+
+    $this->assertGreaterThan(
+      $previous_revision_id,
+      $latest_revision->getRevisionId(),
+      'A new revision was created.'
+    );
+    $this->assertNotEquals(
+      $past_timestamp,
+      $latest_revision->getRevisionCreationTime(),
+      'Revision creation time is not copied from the previous revision.'
+    );
+    $this->assertGreaterThanOrEqual(
+      $save_start,
+      $latest_revision->getRevisionCreationTime(),
+      'Revision creation time is updated to the current save time.'
+    );
+  }
+
+}


### PR DESCRIPTION
Fixes #4621 

## Describe your changes
This explicitly sets data node revision time so that programatic changes like publish reflect the time of the publish, and don't repeat the time of the draft.
This results in revisions that look like
<img width="782" height="283" alt="different revision dates" src="https://github.com/user-attachments/assets/e830b218-26b9-4b98-b2ae-bc73a613bb44" />

as opposed to the current  situation of 

<img width="865" height="282" alt="confusing same revision dates" src="https://github.com/user-attachments/assets/46e4afe7-52ee-4f88-b4d8-c2075baa9b30" />



## QA Steps
- [ ] git checkout 4621-set-revision-date-4
- [ ] Save a dataset as draft.
- [ ] publish it using either a drush command or a bulk operation in the UI.
- [ ] Visit the revisions tab for the dataset. validate that the first line  for each of the recent revisions has its own date and time. (rather than repeating the time.)
- [ ] validate that the revision message, which also looks like a time stamp did not change should still say something like "Created on <date>" and the date should match the message from the draft revision.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
