### PR TITLE
Datastore commands functional tests

### DIFF
--- a/modules/dkan_common/tests/files/1.csv
+++ b/modules/dkan_common/tests/files/1.csv
@@ -1,0 +1,3 @@
+one
+un
+uno

--- a/modules/dkan_common/tests/files/2.csv
+++ b/modules/dkan_common/tests/files/2.csv
@@ -1,0 +1,3 @@
+one,two
+un,deux
+uno,dos

--- a/modules/dkan_common/tests/files/3.csv
+++ b/modules/dkan_common/tests/files/3.csv
@@ -1,0 +1,3 @@
+one,two,three
+un,deux,trois
+uno,dos,tres

--- a/modules/dkan_common/tests/files/4.csv
+++ b/modules/dkan_common/tests/files/4.csv
@@ -1,0 +1,3 @@
+one,two,three,four
+un,deux,trois,quatre
+uno,dos,tres,cuatro

--- a/modules/dkan_common/tests/files/5.csv
+++ b/modules/dkan_common/tests/files/5.csv
@@ -1,0 +1,3 @@
+one,two,three,four,five
+un,deux,trois,quatre,cinq
+uno,dos,tres,cuatro,cinco

--- a/modules/dkan_common/tests/files/district_centerpoints_small.csv
+++ b/modules/dkan_common/tests/files/district_centerpoints_small.csv
@@ -1,0 +1,3 @@
+"lon","lat","Unit_Type","Dist_Name","Prov_Name"
+61.33,32.4,"District","Qala-e-Kah","Farah"
+62.06,32.49,"District","Pusht Rod","Farah"

--- a/modules/dkan_common/tests/src/Traits/GetDataTrait.php
+++ b/modules/dkan_common/tests/src/Traits/GetDataTrait.php
@@ -4,6 +4,8 @@ namespace Drupal\Tests\dkan_common\Traits;
 
 /**
  * Trait for getting data remote for tests.
+ *
+ * @deprecated Use GetLocalDataTrait instead.
  */
 trait GetDataTrait {
 

--- a/modules/dkan_common/tests/src/Traits/GetLocalDataTrait.php
+++ b/modules/dkan_common/tests/src/Traits/GetLocalDataTrait.php
@@ -12,22 +12,7 @@ trait GetLocalDataTrait {
    *
    * @param string $filename
    *   The filename to get the download URL for. There are a number of test
-   *   files available in modules/dkan_common/tests/files:
-   *    - 1.csv
-   *    - 2.csv
-   *    - Bike_Lane.csv
-   *    - columnspaces.csv
-   *    - countries.csv
-   *    - data-dict.csv
-   *    - duplicate-headers.csv
-   *    - empty.csv
-   *    - hello.txt
-   *    - longcolumn.csv
-   *    - newlines_in_headers.csv
-   *    - non-text.csv
-   *    - states_with_dupes.csv
-   *    - states_with_dupes_link.csv
-   *    - years_colors.csv.
+   *   files available in modules/dkan_common/tests/files.
    *
    * @return string
    *   The download URL for the file.
@@ -73,11 +58,17 @@ trait GetLocalDataTrait {
       'fn' => 'Test Name',
       'hasEmail' => 'test@example.com',
     ];
-  
+
     foreach ($filenames as $key => $filename) {
+      if (str_contains($filename, '://')) {
+        $downloadUrl = $filename;
+      }
+      else {
+        $downloadUrl = $this->getDownloadUrl($filename);
+      }
       $distribution = new \stdClass();
       $distribution->title = "Distribution #{$key} for {$identifier}";
-      $distribution->downloadURL = $this->getDownloadUrl($filename);
+      $distribution->downloadURL = $downloadUrl;
       $distribution->mediaType = "text/csv";
       if ($describedBy) {
         $distribution->describedBy = $describedBy;

--- a/modules/dkan_common/tests/src/Traits/GetLocalDataTrait.php
+++ b/modules/dkan_common/tests/src/Traits/GetLocalDataTrait.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Drupal\Tests\dkan_common\Traits;
+
+/**
+ * Trait for getting local data for tests.
+ */
+trait GetLocalDataTrait {
+
+  /**
+   * Get the download URL for a file.
+   *
+   * @param string $filename
+   *   The filename to get the download URL for. There are a number of test
+   *   files available in modules/dkan_common/tests/files:
+   *    - 1.csv
+   *    - 2.csv
+   *    - Bike_Lane.csv
+   *    - columnspaces.csv
+   *    - countries.csv
+   *    - data-dict.csv
+   *    - duplicate-headers.csv
+   *    - empty.csv
+   *    - hello.txt
+   *    - longcolumn.csv
+   *    - newlines_in_headers.csv
+   *    - non-text.csv
+   *    - states_with_dupes.csv
+   *    - states_with_dupes_link.csv
+   *    - years_colors.csv.
+   *
+   * @return string
+   *   The download URL for the file.
+   */
+  private function getDownloadUrl(string $filename) {
+    $files_dir = realpath(__DIR__ . '/../../files');
+    if (!$files_dir || !is_dir($files_dir)) {
+      throw new \RuntimeException("Test files directory not found relative to trait location: " . __DIR__);
+    }
+    return 'file://' . $files_dir . '/' . $filename;
+  }
+
+  /**
+   * Generate dataset metadata, possibly with multiple distributions.
+   *
+   * @param string $identifier
+   *   Dataset identifier.
+   * @param string $title
+   *   Dataset title.
+   * @param array $filenames
+   *   Array of resource files URLs for this dataset.
+   * @param string|null $describedBy
+   *   (Optional) URI for describedBy for all the download URLs. describedByType
+   *   will be set to 'application/vnd.tableschema+json' if present.
+   *
+   * @return string|false
+   *   Json encoded string of this dataset's metadata, or FALSE if error.
+   */
+  private function getDataset(string $identifier, string $title, array $filenames, ?string $describedBy = NULL) {
+
+    $data = new \stdClass();
+    $data->title = $title;
+    $data->description = 'This & that description. <a onauxclick=prompt(document.domain)>Right click me</a>.';
+    $data->identifier = $identifier;
+    $data->accessLevel = "public";
+    $data->modified = "06-04-2020";
+    $data->keyword = ["some keyword"];
+    $data->distribution = [];
+    $data->publisher = (object) [
+      'name' => 'Test Publisher',
+    ];
+    $data->contactPoint = (object) [
+      'fn' => 'Test Name',
+      'hasEmail' => 'test@example.com',
+    ];
+  
+    foreach ($filenames as $key => $filename) {
+      $distribution = new \stdClass();
+      $distribution->title = "Distribution #{$key} for {$identifier}";
+      $distribution->downloadURL = $this->getDownloadUrl($filename);
+      $distribution->mediaType = "text/csv";
+      if ($describedBy) {
+        $distribution->describedBy = $describedBy;
+        $distribution->describedByType = 'application/vnd.tableschema+json';
+      }
+
+      $data->distribution[] = $distribution;
+    }
+
+    return json_encode($data, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES);
+  }
+
+  /**
+   * Generate data-dictionary metadata.
+   *
+   * Input fields format:
+   * ```php
+   * [
+   *   'name' => string,
+   *   'title' => string,
+   *   'type' => string,
+   *   'format' => string,
+   * ]
+   * ```
+   *
+   * Input indexes format:
+   * ```php
+   * [
+   *   'fields' => [
+   *     'name' => string,
+   *     'length' => integer,
+   *   ]
+   *   'type' => enum('index', 'fulltext'),
+   *   'description' => string,
+   * ]
+   * ```
+   *
+   * @param array[] $fields
+   *   Data-Dictionary fields.
+   * @param array[] $indexes
+   *   Data-Dictionary indexes.
+   * @param string $identifier
+   *   Data-Dictionary identifier.
+   * @param string|null $title
+   *   Data-Dictionary title.
+   *
+   * @return string|false
+   *   Json encoded string of this dataset's metadata, or FALSE if error.
+   */
+  private function getDataDictionary(array $fields, array $indexes, string $identifier, string $title = 'Test DataDict') {
+    return json_encode([
+      'identifier' => $identifier,
+      'data' => [
+        'title' => $title,
+        'fields' => $fields,
+        'indexes' => $indexes,
+      ],
+    ], JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES);
+  }
+
+}

--- a/modules/dkan_datastore/modules/dkan_datastore_mysql_import/tests/src/Functional/StrictModeOffDictionaryEnforcerTest.php
+++ b/modules/dkan_datastore/modules/dkan_datastore_mysql_import/tests/src/Functional/StrictModeOffDictionaryEnforcerTest.php
@@ -8,7 +8,7 @@ use Drupal\Core\File\FileSystemInterface;
 use Drupal\dkan_datastore\Controller\ImportController;
 use Drupal\dkan_datastore\Service\ResourceLocalizer;
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\dkan_common\Traits\GetDataTrait;
+use Drupal\Tests\dkan_common\Traits\GetLocalDataTrait;
 use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
 use Drupal\dkan_metastore\DataDictionary\DataDictionaryDiscovery;
 use RootedData\RootedJsonData;
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class StrictModeOffDictionaryEnforcerTest extends BrowserTestBase {
 
-  use GetDataTrait, QueueRunnerTrait;
+  use GetLocalDataTrait, QueueRunnerTrait;
 
   /**
    * Uploaded resource file destination.
@@ -105,7 +105,6 @@ class StrictModeOffDictionaryEnforcerTest extends BrowserTestBase {
           $dataset_id,
           'Test ' . $dataset_id,
           [$resourceUrl],
-          TRUE,
           'dkan://metastore/schemas/data-dictionary/items/' . $dictionary_id
         ),
         'dataset'

--- a/modules/dkan_datastore/src/Drush/Commands/DatastoreCommands.php
+++ b/modules/dkan_datastore/src/Drush/Commands/DatastoreCommands.php
@@ -288,6 +288,9 @@ final class DatastoreCommands extends DrushCommands {
       $this->output()->writeln('Dataset UUID = ' . $dataset_uuid);
       return DrushCommands::EXIT_SUCCESS;
     }
+    // @todo This is dead code because if there is no dataset, the command will
+    // exit with a failure before this point. We should probably try to catch
+    // the exception.
     $this->output()->writeln('Can not map datastore table to dataset: ' . $table_name);
     return DrushCommands::EXIT_FAILURE;
   }

--- a/modules/dkan_datastore/tests/src/Functional/Commands/DatastoreCommandsTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/Commands/DatastoreCommandsTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Drupal\Tests\dkan_datastore\Functional\Commands;
+
+use Drupal\Tests\dkan_common\Traits\GetLocalDataTrait;
+use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
+use Drupal\Tests\BrowserTestBase;
+use Drush\TestTraits\DrushTestTrait;
+use Procrastinator\Result;
+
+class DatastoreCommandsTest extends BrowserTestBase {
+  use DrushTestTrait, GetLocalDataTrait, QueueRunnerTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['dkan_datastore', 'dkan_metastore'];
+
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Tests the dkan:datastore:list command.
+   */
+  public function testListCommand() {
+    // Check initial state is disabled.
+    foreach (['1.csv', '2.csv'] as $n => $filename) {
+      $this->createDataset($filename, "test-dataset-{$n}");
+    }
+    $this->runQueues(['localize_import', 'datastore_import']);
+    $this->drush('dkan:datastore:list');
+    $this->assertStringContainsString(
+      'Resource UUID File Name FileFetcher Processed Importer Processed',
+      $this->getSimplifiedOutput()
+    );
+    // Assert that the datasets are listed in the output.
+    foreach (['1.csv', '2.csv'] as $filename) {
+      $this->assertStringContainsString(
+        "$filename",
+        $this->getSimplifiedOutput()
+      );
+    }
+  }
+
+  /**
+   * Tests the dkan:datastore:import command.
+   */
+  public function testImportCommand() {
+    // Create a single dataset. Do not run any queues, so the resource is not
+    // yet localized or imported.
+    $dataset_id = $this->createDataset('1.csv', 'test-dataset-import');
+    $resource = $this->getResourceIdentifier($dataset_id);
+
+    // Run the import command directly against the resource identifier. This
+    // is not deferred, so the import should complete immediately.
+    $this->drush('dkan:datastore:import', [$resource['resource_id']]);
+
+    // Assert the drush command logged a successful run.
+    $this->assertStringContainsString(
+      'Ran import for ' . $resource['resource_id'],
+      $this->getErrorOutput()
+    );
+
+    // ImportInfo should now report the import as done.
+    $import_info = \Drupal::service('dkan.datastore.import_info');
+    $item = $import_info->getItem($resource['resource_id'], $resource['resource_version']);
+    $this->assertEquals(
+      Result::DONE,
+      $item->importerStatus,
+      "ImportInfo should report a completed import for resource {$resource['resource_id']}."
+    );
+
+    // Verify the datastore table now exists.
+    $table_name = $this->getResourceInfo($dataset_id)['table_name'];
+    $this->assertTrue(
+      \Drupal::database()->schema()->tableExists($table_name),
+      "Datastore table $table_name should exist after import."
+    );
+  }
+
+  /**
+   * Tests the dkan:datastore:drop-all command.
+   */
+  public function testDropAllCommand() {
+    // Create datasets.
+    $dataset_ids = [];
+    foreach (['1.csv', '2.csv'] as $n => $filename) {
+      $dataset_ids[] = $this->createDataset($filename, "test-dataset-dropall-{$n}");
+    }
+    $this->runQueues(['localize_import', 'datastore_import']);
+
+    // Collect resource info (table name, identifier, version) now that
+    // resources are localized.
+    $resource_infos = array_map([$this, 'getResourceInfo'], $dataset_ids);
+
+    // Verify the tables exist, and ImportInfo reflects a completed import,
+    // before dropping.
+    $connection = \Drupal::database();
+    $import_info = \Drupal::service('dkan.datastore.import_info');
+    foreach ($resource_infos as $info) {
+      $this->assertTrue(
+        $connection->schema()->tableExists($info['table_name']),
+        "Datastore table {$info['table_name']} should exist after import."
+      );
+      $item = $import_info->getItem($info['resource_id'], $info['resource_version']);
+      $this->assertEquals(
+        Result::DONE,
+        $item->importerStatus,
+        "ImportInfo should report a completed import for resource {$info['resource_id']}."
+      );
+    }
+
+    // Run the drop-all command.
+    $this->drush('dkan:datastore:drop-all');
+
+    // Assert that the drop command's "removed" notice was logged for each
+    // dropped resource.
+    $this->assertStringContainsString(
+      'Successfully removed the post import job status for resource',
+      $this->getErrorOutput()
+    );
+
+    // Verify the tables no longer exist, and ImportInfo no longer reflects a
+    // completed import.
+    foreach ($resource_infos as $info) {
+      $this->assertFalse(
+        $connection->schema()->tableExists($info['table_name']),
+        "Datastore table {$info['table_name']} should not exist after drop-all."
+      );
+      $item = $import_info->getItem($info['resource_id'], $info['resource_version']);
+      $this->assertNotEquals(
+        Result::DONE,
+        $item->importerStatus,
+        "ImportInfo should not report a completed import for resource {$info['resource_id']} after drop-all."
+      );
+      $this->assertNotEquals(
+        Result::DONE,
+        $item->fileFetcherStatus,
+        "ImportInfo should not report a completed file fetch for resource {$info['resource_id']} after drop-all."
+      );
+    }
+  }
+
+  /**
+   * Create datasets and import resources for testing.
+   *
+   * @param string $filename
+   *   The name of the resource file.
+   * @param string $dataset_id
+   *   An arbitrary dataset UUID.
+   *
+   * @return string
+   *   The UUID of the created dataset.
+   */
+  private function createDataset(string $filename, string $dataset_id) {
+    $json = $this->getDataset($dataset_id,'Test ' . $dataset_id, [$filename]);
+    $valid_metadata_factory = $this->container->get('dkan.metastore.valid_metadata');
+    $dataset = $valid_metadata_factory->get($json, 'dataset');
+    return $this->container->get('dkan.metastore.service')->post('dataset', $dataset);
+  }
+
+  /**
+   * Get the resource identifier and version for a dataset's first distribution.
+   *
+   * Unlike getResourceInfo(), this does not require the resource to already
+   * be localized or imported, so it can be used before an import has run.
+   *
+   * @param string $dataset_id
+   *   The dataset identifier.
+   *
+   * @return array
+   *   An array with 'resource_id' and 'resource_version' keys.
+   */
+  private function getResourceIdentifier(string $dataset_id): array {
+    $dataset_info = \Drupal::service('dkan.common.dataset_info')->gather($dataset_id);
+    $distribution = $dataset_info['latest_revision']['distributions'][0] ?? [];
+    if (empty($distribution['resource_id'])) {
+      throw new \Exception("Could not determine resource identifier for dataset $dataset_id.");
+    }
+    return [
+      'resource_id' => $distribution['resource_id'],
+      'resource_version' => $distribution['resource_version'] ?? NULL,
+    ];
+  }
+
+  /**
+   * Get resource info for a dataset's first distribution.
+   *
+   * @param string $dataset_id
+   *   The dataset identifier.
+   *
+   * @return array
+   *   An array with 'resource_id', 'resource_version', and 'table_name' keys.
+   */
+  private function getResourceInfo(string $dataset_id): array {
+    $dataset_info = \Drupal::service('dkan.common.dataset_info')->gather($dataset_id);
+    $distribution = $dataset_info['latest_revision']['distributions'][0] ?? [];
+    if (empty($distribution['table_name']) || empty($distribution['resource_id'])) {
+      throw new \Exception("Could not determine resource info for dataset $dataset_id.");
+    }
+    return [
+      'resource_id' => $distribution['resource_id'],
+      'resource_version' => $distribution['resource_version'] ?? NULL,
+      'table_name' => $distribution['table_name'],
+    ];
+  }
+
+}

--- a/modules/dkan_datastore/tests/src/Functional/Commands/DatastoreCommandsTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/Commands/DatastoreCommandsTest.php
@@ -9,6 +9,13 @@ use Drupal\Tests\BrowserTestBase;
 use Drush\TestTraits\DrushTestTrait;
 use Procrastinator\Result;
 
+/**
+ * Datastore Commands functional rests.
+ *
+ * @group dkan
+ * @group functional
+ * @group functional2
+ */
 class DatastoreCommandsTest extends BrowserTestBase {
   use DrushTestTrait, GetLocalDataTrait, QueueRunnerTrait;
 

--- a/modules/dkan_datastore/tests/src/Functional/Commands/DatastoreCommandsTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/Commands/DatastoreCommandsTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\dkan_datastore\Functional\Commands;
 
+use Drupal\dkan_datastore\Service\ResourceLocalizer;
 use Drupal\Tests\dkan_common\Traits\GetLocalDataTrait;
 use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
 use Drupal\Tests\BrowserTestBase;
@@ -17,6 +18,45 @@ class DatastoreCommandsTest extends BrowserTestBase {
   protected static $modules = ['dkan_datastore', 'dkan_metastore'];
 
   protected $defaultTheme = 'stark';
+
+  /**
+   * Tests the dkan:datastore:import command.
+   */
+  public function testImportCommand() {
+    // Create a single dataset. Do not run any queues, so the resource is not
+    // yet localized or imported.
+    $dataset_id = $this->createDataset('1.csv', 'test-dataset-import');
+    $resource = $this->getResourceIdentifier($dataset_id);
+
+    // Run the import command directly against the resource identifier. This
+    // is not deferred, so the import should complete immediately.
+    $this->drush('dkan:datastore:import', [$resource['resource_id']]);
+
+    // Assert the drush command logged a successful run.
+    $this->assertStringContainsString(
+      'Ran import for ' . $resource['resource_id'],
+      $this->getErrorOutput()
+    );
+
+    // Now that the import has run, get the full resource info (including the
+    // table name) in a single call.
+    $resource = $this->getResourceInfo($dataset_id);
+
+    // ImportInfo should now report the import as done.
+    $import_info = \Drupal::service('dkan.datastore.import_info');
+    $item = $import_info->getItem($resource['resource_id'], $resource['resource_version']);
+    $this->assertEquals(
+      Result::DONE,
+      $item->importerStatus,
+      "ImportInfo should report a completed import for resource {$resource['resource_id']}."
+    );
+
+    // Verify the datastore table now exists.
+    $this->assertTrue(
+      \Drupal::database()->schema()->tableExists($resource['table_name']),
+      "Datastore table {$resource['table_name']} should exist after import."
+    );
+  }
 
   /**
    * Tests the dkan:datastore:list command.
@@ -42,25 +82,24 @@ class DatastoreCommandsTest extends BrowserTestBase {
   }
 
   /**
-   * Tests the dkan:datastore:import command.
+   * Tests the dkan:datastore:drop command.
    */
-  public function testImportCommand() {
-    // Create a single dataset. Do not run any queues, so the resource is not
-    // yet localized or imported.
-    $dataset_id = $this->createDataset('1.csv', 'test-dataset-import');
+  public function testDropCommand() {
+    // Create a single dataset and import it.
+    $dataset_id = $this->createDataset('1.csv', 'test-dataset-drop');
     $resource = $this->getResourceIdentifier($dataset_id);
-
-    // Run the import command directly against the resource identifier. This
-    // is not deferred, so the import should complete immediately.
     $this->drush('dkan:datastore:import', [$resource['resource_id']]);
 
-    // Assert the drush command logged a successful run.
-    $this->assertStringContainsString(
-      'Ran import for ' . $resource['resource_id'],
-      $this->getErrorOutput()
-    );
+    // Get the full resource info now that the import has run.
+    $resource = $this->getResourceInfo($dataset_id);
 
-    // ImportInfo should now report the import as done.
+    // Verify the table exists, and ImportInfo reflects a completed import,
+    // before dropping.
+    $connection = \Drupal::database();
+    $this->assertTrue(
+      $connection->schema()->tableExists($resource['table_name']),
+      "Datastore table {$resource['table_name']} should exist after import."
+    );
     $import_info = \Drupal::service('dkan.datastore.import_info');
     $item = $import_info->getItem($resource['resource_id'], $resource['resource_version']);
     $this->assertEquals(
@@ -69,11 +108,35 @@ class DatastoreCommandsTest extends BrowserTestBase {
       "ImportInfo should report a completed import for resource {$resource['resource_id']}."
     );
 
-    // Verify the datastore table now exists.
-    $table_name = $this->getResourceInfo($dataset_id)['table_name'];
-    $this->assertTrue(
-      \Drupal::database()->schema()->tableExists($table_name),
-      "Datastore table $table_name should exist after import."
+    // Run the drop command.
+    $this->drush('dkan:datastore:drop', [$resource['resource_id']]);
+
+    // Assert the drop command logged both success notices.
+    $this->assertStringContainsString(
+      'Successfully dropped the datastore for resource ' . $resource['resource_id'],
+      $this->getErrorOutput()
+    );
+    $this->assertStringContainsString(
+      'Successfully removed the post import job status for resource ' . $resource['resource_id'],
+      $this->getErrorOutput()
+    );
+
+    // Verify the table no longer exists, and ImportInfo no longer reflects a
+    // completed import.
+    $this->assertFalse(
+      $connection->schema()->tableExists($resource['table_name']),
+      "Datastore table {$resource['table_name']} should not exist after drop."
+    );
+    $item = $import_info->getItem($resource['resource_id'], $resource['resource_version']);
+    $this->assertNotEquals(
+      Result::DONE,
+      $item->importerStatus,
+      "ImportInfo should not report a completed import for resource {$resource['resource_id']} after drop."
+    );
+    $this->assertNotEquals(
+      Result::DONE,
+      $item->fileFetcherStatus,
+      "ImportInfo should not report a completed file fetch for resource {$resource['resource_id']} after drop."
     );
   }
 
@@ -138,6 +201,109 @@ class DatastoreCommandsTest extends BrowserTestBase {
         "ImportInfo should not report a completed file fetch for resource {$info['resource_id']} after drop-all."
       );
     }
+  }
+
+  /**
+   * Tests the dkan:datastore:prepare-localized command.
+   */
+  public function testPrepareLocalizedCommand() {
+    // Create a single dataset. Do not run any queues, so the resource is not
+    // yet localized.
+    $dataset_id = $this->createDataset('1.csv', 'test-dataset-prepare-localized');
+    $resource = $this->getResourceIdentifier($dataset_id);
+
+    // The resource should not yet be registered under the local file
+    // perspective.
+    $resource_mapper = \Drupal::service('dkan.metastore.resource_mapper');
+    $this->assertNull(
+      $resource_mapper->get($resource['resource_id'], ResourceLocalizer::LOCAL_FILE_PERSPECTIVE, $resource['resource_version']),
+      "Resource {$resource['resource_id']} should not have a local file perspective registered before running prepare-localized."
+    );
+
+    // Run the prepare-localized command.
+    $this->drush('dkan:datastore:prepare-localized', [$resource['resource_id']]);
+
+    // Assert the command output the expected localization paths as JSON.
+    $output = $this->getOutput();
+    $this->assertStringContainsString('"source":', $output);
+    $this->assertStringContainsString('"path_uri":', $output);
+    $this->assertStringContainsString('"path":', $output);
+    $this->assertStringContainsString('"file_uri":', $output);
+    $this->assertStringContainsString('"file":', $output);
+
+    // The resource should now be registered under the local file
+    // perspective, though the file itself has not actually been fetched yet.
+    $local_file_resource = $resource_mapper->get($resource['resource_id'], ResourceLocalizer::LOCAL_FILE_PERSPECTIVE, $resource['resource_version']);
+    $this->assertNotNull(
+      $local_file_resource,
+      "Resource {$resource['resource_id']} should have a local file perspective registered after running prepare-localized."
+    );
+  }
+
+  /**
+   * Tests the dkan:datastore:localize command.
+   */
+  public function testLocalizeCommand() {
+    // Create a single dataset. Do not run any queues, so the resource is not
+    // yet localized.
+    $dataset_id = $this->createDataset('1.csv', 'test-dataset-localize');
+    $resource = $this->getResourceIdentifier($dataset_id);
+
+    // The resource should not yet be registered under the local file
+    // perspective.
+    $resource_mapper = \Drupal::service('dkan.metastore.resource_mapper');
+    $this->assertNull(
+      $resource_mapper->get($resource['resource_id'], ResourceLocalizer::LOCAL_FILE_PERSPECTIVE, $resource['resource_version']),
+      "Resource {$resource['resource_id']} should not have a local file perspective registered before running localize."
+    );
+
+    // Run the localize command directly against the resource identifier.
+    $this->drush('dkan:datastore:localize', [$resource['resource_id']]);
+
+    // Confirm the local file perspective is registered by reading it back
+    // from the resource mapper.
+    $localized_resource = $resource_mapper->get($resource['resource_id'], ResourceLocalizer::LOCAL_FILE_PERSPECTIVE, $resource['resource_version']);
+    $this->assertNotNull(
+      $localized_resource,
+      "Resource {$resource['resource_id']} should be localized after running localize."
+    );
+
+    // Verify the localized file actually exists on disk.
+    $this->assertFileExists(
+      $localized_resource->getFilePath(),
+      "Localized file {$localized_resource->getFilePath()} should exist after running localize."
+    );
+  }
+
+  /**
+   * Tests the dkan:datastore:reverse-dataset-lookup command.
+   */
+  public function testReverseDatasetLookupCommand() {
+    // Create a single dataset and import it, so the datastore table exists.
+    $dataset_id = $this->createDataset('1.csv', 'test-dataset-rdl');
+    $resource = $this->getResourceIdentifier($dataset_id);
+    $this->drush('dkan:datastore:import', [$resource['resource_id']]);
+
+    // Get the full resource info now that the import has run, including the
+    // table name.
+    $resource = $this->getResourceInfo($dataset_id);
+
+    // Run the reverse-dataset-lookup command against the datastore table
+    // name, and confirm it works backwards to find the correct dataset.
+    $this->drush('dkan:datastore:reverse-dataset-lookup', [$resource['table_name']]);
+    $this->assertStringContainsString(
+      'Dataset UUID = ' . $dataset_id,
+      $this->getOutput()
+    );
+
+    // A table name that cannot be mapped to a resource throws an exception
+    // (rather than the command's own "Can not map..." failure message,
+    // since tableToResourceLookup() never returns an empty string).
+    $this->drush('dkan:datastore:reverse-dataset-lookup', ['datastore_nonexistent'], [], NULL, NULL, 1);
+    $this->assertStringContainsString(
+      'Can not map datastore table name datastore_nonexistent',
+      $this->getErrorOutput()
+    );
   }
 
   /**

--- a/modules/dkan_datastore/tests/src/Functional/Commands/DatastoreCommandsTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/Commands/DatastoreCommandsTest.php
@@ -24,6 +24,9 @@ class DatastoreCommandsTest extends BrowserTestBase {
    */
   protected static $modules = ['dkan_datastore', 'dkan_metastore'];
 
+  /**
+   * {@inheritdoc}
+   */
   protected $defaultTheme = 'stark';
 
   /**

--- a/modules/dkan_datastore/tests/src/Functional/Controller/QueryDownloadControllerTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/Controller/QueryDownloadControllerTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\dkan_datastore\Functional\Controller;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\dkan_metastore\DataDictionary\DataDictionaryDiscovery;
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\dkan_common\Traits\GetDataTrait;
+use Drupal\Tests\dkan_common\Traits\GetLocalDataTrait;
 use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
 use RootedData\RootedJsonData;
 
@@ -20,7 +20,7 @@ use RootedData\RootedJsonData;
  */
 class QueryDownloadControllerTest extends BrowserTestBase {
 
-  use GetDataTrait, QueueRunnerTrait;
+  use GetLocalDataTrait, QueueRunnerTrait;
 
   /**
    * Uploaded resource file destination.
@@ -65,7 +65,6 @@ class QueryDownloadControllerTest extends BrowserTestBase {
           $dataset_id,
           'Test ' . $dataset_id,
           [$resourceUrl],
-          TRUE
         ),
         'dataset'
       )
@@ -225,7 +224,6 @@ class QueryDownloadControllerTest extends BrowserTestBase {
           $dataset_id,
           'Test ' . $dataset_id,
           [$resourceUrl],
-          TRUE,
           'dkan://metastore/schemas/data-dictionary/items/' . $dict_id
         ),
         'dataset'

--- a/modules/dkan_datastore/tests/src/Functional/DictionaryEnforcerTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/DictionaryEnforcerTest.php
@@ -6,7 +6,7 @@ namespace Drupal\Tests\dkan_datastore\Functional;
 
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\dkan_common\Traits\GetDataTrait;
+use Drupal\Tests\dkan_common\Traits\GetLocalDataTrait;
 use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
 use Drupal\dkan_datastore\Controller\ImportController;
 use Drupal\dkan_metastore\DataDictionary\DataDictionaryDiscovery;
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class DictionaryEnforcerTest extends BrowserTestBase {
 
-  use GetDataTrait, QueueRunnerTrait;
+  use GetLocalDataTrait, QueueRunnerTrait;
 
   protected $defaultTheme = 'stark';
 
@@ -204,7 +204,7 @@ class DictionaryEnforcerTest extends BrowserTestBase {
     $this->assertInstanceOf(
       RootedJsonData::class,
       $dataset = $this->validMetadataFactory->get(
-        $this->getDataset($dataset_id, 'Test ' . $dataset_id, [$this->resourceUrl], TRUE),
+        $this->getDataset($dataset_id, 'Test ' . $dataset_id, [$this->resourceUrl]),
         'dataset'
       )
     );

--- a/modules/dkan_datastore/tests/src/Functional/Service/ResourcePurgerTest.php
+++ b/modules/dkan_datastore/tests/src/Functional/Service/ResourcePurgerTest.php
@@ -3,8 +3,7 @@
 namespace Drupal\Tests\dkan_datastore\Functional\Service;
 
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\dkan_common\Traits\CleanUp;
-use Drupal\Tests\dkan_common\Traits\GetDataTrait;
+use Drupal\Tests\dkan_common\Traits\GetLocalDataTrait;
 use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
 use Drupal\Tests\dkan_metastore\Unit\MetastoreServiceTest;
 
@@ -20,7 +19,7 @@ use Drupal\Tests\dkan_metastore\Unit\MetastoreServiceTest;
  * @group functional1
  */
 class ResourcePurgerTest extends BrowserTestBase {
-  use GetDataTrait;
+  use GetLocalDataTrait;
   use QueueRunnerTrait;
 
   protected static $modules = [

--- a/modules/dkan_metastore/tests/src/Functional/OrphanCheckerTest.php
+++ b/modules/dkan_metastore/tests/src/Functional/OrphanCheckerTest.php
@@ -3,7 +3,7 @@
 namespace Drupal\Tests\dkan_metastore\Functional;
 
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\dkan_common\Traits\GetDataTrait;
+use Drupal\Tests\dkan_common\Traits\GetLocalDataTrait;
 use Drupal\Tests\dkan_common\Traits\QueueRunnerTrait;
 use Drupal\Tests\dkan_metastore\Unit\MetastoreServiceTest;
 
@@ -15,7 +15,7 @@ use Drupal\Tests\dkan_metastore\Unit\MetastoreServiceTest;
  * @group functional1
  */
 class OrphanCheckerTest extends BrowserTestBase {
-  use GetDataTrait;
+  use GetLocalDataTrait;
   use QueueRunnerTrait;
 
   protected static $modules = [

--- a/tests/src/Functional/DatasetBTBTest.php
+++ b/tests/src/Functional/DatasetBTBTest.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace Drupal\Tests\dkan\Functional;
-
+use Drupal\Tests\dkan_common\Traits\GetLocalDataTrait;
 use Drupal\dkan_common\DataResource;
 use Drupal\dkan_datastore\Service\ResourceLocalizer;
 use Drupal\dkan_harvest\HarvestService;
@@ -23,6 +23,7 @@ use RootedData\RootedJsonData;
  */
 class DatasetBTBTest extends BrowserTestBase {
 
+  use GetLocalDataTrait;
   use QueueRunnerTrait;
 
   /**
@@ -476,66 +477,27 @@ class DatasetBTBTest extends BrowserTestBase {
   }
 
   /**
-   * Get the download URL for a resource file.
-   *
-   * @param string $filename
-   *   The filename of the resource.
-   *
-   * @return string
-   *   The download URL for the resource file from S3 bucket.
-   */
-  private function getDownloadUrl(string $filename) {
-    return 'file://' . __DIR__ . '/../../files/' . $filename;
-  }
-
-  /**
    * Generate dataset metadata, possibly with multiple distributions.
    *
    * @param string $identifier
    *   Dataset identifier.
    * @param string $title
    *   Dataset title.
-   * @param array $downloadUrls
+   * @param array $filenames
    *   Array of resource files URLs for this dataset.
    *
    * @return \RootedData\RootedJsonData
    *   Json encoded string of this dataset's metadata, or FALSE if error.
    */
-  private function getData(string $identifier, string $title, array $downloadUrls): RootedJsonData {
+  private function getData(string $identifier, string $title, array $filenames): RootedJsonData {
     /** @var \Drupal\dkan_metastore\ValidMetadataFactory $valid_metadata_factory */
     $valid_metadata_factory = $this->container->get('dkan.metastore.valid_metadata');
 
-    $data = new \stdClass();
-    $data->title = $title;
-    $data->description = 'This & that description. <a onauxclick=prompt(document.domain)>Right click me</a>.';
-    $data->identifier = $identifier;
-    $data->accessLevel = 'public';
-    $data->modified = '06-04-2020';
-    $data->keyword = ['some keyword'];
-    $data->distribution = [];
-    $data->publisher = (object) [
-      'name' => 'Test Publisher',
-    ];
-    $data->contactPoint = (object) [
-      'fn' => 'Test Name',
-      'hasEmail' => 'test@example.com',
-    ];
+    $json = $this->getDataset($identifier, $title, $filenames);
 
-    foreach ($downloadUrls as $key => $downloadUrl) {
-      $distribution = new \stdClass();
-      $distribution->title = 'Distribution #' . $key . ' for ' . $identifier;
-      $distribution->downloadURL = $this->getDownloadUrl($downloadUrl);
-      $distribution->mediaType = 'text/csv';
-      $data->distribution[] = $distribution;
-    }
-    $this->assertGreaterThan(
-      0,
-      count($data->distribution),
-      'JSON Schema requires one or more distributions.'
-    );
     // @todo Figure out how to assert against $factory->getResult()->getError()
     // so we can have a useful test fail message.
-    return $valid_metadata_factory->get(json_encode($data), 'dataset');
+    return $valid_metadata_factory->get($json, 'dataset');
   }
 
   /**


### PR DESCRIPTION
Adds baseline functional tests for Datastore commands. These will be useful to catch any regressions in the work for #4380.

Also replaces the GetDataTrait with new GetLocalDataTrait in several other test classes, moving us closer to having no S3 dependencies for tests. Parts of DatasetBTB test were redundant with this trait, and it's been added to that class also.

The new command functional tests were mostly generated with copilot, but thoroughly reviewed and tweaked before committing.