### PR TITLE
Update data dict behavior to support non-ref distros

### DIFF
--- a/modules/dkan_datastore/modules/dkan_datastore_mysql_import/tests/src/Functional/StrictModeOffDictionaryEnforcerTest.php
+++ b/modules/dkan_datastore/modules/dkan_datastore_mysql_import/tests/src/Functional/StrictModeOffDictionaryEnforcerTest.php
@@ -11,6 +11,7 @@ use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\dkan_common\Traits\GetDataTrait;
 use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
 use Drupal\dkan_metastore\DataDictionary\DataDictionaryDiscovery;
+use Drupal\Tests\dkan_common\Traits\DistributionReferenceModeTrait;
 use RootedData\RootedJsonData;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -26,7 +27,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class StrictModeOffDictionaryEnforcerTest extends BrowserTestBase {
 
-  use GetDataTrait, QueueRunnerTrait;
+  use GetDataTrait, QueueRunnerTrait, DistributionReferenceModeTrait;
 
   /**
    * Uploaded resource file destination.
@@ -49,13 +50,22 @@ class StrictModeOffDictionaryEnforcerTest extends BrowserTestBase {
 
   protected $defaultTheme = 'stark';
 
-  public function testPostImport() {
-    // Enable strict mode disabled for datastore MySQL import.
+  /**
+   * Test that we can apply a data dictionary to a dataset with 300 columns.
+   *
+   * @param string $distribution_reference
+   *   The distribution reference mode to use for the test.
+   *
+   * @dataProvider distributionReferenceProvider
+   */
+  public function testPostImport($distribution_reference) {
+    $this->setDistributionReferenceModeFromConfig($distribution_reference);    // Enable strict mode disabled for datastore MySQL import.
+
     $this->config('dkan_datastore_mysql_import.settings')
       ->set('strict_mode_disabled', TRUE)
       ->save();
 
-      // Dependencies.
+    // Dependencies.
     $resourceFile = 'very_wide.csv';
     $uuid = $this->container->get('uuid');
     /** @var \Drupal\dkan_metastore\ValidMetadataFactory $validMetadataFactory */
@@ -128,11 +138,11 @@ class StrictModeOffDictionaryEnforcerTest extends BrowserTestBase {
     // https URL-style reference.
     $this->assertStringContainsString(
       $dictionary_id,
-      $dataset->{'$["%Ref:distribution"][0].data.describedBy'}
+      $dataset->{'$.distribution[0].describedBy'}
     );
     // Get the distribution ID.
     $this->assertNotEmpty(
-      $distribution_id = $dataset->{'$["%Ref:distribution"][0].identifier'} ?? NULL
+      $resource_id = $dataset->{'$[distribution][0]["%Ref:downloadURL"][0].identifier'} ?? NULL
     );
 
     // Dictionary fields are applied to the dataset.
@@ -140,10 +150,10 @@ class StrictModeOffDictionaryEnforcerTest extends BrowserTestBase {
     $dictionary_enforcer = $this->container->get('dkan.datastore.service.resource_processor.dictionary_enforcer');
     $this->assertCount(
       count($dictionary_fields),
-      $dictionary_enforcer->returnDataDictionaryFields($distribution_id)
+      $dictionary_enforcer->returnDataDictionaryFields($resource_id)
     );
 
-    $distribution_data = $dataset->{'$["%Ref:distribution"][0].data'} ?? NULL;
+    $distribution_data = $dataset->{'$.distribution[0]'} ?? NULL;
     $resource_identifier = $distribution_data['%Ref:downloadURL'][0]['data']['identifier'] ?? NULL;
     $resource_version = $distribution_data['%Ref:downloadURL'][0]['data']['version'] ?? NULL;
 
@@ -164,7 +174,7 @@ class StrictModeOffDictionaryEnforcerTest extends BrowserTestBase {
 
     // Retrieve schema for dataset resource.
     $response = $importController->summary(
-      $distribution_id,
+      $resource_id,
       Request::create('http://blah/api')
     );
     $this->assertEquals(200, $response->getStatusCode(), $response->getContent());

--- a/modules/dkan_datastore/modules/dkan_datastore_mysql_import/tests/src/Functional/StrictModeOffDictionaryEnforcerTest.php
+++ b/modules/dkan_datastore/modules/dkan_datastore_mysql_import/tests/src/Functional/StrictModeOffDictionaryEnforcerTest.php
@@ -140,7 +140,7 @@ class StrictModeOffDictionaryEnforcerTest extends BrowserTestBase {
       $dictionary_id,
       $dataset->{'$.distribution[0].describedBy'}
     );
-    // Get the distribution ID.
+    // Get the resource ID.
     $this->assertNotEmpty(
       $resource_id = $dataset->{'$[distribution][0]["%Ref:downloadURL"][0].identifier'} ?? NULL
     );

--- a/modules/dkan_datastore/tests/src/Functional/Controller/QueryDownloadControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/Controller/QueryDownloadControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace Drupal\Tests\dkan_datastore\Functional\Controller;
-
+use Drupal\Tests\dkan_common\Traits\DistributionReferenceModeTrait;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\dkan_metastore\DataDictionary\DataDictionaryDiscovery;
 use Drupal\Tests\BrowserTestBase;
@@ -20,7 +20,7 @@ use RootedData\RootedJsonData;
  */
 class QueryDownloadControllerTest extends BrowserTestBase {
 
-  use GetDataTrait, QueueRunnerTrait;
+  use GetDataTrait, QueueRunnerTrait, DistributionReferenceModeTrait;
 
   /**
    * Uploaded resource file destination.
@@ -167,8 +167,11 @@ class QueryDownloadControllerTest extends BrowserTestBase {
 
   /**
    * Test application of data dictionary schema to CSV generated for download.
+   *
+   * @dataProvider distributionReferenceProvider
    */
-  public function testDownloadWithDataDictionary() {
+  public function testDownloadWithDataDictionary($distribution_reference) {
+    $this->setDistributionReferenceModeFromConfig($distribution_reference);
     // Set per-reference data-dictionary in metastore config.
     $this->config('dkan_metastore.settings')
       ->set('data_dictionary_mode', DataDictionaryDiscovery::MODE_REFERENCE)
@@ -248,17 +251,18 @@ class QueryDownloadControllerTest extends BrowserTestBase {
     // URL-style reference.
     $this->assertStringContainsString(
       $dict_id,
-      $dataset->{'$["%Ref:distribution"][0].data.describedBy'}
+      $dataset->{'$.distribution[0].describedBy'}
     );
-    // Get the distribution ID.
-    $distribution_id = $dataset->{'$["%Ref:distribution"][0].identifier'};
+    // Get the resource identifier.
+    $resource_id = $dataset->{'$[distribution][0]["%Ref:downloadURL"][0].identifier'};
+    $this->assertNotEmpty($resource_id);
 
     // Dictionary fields are applied to the dataset.
     /** @var \Drupal\dkan_datastore\Service\ResourceProcessor\DictionaryEnforcer $dictionary_enforcer */
     $dictionary_enforcer = $this->container->get('dkan.datastore.service.resource_processor.dictionary_enforcer');
     $this->assertCount(
       1,
-      $dictionary_fields = $dictionary_enforcer->returnDataDictionaryFields($distribution_id)
+      $dictionary_fields = $dictionary_enforcer->returnDataDictionaryFields($resource_id)
     );
     $this->assertEquals($date_format, $dictionary_fields[0]['format'] ?? 'not found');
 

--- a/modules/dkan_datastore/tests/src/Functional/DictionaryEnforcerTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/DictionaryEnforcerTest.php
@@ -8,6 +8,7 @@ use Drupal\Core\File\FileSystemInterface;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\dkan_common\Traits\GetDataTrait;
 use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
+use Drupal\Tests\dkan_common\Traits\DistributionReferenceModeTrait;
 use Drupal\dkan_datastore\Controller\ImportController;
 use Drupal\dkan_metastore\DataDictionary\DataDictionaryDiscovery;
 use GuzzleHttp\Client;
@@ -26,7 +27,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class DictionaryEnforcerTest extends BrowserTestBase {
 
-  use GetDataTrait, QueueRunnerTrait;
+  use GetDataTrait, QueueRunnerTrait, DistributionReferenceModeTrait;
 
   protected $defaultTheme = 'stark';
 
@@ -134,8 +135,11 @@ class DictionaryEnforcerTest extends BrowserTestBase {
 
   /**
    * Test dictionary enforcement.
+   *
+   * @dataProvider distributionReferenceProvider
    */
-  public function testDictionaryEnforcement(): void {
+  public function testDictionaryEnforcement(string $distribution_reference): void {
+    $this->setDistributionReferenceModeFromConfig($distribution_reference);
     // Build data-dictionary.
     $dict_id = $this->uuid->generate();
     $fields = [
@@ -222,11 +226,13 @@ class DictionaryEnforcerTest extends BrowserTestBase {
       $dataset = $this->metastore->get('dataset', $dataset_id)
     );
     $this->assertNotEmpty(
-      $dist_id = $dataset->{'$["%Ref:distribution"][0].identifier'} ?? NULL
+      $resource_id = $dataset->{'$.distribution[0]["%Ref:downloadURL"][0].data.identifier'}
     );
+    $resource_version = $dataset->{'$.distribution[0]["%Ref:downloadURL"][0].data.version'};
+    $resource_identifier = $resource_id . '__' . $resource_version;
     // Retrieve schema for dataset resource.
     $response = $this->importController->summary(
-      $dist_id,
+      $resource_identifier,
       Request::create('http://blah/api')
     );
     $this->assertEquals(200, $response->getStatusCode(), $response->getContent());
@@ -284,11 +290,11 @@ class DictionaryEnforcerTest extends BrowserTestBase {
       'numOfRows' => 8,
     ], $result);
 
-    //  Validate boolean values
+    // Validate boolean values.
     $column_e = [];
     $response = $this->httpClient->get("api/1/datastore/query/$dataset_id/0");
     if ($response->getStatusCode() === 200) {
-      $data = json_decode($response->getBody()->getContents(), true);
+      $data = json_decode($response->getBody()->getContents(), TRUE);
       if (isset($data['results']) && is_array($data['results'])) {
         $column_e = array_column($data['results'], 'e');
       }

--- a/modules/dkan_datastore/tests/src/Kernel/Service/ResourceProcessor/DictionaryEnforcerTest.php
+++ b/modules/dkan_datastore/tests/src/Kernel/Service/ResourceProcessor/DictionaryEnforcerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace Drupal\Tests\dkan_datastore\Kernel\Service\ResourceProcessor;
-
+use Drupal\Tests\dkan_common\Traits\DistributionReferenceModeTrait;
 use Drupal\dkan_common\DataResource;
 use Drupal\dkan_datastore\Service\ResourceProcessor\DictionaryEnforcer;
 use Drupal\dkan_datastore\Service\ResourceProcessor\ResourceDoesNotHaveDictionary;
@@ -18,6 +18,8 @@ use Drupal\dkan_metastore\DataDictionary\DataDictionaryDiscoveryInterface;
  */
 class DictionaryEnforcerTest extends KernelTestBase {
 
+  use DistributionReferenceModeTrait;
+
   protected static $modules = [
     'dkan_common',
     'dkan_datastore',
@@ -27,9 +29,12 @@ class DictionaryEnforcerTest extends KernelTestBase {
   /**
    * Test exception thrown if no dictionary is found for resource.
    *
+   * @dataProvider distributionReferenceProvider
+   *
    * @covers ::getDataDictionaryForResource
    */
-  public function testNoDictionaryIdFoundForResourceException() {
+  public function testNoDictionaryIdFoundForResourceException(string $distribution_reference) {
+    $this->setDistributionReferenceModeFromConfig($distribution_reference);
     $resource = new DataResource('test.csv', 'text/csv');
 
     $discovery = $this->getMockBuilder(DataDictionaryDiscoveryInterface::class)

--- a/modules/dkan_metastore/src/DataDictionary/DataDictionaryDiscovery.php
+++ b/modules/dkan_metastore/src/DataDictionary/DataDictionaryDiscovery.php
@@ -4,9 +4,11 @@ namespace Drupal\dkan_metastore\DataDictionary;
 
 use Drupal\Core\Config\Config;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\dkan_metastore\Reference\HelperTrait;
 use Drupal\dkan_metastore\Reference\MetastoreUrlGenerator;
 use Drupal\dkan_metastore\ReferenceLookupInterface;
 use Drupal\dkan_metastore\MetastoreService;
+use RootedData\RootedJsonData;
 
 /**
  * Data dictionary service.
@@ -14,6 +16,10 @@ use Drupal\dkan_metastore\MetastoreService;
  * Find the correct data dictionary for a dataset or distribution.
  */
 class DataDictionaryDiscovery implements DataDictionaryDiscoveryInterface {
+
+  use HelperTrait;
+
+  const DICT_MIMETYPE = 'application/vnd.tableschema+json';
 
   /**
    * Metastore settings config object.
@@ -68,47 +74,48 @@ class DataDictionaryDiscovery implements DataDictionaryDiscoveryInterface {
    */
   public function getReferenceDictionaryId(string $resourceId, int $resourceIdVersion): ?string {
     $resource_id = $resourceId . "__" . $resourceIdVersion;
-    $distributionId = $this->getDistributionId($resource_id);
-    if ($distributionId === NULL) {
+    $datasetId = $this->getDatasetId($resource_id);
+    if ($datasetId === NULL) {
       return NULL;
     }
-    $distribution = $this->metastore->get('distribution', $distributionId);
-    if (!$this->hasValidDescribedBy($distribution)) {
-      return NULL;
-    }
-    return $this->extractDictionaryId($distribution->{"$.data.describedBy"});
+    $dataset = $this->metastore->get('dataset', $datasetId);
+    return $this->extractDictionaryId($dataset);
   }
 
   /**
-   * Get the distribution ID for a given resource ID.
+   * Get the dataset ID for a given resource ID.
    */
-  private function getDistributionId(string $resource_id): ?string {
-    $referencers = $this->lookup->getReferencers('distribution', $resource_id, 'downloadURL');
+  private function getDatasetId(string $resource_id): ?string {
+    $referencers = $this->lookup->getReferencers('dataset', $resource_id, 'downloadURL');
     if (empty($referencers)) {
-      throw new \RuntimeException("Distribution lookup: Can not map resource ID {$resource_id} to distribution UUID. Please make sure your resource exists in the database.");
+      throw new \RuntimeException("Dataset lookup: Can not map resource ID {$resource_id} to dataset UUID. Please make sure your resource exists in the database.");
     }
     return $referencers[0] ?? NULL;
   }
 
   /**
-   * Verify that the distribution has a valid describedBy URL.
+   * Extract the data dictionary ID from the describedBy URL or a dataset.
+   *
+   * @param RootedData\RootedJsonData $dataset
+   *   The dataset.
+   *
+   * @return string|null
+   *   The data dictionary ID or NULL if none exists.
    */
-  private function hasValidDescribedBy($distribution): bool {
-    return isset($distribution->{"$.data.describedBy"})
-      && (($distribution->{"$.data.describedByType"} ?? NULL) === 'application/vnd.tableschema+json');
-  }
-
-  /**
-   * Extract the data dictionary ID from the describedBy URL.
-   */
-  private function extractDictionaryId(string $describedBy): ?string {
-    try {
-      $uri = $this->urlGenerator->uriFromUrl($describedBy);
-      return $this->urlGenerator->extractItemId($uri, "data-dictionary");
+  protected function extractDictionaryId(RootedJsonData $dataset): ?string {
+    foreach ($dataset->{'$.distribution'} ?? [] as $distribution) {
+      if ($distribution['describedByType'] ?? NULL === self::DICT_MIMETYPE) {
+        $describedBy = $distribution['describedBy'] ?? '';
+        try {
+          $uri = $this->urlGenerator->uriFromUrl($describedBy);
+          return $this->urlGenerator->extractItemId($uri, "data-dictionary");
+        }
+        catch (\DomainException) {
+          continue;
+        }
+      }
     }
-    catch (\DomainException) {
-      return NULL;
-    }
+    return NULL;
   }
 
   /**

--- a/modules/dkan_metastore/src/DataDictionary/DataDictionaryDiscovery.php
+++ b/modules/dkan_metastore/src/DataDictionary/DataDictionaryDiscovery.php
@@ -27,33 +27,16 @@ class DataDictionaryDiscovery implements DataDictionaryDiscoveryInterface {
   protected Config $config;
 
   /**
-   * Metastore service.
-   */
-  protected MetastoreService $metastore;
-
-  /**
-   * Reference lookup service.
-   */
-  protected ReferenceLookupInterface $lookup;
-
-  /**
-   * URL generator service.
-   */
-  protected MetastoreUrlGenerator $urlGenerator;
-
-  /**
    * Constructor.
    */
   public function __construct(
-    ConfigFactoryInterface $configFactory,
-    MetastoreService $metastore,
-    ReferenceLookupInterface $lookup,
-    MetastoreUrlGenerator $urlGenerator,
+    ConfigFactoryInterface $configService,
+    protected MetastoreService $metastore,
+    protected ReferenceLookupInterface $lookup,
+    protected MetastoreUrlGenerator $urlGenerator,
   ) {
-    $this->config = $configFactory->get('dkan_metastore.settings');
-    $this->metastore = $metastore;
-    $this->lookup = $lookup;
-    $this->urlGenerator = $urlGenerator;
+    $this->config = $configService->get('dkan_metastore.settings');
+    $this->setConfigService($configService);
   }
 
   /**
@@ -74,48 +57,61 @@ class DataDictionaryDiscovery implements DataDictionaryDiscoveryInterface {
    */
   public function getReferenceDictionaryId(string $resourceId, int $resourceIdVersion): ?string {
     $resource_id = $resourceId . "__" . $resourceIdVersion;
-    $datasetId = $this->getDatasetId($resource_id);
-    if ($datasetId === NULL) {
+
+    $distribution = $this->getDistributionObject($resource_id);
+    if ($distribution === NULL) {
       return NULL;
     }
-    $dataset = $this->metastore->get('dataset', $datasetId);
-    return $this->extractDictionaryId($dataset);
+    if (!$this->hasValidDescribedBy($distribution)) {
+      return NULL;
+    }
+    return $this->extractDictionaryId($distribution->describedBy);
   }
 
   /**
-   * Get the dataset ID for a given resource ID.
+   * Get the distribution ID for a given resource ID.
    */
-  private function getDatasetId(string $resource_id): ?string {
+  private function getDistributionObject(string $resource_id): ?object {
+    if ($this->distributionsAreReferenced()) {
+      $referencers = $this->lookup->getReferencers('distribution', $resource_id, 'downloadURL');
+      if (empty($referencers)) {
+        throw new \RuntimeException("Distribution lookup: Can not map resource ID {$resource_id} to distribution UUID. Please make sure your resource exists in the database.");
+      }
+      $distribution = $this->metastore->get("distribution", $referencers[0]);
+      return (object) $distribution->{"$.data"};
+    }
+    // Otherwise look for a dataset that references the resource ID.
     $referencers = $this->lookup->getReferencers('dataset', $resource_id, 'downloadURL');
     if (empty($referencers)) {
       throw new \RuntimeException("Dataset lookup: Can not map resource ID {$resource_id} to dataset UUID. Please make sure your resource exists in the database.");
     }
-    return $referencers[0] ?? NULL;
-  }
-
-  /**
-   * Extract the data dictionary ID from the describedBy URL or a dataset.
-   *
-   * @param RootedData\RootedJsonData $dataset
-   *   The dataset.
-   *
-   * @return string|null
-   *   The data dictionary ID or NULL if none exists.
-   */
-  protected function extractDictionaryId(RootedJsonData $dataset): ?string {
-    foreach ($dataset->{'$.distribution'} ?? [] as $distribution) {
-      if ($distribution['describedByType'] ?? NULL === self::DICT_MIMETYPE) {
-        $describedBy = $distribution['describedBy'] ?? '';
-        try {
-          $uri = $this->urlGenerator->uriFromUrl($describedBy);
-          return $this->urlGenerator->extractItemId($uri, "data-dictionary");
-        }
-        catch (\DomainException) {
-          continue;
-        }
+    $dataset = $this->metastore->get("dataset", $referencers[0]);
+    foreach ($dataset->{"$.distribution"} ?? [] as $distribution) {
+      if ($distribution['downloadURL'] ?? NULL === $resource_id) {
+        return (object) $distribution;
       }
     }
     return NULL;
+  }
+
+  /**
+   * Verify that the distribution has a valid describedBy URL.
+   */
+  private function hasValidDescribedBy(object $distribution): bool {
+    return isset($distribution->describedBy) && (($distribution->describedByType ?? NULL) == self::DICT_MIMETYPE);
+  }
+
+  /**
+   * Extract the data dictionary ID from the describedBy URL.
+   */
+  private function extractDictionaryId(string $describedBy): ?string {
+    try {
+      $uri = $this->urlGenerator->uriFromUrl($describedBy);
+      return $this->urlGenerator->extractItemId($uri, "data-dictionary");
+    }
+    catch (\DomainException) {
+      return NULL;
+    }
   }
 
   /**

--- a/modules/dkan_metastore/src/DataDictionary/DataDictionaryDiscovery.php
+++ b/modules/dkan_metastore/src/DataDictionary/DataDictionaryDiscovery.php
@@ -8,7 +8,6 @@ use Drupal\dkan_metastore\Reference\HelperTrait;
 use Drupal\dkan_metastore\Reference\MetastoreUrlGenerator;
 use Drupal\dkan_metastore\ReferenceLookupInterface;
 use Drupal\dkan_metastore\MetastoreService;
-use RootedData\RootedJsonData;
 
 /**
  * Data dictionary service.

--- a/modules/dkan_metastore/src/Reference/HelperTrait.php
+++ b/modules/dkan_metastore/src/Reference/HelperTrait.php
@@ -43,6 +43,17 @@ trait HelperTrait {
   }
 
   /**
+   * Read from the config service whether distributions are referenced.
+   *
+   * @return bool
+   *   True if the distribution property is referenced.
+   */
+  protected function distributionsAreReferenced(): bool {
+    $propertyList = $this->getPropertyList();
+    return ($propertyList['distribution'] ?? NULL == 'distribution');
+  }
+
+  /**
    * Normalize an "empty" property against an array.
    *
    * @param mixed $data

--- a/modules/dkan_metastore/src/Reference/HelperTrait.php
+++ b/modules/dkan_metastore/src/Reference/HelperTrait.php
@@ -50,7 +50,7 @@ trait HelperTrait {
    */
   protected function distributionsAreReferenced(): bool {
     $propertyList = $this->getPropertyList();
-    return ($propertyList['distribution'] ?? NULL == 'distribution');
+    return in_array('distribution', $propertyList);
   }
 
   /**

--- a/modules/dkan_metastore/src/Reference/ReferenceLookup.php
+++ b/modules/dkan_metastore/src/Reference/ReferenceLookup.php
@@ -48,12 +48,17 @@ class ReferenceLookup implements ReferenceLookupInterface {
       [$identifier, $metadata] = $this->decodeJsonMetadata($item);
       $propertyValue = NULL;
       if (is_array($metadata)) {
-        $propertyValue = $metadata[$propertyId] ?? NULL;
+        foreach ($metadata as $object) {
+          if (is_object($object)) {
+            $propertyValue = $object->{$propertyId} ?? NULL;
+            $referencers[] = self::valueContainsStartsWith($referenceId, $propertyValue) ? $identifier : NULL;
+          }
+        }
       }
       elseif (is_object($metadata)) {
         $propertyValue = $metadata->{$propertyId} ?? NULL;
+        $referencers[] = self::valueContainsStartsWith($referenceId, $propertyValue) ? $identifier : NULL;
       }
-      $referencers[] = self::valueContainsStartsWith($referenceId, $propertyValue) ? $identifier : NULL;
     }
 
     return array_filter($referencers);

--- a/modules/dkan_metastore/src/Reference/ReferenceLookup.php
+++ b/modules/dkan_metastore/src/Reference/ReferenceLookup.php
@@ -37,7 +37,8 @@ class ReferenceLookup implements ReferenceLookupInterface {
   /**
    * {@inheritdoc}
    *
-   * @todo Refactor when this storage vs item factory mess is resolved.
+   * @todo Refactor when this storage vs item factory mess is resolved. Should
+   * probably also use JSON path syntax rather than property ID and recursion.
    */
   public function getReferencers(string $schemaId, string $referenceId, string $propertyId) {
     // This will give us a smaller subset of metastore items to parse through.
@@ -46,22 +47,49 @@ class ReferenceLookup implements ReferenceLookupInterface {
     $referencers = [];
     foreach ($metastoreItems as $item) {
       [$identifier, $metadata] = $this->decodeJsonMetadata($item);
-      $propertyValue = NULL;
-      if (is_array($metadata)) {
-        foreach ($metadata as $object) {
-          if (is_object($object)) {
-            $propertyValue = $object->{$propertyId} ?? NULL;
-            $referencers[] = self::valueContainsStartsWith($referenceId, $propertyValue) ? $identifier : NULL;
-          }
-        }
-      }
-      elseif (is_object($metadata)) {
-        $propertyValue = $metadata->{$propertyId} ?? NULL;
-        $referencers[] = self::valueContainsStartsWith($referenceId, $propertyValue) ? $identifier : NULL;
+      if (self::propertyContainsReference($propertyId, $referenceId, $metadata)) {
+        $referencers[] = $identifier;
       }
     }
 
     return array_filter($referencers);
+  }
+
+  /**
+   * Recurse through a metadata object.
+   *
+   * Look for keys matching a property ID, and check whether any matching value
+   * contains a reference to the given ID.
+   *
+   * @param string $propertyId
+   *   The metadata property key to search for.
+   * @param string $referenceId
+   *   The reference ID fragment to look for.
+   * @param mixed $metadata
+   *   The metadata object or array to recurse through.
+   *
+   * @return bool
+   *   TRUE if a matching property contains the reference ID.
+   */
+  protected static function propertyContainsReference(string $propertyId, string $referenceId, $metadata): bool {
+    if (is_object($metadata)) {
+      foreach (get_object_vars($metadata) as $key => $value) {
+        if ($key == $propertyId && self::valueContainsStartsWith($referenceId, $value)) {
+          return TRUE;
+        }
+        if (self::propertyContainsReference($propertyId, $referenceId, $value)) {
+          return TRUE;
+        }
+      }
+    }
+    if (is_array($metadata)) {
+      foreach ($metadata as $value) {
+        if (self::propertyContainsReference($propertyId, $referenceId, $value)) {
+          return TRUE;
+        }
+      }
+    }
+    return FALSE;
   }
 
   /**

--- a/modules/dkan_metastore/tests/src/Unit/DataDictionary/DataDictionaryDiscoveryTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/DataDictionary/DataDictionaryDiscoveryTest.php
@@ -119,6 +119,7 @@ class DataDictionaryDiscoveryTest extends TestCase {
     $options = (new Options())
       ->add('data_dictionary_mode', $mode)
       ->add('data_dictionary_sitewide', $sitewideId)
+      ->add('property_list', ['distribution', 'identifier', 'downloadURL'])
       ->index(0);
 
     return (new Chain($this))
@@ -134,6 +135,11 @@ class DataDictionaryDiscoveryTest extends TestCase {
         'describedByType' => 'application/vnd.tableschema+json',
       ],
     ]);
+    $json3 = json_encode((object) [
+      'data' => (object) [
+        'describedBy' => "https://example.com/api/1/metastore/schemas/data-dictionary/items/333",
+      ],
+    ]);
     $json4 = json_encode((object) [
       'data' => (object) [
         'describedBy' => "dkan://metastore/schemas/dataset/items/444",
@@ -142,7 +148,7 @@ class DataDictionaryDiscoveryTest extends TestCase {
     ]);
     $sequence = (new options())
       ->add('111', new RootedJsonData($json1, "{}"))
-      ->add('333', new RootedJsonData())
+      ->add('333', new RootedJsonData($json3, "{}"))
       ->add('444', new RootedJsonData($json4, "{}"))
       ->index(1);
     return (new Chain($this))
@@ -153,10 +159,13 @@ class DataDictionaryDiscoveryTest extends TestCase {
   private function getUrlGenerator() {
     $extract = (new Options())
       ->add('dkan://metastore/schemas/data-dictionary/items/111', '111')
+      ->add('dkan://metastore/schemas/data-dictionary/items/222', '222')
       ->add('dkan://metastore/schemas/dataset/items/444', new \DomainException())
       ->index(0);
     $uriFromUrl = (new Options())
       ->add('https://example.com/api/1/metastore/schemas/data-dictionary/items/111', 'dkan://metastore/schemas/data-dictionary/items/111')
+      ->add('https://example.com/api/1/metastore/schemas/data-dictionary/items/222', 'dkan://metastore/schemas/data-dictionary/items/222')
+      ->add('dkan://metastore/schemas/data-dictionary/items/222', 'dkan://metastore/schemas/data-dictionary/items/222')
       ->add('dkan://metastore/schemas/dataset/items/444', 'dkan://metastore/schemas/dataset/items/444');
 
     return (new Chain($this))
@@ -166,11 +175,11 @@ class DataDictionaryDiscoveryTest extends TestCase {
   }
 
   /**
-   * Test extracting dictionary ID from various URL formats.
+   * Test extracting dictionary ID from describedBy URL.
    *
    * @dataProvider extractDictionaryIdProvider
    */
-  public function testExtractDictionaryId($dataset, $expected) {
+  public function testExtractDictionaryId($describedBy, $expected) {
     $discovery = new DataDictionaryDiscovery(
       $this->getConfigFactoryMock(DataDictionaryDiscovery::MODE_SITEWIDE, 'abc-123'),
       $this->getMetastoreService(),
@@ -178,12 +187,12 @@ class DataDictionaryDiscoveryTest extends TestCase {
       $this->getUrlGenerator()
     );
 
-    // Use reflection to call the protected method.
+    // Use reflection to call the private method.
     $reflection = new \ReflectionMethod($discovery, 'extractDictionaryId');
     $reflection->setAccessible(TRUE);
 
-    // Test valid data-dictionary URL.
-    $id = $reflection->invoke($discovery, $dataset);
+    // Test extracting dictionary ID from describedBy URL.
+    $id = $reflection->invoke($discovery, $describedBy);
     $this->assertEquals($expected, $id);
   }
 
@@ -192,29 +201,18 @@ class DataDictionaryDiscoveryTest extends TestCase {
    */
   public static function extractDictionaryIdProvider(): array {
     return [
-      'valid' => [new RootedJsonData(json_encode((object) [
-        'distribution' => [
-          (object) [
-            'describedBy' => "https://example.com/api/1/metastore/schemas/data-dictionary/items/111",
-            'describedByType' => 'application/vnd.tableschema+json',
-          ],
-        ],
-      ]), "{}"), '111'],
-      'missingType' => [new RootedJsonData(json_encode((object) [
-        'distribution' => [
-          (object) [
-            'describedBy' => "https://example.com/api/1/metastore/schemas/data-dictionary/items/111",
-          ],
-        ],
-      ])), NULL],
-      'wrongSchema' => [new RootedJsonData(json_encode((object) [
-        'distribution' => [
-          (object) [
-            'describedBy' => "dkan://metastore/schemas/dataset/items/444",
-            'describedByType' => 'application/vnd.tableschema+json',
-          ],
-        ],
-      ])), NULL],
+      'valid https url' => [
+        "https://example.com/api/1/metastore/schemas/data-dictionary/items/111",
+        '111'
+      ],
+      'valid dkan uri' => [
+        "dkan://metastore/schemas/data-dictionary/items/222",
+        '222'
+      ],
+      'wrong schema type' => [
+        "dkan://metastore/schemas/dataset/items/444",
+        NULL
+      ],
     ];
   }
 

--- a/modules/dkan_metastore/tests/src/Unit/DataDictionary/DataDictionaryDiscoveryTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/DataDictionary/DataDictionaryDiscoveryTest.php
@@ -16,7 +16,9 @@ use RootedData\RootedJsonData;
 
 class DataDictionaryDiscoveryTest extends TestCase {
 
-  // If mode is set to "none", we should get NULL no matter what.
+  /**
+   * If mode is set to "none", we should get NULL no matter what.
+   */
   public function testModeNone() {
     $discovery = new Discovery(
       $this->getConfigFactoryMock(Discovery::MODE_NONE, 'abc-123'),
@@ -28,8 +30,9 @@ class DataDictionaryDiscoveryTest extends TestCase {
     $this->assertEquals("Disabled", $id);
   }
 
-  // If mode is sitewide, and we have a sitewide dictionary ID set, it should be
-  // returned, no matter what resource we pass to the method.
+  /**
+   * Test that if mode is sitewide we should always get the sitewide ID.
+   */
   public function testSitewideId() {
     $discovery = new Discovery(
       $this->getConfigFactoryMock(Discovery::MODE_SITEWIDE, 'abc-123'),
@@ -43,7 +46,9 @@ class DataDictionaryDiscoveryTest extends TestCase {
     $this->assertEquals('abc-123', $idVersion);
   }
 
-  // If mode is sitewide but sitewide ID unset, we should get an exception.
+  /**
+   * If mode is sitewide but sitewide ID unset, we should get an exception.
+   */
   public function testSitewideIdUnset() {
     // Need to use 0 because MockChain\Options doesn't support NULL returns.
     $discovery = new Discovery(
@@ -57,7 +62,9 @@ class DataDictionaryDiscoveryTest extends TestCase {
     $discovery->dictionaryIdFromResource('resource1', 1);
   }
 
-  // Test the reference type, four different flows:
+  /**
+   * Test the reference type, four different flows.
+   */
   public function testGetReferenceDictId() {
     $discovery = new Discovery(
       $this->getConfigFactoryMock(Discovery::MODE_REFERENCE, 'abc-123'),
@@ -78,7 +85,9 @@ class DataDictionaryDiscoveryTest extends TestCase {
     $id = $discovery->dictionaryIdFromResource('resource2', 2);
   }
 
-  // Test if bad mode in settings
+  /**
+   * Test if bad mode in settings.
+   */
   public function testDictBadMode() {
     $discovery = new Discovery(
       $this->getConfigFactoryMock('foo', 'abc-123'),
@@ -90,6 +99,7 @@ class DataDictionaryDiscoveryTest extends TestCase {
     $this->expectException(\OutOfRangeException::class);
     $discovery->dictionaryIdFromResource('resource1', 1);
   }
+
   private function getLookup() {
     $options = (new Options())
       ->add('resource1__1', ['111'])
@@ -102,7 +112,9 @@ class DataDictionaryDiscoveryTest extends TestCase {
       ->getMock();
   }
 
-  // Build mock config service, based on arguments for mode and sitewide ID.
+  /**
+   * Build mock config service, based on arguments for mode and sitewide ID.
+   */
   private function getConfigFactoryMock($mode, $sitewideId) {
     $options = (new Options())
       ->add('data_dictionary_mode', $mode)

--- a/modules/dkan_metastore/tests/src/Unit/DataDictionary/DataDictionaryDiscoveryTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/DataDictionary/DataDictionaryDiscoveryTest.php
@@ -2,16 +2,15 @@
 
 namespace Drupal\Tests\dkan_metastore\Unit\DataDictionary;
 
-use DomainException;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Config\ImmutableConfig;
 use Drupal\dkan_metastore\DataDictionary\DataDictionaryDiscovery as Discovery;
+use Drupal\dkan_metastore\DataDictionary\DataDictionaryDiscovery;
 use Drupal\dkan_metastore\MetastoreService;
 use Drupal\dkan_metastore\Reference\MetastoreUrlGenerator;
 use Drupal\dkan_metastore\Reference\ReferenceLookup;
 use MockChain\Chain;
 use MockChain\Options;
-use OutOfRangeException;
 use PHPUnit\Framework\TestCase;
 use RootedData\RootedJsonData;
 
@@ -88,7 +87,7 @@ class DataDictionaryDiscoveryTest extends TestCase {
       $this->getUrlGenerator()
     );
 
-    $this->expectException(OutOfRangeException::class);
+    $this->expectException(\OutOfRangeException::class);
     $discovery->dictionaryIdFromResource('resource1', 1);
   }
   private function getLookup() {
@@ -142,7 +141,7 @@ class DataDictionaryDiscoveryTest extends TestCase {
   private function getUrlGenerator() {
     $extract = (new Options())
       ->add('dkan://metastore/schemas/data-dictionary/items/111', '111')
-      ->add('dkan://metastore/schemas/dataset/items/444', new DomainException())
+      ->add('dkan://metastore/schemas/dataset/items/444', new \DomainException())
       ->index(0);
     $uriFromUrl = (new Options())
       ->add('https://example.com/api/1/metastore/schemas/data-dictionary/items/111', 'dkan://metastore/schemas/data-dictionary/items/111')
@@ -152,6 +151,59 @@ class DataDictionaryDiscoveryTest extends TestCase {
       ->add(MetastoreUrlGenerator::class, 'uriFromUrl', $uriFromUrl)
       ->add(MetastoreUrlGenerator::class, 'extractItemId', $extract)
       ->getMock();
+  }
+
+  /**
+   * Test extracting dictionary ID from various URL formats.
+   *
+   * @dataProvider extractDictionaryIdProvider
+   */
+  public function testExtractDictionaryId($dataset, $expected) {
+    $discovery = new DataDictionaryDiscovery(
+      $this->getConfigFactoryMock(DataDictionaryDiscovery::MODE_SITEWIDE, 'abc-123'),
+      $this->getMetastoreService(),
+      $this->getLookup(),
+      $this->getUrlGenerator()
+    );
+
+    // Use reflection to call the protected method.
+    $reflection = new \ReflectionMethod($discovery, 'extractDictionaryId');
+    $reflection->setAccessible(TRUE);
+
+    // Test valid data-dictionary URL.
+    $id = $reflection->invoke($discovery, $dataset);
+    $this->assertEquals($expected, $id);
+  }
+
+  /**
+   * Data provider for testExtractDictionaryId.
+   */
+  public static function extractDictionaryIdProvider(): array {
+    return [
+      'valid' => [new RootedJsonData(json_encode((object) [
+        'distribution' => [
+          (object) [
+            'describedBy' => "https://example.com/api/1/metastore/schemas/data-dictionary/items/111",
+            'describedByType' => 'application/vnd.tableschema+json',
+          ],
+        ],
+      ]), "{}"), '111'],
+      'missingType' => [new RootedJsonData(json_encode((object) [
+        'distribution' => [
+          (object) [
+            'describedBy' => "https://example.com/api/1/metastore/schemas/data-dictionary/items/111",
+          ],
+        ],
+      ])), NULL],
+      'wrongSchema' => [new RootedJsonData(json_encode((object) [
+        'distribution' => [
+          (object) [
+            'describedBy' => "dkan://metastore/schemas/dataset/items/444",
+            'describedByType' => 'application/vnd.tableschema+json',
+          ],
+        ],
+      ])), NULL],
+    ];
   }
 
 }

--- a/modules/dkan_metastore/tests/src/Unit/Reference/ReferenceLookupTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/Reference/ReferenceLookupTest.php
@@ -55,19 +55,30 @@ class ReferenceLookupTest extends TestCase {
       ->expects($this->exactly(count($contains_items)))
       ->method('decodeJsonMetadata')
       ->willReturnOnConsecutiveCalls(
-        ['ref-array', [(object) ['foo' => 'bar'], (object) ['identifier' => 'abc-array']]],
-        ['ref-object', (object) ['identifier' => (object) ['value' => 'abc-object']]],
         ['ref-string', (object) ['identifier' => 'abc-object']],
+        ['ref-array', (object) ['identifier' => ['other', 'abc-array']]],
+        ['ref-object', (object) ['identifier' => (object) ['value' => 'abc-object']]],
+        ['ref-nested-object', (object) ['nested' => (object) ['identifier' => 'abc-nested-object']]],
+        ['ref-nested-in-array-of-objects', [(object) ['foo' => 'bar'], (object) ['identifier' => 'abc-array']]],
         ['array-not-match', ['identifier' => ['other', 'still-other']]],
         ['object-not-match', (object) ['identifier' => (object) ['value' => 'other']]],
         ['unknown-shape', 'not-array-or-object']
       );
 
+    // The expected IDs to pass.
+    $expected = [
+      'ref-string',
+      'ref-array',
+      'ref-object',
+      'ref-nested-object',
+      'ref-nested-in-array-of-objects',
+    ];
+
     $referencers = $referenceLookup->getReferencers('test-identifier', 'abc', 'identifier');
 
     $this->assertIsArray($referencers);
     // The first two returns matched the reference.
-    $this->assertSame(['ref-array', 'ref-object', 'ref-string'], array_values($referencers));
+    $this->assertSame($expected, array_values($referencers));
   }
 
 }

--- a/modules/dkan_metastore/tests/src/Unit/Reference/ReferenceLookupTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/Reference/ReferenceLookupTest.php
@@ -55,7 +55,7 @@ class ReferenceLookupTest extends TestCase {
       ->expects($this->exactly(count($contains_items)))
       ->method('decodeJsonMetadata')
       ->willReturnOnConsecutiveCalls(
-        ['ref-array', ['identifier' => ['other', 'abc-array']]],
+        ['ref-array', [(object) ['foo' => 'bar'], (object) ['identifier' => 'abc-array']]],
         ['ref-object', (object) ['identifier' => (object) ['value' => 'abc-object']]],
         ['ref-string', (object) ['identifier' => 'abc-object']],
         ['array-not-match', ['identifier' => ['other', 'still-other']]],

--- a/modules/dkan_metastore/tests/src/Unit/Reference/ReferenceLookupTest.php
+++ b/modules/dkan_metastore/tests/src/Unit/Reference/ReferenceLookupTest.php
@@ -23,6 +23,7 @@ class ReferenceLookupTest extends TestCase {
 
   /**
    * @covers ::getReferencers
+   * @covers ::propertyContainsReference
    * @covers ::valueContainsStartsWith
    */
   public function testGetReferencers() {


### PR DESCRIPTION
Fixes #4736

The main change here is to DataDictionaryDiscovery. The ::getReferenceDictionaryId method now checks is references are enabled and behaves accordingly. Related private methods have been refactored.

I have also changed ReferenceLookup to allow recursive searching into nested metadata structures to find reference properties. This lets us look for a reference in downloadURL whether we're using datasets or distributions.

A number of tests were updated to test in both modes.