### PR TITLE
Stop using remote files for DatasetBTB

### DIFF
--- a/tests/files/1.csv
+++ b/tests/files/1.csv
@@ -1,0 +1,3 @@
+one
+un
+uno

--- a/tests/files/2.csv
+++ b/tests/files/2.csv
@@ -1,0 +1,3 @@
+one,two
+un,deux
+uno,dos

--- a/tests/files/3.csv
+++ b/tests/files/3.csv
@@ -1,0 +1,3 @@
+one,two,three
+un,deux,trois
+uno,dos,tres

--- a/tests/files/4.csv
+++ b/tests/files/4.csv
@@ -1,0 +1,3 @@
+one,two,three,four
+un,deux,trois,quatre
+uno,dos,tres,cuatro

--- a/tests/files/5.csv
+++ b/tests/files/5.csv
@@ -1,0 +1,3 @@
+one,two,three,four,five
+un,deux,trois,quatre,cinq
+uno,dos,tres,cuatro,cinco

--- a/tests/files/district_centerpoints_small.csv
+++ b/tests/files/district_centerpoints_small.csv
@@ -1,0 +1,3 @@
+"lon","lat","Unit_Type","Dist_Name","Prov_Name"
+61.33,32.4,"District","Qala-e-Kah","Farah"
+62.06,32.49,"District","Pusht Rod","Farah"

--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -51,9 +51,6 @@ class DatasetBTBTest extends BrowserTestBase {
    */
   protected $strictConfigSchema = FALSE;
 
-  private const S3_PREFIX = 'https://dkan-default-content-files.s3.amazonaws.com/phpunit';
-  private const FILENAME_PREFIX = 'dkan_default_content_files_s3_amazonaws_com_phpunit_';
-
   /**
    * Test the resource purger when the default moderation state is 'draft'.
    */
@@ -497,7 +494,7 @@ class DatasetBTBTest extends BrowserTestBase {
    *
    */
   private function getDownloadUrl(string $filename) {
-    return self::S3_PREFIX . '/' . $filename;
+    return 'file://' . __DIR__ . '/../../files/' . $filename;
   }
 
   /**
@@ -614,9 +611,10 @@ class DatasetBTBTest extends BrowserTestBase {
       return [];
     }
     $filesObjects = $fileSystem->scanDirectory($dir, '/.*\.csv$/i', ['recurse' => TRUE]);
-    $filenames = array_values(array_map(function ($obj) {
-      return str_replace(self::FILENAME_PREFIX, '', $obj->filename);
-    }, $filesObjects));
+    $filenames = [];
+    foreach ($filesObjects as $object) {
+      $filenames[] = $object->filename;
+    }
     sort($filenames);
     return $filenames;
   }

--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -534,7 +534,7 @@ class DatasetBTBTest extends BrowserTestBase {
       $distribution = new \stdClass();
       $distribution->title = 'Distribution #' . $key . ' for ' . $identifier;
       $distribution->downloadURL = $this->getDownloadUrl($downloadUrl);
-      // Don't provide mime type or format fields since they're not required.
+      $distribution->mediaType = 'text/csv';
       $data->distribution[] = $distribution;
     }
     $this->assertGreaterThan(


### PR DESCRIPTION
I've started noticing some occasional failures when accessing the test files from CircleCI, and even sometimes from local runs. We really should not be using remote files for functional tests, they should be self-contained and not dependent on things external to the testing environment.

These failures have caused some of the functional tests to get flaky for the first time. The place I see this happen the most is in DatasetBTBTest. This switches to using local files for all tests there. It also adds the `mediaType` field to the distribution fixtures, as it doesn't seem to be auto-detected when using file:// URLs (this is something to probably address later).

This pattern could be applied to the other functional tests still using test fixtures in S3.