### PR TITLE
Move drupal/coder to 9.x releases for CI

### DIFF
--- a/.qlty/configs/composer.json
+++ b/.qlty/configs/composer.json
@@ -6,7 +6,7 @@
         }
     ],
     "require": {
-        "drupal/coder": "^8.3.13"
+        "drupal/coder": "^9.0.0"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
In response to https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq

This only applies to qlty.sh builds, not DKAN itself