### PR TITLE
Add Drupal AI Best Practices to composer file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ docs/.venv
 /.ddev/web-build/*
 !/.ddev/web-build/Dockerfile
 tmp
+# For now, ignore any artifacts from Drupal AI Best Practices.
+/AGENTS.md
+/CLAUDE.md
+/GEMINI.md
+/.agents
+/ai_best_practices.yaml

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "drush/drush": "*",
         "getdkan/mock-chain": "~1.4.1",
         "osteel/openapi-httpfoundation-testing": "^0.13",
-        "drupal/admin_toolbar": "^3.0"
+        "drupal/admin_toolbar": "^3.0",
+        "drupal/ai_best_practices": "@dev"
     },
     "repositories": {
         "drupal": {
@@ -53,7 +54,8 @@
         "allow-plugins": {
             "php-http/discovery": true,
             "tbachert/spi": true,
-            "drupal/core-composer-scaffold": true
+            "drupal/core-composer-scaffold": true,
+            "drupal/ai_best_practices": true
         }
     },
     "extra": {
@@ -69,5 +71,8 @@
                 }
             }
         }
+    },
+    "scripts": {
+        "drupal-ai": "Drupal\\AiBestPractices\\Console\\AiBestPracticesApplication::runFromComposer"
     }
 }


### PR DESCRIPTION
This adds everything needed to

a) Add the AI best practices (optionally) to your dev environment when using the ddev contrib workflow.
b) Not add any of the assets it adds to version control by accident

While adding the AI assets to a project repo might be a good practice (it is what's recommended) I don't think it belongs in a module repo.

## QA Steps

1. After checking out branch, run ``dev poser`
2. Run `ddev composer drupal-ai skills-sync`
3. Confirm that you now have a .agents folder populated with skills, and that it is ignored by version control
4. Run `ddev composer drupal-ai skills-list` and confirm that you have 8 skills installed.