### PR TITLE
Drupal 11.4 in testing matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,8 +287,8 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~10.6.9", "~11.3.10"]
-              php_version: ["8.3", "8.5"]
+              drupal_core_constraint: ["~11.3.10"]
+              php_version: ["8.5"]
               database_version: ["mariadb:10.11"]
       - phpunit:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,8 +287,14 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~11.2.12", "~11.3.10",  "~11.4.0"]
+              drupal_core_constraint: ["~11.3.10",  "~11.4.0"]
               php_version: ["8.4"]
+              database_version: ["mariadb:10.11"]
+      - phpunit:
+          matrix:
+            parameters:
+              drupal_core_constraint: ["~11.2.12", "~11.3.10",  "~11.4.0"]
+              php_version: ["8.3"]
               database_version: ["mariadb:10.11"]
       - phpunit:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,30 +277,30 @@ workflows:
           name: install_test_cypress
           drupal_core_constraint: "~10.5.10"
       - phpunit:
-          name: "Install target (Drupal 10.5, PHP 8.3)"
+          name: "Install target (Drupal 10.6, PHP 8.4)"
           report_coverage: true
           matrix:
             parameters:
-              drupal_core_constraint: ["~10.5.10"]
-              php_version: ["8.3"]
-              database_version: ["mysql:5.7"]
-      - phpunit:
-          matrix:
-            parameters:
-              drupal_core_constraint: ["~10.6.9", "~11.2.12", "~11.3.10"]
-              php_version: ["8.3"]
-              database_version: ["mariadb:10.11"]
-      - phpunit:
-          matrix:
-            parameters:
-              drupal_core_constraint: ["~10.6.9", "~11.2.12", "~11.3.10"]
+              drupal_core_constraint: ["~10.6.9"]
               php_version: ["8.4"]
               database_version: ["mariadb:10.11"]
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~10.5.10"]
-              php_version: ["8.1", "8.2", "8.4"]
+              drupal_core_constraint: ["~10.6.9", "~11.3.10"]
+              php_version: ["8.3", "8.5"]
+              database_version: ["mariadb:10.11"]
+      - phpunit:
+          matrix:
+            parameters:
+              drupal_core_constraint: ["~11.2.12", "~11.3.10",  "~11.4.0"]
+              php_version: ["8.4"]
+              database_version: ["mariadb:10.11"]
+      - phpunit:
+          matrix:
+            parameters:
+              drupal_core_constraint: ["~10.6.9"]
+              php_version: ["8.1", "8.2"]
               database_version: ["mysql:5.7"]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,7 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~11.3.10",  "~11.4.0"]
+              drupal_core_constraint: ["~11.4.0"]
               php_version: ["8.4"]
               database_version: ["mariadb:10.11"]
       - phpunit:
@@ -300,7 +300,7 @@ workflows:
           matrix:
             parameters:
               drupal_core_constraint: ["~10.6.9"]
-              php_version: ["8.1", "8.2", "8.3"]
+              php_version: ["8.2", "8.3"]
               database_version: ["mysql:5.7"]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,7 @@ workflows:
           matrix:
             parameters:
               drupal_core_constraint: ["~10.6.9"]
-              php_version: ["8.1", "8.2"]
+              php_version: ["8.1", "8.2", "8.3"]
               database_version: ["mysql:5.7"]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,7 @@ workflows:
     jobs:
       - cypress:
           name: install_test_cypress
-          drupal_core_constraint: "~10.5.10"
+          drupal_core_constraint: "~10.6.9"
       - phpunit:
           name: "Install target (Drupal 10.6, PHP 8.4)"
           report_coverage: true
@@ -309,4 +309,4 @@ workflows:
       - cypress:
           name: upgrade_test_cypress
           upgrade: true
-          drupal_core_constraint: "~10.5.10"
+          drupal_core_constraint: "~10.6.9"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,12 +287,6 @@ workflows:
       - phpunit:
           matrix:
             parameters:
-              drupal_core_constraint: ["~11.3.10"]
-              php_version: ["8.5"]
-              database_version: ["mariadb:10.11"]
-      - phpunit:
-          matrix:
-            parameters:
               drupal_core_constraint: ["~11.2.12", "~11.3.10",  "~11.4.0"]
               php_version: ["8.4"]
               database_version: ["mariadb:10.11"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DKAN
 An Open Data Catalog module for [Drupal 10+](https://www.drupal.org/documentation).
 
-[![GetDKAN](https://circleci.com/gh/GetDKAN/dkan/tree/2.x.svg?style=svg)](https://circleci.com/gh/GetDKAN/dkan/tree/2.x)
+[![GetDKAN](https://circleci.com/gh/GetDKAN/dkan/tree/4.x.svg?style=svg)](https://circleci.com/gh/GetDKAN/dkan/tree/4.x)
 [![Maintainability](https://qlty.sh/gh/GetDKAN/projects/dkan/maintainability.svg)](https://qlty.sh/gh/GetDKAN/projects/dkan)
 [![Code Coverage](https://qlty.sh/gh/GetDKAN/projects/dkan/coverage.svg)](https://qlty.sh/gh/GetDKAN/projects/dkan)
 [![GPL license](https://img.shields.io/badge/License-GPL(>=2)-blue.svg)](http://www.gnu.org/licenses/gpl.html)

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
         "allow-plugins": {
             "php-http/discovery": true,
             "tbachert/spi": true,
-            "drupal/core-composer-scaffold": true
+            "drupal/core-composer-scaffold": true,
+            "symfony/runtime": true
         }
     },
     "extra": {

--- a/modules/dkan_common/tests/src/Unit/UrlHostTokenResolverTest.php
+++ b/modules/dkan_common/tests/src/Unit/UrlHostTokenResolverTest.php
@@ -49,6 +49,7 @@ class UrlHostTokenResolverTest extends TestCase {
 
     $container = (new Chain($this))
       ->add(Container::class, 'get', $options)
+      ->add(StreamWrapperManager::class, 'getViaUri', FALSE)
       ->add(RequestStack::class, 'getCurrentRequest', Request::class)
       ->add(Request::class, 'getHost', 'replacement')
       ->getMock();

--- a/modules/dkan_datastore/src/DatastoreLookup.php
+++ b/modules/dkan_datastore/src/DatastoreLookup.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\dkan_datastore;
 
 use Drupal\Core\Database\Connection;
-use Drupal\Core\Database\Statement\FetchAs;
 use Drupal\dkan_metastore\Reference\ReferenceLookup;
 
 /**
@@ -53,12 +52,10 @@ class DatastoreLookup implements DatastoreLookupInterface {
       'CONCAT(\'datastore_\', MD5(CONCAT(identifier, \'__\', version, \'__\', perspective))) = :table_name',
       [':table_name' => $table_name]
     );
-    // Execute the query and fetch the results as an associative array.
-    $resource_result = $resource_query->execute()->fetchAll(FetchAs::Associative);
-    // Extract the identifier value.
-    if ($resource_result) {
-      $resource_identifier = $resource_result[0]['identifier'];
-      return $resource_identifier;
+    // Fetch the first identifier directly for Drupal 10/11 compatibility.
+    $resource_identifier = $resource_query->execute()->fetchField();
+    if ($resource_identifier !== FALSE && $resource_identifier !== NULL) {
+      return (string) $resource_identifier;
     }
     else {
       throw new \Exception("Resource lookup: Can not map datastore table name {$table_name}

--- a/modules/dkan_datastore/src/DatastoreLookup.php
+++ b/modules/dkan_datastore/src/DatastoreLookup.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\dkan_datastore;
 
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\Statement\FetchAs;
 use Drupal\dkan_metastore\Reference\ReferenceLookup;
 
 /**
@@ -53,7 +54,7 @@ class DatastoreLookup implements DatastoreLookupInterface {
       [':table_name' => $table_name]
     );
     // Execute the query and fetch the results as an associative array.
-    $resource_result = $resource_query->execute()->fetchAll(\PDO::FETCH_ASSOC);
+    $resource_result = $resource_query->execute()->fetchAll(FetchAs::Associative);
     // Extract the identifier value.
     if ($resource_result) {
       $resource_identifier = $resource_result[0]['identifier'];

--- a/modules/dkan_datastore/tests/src/Unit/DatastoreLookupTest.php
+++ b/modules/dkan_datastore/tests/src/Unit/DatastoreLookupTest.php
@@ -67,14 +67,11 @@ class DatastoreLookupTest extends TestCase {
     // Mock the SelectInterface.
     $select = $this->createMock(SelectInterface::class);
 
-    // Mock the query result.
-    $query_result = [['identifier' => $expected_identifier]];
-
     // Mock the StatementInterface.
     $statement = $this->createMock(StatementInterface::class);
     $statement->expects($this->once())
-      ->method('fetchAll')
-      ->willReturn($query_result);
+      ->method('fetchField')
+      ->willReturn($expected_identifier);
 
     // Set up the expectations for the database select query.
     $this->database->expects($this->once())
@@ -117,14 +114,11 @@ class DatastoreLookupTest extends TestCase {
     // Mock the SelectInterface.
     $select = $this->createMock(SelectInterface::class);
 
-    // Mock the query result.
-    $query_result = [];
-
     // Mock the StatementInterface.
     $statement = $this->createMock(StatementInterface::class);
     $statement->expects($this->once())
-      ->method('fetchAll')
-      ->willReturn($query_result);
+      ->method('fetchField')
+      ->willReturn(FALSE);
 
     // Set up the expectations for the database select query.
     $this->database->expects($this->once())

--- a/modules/dkan_harvest/src/HarvestUtility.php
+++ b/modules/dkan_harvest/src/HarvestUtility.php
@@ -4,6 +4,7 @@ namespace Drupal\dkan_harvest;
 
 use Drupal\Component\Uuid\UuidInterface;
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\Statement\FetchAs;
 use Drupal\dkan_harvest\Entity\HarvestRunRepository;
 use Drupal\dkan_harvest\Storage\DatabaseTableFactory;
 use Drupal\dkan_harvest\Storage\HarvestHashesDatabaseTableFactory;
@@ -342,7 +343,7 @@ class HarvestUtility {
       ->fields('hrt', ['id', 'harvest_plan_id', 'data', 'extract_status'])
       ->condition('id', $timestamp, '=')
       ->orderBy('id', 'ASC');
-    $result = $query->execute()->fetchAll(\PDO::FETCH_ASSOC);
+    $result = $query->execute()->fetchAll(FetchAs::Associative);
     return reset($result);
   }
 

--- a/modules/dkan_harvest/src/HarvestUtility.php
+++ b/modules/dkan_harvest/src/HarvestUtility.php
@@ -4,7 +4,6 @@ namespace Drupal\dkan_harvest;
 
 use Drupal\Component\Uuid\UuidInterface;
 use Drupal\Core\Database\Connection;
-use Drupal\Core\Database\Statement\FetchAs;
 use Drupal\dkan_harvest\Entity\HarvestRunRepository;
 use Drupal\dkan_harvest\Storage\DatabaseTableFactory;
 use Drupal\dkan_harvest\Storage\HarvestHashesDatabaseTableFactory;
@@ -301,76 +300,6 @@ class HarvestUtility {
       $this->logger->notice('Updating namespace for ' . $plan_id);
       $this->updateTypeNamespace($plan_id);
     }
-  }
-
-  /**
-   * Get the ids from the temp harvest run table.
-   *
-   * Only needed for harvest_update_8010.
-   *
-   * @param mixed $table_name_temp
-   *   The name of the temp table.
-   *
-   * @return array
-   *   The ids of all the harvest runs in the table sorted oldest to newest.
-   */
-  public function getTempRunIdsForUpdate($table_name_temp) : array {
-    $query = $this->connection->select($table_name_temp, 'hrt')
-      ->fields('hrt', ['id'])
-      ->orderBy('id', 'ASC');
-    $result = $query->execute()->fetchCol(0);
-    // Can't rely on orderBy as the sort ends up natural, not numeric.
-    asort($result, SORT_NUMERIC);
-
-    return $result ?? [];
-  }
-
-  /**
-   * Reads a single harvest row from the harvest run temp table.
-   *
-   * Only needed for harvest_update_8010.
-   *
-   * @param string $table_name_temp
-   *   Name of the table to read from.
-   * @param string $timestamp
-   *   The id to read from, which was also the timestamp.
-   *
-   * @return array
-   *   Elements from the row['id', 'harvest_plan_id', 'data', 'extract_status'].
-   */
-  public function readTempHarvestRunForUpdate(string $table_name_temp, string $timestamp): array {
-    $query = $this->connection->select($table_name_temp, 'hrt')
-      ->fields('hrt', ['id', 'harvest_plan_id', 'data', 'extract_status'])
-      ->condition('id', $timestamp, '=')
-      ->orderBy('id', 'ASC');
-    $result = $query->execute()->fetchAll(FetchAs::Associative);
-    return reset($result);
-  }
-
-  /**
-   * Creates a new entry in harvest_run based on data from harvest run temp.
-   *
-   * Only needed for harvest_update_8010.
-   *
-   * @param string $timestamp
-   *   The id from the old harvest run, which was a timestamp.
-   * @param string $harvest_plan_id
-   *   The harvest plan id.
-   * @param string $data
-   *   Data about the harvest.
-   * @param string $extract_status
-   *   The status of the harvest.
-   */
-  public function writeHarvestRunFromUpdate(string $timestamp, string $harvest_plan_id, string $data, string $extract_status): void {
-    $this->connection->insert('harvest_runs')
-      ->fields([
-        'timestamp' => (int) $timestamp,
-        'harvest_plan_id' => $harvest_plan_id,
-        'uuid' => $this->uuidService->generate(),
-        'data' => $data,
-        'extract_status' => $extract_status,
-      ])
-      ->execute();
   }
 
 }

--- a/modules/dkan_metastore/tests/src/Unit/Reference/ReferencerTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/Reference/ReferencerTest.php
@@ -140,6 +140,7 @@ class ReferencerTest extends TestCase {
 
     return (new Chain($this))
       ->add(Container::class, 'get', $options)
+      ->add(StreamWrapperManager::class, 'getViaUri', FALSE)
       ->add(RequestStack::class, 'getCurrentRequest', Request::class)
       ->add(Request::class, 'getHost', 'test.test')
       ->add(ResourceMapper::class, 'register', TRUE, 'resource')


### PR DESCRIPTION
Update CircleCI testing matrix to add Drupal 11.4, drop 10.5.

Update the build pass/fail badge in the 4.x branch.

Removes a bunch of dead Harvest code that was causing issues due to changing signatures in DB API.