### PR TITLE
4478: Surface the checksum in API and dkan:dataset-info

### DIFF
--- a/modules/dkan_datastore/src/Plugin/DatasetInfo/DatastoreInfo.php
+++ b/modules/dkan_datastore/src/Plugin/DatasetInfo/DatastoreInfo.php
@@ -132,6 +132,7 @@ class DatastoreInfo extends DatasetInfoPluginBase {
       'fetcher_status' => $import_info->fileFetcherStatus,
       'fetcher_percent_done' => $import_info->fileFetcherPercentDone ?? 0,
       'file_path' => isset($fileMapper) ? $fileMapper->getFilePath() : 'not found',
+      'file_checksum' => isset($fileMapper) ? $fileMapper->getChecksum() : 'not found',
       'importer_percent_done' => $import_info->importerPercentDone ?? 0,
       'importer_status' => $import_info->importerStatus,
       'importer_error' => $import_info->importerError,

--- a/modules/dkan_datastore/src/Service/ResourceLocalizer.php
+++ b/modules/dkan_datastore/src/Service/ResourceLocalizer.php
@@ -3,13 +3,13 @@
 namespace Drupal\dkan_datastore\Service;
 
 use Contracts\FactoryInterface;
-use Drupal\dkan_common\DataResource;
-use Drupal\dkan_common\Events\Event;
-use Drupal\dkan_common\UrlHostTokenResolver;
-use Drupal\dkan_common\Util\DrupalFiles;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Queue\QueueFactory;
+use Drupal\dkan_common\DataResource;
+use Drupal\dkan_common\Events\Event;
 use Drupal\dkan_common\Storage\FileFetcherJobStoreFactory;
+use Drupal\dkan_common\UrlHostTokenResolver;
+use Drupal\dkan_common\Util\DrupalFiles;
 use Drupal\dkan_metastore\Exception\AlreadyRegistered;
 use Drupal\dkan_metastore\ResourceMapper;
 use FileFetcher\FileFetcher;
@@ -191,18 +191,24 @@ class ResourceLocalizer {
     $localUrl = $this->drupalFiles->fileCreateUrl($localFileDrupalUri);
     $localUrl = UrlHostTokenResolver::hostify($localUrl);
 
-    $new = $resource->createNewPerspective(self::LOCAL_FILE_PERSPECTIVE, $localFilePath);
-
+    $localFilePerspective = $resource->createNewPerspective(self::LOCAL_FILE_PERSPECTIVE, $localFilePath);
     try {
-      $this->resourceMapper->registerNewPerspective($new);
+      $this->resourceMapper->registerNewPerspective($localFilePerspective);
     }
     catch (AlreadyRegistered) {
     }
 
     $localUrlPerspective = $resource->createNewPerspective(self::LOCAL_URL_PERSPECTIVE, $localUrl);
 
+    // createNewPerspective() will have calculated an MD5 hash for the
+    // LOCAL_FILE_PERSPECTIVE file if it exists, so we want to use that
+    // perspective to generate our LOCAL_URL_PERSPECTIVE and keep the hash.
+    // Since we can't explicitly set the checksum in the new DataResource, we
+    // rely on the side-effects of createNewPerspective().
     try {
-      $this->resourceMapper->registerNewPerspective($localUrlPerspective);
+      $this->resourceMapper->registerNewPerspective(
+        $localFilePerspective->createNewPerspective(self::LOCAL_URL_PERSPECTIVE, $localUrl)
+      );
     }
     catch (AlreadyRegistered) {
     }


### PR DESCRIPTION
Fixes #4478

Refresh of the https://github.com/GetDKAN/dkan/pull/4642 PR.

## Describe your changes

Enables `LOCAL_URL_PERSPECTIVE` to inherit the checksum from `LOCAL_FILE_PERSPECTIVE`.

We really should get rid of `LOCAL_URL_PERSPECTIVE` altogether, but this is a more minimal change.

```bash
% ddev drush dkan:dataset-info 95f8eac4-fd1f-4b35-8472-5c87e9425dfa      
{
    "latest_revision": {
        "uuid": "95f8eac4-fd1f-4b35-8472-5c87e9425dfa",
[...]
        "distributions": [
            {
[...]
                "file_path": "public:\/\/resources\/6e5a8b0e5f9ae95d1e239844aaab2db4_1767909623\/Asthma-Prevalence-Map-2017.csv",
                "file_checksum": "504180d7a251b915e5494bc48690dd6d",
[...]
            }
        ]
    }
}
```

## QA Steps

- [ ] Add manual QA steps in checklist format for a reviewer to perform. Be as specific as possible, provide examples if appropriate.

## Checklist before requesting review

_If any of these are left unchecked, please provide an explanation_

- [ ] I have updated or added tests to cover my code
- [ ] I have updated or added documentation
