### PR TITLE
Fix flaky cypress test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,6 @@ jobs:
           php_version: << parameters.php_version >>
       - run:
           name: Run Cypress tests
-          max_auto_reruns: 3
           command: |
             rm -rf cypress/tmp cypress/results
             mkdir cypress/tmp

--- a/.ddev/commands/host/dkan-module-test-cypress
+++ b/.ddev/commands/host/dkan-module-test-cypress
@@ -33,8 +33,12 @@ fi
 TEST_USERS_JSON='[
   {"name":"testadmin","mail":"testadmin@test.com","role":"administrator"}
 ]'
-readarray -t TU_TEST_USERS < <(jq -c '.[]' <<<"$TEST_USERS_JSON")
-for TU_TEST_USER in "${TU_TEST_USERS[@]}"; do
+TEST_USER_NAMES=""
+jq -r '.[] | .name' <<<"$TEST_USERS_JSON" | while read -r name; do
+  TEST_USER_NAMES="$TEST_USER_NAMES $name"
+done
+
+jq -c '.[]' <<<"$TEST_USERS_JSON" | while read -r TU_TEST_USER; do
   name=$(jq -r '.name' <<<"$TU_TEST_USER")
   mail=$(jq -r '.mail' <<<"$TU_TEST_USER")
   role=$(jq -r '.role' <<<"$TU_TEST_USER")
@@ -46,8 +50,7 @@ npx cypress@"$DKAN_MODULE_CYPRESS_VERSION" info
 CYPRESS_baseUrl="$DDEV_PRIMARY_URL" npx cypress@"$DKAN_MODULE_CYPRESS_VERSION" run "$@"
 DKAN_MODULE_RESULT=$?
 
-for TU_TEST_USER in "${TU_TEST_USERS[@]}"; do
-  name=$(jq -r '.name' <<<"$TU_TEST_USER")
+jq -r '.[] | .name' <<<"$TEST_USERS_JSON" | while read -r name; do
   ddev drush user:cancel --delete-content $name -y
 done
 

--- a/.ddev/commands/host/dkan-module-test-cypress
+++ b/.ddev/commands/host/dkan-module-test-cypress
@@ -28,15 +28,9 @@ else
   echo "No package.json present, not trying to install."
 fi
 
-  # Commenting out until we get a lower roll worked out.
-  # {"name":"testapiuser","mail":"testapiuser@test.com","role":"api_user"},
 TEST_USERS_JSON='[
   {"name":"testadmin","mail":"testadmin@test.com","role":"administrator"}
 ]'
-TEST_USER_NAMES=""
-jq -r '.[] | .name' <<<"$TEST_USERS_JSON" | while read -r name; do
-  TEST_USER_NAMES="$TEST_USER_NAMES $name"
-done
 
 jq -c '.[]' <<<"$TEST_USERS_JSON" | while read -r TU_TEST_USER; do
   name=$(jq -r '.name' <<<"$TU_TEST_USER")

--- a/cypress/e2e/10_workflow_transitions.cy.js
+++ b/cypress/e2e/10_workflow_transitions.cy.js
@@ -144,8 +144,12 @@ context('DKAN Workflow', () => {
       cy.get('#edit-submit').click()
       cy.get('.messages--status').should('contain', 'has been updated')
 
-      // Ensure dataset is now hidden from search
-      dkan.searchMetastore({fulltext: dataset_title, facets: ''}).then((response) => {
+      // Ensure dataset is now hidden from search (poll until index reflects the
+      // state change, since search-index updates can be asynchronous in CI)
+      dkan.searchMetastoreUntil(
+        {fulltext: dataset_title, facets: ''},
+        (body) => !body.results || body.results.length === 0
+      ).then((response) => {
         expect(response.status).to.eq(200)
         expect(response.body.results).to.be.empty
       })

--- a/cypress/support/helpers/dkan.js
+++ b/cypress/support/helpers/dkan.js
@@ -100,6 +100,27 @@ export function searchMetastore (params = {}) {
   return cy.request('GET', url)
 }
 
+// Poll the metastore search endpoint until the predicate returns true or the
+// timeout elapses. Useful when search-index updates are asynchronous (e.g.
+// after a moderation-state transition in CI).
+export function searchMetastoreUntil (params = {}, predicate, timeout = 15000) {
+  const interval = 2000
+  const param_string = (new URLSearchParams(params)).toString()
+  const url = getMetastoreSearchEndpoint() + '?' + param_string
+  const deadline = Date.now() + timeout
+
+  function attempt () {
+    return cy.request('GET', url).then((response) => {
+      if (predicate(response.body) || Date.now() >= deadline) {
+        return cy.wrap(response)
+      }
+      return cy.wait(interval).then(() => attempt())
+    })
+  }
+
+  return attempt()
+}
+
 export function generateMetastore (schema_id, identifier = null) {
   // Generate a unique metastore identifier if one was not supplied.
   identifier = identifier || generateMetastoreIdentifier()

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "cypress": "^15.18.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,0 @@
-{
-  "devDependencies": {
-    "cypress": "^15.18.1"
-  }
-}


### PR DESCRIPTION
Attempt to fix the flaky Workflow cypress test fails nearly half the time. May be due to search index delay.

Also fixes the cypress command so that it works in both bash and zsh.

Note the update cypress test was run multiple times in CI and had no failure.