### PR TITLE
Try cypress config update to address memory issues

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,6 +2,8 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   apiUri: 'api/1',
+  experimentalMemoryManagement: true,
+  numTestsKeptInMemory: 0,
   env: {
     TEST_USER_CREDENTIALS: {
       user: 'testadmin',


### PR DESCRIPTION
We fixed (I think) one problem with the workflow cypress test with #4758, and got another one. We've been seeing a lot of these errors in CI:

```
We detected that the Electron Renderer process just crashed.

We have failed the current spec but will continue running the next spec.

This can happen for a number of different reasons.

If you're running lots of tests on a memory intense application.
  - Try increasing the CPU/memory on the machine you're running on.
  - Try enabling experimentalMemoryManagement in your config file.
  - Try lowering numTestsKeptInMemory in your config file during 'cypress open'.

You can learn more here:

https://on.cypress.io/renderer-process-crashed
```

Following the second two recommendations here. I don't actually think setting `numTestsKeptInMemory` to zero will do anything, since if I understand the docs that's the default anyway for `run`, but hopefully the `experimentalMemoryManagement` will help.

Will re-run the cypress job several times to see if I can still get a memory error. No guarantee, but couldn't hurt?